### PR TITLE
Fix eval for causal language modeling example

### DIFF
--- a/examples/causal_language_modeling/peft_lora_clm_accelerate_ds_zero3_offload.py
+++ b/examples/causal_language_modeling/peft_lora_clm_accelerate_ds_zero3_offload.py
@@ -281,7 +281,7 @@ def main():
                         **batch, synced_gpus=is_ds_zero_3, max_new_tokens=10
                     )  # synced_gpus=True for DS-stage 3
                 outputs = accelerator.pad_across_processes(outputs, dim=1, pad_index=tokenizer.pad_token_id)
-                preds = accelerator.gather(outputs)
+                preds = accelerator.gather_for_metrics(outputs)
                 preds = preds[:, max_length:].detach().cpu().numpy()
                 eval_preds.extend(tokenizer.batch_decode(preds, skip_special_tokens=True))
 


### PR DESCRIPTION
Similar to the fix in (#296 ), we utilize gather_for_metrics instead of gather which should fix the assertion error on line 309 when running with multiple processes.