### PR TITLE
[`core`] Add safetensors integration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "torch>=1.13.0",
         "transformers",
         "accelerate",
+        "safetensors",
     ],
     extras_require=extras,
     classifiers=[

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -399,9 +399,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     f"Please check that the file {WEIGHTS_NAME} is present at {model_id}."
                 )
 
-        # adapters_weights = torch.load(
-        #     filename, map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        # )
         adapters_weights = safe_load_file(filename)
 
         # load the weights into the model

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -23,6 +23,7 @@ from accelerate import dispatch_model, infer_auto_device_map
 from accelerate.hooks import AlignDevicesHook, add_hook_to_module, remove_hook_from_submodules
 from accelerate.utils import get_balanced_memory
 from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import EntryNotFoundError
 from safetensors.torch import load_file as safe_load_file
 from safetensors.torch import save_file as safe_save_file
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
@@ -407,12 +408,12 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 filename = hf_hub_download(
                     model_id, SAFETENSORS_WEIGHTS_NAME, subfolder=kwargs.get("subfolder", None), **kwargs
                 )
-            except:  # noqa
+            except EntryNotFoundError:
                 try:
                     filename = hf_hub_download(
                         model_id, WEIGHTS_NAME, subfolder=kwargs.get("subfolder", None), **kwargs
                     )
-                except:  # noqa
+                except EntryNotFoundError:
                     raise ValueError(
                         f"Can't find weights for {model_id} in {model_id} or in the Hugging Face Hub. "
                         f"Please check that the file {WEIGHTS_NAME} or {SAFETENSORS_WEIGHTS_NAME} is present at {model_id}."

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -419,7 +419,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 )
 
         if use_safetensors:
