### PR TITLE
Causal LM generation fix for prefix tuning: GPT2 model

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -582,7 +582,10 @@ class PeftModelForCausalLM(PeftModel):
             else:
                 if "input_ids" not in kwargs:
                     raise ValueError("input_ids must be provided for Peft model generation")
-                if kwargs.get("attention_mask", None) is not None:
+                # For gpt2 models, we construct postion_ids on the fly by using attention mask, and position ids need to match input_shape. 
+                # for prefix tuning, input shape is determined using `input_ids`. Thus we should not expand 'attention_mask' here
+                # for prompt tuning input_ids is not passed but a concatenated input_embeds is passed. Thus attention_mask needs to be of same size of num_virtual_tokens + input_ids
+                if kwargs.get("attention_mask", None) is not None and self.peft_config.peft_type == PeftType.PROMPT_TUNING:
                     # concat prompt attention mask
                     prefix_attention_mask = torch.ones(
                         kwargs["input_ids"].shape[0], self.peft_config.num_virtual_tokens
@@ -611,6 +614,10 @@ class PeftModelForCausalLM(PeftModel):
     def prepare_inputs_for_generation(self, *args, **kwargs):
         model_kwargs = self.base_model_prepare_inputs_for_generation(*args, **kwargs)
         if isinstance(self.peft_config, PromptLearningConfig):
+            if self.peft_config.peft_type == PeftType.PREFIX_TUNING:
+                prefix_attention_mask = torch.ones(model_kwargs["input_ids"].shape[0], self.peft_config.num_virtual_tokens).to(model_kwargs["input_ids"].device)
+                model_kwargs["attention_mask"] = torch.cat((prefix_attention_mask, model_kwargs["attention_mask"]), dim=1)
+
             if model_kwargs["past_key_values"] is None and self.peft_config.peft_type == PeftType.PREFIX_TUNING:
                 past_key_values = self.get_prompt(batch_size=model_kwargs["input_ids"].shape[0])
                 model_kwargs["past_key_values"] = past_key_values

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -582,10 +582,13 @@ class PeftModelForCausalLM(PeftModel):
             else:
                 if "input_ids" not in kwargs:
                     raise ValueError("input_ids must be provided for Peft model generation")
-                # For gpt2 models, we construct postion_ids on the fly by using attention mask, and position ids need to match input_shape. 
+                # For gpt2 models, we construct postion_ids on the fly by using attention mask, and position ids need to match input_shape.
                 # for prefix tuning, input shape is determined using `input_ids`. Thus we should not expand 'attention_mask' here
                 # for prompt tuning input_ids is not passed but a concatenated input_embeds is passed. Thus attention_mask needs to be of same size of num_virtual_tokens + input_ids
-                if kwargs.get("attention_mask", None) is not None and self.peft_config.peft_type == PeftType.PROMPT_TUNING:
+                if (
+                    kwargs.get("attention_mask", None) is not None
+                    and self.peft_config.peft_type == PeftType.PROMPT_TUNING
+                ):
                     # concat prompt attention mask
                     prefix_attention_mask = torch.ones(
                         kwargs["input_ids"].shape[0], self.peft_config.num_virtual_tokens
@@ -615,8 +618,12 @@ class PeftModelForCausalLM(PeftModel):
         model_kwargs = self.base_model_prepare_inputs_for_generation(*args, **kwargs)
         if isinstance(self.peft_config, PromptLearningConfig):
             if self.peft_config.peft_type == PeftType.PREFIX_TUNING:
-                prefix_attention_mask = torch.ones(model_kwargs["input_ids"].shape[0], self.peft_config.num_virtual_tokens).to(model_kwargs["input_ids"].device)
-                model_kwargs["attention_mask"] = torch.cat((prefix_attention_mask, model_kwargs["attention_mask"]), dim=1)
+                prefix_attention_mask = torch.ones(
+                    model_kwargs["input_ids"].shape[0], self.peft_config.num_virtual_tokens
+                ).to(model_kwargs["input_ids"].device)
+                model_kwargs["attention_mask"] = torch.cat(
+                    (prefix_attention_mask, model_kwargs["attention_mask"]), dim=1
+                )
 
             if model_kwargs["past_key_values"] is None and self.peft_config.peft_type == PeftType.PREFIX_TUNING:
                 past_key_values = self.get_prompt(batch_size=model_kwargs["input_ids"].shape[0])

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -587,7 +587,7 @@ class PeftModelForCausalLM(PeftModel):
                 # for prompt tuning input_ids is not passed but a concatenated input_embeds is passed. Thus attention_mask needs to be of same size of num_virtual_tokens + input_ids
                 if (
                     kwargs.get("attention_mask", None) is not None
-                    and self.peft_config.peft_type == PeftType.PROMPT_TUNING
+                    and self.peft_config.peft_type in [PeftType.PROMPT_TUNING, PeftType.P_TUNING]
                 ):
                     # concat prompt attention mask
                     prefix_attention_mask = torch.ones(

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -585,10 +585,10 @@ class PeftModelForCausalLM(PeftModel):
                 # For gpt2 models, we construct postion_ids on the fly by using attention mask, and position ids need to match input_shape.
                 # for prefix tuning, input shape is determined using `input_ids`. Thus we should not expand 'attention_mask' here
                 # for prompt tuning input_ids is not passed but a concatenated input_embeds is passed. Thus attention_mask needs to be of same size of num_virtual_tokens + input_ids
-                if (
-                    kwargs.get("attention_mask", None) is not None
-                    and self.peft_config.peft_type in [PeftType.PROMPT_TUNING, PeftType.P_TUNING]
-                ):
+                if kwargs.get("attention_mask", None) is not None and self.peft_config.peft_type in [
+                    PeftType.PROMPT_TUNING,
+                    PeftType.P_TUNING,
+                ]:
                     # concat prompt attention mask
                     prefix_attention_mask = torch.ones(
                         kwargs["input_ids"].shape[0], self.peft_config.num_virtual_tokens


### PR DESCRIPTION
Hi @pacman100 

Causal LM generation with prefix tuning fails for GPT2 models. This is due to mismatch in size in input_ids and position_ids (which GPT2 model creates on the fly). This, PR fixes it. Please have a look.

Minimal code to reproduce the issue:

```python
import torch
from transformers import AutoModelForCausalLM
from peft import PrefixTuningConfig, TaskType, get_peft_model


model_name_or_path = "gpt2"
peft_config = PrefixTuningConfig(task_type=TaskType.CAUSAL_LM, num_virtual_tokens=3)
model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
model = get_peft_model(model, peft_config)

inputs = {
    'input_ids': torch.tensor([1, 2]).unsqueeze(0),
    'attention_mask': torch.tensor([1, 1]).unsqueeze(0),
}

outputs = model.generate(
    **inputs, max_new_tokens=20, eos_token_id=3
)
print(outputs)
```