### PR TITLE
Implement adaption prompt from Llama-Adapter paper

### DIFF
--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -28,6 +28,8 @@ from .peft_model import (
     PeftModelForTokenClassification,
 )
 from .tuners import (
+    AdaptionPromptConfig,
+    AdaptionPromptModel,
     LoraConfig,
     LoraModel,
     AdaLoraConfig,

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -101,21 +101,6 @@ def _prepare_prompt_learning_config(peft_config, model_config):
     return peft_config
 
 
-def _prepare_adaption_prompt_config(
-    peft_config: AdaptionPromptConfig,
-    model,
-) -> AdaptionPromptConfig:
-    from transformers import LlamaForCausalLM, LlamaModel
-
-    if isinstance(model, LlamaModel):
-        peft_config.target_layers = "layers"
-    elif isinstance(model, LlamaForCausalLM):
-        peft_config.target_layers = "model.layers"
-    else:
-        raise ValueError(f"Unsupported model type for adaption prompt: '{type(model)}'")
-    return peft_config
-
-
 def get_peft_model(model, peft_config):
     """
     Returns a Peft model object from a model and a config.
@@ -126,14 +111,10 @@ def get_peft_model(model, peft_config):
     """
     model_config = model.config.to_dict() if hasattr(model.config, "to_dict") else model.config
     peft_config.base_model_name_or_path = model.__dict__.get("name_or_path", None)
-
-    if isinstance(peft_config, PromptLearningConfig):
-        peft_config = _prepare_prompt_learning_config(peft_config, model_config)
-    elif isinstance(peft_config, AdaptionPromptConfig):
-        peft_config = _prepare_adaption_prompt_config(peft_config, model)
-
     if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys() and not isinstance(
         peft_config, PromptLearningConfig
     ):
         return PeftModel(model, peft_config)
+    if isinstance(peft_config, PromptLearningConfig):
+        peft_config = _prepare_prompt_learning_config(peft_config, model_config)
     return MODEL_TYPE_TO_PEFT_MODEL_MAPPING[peft_config.task_type](model, peft_config)

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -28,7 +28,17 @@ from transformers import PreTrainedModel
 from transformers.modeling_outputs import SequenceClassifierOutput, TokenClassifierOutput
 from transformers.utils import PushToHubMixin
 
-from .tuners import AdaLoraModel, LoraModel, PrefixEncoder, PromptEmbedding, PromptEncoder
+from .tuners import (
+    AdaLoraConfig,
+    AdaLoraModel,
+    AdaptionPromptConfig,
+    AdaptionPromptModel,
+    LoraConfig,
+    LoraModel,
+    PrefixEncoder,
+    PromptEmbedding,
+    PromptEncoder,
+)
 from .utils import (
     TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING,
     WEIGHTS_NAME,
@@ -92,8 +102,12 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 self.base_model, self.peft_config, adapter_name
             )
             self.set_additional_trainable_modules(peft_config, adapter_name)
-        else:
+        elif isinstance(peft_config, (LoraConfig, AdaLoraConfig)):
             self.add_adapter(adapter_name, peft_config)
+        elif isinstance(peft_config, AdaptionPromptConfig):
+            self.base_model = AdaptionPromptModel(peft_config, model)
+        else:
+            raise ValueError(f"Unsupported config type '{type(peft_config)}'")
 
     def save_pretrained(self, save_directory, **kwargs):
         r"""

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -29,11 +29,8 @@ from transformers.modeling_outputs import SequenceClassifierOutput, TokenClassif
 from transformers.utils import PushToHubMixin
 
 from .tuners import (
-    AdaLoraConfig,
     AdaLoraModel,
-    AdaptionPromptConfig,
     AdaptionPromptModel,
-    LoraConfig,
     LoraModel,
     PrefixEncoder,
     PromptEmbedding,
@@ -60,6 +57,7 @@ PEFT_TYPE_TO_MODEL_MAPPING = {
     PeftType.P_TUNING: PromptEncoder,
     PeftType.PREFIX_TUNING: PrefixEncoder,
     PeftType.ADALORA: AdaLoraModel,
+    PeftType.ADAPTION_PROMPT: AdaptionPromptModel,
 }
 
 
@@ -102,12 +100,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 self.base_model, self.peft_config, adapter_name
             )
             self.set_additional_trainable_modules(peft_config, adapter_name)
-        elif isinstance(peft_config, (LoraConfig, AdaLoraConfig)):
-            self.add_adapter(adapter_name, peft_config)
-        elif isinstance(peft_config, AdaptionPromptConfig):
-            self.base_model = AdaptionPromptModel(peft_config, model)
         else:
-            raise ValueError(f"Unsupported config type '{type(peft_config)}'")
+            self.add_adapter(adapter_name, peft_config)
 
     def save_pretrained(self, save_directory, **kwargs):
         r"""

--- a/src/peft/tuners/__init__.py
+++ b/src/peft/tuners/__init__.py
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .adaption_prompt import AdaptionPromptConfig, AdaptionPromptModel
 from .lora import LoraConfig, LoraModel
 from .adalora import AdaLoraConfig, AdaLoraModel
 from .p_tuning import PromptEncoder, PromptEncoderConfig, PromptEncoderReparameterizationType

--- a/src/peft/tuners/adaption_prompt.py
+++ b/src/peft/tuners/adaption_prompt.py
@@ -273,13 +273,17 @@ class AdaptedAttention(nn.Module):
         self.model_type = model_type
         self.model = model
         self.adapter_len = adapter_len
+        # Assume all parameters of the attention model we are wrapping are on the same device.
+        device = next(model.parameters()).device
         # Don't think this was specified in the paper, but we follow the official repo which used an Embedding
         # which initializes the tokens with standard normal values.
         # https://github.com/ZrrSkywalker/LLaMA-Adapter/blob/41c3546fe1997ab8a65809dc8d8f9252b19d9faf/llama/model.py#L234
         # (bsz, adapter_len, hidden_size)
-        self.adaption_prompt = nn.Parameter(torch.empty(1, adapter_len, self.model.hidden_size).normal_())
+        self.adaption_prompt = nn.Parameter(
+            torch.empty(1, adapter_len, self.model.hidden_size, device=device).normal_()
+        )
         # Initialize the gate to 0 as this is "zero-init".
-        self.adaption_gate = nn.Parameter(torch.zeros(1))
+        self.adaption_gate = nn.Parameter(torch.zeros(1, device=device))
 
     def forward(self, **kwargs):
         """

--- a/src/peft/tuners/adaption_prompt.py
+++ b/src/peft/tuners/adaption_prompt.py
@@ -1,0 +1,253 @@
+# coding=utf-8
+# Copyright 2023-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import math
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from peft.utils.config import PeftConfig, PeftType
+
+
+def is_llama_available() -> bool:
+    """Check if Llama is available in the transformers library (it's not in earlier versions)."""
+    try:
+        return importlib.util.find_spec("transformers.models.llama.modeling_llama") is not None
+    except ModuleNotFoundError:
+        return False
+
+
+if is_llama_available():
+    # We guard the import statement so that this won't get in the way of using peft with earlier versions of
+    # transformers that don't have Llama.
+    from transformers.models.llama.modeling_llama import LlamaAttention, apply_rotary_pos_emb
+
+
+def is_adaption_prompt_trainable(module: str) -> bool:
+    """Return True if module is trainable under adaption prompt fine-tuning."""
+    return module.split(".")[-1].startswith("adaption_")
+
+
+@dataclass
+class AdaptionPromptConfig(PeftConfig):
+    """Stores the configuration of an [`AdaptionPromptModel`]."""
+
+    target_layers: str = field(default=None, metadata={"help": "Name of the submodule containing the decoder layers."})
+    adapter_len: int = field(default=None, metadata={"help": "Number of adapter tokens to insert"})
+    adapter_layers: int = field(default=None, metadata={"help": "Number of adapter layers (from the top)"})
+
+    def __post_init__(self):
+        self.peft_type = PeftType.ADAPTION_PROMPT
+
+
+class AdaptionPromptModel(nn.Module):
+    """
+    Implments adaption propmts as described in https://arxiv.org/pdf/2303.16199.pdf.
+
+    This implementation only supports Llama models at the moment, but it can be extended to other models.
+    """
+
+    def __init__(self, config: AdaptionPromptConfig, model):
+        super().__init__()
+        self.config = config
+        self.model = model
+        self._find_and_replace()
+        self._mark_only_adaption_prompts_as_trainable()
+
+    def _find_and_replace(self) -> None:
+        """Find and replace LlamaAttention modules with AdaptedAttention modules."""
+        layers = self.model.get_submodule(self.config.target_layers)
+
+        if len(layers) < self.config.adapter_layers:
+            raise ValueError(
+                f"Config specifies more adapter layers '{self.config.adapter_layers}'"
+                f" than the model has '{len(layers)}'."
+            )
+
+        for layer in layers[-self.config.adapter_layers :]:
+            layer.self_attn = AdaptedAttention(self.config.adapter_len, layer.self_attn)
+
+    def _mark_only_adaption_prompts_as_trainable(self) -> None:
+        """Freeze all parameters of the model except the adaption prompts."""
+        for n, p in self.model.named_parameters():
+            if not is_adaption_prompt_trainable(n):
+                p.requires_grad = False
+
+    def __getattr__(self, name: str):
+        """Forward missing attributes to the wrapped module."""
+        try:
+            return super().__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            return getattr(self.model, name)
+
+
+class AdaptedAttention(nn.Module):
+    """This module wraps a LLamaAttention module and injects adaption prompts."""
+
+    def __init__(self, adapter_len: int, model):
+        if not isinstance(model, LlamaAttention):
+            raise ValueError("Only LlamaAttention modules are supported at the moment.")
+
+        super().__init__()
+        self.model = model
+        self.adapter_len = adapter_len
+        # Don't think this was specified in the paper, but we follow the official repo which used an Embedding
+        # which initializes the tokens with standard normal values.
+        # https://github.com/ZrrSkywalker/LLaMA-Adapter/blob/41c3546fe1997ab8a65809dc8d8f9252b19d9faf/llama/model.py#L234
+        # (bsz, adapter_len, hidden_size)
+        self.adaption_prompt = nn.Parameter(torch.empty(1, adapter_len, self.model.hidden_size).normal_())
+        # Initialize the gate to 0 as this is "zero-init".
+        self.adaption_gate = nn.Parameter(torch.zeros(1))
+
+    def _modified_forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+    ):
+        """
+        Modified from:
+        https://github.com/huggingface/transformers/blob/d143087d189a183b153090c8b37daa6c7c031039/src/transformers/models/llama/modeling_llama.py#L185
+
+        The original forward function is bypassed in favor of this one, which was modified to:
+        1. Return query_states.
+        2. Not apply o_proj yet.
+
+        The alternatives are:
+        1. to refactor the LlamaAttention module in the transformers package,
+        2. or to use the original forward() and recompute some of the intermediate local variables.
+        """
+        bsz, q_len, _ = hidden_states.size()
+
+        # (bsz, num_heads, q_len, head_dim)
+        query_states = (
+            self.model.q_proj(hidden_states)
+            .view(bsz, q_len, self.model.num_heads, self.model.head_dim)
+            .transpose(1, 2)
+        )
+        # (bsz, num_heads, q_len, head_dim)
+        key_states = (
+            self.model.k_proj(hidden_states)
+            .view(bsz, q_len, self.model.num_heads, self.model.head_dim)
+            .transpose(1, 2)
+        )
+        # (bsz, num_heads, q_len, head_dim)
+        value_states = (
+            self.model.v_proj(hidden_states)
+            .view(bsz, q_len, self.model.num_heads, self.model.head_dim)
+            .transpose(1, 2)
+        )
+
+        kv_seq_len = key_states.shape[-2]
+        if past_key_value is not None:
+            kv_seq_len += past_key_value[0].shape[-2]
+        cos, sin = self.model.rotary_emb(value_states, seq_len=kv_seq_len)
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+        # [bsz, nh, t, hd]
+
+        if past_key_value is not None:
+            # reuse k, v, self_attention
+            key_states = torch.cat([past_key_value[0], key_states], dim=2)
+            value_states = torch.cat([past_key_value[1], value_states], dim=2)
+
+        past_key_value = (key_states, value_states) if use_cache else None
+
+        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.model.head_dim)
+
+        if attn_weights.size() != (bsz, self.model.num_heads, q_len, kv_seq_len):
+            raise ValueError(
+                f"Attention weights should be of size {(bsz * self.model.num_heads, q_len, kv_seq_len)}, but is"
+                f" {attn_weights.size()}"
+            )
+
+        if attention_mask is not None:
+            if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+                raise ValueError(
+                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                )
+            attn_weights = attn_weights + attention_mask
+            attn_weights = torch.max(attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min))
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        if attn_output.size() != (bsz, self.model.num_heads, q_len, self.model.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.model.num_heads, q_len, self.model.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2)
+        attn_output = attn_output.reshape(bsz, q_len, self.model.hidden_size)
+
+        if not output_attentions:
+            attn_weights = None
+
+        return query_states, attn_output, attn_weights, past_key_value
+
+    def forward(self, **kwargs):
+        """
+        Forward pass for the adapter which wraps the original LlamaAttention module.
+
+        "Official" paper implementation:
+        https://github.com/ZrrSkywalker/LLaMA-Adapter/blob/41c3546fe1997ab8a65809dc8d8f9252b19d9faf/llama/model.py#L141
+
+        :param kwargs: See the original LlamaAttention module.
+        """
+        if kwargs.get("use_cache", False):
+            raise NotImplementedError("use_cache is not currently supported.")
+        if kwargs.get("output_attention", False):
+            raise NotImplementedError("output_attention is not currently supported.")
+
+        # The original forward() was modified to return query_states and not to apply
+        # `self.model.o_proj` to output yet.
+        # query_states: (bsz, num_heads, q_len, head_dim)
+        query_states, output, _, _ = self._modified_forward(**kwargs)
+        bsz = output.shape[0]
+        q_len = output.shape[1]
+        # (bsz, num_heads, adapter_len, head_dim)
+        adapter_k = (
+            self.model.k_proj(self.adaption_prompt)
+            .view(1, self.adapter_len, self.model.num_heads, self.model.head_dim)
+            .repeat(bsz, 1, 1, 1)
+            .transpose(1, 2)
+        )
+        # (bsz, num_heads, adapter_len, head_dim)
+        adapter_v = (
+            self.model.v_proj(self.adaption_prompt)
+            .view(1, self.adapter_len, self.model.num_heads, self.model.head_dim)
+            .repeat(bsz, 1, 1, 1)
+            .transpose(1, 2)
+        )
+        # (bsz, num_heads, q_len, adapter_len)
+        scores = torch.matmul(query_states, adapter_k.transpose(2, 3)) / math.sqrt(self.model.head_dim)
+        # Upcast attention to fp32
+        # (bsz, num_heads, q_len, adapter_len)
+        scores = self.adaption_gate * F.softmax(scores, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        # (bsz, q_len, num_heads * head_dim)
+        adapter_output = torch.matmul(scores, adapter_v).transpose(1, 2).reshape(bsz, q_len, -1)
+        output = output + adapter_output
+        # (bsz, q_len, hidden_size)
+        output = self.model.o_proj(output)
+
+        return output, None, None

--- a/src/peft/tuners/adaption_prompt.py
+++ b/src/peft/tuners/adaption_prompt.py
@@ -75,10 +75,18 @@ def llama_compute_query_states(model: nn.Module, **kwargs) -> torch.Tensor:
 
 
 # Contains the config that is specific to a transformers model type.
-ModelTypeConfig = namedtuple("ModelTypeConfig", ["compute_query_states", "target_modules", "k_proj_layer", "v_proj_layer", "o_proj_layer"])
+ModelTypeConfig = namedtuple(
+    "ModelTypeConfig", ["compute_query_states", "target_modules", "k_proj_layer", "v_proj_layer", "o_proj_layer"]
+)
 # Mapping of transformers model types to their specific configuration.
 TRANSFORMERS_MODEL_CONFIG = {
-    "llama": ModelTypeConfig(compute_query_states=llama_compute_query_states, target_modules="self_attn", k_proj_layer="k_proj", v_proj_layer="v_proj", o_proj_layer="o_proj"),
+    "llama": ModelTypeConfig(
+        compute_query_states=llama_compute_query_states,
+        target_modules="self_attn",
+        k_proj_layer="k_proj",
+        v_proj_layer="v_proj",
+        o_proj_layer="o_proj",
+    ),
 }
 
 
@@ -311,19 +319,17 @@ class AdaptedAttention(nn.Module):
         if k_proj_layer == v_proj_layer:
             _, key, value = getattr(self.model, k_proj_layer)(self.adaption_prompt).split(embed_dim, dim=2)
         else:
-            key =  getattr(self.model, k_proj_layer)(self.adaption_prompt)
-            value =  getattr(self.model, v_proj_layer)(self.adaption_prompt)
+            key = getattr(self.model, k_proj_layer)(self.adaption_prompt)
+            value = getattr(self.model, v_proj_layer)(self.adaption_prompt)
         # (bsz, num_heads, adapter_len, head_dim)
         adapter_k = (
-            key
-            .view(1, self.adapter_len, self.model.num_heads, self.model.head_dim)
+            key.view(1, self.adapter_len, self.model.num_heads, self.model.head_dim)
             .repeat(bsz, 1, 1, 1)
             .transpose(1, 2)
         )
         # (bsz, num_heads, adapter_len, head_dim)
         adapter_v = (
-            value
-            .view(1, self.adapter_len, self.model.num_heads, self.model.head_dim)
+            value.view(1, self.adapter_len, self.model.num_heads, self.model.head_dim)
             .repeat(bsz, 1, 1, 1)
             .transpose(1, 2)
         )

--- a/src/peft/utils/config.py
+++ b/src/peft/utils/config.py
@@ -30,6 +30,7 @@ class PeftType(str, enum.Enum):
     PREFIX_TUNING = "PREFIX_TUNING"
     LORA = "LORA"
     ADALORA = "ADALORA"
+    ADAPTION_PROMPT = "ADAPTION_PROMPT"
 
 
 class TaskType(str, enum.Enum):

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from peft.tuners.adaption_prompt import AdaptionPromptConfig
-
 from .config import PeftType, PromptLearningConfig
 
 
@@ -51,7 +49,6 @@ def get_peft_model_state_dict(model, state_dict=None, adapter_name="default"):
                         to_return[bias_name] = state_dict[bias_name]
         else:
             raise NotImplementedError
-
         to_return = {k: v for k, v in to_return.items() if (("lora_" in k and adapter_name in k) or ("bias" in k))}
         if config.peft_type == PeftType.ADALORA:
             rank_pattern = config.rank_pattern
@@ -60,7 +57,7 @@ def get_peft_model_state_dict(model, state_dict=None, adapter_name="default"):
                 config.rank_pattern = rank_pattern
                 to_return = model.resize_state_dict_by_rank_pattern(rank_pattern, to_return, adapter_name)
 
-    elif model.peft_config.peft_type == PeftType.ADAPTION_PROMPT:
+    elif config.peft_type == PeftType.ADAPTION_PROMPT:
         to_return = {k: state_dict[k] for k in state_dict if k.split(".")[-1].startswith("adaption_")}
     elif isinstance(config, PromptLearningConfig):
         to_return = {}
@@ -118,7 +115,7 @@ def set_peft_model_state_dict(model, peft_model_state_dict, adapter_name="defaul
             rank_pattern = config.rank_pattern
             if rank_pattern is not None:
                 model.resize_modules_by_rank_pattern(rank_pattern, adapter_name)
-    elif isinstance(config, (PromptLearningConfig, AdaptionPromptConfig)):
+    elif isinstance(config, PromptLearningConfig) or config.peft_type == PeftType.ADAPTION_PROMPT:
         peft_model_state_dict = state_dict
     else:
         raise NotImplementedError

--- a/tests/test_adaption_prompt.py
+++ b/tests/test_adaption_prompt.py
@@ -1,0 +1,164 @@
+# coding=utf-8
+# Copyright 2023-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+from unittest import TestCase
+
+import torch
+
+from peft.mapping import get_peft_model
+from peft.peft_model import PeftModel
+from peft.tuners.adaption_prompt import AdaptionPromptConfig, is_llama_available
+from peft.utils.other import prepare_model_for_int8_training
+from peft.utils.save_and_load import get_peft_model_state_dict
+from tests.testing_common import PeftCommonTester
+
+
+if is_llama_available():
+    # We guard the import statement so that our unit tests will pass in CI environments
+    # that don't have a transformers package with Llama.
+    from transformers import LlamaConfig, LlamaForCausalLM, LlamaModel
+
+
+class AdaptionPromptTester(TestCase, PeftCommonTester):
+    """
+    Tests for the AdaptionPrompt model.
+
+    These tests were mostly adapted from `test_peft_model.py`, but since we haven't checked in the test checkpoints for
+    Llama into `hf-internal-testing`, we separate them for now.
+    """
+
+    def setUp(self):
+        """Check that llama is available in transformers package before running each test."""
+        if not is_llama_available():
+            self.skipTest("Llama not available in transformers. Skipping test.")
+
+    @staticmethod
+    def _create_test_llama_config():
+        """Create a test config for a small Llama model for testing."""
+        return LlamaConfig(
+            vocab_size=16,
+            hidden_size=8,
+            intermediate_size=8,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            use_cache=False,
+        )
+
+    def test_attributes(self) -> None:
+        model = LlamaModel(self._create_test_llama_config())
+        config = AdaptionPromptConfig(adapter_layers=1, adapter_len=4)
+        model = get_peft_model(model, config)
+
+        self.assertTrue(hasattr(model, "save_pretrained"))
+        self.assertTrue(hasattr(model, "from_pretrained"))
+        self.assertTrue(hasattr(model, "push_to_hub"))
+
+    def test_prepare_for_training(self) -> None:
+        model = LlamaForCausalLM(self._create_test_llama_config())
+        config = AdaptionPromptConfig(adapter_layers=1, adapter_len=4, task_type="CAUSAL_LM")
+        model = get_peft_model(model, config)
+
+        dummy_input = torch.LongTensor([[1, 1, 1]]).to(self.torch_device)
+        dummy_output = model.get_input_embeddings()(dummy_input)
+
+        self.assertTrue(not dummy_output.requires_grad)
+
+    def test_prepare_for_int8_training(self) -> None:
+        model = LlamaForCausalLM(self._create_test_llama_config())
+        model = prepare_model_for_int8_training(model)
+
+        for param in model.parameters():
+            self.assertTrue(not param.requires_grad)
+
+        config = AdaptionPromptConfig(adapter_layers=1, adapter_len=4, task_type="CAUSAL_LM")
+        model = get_peft_model(model, config)
+
+        # For backward compatibility
+        if hasattr(model, "enable_input_require_grads"):
+            model.enable_input_require_grads()
+        else:
+
+            def make_inputs_require_grad(module, input, output):
+                output.requires_grad_(True)
+
+            model.get_input_embeddings().register_forward_hook(make_inputs_require_grad)
+
+        dummy_input = torch.LongTensor([[1, 1, 1]]).to(self.torch_device)
+        dummy_output = model.get_input_embeddings()(dummy_input)
+
+        self.assertTrue(dummy_output.requires_grad)
+
+    def test_save_pretrained(self) -> None:
+        seed = 420
+        torch.manual_seed(seed)
+        model = LlamaForCausalLM(self._create_test_llama_config())
+        config = AdaptionPromptConfig(adapter_layers=2, adapter_len=4, task_type="CAUSAL_LM")
+        model = get_peft_model(model, config)
+        model = model.to(self.torch_device)
+
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            model.save_pretrained(tmp_dirname)
+
+            torch.manual_seed(seed)
+            model_from_pretrained = LlamaForCausalLM(self._create_test_llama_config())
+            model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
+
+            # check if the state dicts are equal
+            state_dict = get_peft_model_state_dict(model)
+            state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained)
+
+            # check if same keys
+            self.assertEqual(state_dict.keys(), state_dict_from_pretrained.keys())
+
+            # Check that the number of saved parameters is 4 -- 2 layers of (tokens and gate).
+            self.assertEqual(len(list(state_dict.keys())), 4)
+
+            # check if tensors equal
+            for key in state_dict.keys():
+                self.assertTrue(
+                    torch.allclose(
+                        state_dict[key].to(self.torch_device), state_dict_from_pretrained[key].to(self.torch_device)
+                    )
+                )
+
+            # check if `adapter_model.bin` is present
+            self.assertTrue(os.path.exists(os.path.join(tmp_dirname, "adapter_model.bin")))
+
+            # check if `adapter_config.json` is present
+            self.assertTrue(os.path.exists(os.path.join(tmp_dirname, "adapter_config.json")))
+
+            # check if `pytorch_model.bin` is not present
+            self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "pytorch_model.bin")))
+
+            # check if `config.json` is not present
+            self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "config.json")))
+
+    def test_generate(self) -> None:
+        model = LlamaForCausalLM(self._create_test_llama_config())
+        config = AdaptionPromptConfig(adapter_layers=2, adapter_len=4, task_type="CAUSAL_LM")
+        model = get_peft_model(model, config)
+        model = model.to(self.torch_device)
+
+        input_ids = torch.LongTensor([[1, 1, 1], [2, 1, 2]]).to(self.torch_device)
+        attention_mask = torch.LongTensor([[1, 1, 1], [1, 0, 1]]).to(self.torch_device)
+
+        # check if `generate` works
+        _ = model.generate(input_ids=input_ids, attention_mask=attention_mask)
+
+        with self.assertRaises(TypeError):
+            # check if `generate` raises an error if no positional arguments are passed
+            _ = model.generate(input_ids, attention_mask=attention_mask)

