### PR TITLE
Fix documentation links on index page

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -18,7 +18,7 @@ Recent state-of-the-art PEFT techniques achieve performance comparable to that o
 
 PEFT is seamlessly integrated with 🤗 Accelerate for large-scale models leveraging DeepSpeed and [Big Model Inference](https://huggingface.co/docs/accelerate/usage_guides/big_modeling).
 
-If you are new to PEFT, get started by reading the [Quicktour](quicktour) guide and conceptual guides for [LoRA](/conceptual_guides/lora) and [Prompting](/conceptual_guides/prompting) methods. 
+If you are new to PEFT, get started by reading the [Quicktour](quicktour) guide and conceptual guides for [LoRA](conceptual_guides/lora) and [Prompting](conceptual_guides/prompting) methods. 
 
 ## Supported methods
 


### PR DESCRIPTION
Fixes documentation links from being absolute links to relative links for conceptual guides. Links currently show as 404 on the live site.