### PR TITLE
fixes and addressing comments from previous PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ If you use 🤗 PEFT in your publication, please cite it by using the following 
 ```bibtex
 @Misc{peft,
   title =        {PEFT: State-of-the-art Parameter-Efficient Fine-Tuning methods},
-  author =       {Sourab Mangrulkar, Sylvain Gugger},
+  author =       {Sourab Mangrulkar, Sylvain Gugger, Lysandre Debut},
   howpublished = {\url{https://github.com/huggingface/peft}},
   year =         {2022}
 }

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The HuggingFace Team. All rights reserved.
+# Copyright 2023 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ setup(
         "torch>=1.13.0",
         "transformers",
         "accelerate",
-        "loralib",
     ],
     extras_require=extras,
     classifiers=[

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0.dev"
+__version__ = "0.1.0.dev0"
 
 from .mapping import MODEL_TYPE_TO_PEFT_MODEL_MAPPING, PEFT_TYPE_TO_CONFIG_MAPPING, get_peft_config, get_peft_model
 from .peft_model import (

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import math
 import warnings
 from dataclasses import asdict, dataclass, field
@@ -24,10 +25,16 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers.pytorch_utils import Conv1D
 
-import loralib as lora  # noqa: F401
-from loralib import mark_only_lora_as_trainable
-
 from ..utils import PeftConfig, PeftType, transpose
+
+
+def is_loralib_available():
+    return importlib.util.find_spec("loralib") is not None
+
+
+if is_loralib_available():
+    import loralib as lora  # noqa: F401
+    from loralib import mark_only_lora_as_trainable
 
 
 @dataclass
@@ -90,6 +97,8 @@ class LoraModel(torch.nn.Module):
     """
 
     def __init__(self, config, model):
+        if not is_loralib_available():
+            raise ImportError("LoRA requires `loralib` to be installed. Please run `pip install loralib`.")
         super().__init__()
         self.peft_config = config
         self.model = model


### PR DESCRIPTION
1. Minor updates/fixes in README.md and setup.py
2. Make `loralib` optional. When using LoRA, if `loralib` isn't installed, following error will be raised:
```bash
ImportError: LoRA requires `loralib` to be installed. Please run `pip install loralib`.
```