### PR TITLE
Improve the README when using PEFT

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -18,7 +18,6 @@ import os
 import warnings
 from contextlib import contextmanager
 
-from . import __version__
 import torch
 from accelerate import dispatch_model, infer_auto_device_map
 from accelerate.hooks import AlignDevicesHook, add_hook_to_module, remove_hook_from_submodules
@@ -32,6 +31,7 @@ from transformers import PreTrainedModel
 from transformers.modeling_outputs import SequenceClassifierOutput, TokenClassifierOutput
 from transformers.utils import PushToHubMixin
 
+from . import __version__
 from .tuners import (
     AdaLoraModel,
     AdaptionPromptModel,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -540,7 +540,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         with open(os.path.join(output_dir, "README.md"), "r") as f:
             lines = f.readlines()
 
-        quantization_config = self.config.quantization_config.to_dict()
+        quantization_config = None
+        if hasattr(self.config, "quantization_config"):
+            quantization_config = self.config.quantization_config.to_dict()
         training_config_text = ""
         # Adds quantization information if it was used
         if quantization_config is not None:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -559,9 +559,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         # Adds peft version
         framework_block_heading = "### Framework versions\n"
         if framework_block_heading in lines:
-            lines.insert(lines.index(framework_block_heading) + 2, "library_name: peft\n")
+            lines.insert(lines.index(framework_block_heading) + 2, f"- PEFT {__version__}\n")
         else:
-            lines.append(f"{framework_block_heading}\n\n- PEFT {__version__}")
+            lines.append(f"{framework_block_heading}\n\n- PEFT {__version__}\n")
 
         # write the lines back to README.md
         with open(os.path.join(output_dir, "README.md"), "w") as f:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -550,14 +550,14 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             training_config_text += "\n".join([f"- {name}: {value}" for name, value in quantization_config.items()])
             training_config_text += "\n"
 
-        training_procedure_heading = "## Training procedure"
+        training_procedure_heading = "## Training procedure\n"
         if training_procedure_heading in lines:
             lines.insert(lines.index(training_procedure_heading) + 2, training_config_text)
         else:
             lines.append(f"{training_procedure_heading}\n{training_config_text}")
 
         # Adds peft version
-        framework_block_heading = "### Framework versions"
+        framework_block_heading = "### Framework versions\n"
         if framework_block_heading in lines:
             lines.insert(lines.index(framework_block_heading) + 2, "library_name: peft\n")
         else:

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -27,7 +27,7 @@ from .other import (
     WEIGHTS_NAME,
     SAFETENSORS_WEIGHTS_NAME,
     _set_trainable,
-    add_or_edit_model_card,
+    add_library_to_model_card,
     bloom_model_postprocess_past_key_value,
     prepare_model_for_int8_training,
     prepare_model_for_kbit_training,

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -21,7 +21,7 @@ import torch
 
 
 # Add or edit model card to have `library_name: peft`
-def add_or_edit_model_card(output_dir):
+def add_library_to_model_card(output_dir):
     if os.path.exists(os.path.join(output_dir, "README.md")):
         with open(os.path.join(output_dir, "README.md"), "r") as f:
             lines = f.readlines()


### PR DESCRIPTION
# What does this PR do?
1. Adds `peft` library tag
2. Adds peft version
3. Adds quantization information if it was used

Code:
```
trainer.push_to_hub()
trainer.model.push_to_hub(trainer.repo.local_dir)
```

Sample Output:

model: https://huggingface.co/smangrul/results

```
---
license: apache-2.0
tags:
- generated_from_trainer
model-index:
- name: results
  results: []
library_name: peft
---

<!-- This model card has been generated automatically according to the information the Trainer had access to. You
should probably proofread and complete it, then remove this comment. -->

# results

This model is a fine-tuned version of [tiiuae/falcon-7b](https://huggingface.co/tiiuae/falcon-7b) on an unknown dataset.

## Model description

More information needed

## Intended uses & limitations

More information needed

## Training and evaluation data

More information needed

## Training procedure


The following `bitsandbytes` quantization config was used during training:
- load_in_8bit: False
- load_in_4bit: True
- llm_int8_threshold: 6.0
- llm_int8_skip_modules: None
- llm_int8_enable_fp32_cpu_offload: False
- llm_int8_has_fp16_weight: False
- bnb_4bit_quant_type: nf4
- bnb_4bit_use_double_quant: False
- bnb_4bit_compute_dtype: bfloat16
### Training hyperparameters

The following hyperparameters were used during training:
- learning_rate: 0.0002
- train_batch_size: 2560
- eval_batch_size: 40
- seed: 42
- gradient_accumulation_steps: 4
- total_train_batch_size: 10240
- optimizer: Adam with betas=(0.9,0.999) and epsilon=1e-08
- lr_scheduler_type: constant
- lr_scheduler_warmup_ratio: 0.03
- training_steps: 1875

### Framework versions

- PEFT 0.4.0.dev0
- Transformers 4.31.0.dev0
- Pytorch 2.0.1+cu117
- Datasets 2.9.0
- Tokenizers 0.13.3
```
