### PR TITLE
Remove merge_weights

### DIFF
--- a/examples/token_classification/peft_lora_token_cls.ipynb
+++ b/examples/token_classification/peft_lora_token_cls.ipynb
@@ -806,7 +806,7 @@
     {
      "data": {
       "text/plain": [
-       "LoRAConfig(pet_type='LORA', task_type='TOKEN_CLS', inference_mode=False, r=16, target_modules=None, lora_alpha=16, lora_dropout=0.1, merge_weights=False, fan_in_fan_out=False, enable_lora=None, bias='all')"
+       "LoRAConfig(pet_type='LORA', task_type='TOKEN_CLS', inference_mode=False, r=16, target_modules=None, lora_alpha=16, lora_dropout=0.1, fan_in_fan_out=False, enable_lora=None, bias='all')"
       ]
      },
      "execution_count": 13,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -829,7 +829,6 @@ class PeftModelForSeq2SeqLM(PeftModel):
         ...     "target_modules": ["q", "v"],
         ...     "lora_alpha": 32,
         ...     "lora_dropout": 0.1,
-        ...     "merge_weights": False,
         ...     "fan_in_fan_out": False,
         ...     "enable_lora": None,
         ...     "bias": "none",

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -311,8 +311,6 @@ class AdaLoraModel(LoraModel):
             peft_config.target_modules = TRANSFORMERS_MODELS_TO_ADALORA_TARGET_MODULES_MAPPING[
                 model_config["model_type"]
             ]
-        if peft_config.inference_mode:
-            peft_config.merge_weights = True
         return peft_config
 
 

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -292,8 +292,6 @@ class LoraModel(torch.nn.Module):
             if model_config["model_type"] not in TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING:
                 raise ValueError("Please specify `target_modules` in `peft_config`")
             peft_config.target_modules = TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING[model_config["model_type"]]
-        if peft_config.inference_mode:
-            peft_config.merge_weights = True
         return peft_config
 
     def merge_and_unload(self):


### PR DESCRIPTION
`merge_weights` is not used anywhere since #227, which introduced `merge_and_unload`.