### PR TITLE
Add thousands separator in print_trainable_parameters

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -287,7 +287,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             if param.requires_grad:
                 trainable_params += num_params
         print(
-            f"trainable params: {trainable_params} || all params: {all_param} || trainable%: {100 * trainable_params / all_param}"
+            f"trainable params: {trainable_params:,d} || all params: {all_param:,d} || trainable%: {100 * trainable_params / all_param}"
         )
 
     def __getattr__(self, name: str):


### PR DESCRIPTION
The tiniest of suggestions, but to improve readability a thousands separator can be useful. Before:

trainable params: 901120 || all params: 479563456 || trainable%: 0.18790422596337283

After:

trainable params: 901,120 || all params: 479,563,456 || trainable%: 0.18790422596337283
