### PR TITLE
Fix minor typo in bug-report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,7 +44,7 @@ body:
       label: Tasks
       description: "The tasks I am working on are:"
       options:
-        - label: "An officially supported task in the `examples` folder (such as GLUE/SQuAD, ...)"
+        - label: "An officially supported task in the `examples` folder"
         - label: "My own task or dataset (give details below)"
 
   - type: textarea


### PR DESCRIPTION
As per title, in fact we don't have Glue/Squad in the examples folder

cc @pacman100 