-            adapters_weights = safe_load_file(filename)
+            adapters_weights = safe_load_file(filename, device="cuda" if torch.cuda.is_available() else "cpu")
         else:
             adapters_weights = torch.load(
                 filename, map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -530,20 +530,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 by a unit (like `"5MB"`).
             create_pr (`bool`, *optional*, defaults to `False`):
                 Whether or not to create a PR with the uploaded files or directly commit.
-
-        Examples:
-
-        ```python
-        from transformers import {object_class}
-
-        {object} = {object_class}.from_pretrained("bert-base-cased")
-
-        # Push the {object} to your namespace with the name "my-finetuned-bert".
-        {object}.push_to_hub("my-finetuned-bert")
-
-        # Push the {object} to an organization with the name "my-finetuned-bert".
-        {object}.push_to_hub("huggingface/my-finetuned-bert")
-        ```
         """
         if "repo_path_or_name" in deprecated_kwargs:
             warnings.warn(

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -30,6 +30,7 @@ from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 from transformers import PreTrainedModel
 from transformers.modeling_outputs import SequenceClassifierOutput, TokenClassifierOutput
 from transformers.utils import PushToHubMixin
+from transformers.utils.generic import working_or_temp_dir
 
 from .tuners import (
     AdaLoraModel,
@@ -407,6 +408,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             has_remote_safetensors_file = hub_file_exists(
                 model_id, SAFETENSORS_WEIGHTS_NAME, revision=kwargs.get("revision", None)
             )
+            use_safetensors = has_remote_safetensors_file
 
             if has_remote_safetensors_file:
                 # Priority 1: load safetensors weights
@@ -491,6 +493,95 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
     @property
     def active_peft_config(self):
         return self.peft_config[self.active_adapter]
+
+    def push_to_hub(
+        self,
+        repo_id: str,
+        use_temp_dir: bool = None,
+        commit_message: str = None,
+        private: bool = None,
+        use_auth_token: bool = None,
+        max_shard_size: str = "10GB",
+        create_pr: bool = False,
+        safe_serialization: bool = False,
+        **deprecated_kwargs,
+    ) -> str:
+        """
+        Copy of the `push_to_hub` method that adds the `safe_serialization` argument for pushing safetensors weights.
+
+        Parameters:
+            repo_id (`str`):
+                The name of the repository you want to push your {object} to. It should contain your organization name
+                when pushing to a given organization.
+            use_temp_dir (`bool`, *optional*):
+                Whether or not to use a temporary directory to store the files saved before they are pushed to the Hub.
+                Will default to `True` if there is no directory named like `repo_id`, `False` otherwise.
+            commit_message (`str`, *optional*):
+                Message to commit while pushing. Will default to `"Upload {object}"`.
+            private (`bool`, *optional*):
+                Whether or not the repository created should be private.
+            use_auth_token (`bool` or `str`, *optional*):
+                The token to use as HTTP bearer authorization for remote files. If `True`, will use the token generated
+                when running `huggingface-cli login` (stored in `~/.huggingface`). Will default to `True` if `repo_url`
+                is not specified.
+            max_shard_size (`int` or `str`, *optional*, defaults to `"10GB"`):
+                Only applicable for models. The maximum size for a checkpoint before being sharded. Checkpoints shard
+                will then be each of size lower than this size. If expressed as a string, needs to be digits followed
+                by a unit (like `"5MB"`).
+            create_pr (`bool`, *optional*, defaults to `False`):
+                Whether or not to create a PR with the uploaded files or directly commit.
+
+        Examples:
+
+        ```python
+        from transformers import {object_class}
+
+        {object} = {object_class}.from_pretrained("bert-base-cased")
+
+        # Push the {object} to your namespace with the name "my-finetuned-bert".
+        {object}.push_to_hub("my-finetuned-bert")
+
+        # Push the {object} to an organization with the name "my-finetuned-bert".
+        {object}.push_to_hub("huggingface/my-finetuned-bert")
+        ```
+        """
+        if "repo_path_or_name" in deprecated_kwargs:
+            warnings.warn(
+                "The `repo_path_or_name` argument is deprecated and will be removed in v5 of Transformers. Use "
+                "`repo_id` instead."
+            )
+            repo_id = deprecated_kwargs.pop("repo_path_or_name")
+        # Deprecation warning will be sent after for repo_url and organization
+        repo_url = deprecated_kwargs.pop("repo_url", None)
+        organization = deprecated_kwargs.pop("organization", None)
+
+        if os.path.isdir(repo_id):
+            working_dir = repo_id
+            repo_id = repo_id.split(os.path.sep)[-1]
+        else:
+            working_dir = repo_id.split("/")[-1]
+
+        repo_id = self._create_repo(
+            repo_id, private=private, use_auth_token=use_auth_token, repo_url=repo_url, organization=organization
+        )
+
+        if use_temp_dir is None:
+            use_temp_dir = not os.path.isdir(working_dir)
+
+        with working_or_temp_dir(working_dir=working_dir, use_temp_dir=use_temp_dir) as work_dir:
+            files_timestamps = self._get_files_timestamps(work_dir)
+
+            # Save all files.
+            self.save_pretrained(work_dir, max_shard_size=max_shard_size, safe_serialization=safe_serialization)
+
+            return self._upload_modified_files(
+                work_dir,
+                repo_id,
+                files_timestamps,
+                commit_message=commit_message,
+                token=use_auth_token,
+                create_pr=create_pr,
+            )
 
 
 class PeftModelForSequenceClassification(PeftModel):

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -51,6 +51,7 @@ from .utils import (
     _set_trainable,
     add_or_edit_model_card,
     get_peft_model_state_dict,
+    hub_file_exists,
     set_peft_model_state_dict,
     shift_tokens_right,
 )
@@ -403,12 +404,16 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             filename = os.path.join(path, WEIGHTS_NAME)
             use_safetensors = False
         else:
-            try:
+            has_remote_safetensors_file = hub_file_exists(
+                model_id, SAFETENSORS_WEIGHTS_NAME, revision=kwargs.get("revision", None)
+            )
+
+            if has_remote_safetensors_file:
                 # Priority 1: load safetensors weights
                 filename = hf_hub_download(
                     model_id, SAFETENSORS_WEIGHTS_NAME, subfolder=kwargs.get("subfolder", None), **kwargs
                 )
-            except EntryNotFoundError:
+            else:
                 try:
                     filename = hf_hub_download(
                         model_id, WEIGHTS_NAME, subfolder=kwargs.get("subfolder", None), **kwargs

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -25,6 +25,7 @@ from .other import (
     COMMON_LAYERS_PATTERN,
     CONFIG_NAME,
     WEIGHTS_NAME,
+    SAFETENSORS_WEIGHTS_NAME,
     _set_trainable,
     add_or_edit_model_card,
     bloom_model_postprocess_past_key_value,

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -38,4 +38,5 @@ from .other import (
     _freeze_adapter,
     ModulesToSaveWrapper,
 )
+from .hub_utils import hub_file_exists
 from .save_and_load import get_peft_model_state_dict, set_peft_model_state_dict

--- a/src/peft/utils/hub_utils.py
+++ b/src/peft/utils/hub_utils.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+# Copyright 2023-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from huggingface_hub import get_hf_file_metadata, hf_hub_url
+from huggingface_hub.utils import EntryNotFoundError
+
+
+def hub_file_exists(repo_id: str, filename: str, revision: str = None, repo_type: str = None) -> bool:
+    r"""
+    Checks if a file exists in a remote Hub repository.
+    """
+    url = hf_hub_url(repo_id=repo_id, filename=filename, repo_type=repo_type, revision=revision)
+    try:
+        get_hf_file_metadata(url)
+        return True
+    except EntryNotFoundError:
+        return False

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -266,4 +266,5 @@ TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING = {
 }
 
 WEIGHTS_NAME = "adapter_model.bin"
+SAFETENSORS_WEIGHTS_NAME = "adapter_model.safetensors"
 CONFIG_NAME = "adapter_config.json"

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -106,8 +106,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     @pytest.mark.multi_gpu_tests
     def test_lora_bnb_4bit_quantization_from_pretrained_safetensors(self):
         r"""
-        Test that tests if the 4bit quantization using LoRA works as expected with safetensors
-        weights.
+        Test that tests if the 4bit quantization using LoRA works as expected with safetensors weights.
         """
         model_id = "facebook/opt-350m"
         peft_model_id = "ybelkada/test-st-lora"

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -103,6 +103,21 @@ class PeftGPUCommonTests(unittest.TestCase):
         )
 
     @require_bitsandbytes
+    @pytest.mark.multi_gpu_tests
+    def test_lora_bnb_4bit_quantization_from_pretrained_safetensors(self):
+        r"""
+        Test that tests if the 4bit quantization using LoRA works as expected with safetensors
+        weights.
+        """
+        model_id = "facebook/opt-350m"
+        peft_model_id = "ybelkada/test-st-lora"
+
+        model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", load_in_4bit=True)
+        model = PeftModel.from_pretrained(model, peft_model_id)
+
+        _ = model.generate(torch.LongTensor([[0, 2, 3, 1]]).to(0))
+
+    @require_bitsandbytes
     def test_lora_bnb_4bit_quantization(self):
         r"""
         Test that tests if the 4bit quantization using LoRA works as expected

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -99,3 +99,7 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_training_decoders_gradient_checkpointing(self, test_name, model_id, config_cls, config_kwargs):
         self._test_training_gradient_checkpointing(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_inference_safetensors(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_inference_safetensors(model_id, config_cls, config_kwargs)

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -102,3 +102,7 @@ class PeftEncoderDecoderModelTester(unittest.TestCase, PeftCommonTester):
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_training_encoder_decoders_gradient_checkpointing(self, test_name, model_id, config_cls, config_kwargs):
         self._test_training_gradient_checkpointing(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_inference_safetensors(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_inference_safetensors(model_id, config_cls, config_kwargs)

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -345,6 +345,39 @@ class PeftCommonTester:
             else:
                 self.assertIsNone(param.grad)
 
+    def _test_inference_safetensors(self, model_id, config_cls, config_kwargs):
+        if config_cls not in (LoraConfig,):
+            return
+
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            layers_to_transform=[0],
+            **config_kwargs,
+        )
+        model = self.transformers_class.from_pretrained(model_id)
+        model = get_peft_model(model, config)
+        model = model.to(self.torch_device)
+
+        inputs = self.prepare_inputs_for_testing()
+
+        # check if `training` works
+        output = model(**inputs)[0]
+        logits = output[0]
+
+        loss = output.sum()
+        loss.backward()
+
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            model.save_pretrained(tmp_dirname, safe_serialization=True)
+            self.assertTrue("adapter_model.safetensors" in os.listdir(tmp_dirname))
+            self.assertTrue("adapter_model.bin" not in os.listdir(tmp_dirname))
+
+            model_from_pretrained = self.transformers_class.from_pretrained(model_id)
+            model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname).to(self.torch_device)
+
+            logits_from_pretrained = model_from_pretrained(**inputs)[0][0]
+            self.assertTrue(torch.allclose(logits, logits_from_pretrained, atol=1e-4, rtol=1e-4))
+
     def _test_training_layer_indexing(self, model_id, config_cls, config_kwargs):
         if config_cls not in (LoraConfig,):
             return

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -380,7 +380,7 @@ class PeftCommonTester:
             model.save_pretrained(tmp_dirname)
 
             model_from_pretrained = self.transformers_class.from_pretrained(model_id)
-            model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
+            model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname).to(self.torch_device)
 
             logits_from_pretrained = model_from_pretrained(**inputs)[0][0]
             self.assertTrue(torch.allclose(logits, logits_from_pretrained, atol=1e-4, rtol=1e-4))


### PR DESCRIPTION
# What does this PR do?

This PR integrates safetensors into peft

The logic now is as follows:

- When saving locally a model, by default save the pickle file.
- If a user wants to go for a safer serialization (recommended), users should pass `safe_serialization=True` to `save_pretrained` method
- Same logic applies for `push_to_hub` method, by default we push on the Hub pickle file, except if a user calls `safe_serialization=True` to that method. 
- Inside from_pretrained, first look if the safetensors weights are present locally, then check for the pickle file. If none of them are present locally, try to fetch the safetensors weights from remote Hub, if not try to fetch the pickle file for remote.

What do you think? 

An example of safetensors adapter weights on the Hub: https://huggingface.co/ybelkada/test-st-lora/tree/main 

Fixes #546 

cc @Narsil @pacman100 