### PR TITLE
Fix lora_dropout operator type when dropout=0

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -372,9 +372,7 @@ class LoraLayer:
         if lora_dropout > 0.0:
             lora_dropout_layer = nn.Dropout(p=lora_dropout)
         else:
-
-            def lora_dropout_layer(x):
-                return x
+            lora_dropout_layer = nn.Identity()
 
         self.lora_dropout.update(nn.ModuleDict({adapter_name: lora_dropout_layer}))
         # Actual trainable parameters


### PR DESCRIPTION
In the original implementation, when `dropout=0`, lora_dropout is a function instead of `nn.Module`, which is not allowed to be set as a submodule.