### PR TITLE
chore: update `pyproject.toml`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include LICENSE

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,12 @@ check_dirs := src tests examples
 # this target runs checks on all files
 quality:
 	black --check $(check_dirs)
-	isort --check-only $(check_dirs)
-	flake8 $(check_dirs)
+	ruff $(check_dirs)
 	doc-builder style src tests --max_len 119 --check_only
 
 # Format source code automatically and check is there are any problems left that need manual fixing
 style:
 	black $(check_dirs)
-	isort $(check_dirs)
+	ruff $(check_dirs) --fix
 	doc-builder style src tests --max_len 119
 	

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ line-length = 119
 
 [tool.ruff.isort]
 default_section = "FIRSTPARTY"
-known_first_party = "pet"
+known_first_party = "peft"
 known_third_party = [
     "numpy",
     "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,27 @@
 [tool.black]
 line-length = 119
 target-version = ['py36']
+
+[tool.isort]
+line_length = 119
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+lines_after_imports = 2
+default_section = "FIRSTPARTY"
+known_first_party = "pet"
+known_third_party = [
+    "numpy",
+    "torch",
+    "accelerate",
+    "transformers",
+]
+
+[tool.pytest.ini_options]
+doctest_optionflags = [
+    "NUMBER",
+    "NORMALIZE_WHITESPACE",
+    "ELLIPSIS",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,14 +2,12 @@
 line-length = 119
 target-version = ['py36']
 
-[tool.isort]
-line_length = 119
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-lines_after_imports = 2
+[tool.ruff]
+ignore = ["C901", "E501", "E741", "W605"]
+select = ["C", "E", "F", "I", "W"]
+line-length = 119
+
+[tool.ruff.isort]
 default_section = "FIRSTPARTY"
 known_first_party = "pet"
 known_third_party = [
@@ -18,10 +16,17 @@ known_third_party = [
     "accelerate",
     "transformers",
 ]
+line_length = 119
+lines_after_imports = 2
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
 
-[tool.pytest.ini_options]
+[tool.pytest]
 doctest_optionflags = [
-    "NUMBER",
     "NORMALIZE_WHITESPACE",
     "ELLIPSIS",
+    "NUMBER",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,23 +1,3 @@
-[isort]
-default_section = FIRSTPARTY
-ensure_newline_before_comments = True
-force_grid_wrap = 0
-include_trailing_comma = True
-known_first_party = pet
-known_third_party =
-    numpy
-    torch
-    accelerate
-    transformers
-
-line_length = 119
-lines_after_imports = 2
-multi_line_output = 3
-use_parentheses = True
-
 [flake8]
 ignore = E203, E722, E501, E741, W503, W605
 max-line-length = 119
-
-[tool:pytest]
-doctest_optionflags=NUMBER NORMALIZE_WHITESPACE ELLIPSIS

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-ignore = E203, E722, E501, E741, W503, W605
-max-line-length = 119

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,8 @@
 
 from setuptools import find_packages, setup
 
-
 extras = {}
-extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3"]
+extras["quality"] = ["black ~= 22.0", "ruff>=0.0.241"]
 extras["docs_specific"] = ["hf-doc-builder"]
 extras["dev"] = extras["quality"] + extras["docs_specific"]
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
+
 
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3"]
@@ -24,6 +24,7 @@ setup(
     name="peft",
     version="0.2.0.dev0",
     description="Parameter-Efficient Fine-Tuning (PEFT)",
+    license_files=["LICENSE"],
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     keywords="deep learning",


### PR DESCRIPTION
Changes proposed by this PR can be summarized as follows:

* Move LICENSE file inclusion to `setup.py` by adding a `license_files` argument to `setup()`. [Source](https://stackoverflow.com/a/66443941/14081966), thereby eliminating the purpose of `MANIFEST.in`
* Move `isort` and `pytest` configuration to `pyproject.toml`. 

Follow up suggestions, `pyproject.toml` is the new standard for python packaging, would recommend moving all packaging related metadata to `pyproject.toml`. It eliminates the need for updating version's explicitly using the `flit` backend instead of `setuptools` and also allows for placing all metadata within one single file. (for the sad exception of `flake8` which doesn't support `pyproject.toml` as of now)