### PR TITLE
adds multiple adapters to a peft model

### DIFF
--- a/examples/multiple_adapters.py
+++ b/examples/multiple_adapters.py
@@ -27,10 +27,10 @@ def print_trainable_parameters(model):
 
 
 lora_config = LoraConfig(
-    r=(16,16),
-    lora_alpha=(32,32),
+    r=[16,8],
+    lora_alpha=32,
     target_modules=None,  #handled automatically by peft
-    lora_dropout=(0.05,0.01),
+    lora_dropout=0.05,
     bias="none",
     task_type="CAUSAL_LM",
     n_adapters=2

--- a/examples/multiple_adapters.py
+++ b/examples/multiple_adapters.py
@@ -27,10 +27,10 @@ def print_trainable_parameters(model):
 
 
 lora_config = LoraConfig(
-    r=16,
-    lora_alpha=32,
+    r=(16,16),
+    lora_alpha=(32,32),
     target_modules=None,  #handled automatically by peft
-    lora_dropout=0.05,
+    lora_dropout=(0.05,0.01),
     bias="none",
     task_type="CAUSAL_LM",
     n_adapters=2

--- a/examples/multiple_adapters.py
+++ b/examples/multiple_adapters.py
@@ -1,0 +1,53 @@
+import torch
+from peft import LoraConfig, get_peft_model, prepare_model_for_int8_training
+
+
+from transformers import AutoModelForCausalLM
+
+model_name = "edbeeching/gpt-neo-125M-imdb"
+model = AutoModelForCausalLM.from_pretrained(model_name, load_in_8bit=True, device_map="auto")
+
+
+"""### Apply LoRA
+Here comes the magic with `peft`! Let's load a `PeftModel` and specify that we are going to use low-rank adapters (LoRA) using `get_peft_model` utility function from `peft`.
+"""
+def print_trainable_parameters(model):
+    """
+    Prints the number of trainable parameters in the model.
+    """
+    trainable_params = 0
+    all_param = 0
+    for _, param in model.named_parameters():
+        all_param += param.numel()
+        if param.requires_grad:
+            trainable_params += param.numel()
+    print(
+        f"trainable params: {trainable_params} || all params: {all_param} || trainable%: {100 * trainable_params / all_param}"
+    )
+
+
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    target_modules=None,  #handled automatically by peft
+    lora_dropout=0.05,
+    bias="none",
+    task_type="CAUSAL_LM",
+    n_adapters=2
+)
+
+model = prepare_model_for_int8_training(model)
+model = get_peft_model(model, lora_config)
+
+model.enable_adapter_index(1)
+model.train()
+out = model(torch.LongTensor([1,2,3,4]).to("cuda"))
+loss = out[0].mean()
+loss.backward()
+
+
+for n, p in model.named_parameters():
+    print(n, p.grad)
+
+# model.enable_adaptor(0)
+# model.disable_adaptor(0)

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -310,6 +310,15 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         else:
             self.base_model.enable_adapter_layers()
 
+    def enable_adapter_index(self, index=0):
+        self.base_model.enable_adapter_layers_index(index)
+
+    def disable_adapter_index(self, index=0):
+        self.base_model.enable_adapter_layers_index(index)
+
+
+    
+
     def get_base_model(self):
         """
         Returns the base model.

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -314,10 +314,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         self.base_model.enable_adapter_layers_index(index)
 
     def disable_adapter_index(self, index=0):
-        self.base_model.enable_adapter_layers_index(index)
-
-
-    
+        self.base_model.disable_adapter_layers_index(index)
 
     def get_base_model(self):
         """

--- a/tests/test_multiple_adapters.py
+++ b/tests/test_multiple_adapters.py
@@ -1,0 +1,204 @@
+import unittest
+import torch
+from peft import LoraConfig, get_peft_model, prepare_model_for_int8_training
+from transformers import AutoModelForCausalLM
+
+class PeftAdapterTester(unittest.TestCase):
+    
+    
+    def test_single_adapter_8bit_model():
+        lora_config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=None,  #handled automatically by peft
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+                n_adapters=2
+        )
+        model_name = "EleutherAI/gpt-neo-125M"
+        model = AutoModelForCausalLM.from_pretrained(model_name, load_in_8bit=True, device_map="auto")
+        
+        model = prepare_model_for_int8_training(model)
+        model = get_peft_model(model, lora_config)
+        out = model(torch.LongTensor([1,2,3,4]).to("cuda"))
+        loss = out[0].mean()
+        loss.backward()
+
+        for n, p in model.named_parameters():
+            print(n, p.grad)
+
+
+    def test_multi_adapters_8bit_model():
+        lora_config = LoraConfig(
+        r=[16,8],
+        lora_alpha=32,
+        target_modules=None,  #handled automatically by peft
+        lora_dropout=[0.05, 0.1],
+        bias="none",
+        task_type="CAUSAL_LM",
+        n_adapters=2
+        )        
+        
+        model_name = "EleutherAI/gpt-neo-125M"
+        model = AutoModelForCausalLM.from_pretrained(model_name, load_in_8bit=True, device_map="auto")
+        
+        model = prepare_model_for_int8_training(model)
+        model = get_peft_model(model, lora_config)
+
+        for i in range(2):
+            model.enable_adapter_index(i)
+            model.train()
+            out = model(torch.LongTensor([1,2,3,4]).to("cuda"))
+            loss = out[0].mean()
+            loss.backward()
+
+            for n, p in model.named_parameters():
+                print(n, p.grad)
+
+
+    def test_single_adapter_model():
+        lora_config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=None,  #handled automatically by peft
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+                n_adapters=2
+        )
+        model_name = "EleutherAI/gpt-neo-125M"
+        model = AutoModelForCausalLM.from_pretrained(model_name)
+        model = get_peft_model(model, lora_config)
+        out = model(torch.LongTensor([1,2,3,4]).to("cuda"))
+        loss = out[0].mean()
+        loss.backward()
+
+        for n, p in model.named_parameters():
+            print(n, p.grad)
+
+
+    def test_multi_adapters_model():
+        lora_config = LoraConfig(
+        r=[16,8],
+        lora_alpha=32,
+        target_modules=None,  #handled automatically by peft
+        lora_dropout=[0.05, 0.1],
+        bias="none",
+        task_type="CAUSAL_LM",
+        n_adapters=2
+        )        
+        
+        model_name = "EleutherAI/gpt-neo-125M"
+        model = AutoModelForCausalLM.from_pretrained(model_name)
+        model = get_peft_model(model, lora_config)
+
+        for i in range(2):
+            model.enable_adapter_index(i)
+            model.train()
+            out = model(torch.LongTensor([1,2,3,4]).to("cuda"))
+            loss = out[0].mean()
+            loss.backward()
+
+            for n, p in model.named_parameters():
+                print(n, p.grad)
+
+
+    def test_single_adapter_8bit_model_merged_linear():
+        lora_config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=None,  #handled automatically by peft
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+                n_adapters=2
+        )
+        model_name = "bigscience/bloom-560m"
+        model = AutoModelForCausalLM.from_pretrained(model_name, load_in_8bit=True, device_map="auto")
+        
+        model = prepare_model_for_int8_training(model)
+        model = get_peft_model(model, lora_config)
+        out = model(torch.LongTensor([1,2,3,4]).to("cuda"))
+        loss = out[0].mean()
+        loss.backward()
+
+        for n, p in model.named_parameters():
+            print(n, p.grad)
+
+
+    def test_multi_adapters_8bit_model_merged_linear():
+        lora_config = LoraConfig(
+        r=[16,8],
+        lora_alpha=32,
+        target_modules=None,  #handled automatically by peft
+        lora_dropout=[0.05, 0.1],
+        bias="none",
+        task_type="CAUSAL_LM",
+        n_adapters=2
+        )        
+        
+        model_name = "bigscience/bloom-560m"
+        model = AutoModelForCausalLM.from_pretrained(model_name, load_in_8bit=True, device_map="auto")
+        
+        model = prepare_model_for_int8_training(model)
+        model = get_peft_model(model, lora_config)
+
+        for i in range(2):
+            model.enable_adapter_index(i)
+            model.train()
+            out = model(torch.LongTensor([1,2,3,4]).to("cuda"))
+            loss = out[0].mean()
+            loss.backward()
+
+            for n, p in model.named_parameters():
+                print(n, p.grad)
+
+
+    def test_single_adapter_model_merged_linear():
+        lora_config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=None,  #handled automatically by peft
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+                n_adapters=2
+        )
+        model_name = "bigscience/bloom-560m"
+        model = AutoModelForCausalLM.from_pretrained(model_name)
+
+        model = get_peft_model(model, lora_config)
+        out = model(torch.LongTensor([1,2,3,4]).to("cuda"))
+        loss = out[0].mean()
+        loss.backward()
+
+        for n, p in model.named_parameters():
+            print(n, p.grad)
+
+
+    def test_multi_adapters_model_merged_linear():
+        lora_config = LoraConfig(
+        r=[16,8],
+        lora_alpha=32,
+        target_modules=None,  #handled automatically by peft
+        lora_dropout=[0.05, 0.1],
+        bias="none",
+        task_type="CAUSAL_LM",
+        n_adapters=2
+        )        
+        
+        model_name = "bigscience/bloom-560m"
+        model = AutoModelForCausalLM.from_pretrained(model_name)
+        
+        model = get_peft_model(model, lora_config)
+
+        for i in range(2):
+            model.enable_adapter_index(i)
+            model.train()
+            out = model(torch.LongTensor([1,2,3,4]).to("cuda"))
+            loss = out[0].mean()
+            loss.backward()
+
+            for n, p in model.named_parameters():
+                print(n, p.grad)

--- a/tests/test_peft_model.py
+++ b/tests/test_peft_model.py
@@ -27,7 +27,7 @@ from peft import (
     PromptTuningConfig,
     get_peft_model,
     get_peft_model_state_dict,
-    prepare_model_for_training,
+    prepare_model_for_int8_training,
 )
 
 
@@ -106,7 +106,7 @@ class PeftModelTester(unittest.TestCase, PeftTestMixin):
 
                 # load with `prepare_model_for_training`
                 model = AutoModelForCausalLM.from_pretrained(model_id)
-                model = prepare_model_for_training(model)
+                model = prepare_model_for_int8_training(model)
 
                 for param in model.parameters():
                     self.assertTrue(not param.requires_grad)


### PR DESCRIPTION
Draft PR to add multiple adapters to a base model.
Implemented for 8bit layers at the moment, I will attempt the implementation for merged layers tomorrow.

See examples/multiple_adapters.py for a very brief demo.

Early feedback would be great! cc @pacman100 