### PR TITLE
fixes `prepare_for_int8_training`

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -30,7 +30,7 @@ def bloom_model_postprocess_past_key_value(past_key_values):
     return tuple(zip(keys, values))
 
 
-def prepare_model_for_int8_training(model, output_embedding_layer_name="lm_head"):
+def prepare_model_for_int8_training(model, output_embedding_layer_name="lm_head", use_gradient_checkpointing=True):
     r"""
     This method wrapps the entire protocol for preparing a model before running a training. This includes:
         1- Cast the layernorm in fp32 2- making output embedding layer require grads 3- Add the upcasting of the lm
@@ -51,17 +51,17 @@ def prepare_model_for_int8_training(model, output_embedding_layer_name="lm_head"
             if param.ndim == 1 and "layer_norm" in name:
                 param.data = param.data.to(torch.float32)
 
-    # For backward compatibility
-    if hasattr(model, "enable_input_require_grads"):
-        model.enable_input_require_grads()
-    else:
+    if loaded_in_8bit and use_gradient_checkpointing:
+        # For backward compatibility
+        if hasattr(model, "enable_input_require_grads"):
+            model.enable_input_require_grads()
+        else:
 
-        def make_inputs_require_grad(module, input, output):
-            output.requires_grad_(True)
+            def make_inputs_require_grad(module, input, output):
+                output.requires_grad_(True)
 
-        model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
+            model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
 
-    if loaded_in_8bit:
         # enable gradient checkpointing for memory efficiency
         model.gradient_checkpointing_enable()
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -30,7 +30,9 @@ def bloom_model_postprocess_past_key_value(past_key_values):
     return tuple(zip(keys, values))
 
 
-def prepare_model_for_int8_training(model, output_embedding_layer_name="lm_head", use_gradient_checkpointing=True):
+def prepare_model_for_int8_training(
+    model, output_embedding_layer_name="lm_head", use_gradient_checkpointing=True, layer_norm_names=["layer_norm"]
+):
     r"""
     This method wrapps the entire protocol for preparing a model before running a training. This includes:
         1- Cast the layernorm in fp32 2- making output embedding layer require grads 3- Add the upcasting of the lm
@@ -48,7 +50,7 @@ def prepare_model_for_int8_training(model, output_embedding_layer_name="lm_head"
 
         if loaded_in_8bit:
             # cast layer norm in fp32 for stability for 8bit models
-            if param.ndim == 1 and "layer_norm" in name:
+            if param.ndim == 1 and any(layer_norm_name in name for layer_norm_name in layer_norm_names):
                 param.data = param.data.to(torch.float32)
 
     if loaded_in_8bit and use_gradient_checkpointing:


### PR DESCRIPTION
### What does this PR do?
1. make gradient checkpointing optional when using PEFT+INT8. This is useful for RLHF wherein `model.generate` is part of the train loop which requires `use_cache` for faster generations. `use_cache` isn't compatible with gradient_checkpointing and this provides a way to speed up the training loop when sequence lengths are not that long
2. Fixes: #130 