### PR TITLE
[`core`] Correctly passing the kwargs all over the place

### DIFF
--- a/src/peft/utils/config.py
+++ b/src/peft/utils/config.py
@@ -101,7 +101,7 @@ class PeftConfigMixin(PushToHubMixin):
             else pretrained_model_name_or_path
         )
 
-        hf_hub_download_kwargs, class_kwargs = cls._split_kwargs(kwargs)
+        hf_hub_download_kwargs, class_kwargs, other_kwargs = cls._split_kwargs(kwargs)
 
         if os.path.isfile(os.path.join(path, CONFIG_NAME)):
             config_file = os.path.join(path, CONFIG_NAME)
@@ -141,14 +141,40 @@ class PeftConfigMixin(PushToHubMixin):
     def _split_kwargs(cls, kwargs):
         hf_hub_download_kwargs = {}
         class_kwargs = {}
+        other_kwargs = {}
 
         for key, value in kwargs.items():
             if key in inspect.signature(hf_hub_download).parameters:
                 hf_hub_download_kwargs[key] = value
-            else:
+            elif key in list(cls.__annotations__):
                 class_kwargs[key] = value
+            else:
+                other_kwargs[key] = value
 
-        return hf_hub_download_kwargs, class_kwargs
+        return hf_hub_download_kwargs, class_kwargs, other_kwargs
+
+    @classmethod
+    def _get_peft_type(
+        cls,
+        model_id,
+        subfolder: Optional[str] = None,
+        revision: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+    ):
+        path = os.path.join(model_id, subfolder) if subfolder is not None else model_id
+
+        if os.path.isfile(os.path.join(path, CONFIG_NAME)):
+            config_file = os.path.join(path, CONFIG_NAME)
+        else:
+            try:
+                config_file = hf_hub_download(
+                    model_id, CONFIG_NAME, subfolder=subfolder, revision=revision, cache_dir=cache_dir
+                )
+            except Exception:
+                raise ValueError(f"Can't find '{CONFIG_NAME}' at '{model_id}'")
+
+        loaded_attributes = cls.from_json_file(config_file)
+        return loaded_attributes["peft_type"]
 
 
 @dataclass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,14 @@ import os
 import tempfile
 import unittest
 
-from peft import AdaptionPromptConfig, LoraConfig, PrefixTuningConfig, PromptEncoderConfig, PromptTuningConfig
+from peft import (
+    AdaptionPromptConfig,
+    LoraConfig,
+    PeftConfig,
+    PrefixTuningConfig,
+    PromptEncoderConfig,
+    PromptTuningConfig,
+)
 
 
 PEFT_MODELS_TO_TEST = [("lewtun/tiny-random-OPTForCausalLM-delta", "v1")]
@@ -96,6 +103,24 @@ class PeftConfigTester(unittest.TestCase, PeftConfigTestMixin):
             config = config_class()
             self.assertEqual(config.to_dict(), config.__dict__)
             self.assertTrue(isinstance(config.to_dict(), dict))
+
+    def test_from_pretrained_cache_dir(self):
+        r"""
+        Test if the config is correctly loaded with extra kwargs
+        """
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            for config_class in self.all_config_classes:
+                for model_name, revision in PEFT_MODELS_TO_TEST:
+                    # Test we can load config from delta
+                    _ = config_class.from_pretrained(model_name, revision=revision, cache_dir=tmp_dirname)
+
+    def test_from_pretrained_cache_dir_remote(self):
+        r"""
+        Test if the config is correctly loaded with a checkpoint from the hub
+        """
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            _ = PeftConfig.from_pretrained("ybelkada/test-st-lora", cache_dir=tmp_dirname)
+            self.assertTrue("models--ybelkada--test-st-lora" in os.listdir(tmp_dirname))
 
     def test_set_attributes(self):
         # manually set attributes and check if they are correctly written

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -103,3 +103,7 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_inference_safetensors(self, test_name, model_id, config_cls, config_kwargs):
         self._test_inference_safetensors(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_peft_model_device_map(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_peft_model_device_map(model_id, config_cls, config_kwargs)

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -106,3 +106,7 @@ class PeftEncoderDecoderModelTester(unittest.TestCase, PeftCommonTester):
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_inference_safetensors(self, test_name, model_id, config_cls, config_kwargs):
         self._test_inference_safetensors(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_peft_model_device_map(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_peft_model_device_map(model_id, config_cls, config_kwargs)


### PR DESCRIPTION
# What does this PR do?

Before this PR we were blindly passing the kwargs all over the place, for example the snippet below would fail:

## Changes introduced

- This PR adds new class methods `_get_peft_type` as the retrieval of the PEFT type is used and call over multiple places
- Adds a `_split_kwargs` methods inside `PeftModel` to filter out kwargs that are used for `hf_hub_download`


## Reproducible snippet

```python
import torch
from peft import PeftModel
from transformers import AutoModelForCausalLM

peft_model_id = "ybelkada/test-st-lora" 
tr_model_id = "facebook/opt-350m"

model = AutoModelForCausalLM.from_pretrained(tr_model_id, torch_dtype=torch.bfloat16)
model = PeftModel.from_pretrained(model, peft_model_id, device_map="auto") # it will fail here
```

This PR fixes that by correctly filtering out the kwargs at different levels

Fixes https://github.com/huggingface/peft/issues/564
Fixes https://github.com/huggingface/peft/issues/579