### PR TITLE
[BugFix] Set alpha and dropout defaults in LoraConfig

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -65,8 +65,8 @@ class LoraConfig(PeftConfig):
             "For example, ['q', 'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$' "
         },
     )
-    lora_alpha: int = field(default=None, metadata={"help": "Lora alpha"})
-    lora_dropout: float = field(default=None, metadata={"help": "Lora dropout"})
+    lora_alpha: int = field(default=1, metadata={"help": "Lora alpha"})
+    lora_dropout: float = field(default=0.0, metadata={"help": "Lora dropout"})
     fan_in_fan_out: bool = field(
         default=False,
         metadata={"help": "Set this to True if the layer to replace stores weight like (fan_in, fan_out)"},

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -65,7 +65,7 @@ class LoraConfig(PeftConfig):
             "For example, ['q', 'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$' "
         },
     )
-    lora_alpha: int = field(default=1, metadata={"help": "Lora alpha"})
+    lora_alpha: int = field(default=8, metadata={"help": "Lora alpha"})
     lora_dropout: float = field(default=0.0, metadata={"help": "Lora dropout"})
     fan_in_fan_out: bool = field(
         default=False,


### PR DESCRIPTION
Instantiating and using a default LoraConfig results in errors due to the fact `lora_alpha` and `lora_dropout` gets initialised to None. 
There are points in the code (see e.g., [here](https://github.com/huggingface/peft/blob/2bb0f98619b567dccef13da3afaa6c3f535ee83c/src/peft/tuners/lora.py#L447), [here](https://github.com/huggingface/peft/blob/2bb0f98619b567dccef13da3afaa6c3f535ee83c/src/peft/tuners/lora.py#L465), [here](https://github.com/huggingface/peft/blob/2bb0f98619b567dccef13da3afaa6c3f535ee83c/src/peft/tuners/lora.py#L457)) where it is assumed they have actual values.
Since all methods already have alpha=1 and dropout=0.0 as defaults I opted to change LoraConfig instead of adding None checks. 