### PR TITLE
[`test`] Adds more CI tests

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -237,7 +237,7 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "layoutlm": ["query", "value"],
     "llama": ["q_proj", "v_proj"],
     "chatglm": ["query_key_value"],
-    "starcoder": ["c_attn"],
+    "gpt_bigcode": ["c_attn"],
     "mpt": ["Wqkv"],
 }
 

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -28,12 +28,21 @@ PEFT_DECODER_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-BloomForCausalLM",
     "hf-internal-testing/tiny-random-gpt_neo",
     "hf-internal-testing/tiny-random-GPTJForCausalLM",
+    "hf-internal-testing/tiny-random-GPTBigCodeForCausalLM",
+    "HuggingFaceM4/tiny-random-LlamaForCausalLM",
 ]
 
 FULL_GRID = {
     "model_ids": PEFT_DECODER_MODELS_TO_TEST,
     "task_type": "CAUSAL_LM",
 }
+
+
+def skip_non_pt_mqa(test_list):
+    r"""
+    Skip tests that are prefix tuning for MQA models (not supported yet)
+    """
+    return [test for test in test_list if not ("prefix_tuning" in test[0] and "GPTBigCodeForCausalLM" in test[0])]
 
 
 class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
@@ -80,11 +89,11 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
     def test_merge_layers(self, test_name, model_id, config_cls, config_kwargs):
         self._test_merge_layers(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID, filter_params_func=skip_non_pt_mqa))
     def test_generate(self, test_name, model_id, config_cls, config_kwargs):
         self._test_generate(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID, filter_params_func=skip_non_pt_mqa))
     def test_generate_half_prec(self, test_name, model_id, config_cls, config_kwargs):
         self._test_generate_half_prec(model_id, config_cls, config_kwargs)
 


### PR DESCRIPTION
# What does this PR do?

This PR adds Llama and Starcoder (GPTBigCode) to the set of Ci suite. Currently generate with prefix tuning seems to be not supported for Starcoder model as it is a MQA model and the past key values needs a special care and further investigation. 

I propose to skip the tests for now until we address a proper fix in the future

cc @pacman100 