### PR TITLE
Fix issue caused by #433 blindly passing **kwargs all over the place

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -164,7 +164,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         # load the config
         config = PEFT_TYPE_TO_CONFIG_MAPPING[
-            PeftConfig.from_pretrained(model_id, subfolder=kwargs.get("subfolder", None), revision=kwargs.get("revision", None)).peft_type
+            PeftConfig.from_pretrained(
+                model_id, subfolder=kwargs.get("subfolder", None), revision=kwargs.get("revision", None)
+            ).peft_type
         ].from_pretrained(model_id, subfolder=kwargs.get("subfolder", None), **kwargs)
 
         if (getattr(model, "hf_device_map", None) is not None) and len(

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -369,7 +369,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 self.modules_to_save.update(peft_config.modules_to_save)
             _set_trainable(self, adapter_name)
 
-    def load_adapter(self, model_id, adapter_name, is_trainable=False, **kwargs):
+    def load_adapter(self, model_id, adapter_name, is_trainable=False, revision=None, **kwargs):
         from .mapping import PEFT_TYPE_TO_CONFIG_MAPPING
 
         if adapter_name not in self.peft_config:
@@ -390,7 +390,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             filename = os.path.join(path, WEIGHTS_NAME)
         else:
             try:
-                filename = hf_hub_download(model_id, WEIGHTS_NAME, subfolder=kwargs.get("subfolder", None), **kwargs)
+                filename = hf_hub_download(model_id, WEIGHTS_NAME, subfolder=kwargs.get("subfolder", None), revision=revision)
             except:  # noqa
                 raise ValueError(
                     f"Can't find weights for {model_id} in {model_id} or in the Hugging Face Hub. "

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -164,7 +164,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         # load the config
         config = PEFT_TYPE_TO_CONFIG_MAPPING[
-            PeftConfig.from_pretrained(model_id, subfolder=kwargs.get("subfolder", None), **kwargs).peft_type
+            PeftConfig.from_pretrained(model_id, subfolder=kwargs.get("subfolder", None), revision=kwargs.get("revision", None)).peft_type
         ].from_pretrained(model_id, subfolder=kwargs.get("subfolder", None), **kwargs)
 
         if (getattr(model, "hf_device_map", None) is not None) and len(

--- a/src/peft/utils/config.py
+++ b/src/peft/utils/config.py
@@ -84,13 +84,15 @@ class PeftConfigMixin(PushToHubMixin):
             writer.write(json.dumps(output_dict, indent=2, sort_keys=True))
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path, subfolder=None, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path, subfolder=None, revision=None, **kwargs):
         r"""
         This method loads the configuration of your adapter model from a directory.
 
         Args:
             pretrained_model_name_or_path (`str`):
                 The directory or the Hub repository id where the configuration is saved.
+            revision (`str`, *optional*):
+                option for choosing revision
             kwargs (additional keyword arguments, *optional*):
                 Additional keyword arguments passed along to the child class initialization.
         """
@@ -104,7 +106,7 @@ class PeftConfigMixin(PushToHubMixin):
         else:
             try:
                 config_file = hf_hub_download(
-                    pretrained_model_name_or_path, CONFIG_NAME, subfolder=subfolder, **kwargs
+                    pretrained_model_name_or_path, CONFIG_NAME, subfolder=subfolder, revision=revision
                 )
             except Exception:
                 raise ValueError(f"Can't find '{CONFIG_NAME}' at '{pretrained_model_name_or_path}'")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,7 +62,7 @@ class PeftConfigTester(unittest.TestCase, PeftConfigTestMixin):
         for config_class in self.all_config_classes:
             for model_name, revision in PEFT_MODELS_TO_TEST:
                 # Test we can load config from delta
-                _ = config_class.from_pretrained(model_name, revision=revision)
+                _ = config_class.from_pretrained(model_name, revision=revision, device_map="auto")
 
     def test_save_pretrained(self):
         r"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,16 @@ class PeftConfigTester(unittest.TestCase, PeftConfigTestMixin):
         for config_class in self.all_config_classes:
             for model_name, revision in PEFT_MODELS_TO_TEST:
                 # Test we can load config from delta
+                _ = config_class.from_pretrained(model_name, revision=revision)
+
+    def test_from_pretrained_device_map_regression(self):
+        r"""
+        Test if the config is correctly loaded with extra device_map kwarg using:
+        - from_pretrained
+        """
+        for config_class in self.all_config_classes:
+            for model_name, revision in PEFT_MODELS_TO_TEST:
+                # Test we can load config from delta
                 _ = config_class.from_pretrained(model_name, revision=revision, device_map="auto")
 
     def test_save_pretrained(self):


### PR DESCRIPTION
#433  caused a regression breaking any code using `device_map` as a kwarg to `PeftModel.from_pretrained`, so like half the internet.