### PR TITLE
[`CI`] Fix CI - pin urlib

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install .[quality]
       - name: Check quality
         run: |
           make quality

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[quality]
+          pip install .[dev]
       - name: Check quality
         run: |
           make quality

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 extras = {}
-extras["quality"] = ["black ~= 22.0", "ruff>=0.0.241"]
+extras["quality"] = ["black ~= 22.0", "ruff>=0.0.241", "urllib3<=2.0.0"]
 extras["docs_specific"] = ["hf-doc-builder"]
 extras["dev"] = extras["quality"] + extras["docs_specific"]
 extras["test"] = extras["dev"] + ["pytest", "pytest-xdist", "parameterized", "datasets"]


### PR DESCRIPTION
# What does this PR do?

This PR pins the `urllib3` version to avoid failing CI tests due to a release of `requests-toolbelt` and `urllib3`

Should resolve all failing CI tests on the PRs

cc @pacman100 
