### PR TITLE
Enable PeftConfig & PeftModel to load from revision

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -161,8 +161,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         # load the config
         config = PEFT_TYPE_TO_CONFIG_MAPPING[
-            PeftConfig.from_pretrained(model_id, subfolder=kwargs.get("subfolder", None)).peft_type
-        ].from_pretrained(model_id, subfolder=kwargs.get("subfolder", None))
+            PeftConfig.from_pretrained(model_id, subfolder=kwargs.get("subfolder", None), **kwargs).peft_type
+        ].from_pretrained(model_id, subfolder=kwargs.get("subfolder", None), **kwargs)
 
         if (getattr(model, "hf_device_map", None) is not None) and len(
             set(model.hf_device_map.values()).intersection({"cpu", "disk"})

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -370,7 +370,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             filename = os.path.join(path, WEIGHTS_NAME)
         else:
             try:
-                filename = hf_hub_download(model_id, WEIGHTS_NAME, subfolder=kwargs.get("subfolder", None))
+                filename = hf_hub_download(model_id, WEIGHTS_NAME, subfolder=kwargs.get("subfolder", None), **kwargs)
             except:  # noqa
                 raise ValueError(
                     f"Can't find weights for {model_id} in {model_id} or in the Hugging Face Hub. "

--- a/src/peft/utils/config.py
+++ b/src/peft/utils/config.py
@@ -103,7 +103,9 @@ class PeftConfigMixin(PushToHubMixin):
             config_file = os.path.join(path, CONFIG_NAME)
         else:
             try:
-                config_file = hf_hub_download(pretrained_model_name_or_path, CONFIG_NAME, subfolder=subfolder)
+                config_file = hf_hub_download(
+                    pretrained_model_name_or_path, CONFIG_NAME, subfolder=subfolder, **kwargs
+                )
             except Exception:
                 raise ValueError(f"Can't find '{CONFIG_NAME}' at '{pretrained_model_name_or_path}'")
 
@@ -144,6 +146,7 @@ class PeftConfig(PeftConfigMixin):
     """
 
     base_model_name_or_path: str = field(default=None, metadata={"help": "The name of the base model to use."})
+    revision: str = field(default=None, metadata={"help": "The specific model version to use."})
     peft_type: Union[str, PeftType] = field(default=None, metadata={"help": "Peft type"})
     task_type: Union[str, TaskType] = field(default=None, metadata={"help": "Task type"})
     inference_mode: bool = field(default=False, metadata={"help": "Whether to use inference mode"})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,9 @@ import unittest
 from peft import AdaptionPromptConfig, LoraConfig, PrefixTuningConfig, PromptEncoderConfig, PromptTuningConfig
 
 
+PEFT_MODELS_TO_TEST = [("lewtun/tiny-random-OPTForCausalLM-delta", "3cedab206cbe8e22fc764a96481e994e6868fe7c")]
+
+
 class PeftConfigTestMixin:
     all_config_classes = (
         LoraConfig,
@@ -50,6 +53,16 @@ class PeftConfigTester(unittest.TestCase, PeftConfigTestMixin):
         for config_class in self.all_config_classes:
             # assert this will not fail
             _ = config_class(task_type="test")
+
+    def test_from_pretrained(self):
+        r"""
+        Test if the config is correctly loaded using:
+        - from_pretrained
+        """
+        for config_class in self.all_config_classes:
+            for model_name, revision in PEFT_MODELS_TO_TEST:
+                # Test we can load config from delta
+                _ = config_class.from_pretrained(model_name, revision=revision)
 
     def test_save_pretrained(self):
         r"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,7 @@ import unittest
 from peft import AdaptionPromptConfig, LoraConfig, PrefixTuningConfig, PromptEncoderConfig, PromptTuningConfig
 
 
-PEFT_MODELS_TO_TEST = [("lewtun/tiny-random-OPTForCausalLM-delta", "3cedab206cbe8e22fc764a96481e994e6868fe7c")]
+PEFT_MODELS_TO_TEST = [("lewtun/tiny-random-OPTForCausalLM-delta", "v1")]
 
 
 class PeftConfigTestMixin:


### PR DESCRIPTION
This PR enables the `from_pretrained` of `PeftConfig` and `PeftModel` to load configs/models with a specific `revision` arg. This is useful when storing many adapter weights as branches in a model repo.

## Sample usage

```python
from peft import PeftConfig, PeftModel
from transformers import AutoModelForCausalLM

model_id = "lewtun/tiny-random-OPTForCausalLM-delta"
revision = "v1"
config = PeftConfig.from_pretrained(model_id, revision=revision)

model = AutoModelForCausalLM.from_pretrained(
    config.base_model_name_or_path,
)
model = PeftModel.from_pretrained(model, model_id, revision=revision)
assert isinstance(model, PeftModel)
```