### PR TITLE
Fixing a bug where a wrong parameter name is used for the offload_folder

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -164,7 +164,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if getattr(model, "hf_device_map", None) is not None:
             device_map = kwargs.get("device_map", "auto")
             max_memory = kwargs.get("max_memory", None)
-            offload_dir = kwargs.get("offload_dir", None)
+            offload_dir = kwargs.get("offload_folder", None)
             offload_index = kwargs.get("offload_index", None)
 
             dispatch_model_kwargs = {}


### PR DESCRIPTION
It should be "offload_folder" instead of "offload_dir".

Fixes https://github.com/huggingface/accelerate/issues/1281