### PR TITLE
making `bnb` optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         "torch>=1.13.0",
         "transformers",
         "accelerate",
-        "bitsandbytes",
     ],
     extras_require=extras,
     classifiers=[

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -134,7 +134,7 @@ class LoraModel(torch.nn.Module):
                     is_target_modules_in_base_model = True
                 parent, target, target_name = self._get_submodules(key)
                 bias = target.bias is not None
-                if isinstance(target, bnb.nn.Linear8bitLt) and self.peft_config.enable_lora is None:
+                if loaded_in_8bit and isinstance(target, bnb.nn.Linear8bitLt) and self.peft_config.enable_lora is None:
                     kwargs.update(
                         {
                             "has_fp16_weights": target.state.has_fp16_weights,


### PR DESCRIPTION
### What does this PR do?
1. Makes `bnb` optional as it is currently required only with LoRA PEFT methods and to avoid issues like #79 