### PR TITLE
Fix ci runner creation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # cpu version of pytorch
-        pip install .[test]
+        pip install .[dev]
     - name: Test with pytest
       run: |
         make test


### PR DESCRIPTION
# What does this PR do?

This PR fixes the CI runner creation, currently `pip install -e ".[tests]"` does not work

cc @pacman100 