### PR TITLE
Fix a minor typo where a non-default token_dim would crash prompt tuning

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -96,7 +96,7 @@ def _prepare_prompt_learning_config(peft_config, model_config):
         peft_config.num_attention_heads = num_attention_heads
 
     if getattr(peft_config, "encoder_hidden_size", None) is None:
-        setattr(peft_config, "encoder_hidden_size", token_dim)
+        setattr(peft_config, "encoder_hidden_size", peft_config.token_dim)
 
     return peft_config
 


### PR DESCRIPTION
A one-line fix to address a bug where the variable `token_dim` can be used when not assigned.
In particular, performing prompt tuning with a non default `token_dim` causes peft to crash.

To illustrate this change, in [this example notebook](https://github.com/huggingface/peft/blob/main/examples/sequence_classification/Prompt_Tuning.ipynb), changing `PromptTuningConfig(task_type="SEQ_CLS", num_virtual_tokens=10)` to `PromptTuningConfig(task_type="SEQ_CLS", num_virtual_tokens=10, token_dim=x)` raises a `Local Variable Referenced Before Assignment Error`, this PR fixes this issue.