### PR TITLE
feat: add type hint to `get_peft_model`

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -101,7 +101,7 @@ def _prepare_prompt_learning_config(peft_config, model_config):
     return peft_config
 
 
-def get_peft_model(model, peft_config):
+def get_peft_model(model, peft_config) -> PeftModel:
     """
     Returns a Peft model object from a model and a config.
 


### PR DESCRIPTION
# Context

This small PR add a return type hint on `get_peft_model`. 

This makes it easier for IDE (in my case pycharm) to propose shortcuts and suggestions if it knows the type of return objet.

For instance without the type hint in pycharm I cannot click on `save_pretrained` of peft a model and see the signature. This is because pycharm don't know that the object is a peft model. Return type hint fixed this