--- a/tests/test_adaption_prompt.py
+++ b/tests/test_adaption_prompt.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import os
 import tempfile
 from unittest import TestCase
@@ -22,10 +23,18 @@ from torch.testing import assert_close
 
 from peft.mapping import get_peft_model
 from peft.peft_model import PeftModel
-from peft.tuners.adaption_prompt import AdaptionPromptConfig, is_llama_available
+from peft.tuners.adaption_prompt import AdaptionPromptConfig
 from peft.utils.other import prepare_model_for_int8_training
 from peft.utils.save_and_load import get_peft_model_state_dict
 from tests.testing_common import PeftCommonTester
+
+
+def is_llama_available() -> bool:
+    """Check if Llama is available in the transformers library (it's not in earlier versions)."""
+    try:
+        return importlib.util.find_spec("transformers.models.llama.modeling_llama") is not None
+    except ModuleNotFoundError:
+        return False
 
 
 if is_llama_available():
@@ -38,8 +47,8 @@ class AdaptionPromptTester(TestCase, PeftCommonTester):
     """
     Tests for the AdaptionPrompt model.
 
-    These tests were mostly adapted from `test_peft_model.py`, but since we haven't checked in the test checkpoints for
-    Llama into `hf-internal-testing`, we separate them for now.
+    Some of these tests were adapted from `test_peft_model.py` (which has been refactored since), but since we haven't
+    checked in the test checkpoints for Llama into `hf-internal-testing`, we separate them for now.
     """
 
     def setUp(self):

