### PR TITLE
return load_result when load_adapter

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -381,7 +381,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             filename, map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu")
         )
         # load the weights into the model
-        set_peft_model_state_dict(self, adapters_weights, adapter_name=adapter_name)
+        load_result = set_peft_model_state_dict(self, adapters_weights, adapter_name=adapter_name)
         if (
             (getattr(self, "hf_device_map", None) is not None)
             and (len(set(self.hf_device_map.values()).intersection({"cpu", "disk"})) > 0)
@@ -424,6 +424,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         # Set model in evaluation mode to deactivate Dropout modules by default
         self.eval()
+        return load_result
 
     def set_adapter(self, adapter_name):
         """

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -120,8 +120,9 @@ def set_peft_model_state_dict(model, peft_model_state_dict, adapter_name="defaul
     else:
         raise NotImplementedError
 
-    model.load_state_dict(peft_model_state_dict, strict=False)
+    load_result = model.load_state_dict(peft_model_state_dict, strict=False)
     if isinstance(config, PromptLearningConfig):
         model.prompt_encoder[adapter_name].embedding.load_state_dict(
             {"weight": peft_model_state_dict["prompt_embeddings"]}, strict=True
         )
+    return load_result


### PR DESCRIPTION
some function need load_result when call load_adapter function to check non-matching keys.