### PR TITLE
enable lora for mpt

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -702,6 +702,19 @@ class PeftModelForCausalLM(PeftModel):
     ):
         peft_config = self.active_peft_config
         if not isinstance(peft_config, PromptLearningConfig):
+            if self.base_model.config.model_type == "mpt":
+                if inputs_embeds is not None:
+                    raise AssertionError("forward in MPTForCausalLM does not support imputs_embeds")
+                return self.base_model(
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    labels=labels,
+                    output_attentions=output_attentions,
+                    output_hidden_states=output_hidden_states,
+                    return_dict=return_dict,
+                    **kwargs,
+                )
+
             return self.base_model(
                 input_ids=input_ids,
                 attention_mask=attention_mask,

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -212,6 +212,7 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "llama": ["q_proj", "v_proj"],
     "chatglm": ["query_key_value"],
     "starcoder": ["c_attn"],
+    "mpt": ["Wqkv"],
 }
 
 COMMON_LAYERS_PATTERN = ["layers", "h", "block", "blocks"]


### PR DESCRIPTION
currently. LORA in peft does not support for mpt model which is https://huggingface.co/mosaicml/mpt-7b.
there's two reasons:
1)mpt is not in TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING. if user does not define the target module explicitly. it will fail in _prepare_lora_config.
2) the forward in https://huggingface.co/mosaicml/mpt-7b/blob/main/modeling_mpt.py#L251 does not contain imputs_embeds. we could skip imputs_embeds if it's None. If it's not None, throw assert to let user know it.