--- a/tests/test_adaption_prompt.py
+++ b/tests/test_adaption_prompt.py
@@ -81,6 +81,7 @@ class AdaptionPromptTester(TestCase, PeftCommonTester):
         model = LlamaForCausalLM(self._create_test_llama_config())
         config = AdaptionPromptConfig(adapter_layers=1, adapter_len=4, task_type="CAUSAL_LM")
         model = get_peft_model(model, config)
+        model = model.to(self.torch_device)
 
         dummy_input = torch.LongTensor([[1, 1, 1]]).to(self.torch_device)
         dummy_output = model.get_input_embeddings()(dummy_input)
@@ -90,6 +91,7 @@ class AdaptionPromptTester(TestCase, PeftCommonTester):
     def test_prepare_for_int8_training(self) -> None:
         model = LlamaForCausalLM(self._create_test_llama_config())
         model = prepare_model_for_int8_training(model)
+        model = model.to(self.torch_device)
 
         for param in model.parameters():
             self.assertTrue(not param.requires_grad)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ import os
 import tempfile
 import unittest
 
-from peft import LoraConfig, PrefixTuningConfig, PromptEncoderConfig, PromptTuningConfig
+from peft import AdaptionPromptConfig, LoraConfig, PrefixTuningConfig, PromptEncoderConfig, PromptTuningConfig
 
 
 class PeftConfigTestMixin:
@@ -25,6 +25,7 @@ class PeftConfigTestMixin:
         PromptEncoderConfig,
         PrefixTuningConfig,
         PromptTuningConfig,
+        AdaptionPromptConfig,
     )
 
 


### PR DESCRIPTION
Issue #235 
Paper: https://arxiv.org/abs/2303.16199
Official Implementation: https://github.com/ZrrSkywalker/LLaMA-Adapter

This implementation is quite specific to Llama although in principle the same technique can be used for other transformer models. It is implemented by replacing some of the `LlamaAttention` modules with `AdaptedAttention` modules that wrap the original ones, but bypass the original `forward()` so that we can inject trainable tokens and a gate. I can add a notebook example in a subsequent PR when I have the time.