### PR TITLE
fix merge_and_unload when LoRA targets embedding layer

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -345,8 +345,11 @@ class LoraModel(torch.nn.Module):
             except AttributeError:
                 continue
             if isinstance(target, LoraLayer):
-                bias = target.bias is not None
-                new_module = torch.nn.Linear(target.in_features, target.out_features, bias=bias)
+                if isinstance(target, nn.Embedding):
+                    new_module = torch.nn.Embedding(target.in_features, target.out_features)
+                else:
+                    bias = target.bias is not None
+                    new_module = torch.nn.Linear(target.in_features, target.out_features, bias=bias)
                 target.merge()
                 self._replace_module(parent, target_name, new_module, target)
 


### PR DESCRIPTION
## What does this PR do?

This is a proposed fix for the crash reported in https://github.com/huggingface/peft/issues/436.

## Pull Request Description

This PR makes a minor change to the implementation of `merge_and_unload` so it can handle `nn.Embedding` modules as well.