### PR TITLE
[`core`] Raise warning on using `prepare_model_for_int8_training`

### DIFF
--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -52,6 +52,7 @@ from .utils import (
     bloom_model_postprocess_past_key_value,
     get_peft_model_state_dict,
     prepare_model_for_int8_training,
+    prepare_model_for_kbit_training,
     set_peft_model_state_dict,
     shift_tokens_right,
 )

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -27,6 +27,7 @@ from .other import (
     _set_trainable,
     bloom_model_postprocess_past_key_value,
     prepare_model_for_int8_training,
+    prepare_model_for_kbit_training,
     shift_tokens_right,
     transpose,
     _get_submodules,

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import copy
+import warnings
 
 import torch
 
@@ -32,7 +33,7 @@ def bloom_model_postprocess_past_key_value(past_key_values):
     return tuple(zip(keys, values))
 
 
-def prepare_model_for_int8_training(model, use_gradient_checkpointing=True):
+def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
     r"""
     This method wraps the entire protocol for preparing a model before running a training. This includes:
         1- Cast the layernorm in fp32 2- making output embedding layer require grads 3- Add the upcasting of the lm
@@ -68,6 +69,14 @@ def prepare_model_for_int8_training(model, use_gradient_checkpointing=True):
         model.gradient_checkpointing_enable()
 
     return model
+
+
+# For backward compatibility
+def prepare_model_for_int8_training(*args, **kwargs):
+    warnings.warn(
+        "prepare_model_for_int8_training is deprecated and will be removed in a future version. Use prepare_model_for_kbit_training instead."
+    )
+    return prepare_model_for_kbit_training(*args, **kwargs)
 
 
 # copied from transformers.models.bart.modeling_bart

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -75,7 +75,7 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
 def prepare_model_for_int8_training(*args, **kwargs):
     warnings.warn(
         "prepare_model_for_int8_training is deprecated and will be removed in a future version. Use prepare_model_for_kbit_training instead.",
-        FutureWarning
+        FutureWarning,
     )
     return prepare_model_for_kbit_training(*args, **kwargs)
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -74,7 +74,8 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
 # For backward compatibility
 def prepare_model_for_int8_training(*args, **kwargs):
     warnings.warn(
-        "prepare_model_for_int8_training is deprecated and will be removed in a future version. Use prepare_model_for_kbit_training instead."
+        "prepare_model_for_int8_training is deprecated and will be removed in a future version. Use prepare_model_for_kbit_training instead.",
+        FutureWarning
     )
     return prepare_model_for_kbit_training(*args, **kwargs)
 


### PR DESCRIPTION
# What does this PR do?

With the addition of 4bit quantization support, the method `prepare_model_for_int8_training` should be renamed to `prepare_model_for_kbit_training` as it also prepares the 4bit models. I propose to add a warning whenever a user uses `prepare_model_for_int8_training` suggesting them to use `prepare_model_for_kbit_training` and remove `prepare_model_for_int8_training` in a major version release.

cc @pacman100 @sgugger 