### PR TITLE
Fix missing arg for transpose in AdaLora

### DIFF
--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -399,7 +399,8 @@ class SVDLinear(nn.Linear, AdaLoraLayer):
             self.weight.data += (
                 transpose(
                     self.lora_B[self.active_adapter]
-                    @ (self.lora_A[self.active_adapter] * self.lora_E[self.active_adapter])
+                    @ (self.lora_A[self.active_adapter] * self.lora_E[self.active_adapter]),
+                    self.fan_in_fan_out,
                 )
                 * self.scaling[self.active_adapter]
                 / (self.ranknum[self.active_adapter] + 1e-5)


### PR DESCRIPTION
`transpose() missing 1 required positional argument: 'fan_in_fan_out'`