### PR TITLE
Fix: unexpected keyword argument 'has_fp16_weights'

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -180,7 +180,8 @@ class LoraModel(torch.nn.Module):
                     )
                 else:
                     if loaded_in_8bit and isinstance(target, bnb.nn.Linear8bitLt):
-                        kwargs.update(
+                        eightbit_kwargs = kwargs.copy()
+                        eightbit_kwargs.update(
                             {
                                 "has_fp16_weights": target.state.has_fp16_weights,
                                 "memory_efficient_backward": target.state.memory_efficient_backward,
@@ -189,7 +190,7 @@ class LoraModel(torch.nn.Module):
                             }
                         )
                         new_module = Linear8bitLt(
-                            adapter_name, target.in_features, target.out_features, bias=bias, **kwargs
+                            adapter_name, target.in_features, target.out_features, bias=bias, **eightbit_kwargs
                         )
                     else:
                         if isinstance(target, torch.nn.Linear):


### PR DESCRIPTION
When iterating over the list of named modules, if a Linear8BitLt module came before a non-8 bit module, the kwargs would be permuted to include the 'has_fp16_weights' and other parameters, and the next time it had to instantiate a 'torch.nn.Linear' object, the constructor would error out because **kwargs contained keyword arguments that were not appropriate for the base constructor.

This fixes that by copying kwargs when sending the extra data to Linear8BitLt.