### PR TITLE
Fix adalora device mismatch issue

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -336,6 +336,8 @@ class LoraModel(torch.nn.Module):
         for name, module in new_module.named_modules():
             if "lora_" in name:
                 module.to(old_module.weight.device)
+            if "ranknum" in name:
+                module.to(old_module.weight.device)
 
     def __getattr__(self, name: str):
         """Forward missing attributes to the wrapped module."""


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/peft/issues/581

In fact the device placement of the adalora layer needs to take into account the `ranknum` module. To reproduce: 

```python
from peft import get_peft_model, AdaLoraConfig, TaskType
from transformers import AutoModelForCausalLM
import transformers

model_id = "facebook/opt-350m"

model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", load_in_4bit=True)
tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)

adaloraconfig = AdaLoraConfig(
    task_type=TaskType.CAUSAL_LM,
    init_r=6,
    target_r=4,
    tinit=50,
    tfinal=100,
    deltaT=5,
    beta1=0.3,
    beta2=0.3,
    orth_reg_weight=0.2,
    lora_alpha=32,
    lora_dropout=0.05,
    bias="none",
)

model = get_peft_model(model, adaloraconfig)

print(model.base_model.model.model.decoder.layers[0].self_attn.k_proj.lora_A['default'].device)
print(model.base_model.model.model.decoder.layers[0].self_attn.k_proj.ranknum['default'].device)
```

cc @pacman100 