### PR TITLE
Only include `labels` as a parameter if it's specified in the functio…

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1065,16 +1065,17 @@ class PeftModelForTokenClassification(PeftModel):
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if not isinstance(peft_config, PromptLearningConfig):
-            return self.base_model(
-                input_ids=input_ids,
-                attention_mask=attention_mask,
-                inputs_embeds=inputs_embeds,
-                labels=labels,
-                output_attentions=output_attentions,
-                output_hidden_states=output_hidden_states,
-                return_dict=return_dict,
-                **kwargs,
-            )
+            kwargs.update({
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "inputs_embeds": inputs_embeds,
+                "output_attentions": output_attentions,
+                "output_hidden_states": output_hidden_states,
+                "return_dict": return_dict,
+            })
+            if labels is not None:
+                kwargs["labels"] = labels
+            return self.base_model(**kwargs)
 
         batch_size = input_ids.shape[0]
         if attention_mask is not None:


### PR DESCRIPTION
Only include `labels` as a parameter if it's specified in the function call.  This way, encoders as opposed to classifier models can also function.  Currently only implemented for the TOKEN_CLS case

addresses https://github.com/huggingface/peft/issues/348