### PR TITLE
Fix `merge_and_unload` when having additional trainable modules

### DIFF
--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -32,5 +32,6 @@ from .other import (
     _get_submodules,
     _set_adapter,
     _freeze_adapter,
+    ModulesToSaveWrapper,
 )
 from .save_and_load import get_peft_model_state_dict, set_peft_model_state_dict


### PR DESCRIPTION
1. Fixes `merge_and_unload` when having additional trainable modules as part of `modules_to_save`. For example, the `classifier`\`score` head for `AutoModelForSequenceClassification`