### PR TITLE
[`AdaptionPrompt`] Add 8bit + 4bit support for adaption prompt

### DIFF
--- a/src/peft/tuners/adaption_prompt.py
+++ b/src/peft/tuners/adaption_prompt.py
@@ -293,13 +293,12 @@ class AdaptedAttention(nn.Module):
         # which initializes the tokens with standard normal values.
         # https://github.com/ZrrSkywalker/LLaMA-Adapter/blob/41c3546fe1997ab8a65809dc8d8f9252b19d9faf/llama/model.py#L234
         # (bsz, adapter_len, hidden_size)
+        target_dtype = model.q_proj.weight.dtype if model.q_proj.weight.dtype != torch.int8 else torch.float32
         self.adaption_prompt = nn.Parameter(
-            torch.empty(
-                1, adapter_len, self.model.hidden_size, device=device, dtype=model.q_proj.weight.dtype
-            ).normal_()
+            torch.empty(1, adapter_len, self.model.hidden_size, device=device, dtype=target_dtype).normal_()
         )
         # Initialize the gate to 0 as this is "zero-init".
-        self.adaption_gate = nn.Parameter(torch.zeros(1, device=device, dtype=model.q_proj.weight.dtype))
+        self.adaption_gate = nn.Parameter(torch.zeros(1, device=device, dtype=target_dtype))
 
     def forward(self, **kwargs):
         """
@@ -347,7 +346,9 @@ class AdaptedAttention(nn.Module):
 
         previous_dtype = query_states.dtype
         # (bsz, num_heads, q_len, adapter_len)
-        scores = torch.matmul(query_states, adapter_k.transpose(2, 3)) / math.sqrt(self.model.head_dim)
+        scores = torch.matmul(query_states, adapter_k.transpose(2, 3).to(previous_dtype)) / math.sqrt(
+            self.model.head_dim
+        )
         # Upcast attention to fp32
         # (bsz, num_heads, q_len, adapter_len)
         scores = self.adaption_gate * F.softmax(scores, dim=-1, dtype=torch.float32).to(previous_dtype)

--- a/src/peft/tuners/adaption_prompt.py
+++ b/src/peft/tuners/adaption_prompt.py
@@ -293,7 +293,9 @@ class AdaptedAttention(nn.Module):
         # which initializes the tokens with standard normal values.
         # https://github.com/ZrrSkywalker/LLaMA-Adapter/blob/41c3546fe1997ab8a65809dc8d8f9252b19d9faf/llama/model.py#L234
         # (bsz, adapter_len, hidden_size)
-        target_dtype = model.q_proj.weight.dtype if model.q_proj.weight.dtype != torch.int8 else torch.float32
+        target_dtype = (
+            model.q_proj.weight.dtype if model.q_proj.weight.dtype not in [torch.int8, torch.uint8] else torch.float32
+        )
         self.adaption_prompt = nn.Parameter(
             torch.empty(1, adapter_len, self.model.hidden_size, device=device, dtype=target_dtype).normal_()
         )

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -246,3 +246,26 @@ class PeftGPUCommonTests(unittest.TestCase):
 
         random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(0)
         _ = model(random_input)
+
+    @require_torch_multi_gpu
+    @pytest.mark.multi_gpu_tests
+    @require_bitsandbytes
+    def test_adaption_prompt_4bit(self):
+        model = LlamaForCausalLM.from_pretrained(
+            "HuggingFaceM4/tiny-random-LlamaForCausalLM",
+            load_in_4bit=True,
+            torch_dtype=torch.float16,
+            device_map="auto",
+        )
+
+        model = prepare_model_for_kbit_training(model)
+
+        config = AdaptionPromptConfig(
+            adapter_len=10,
+            adapter_layers=2,
+            task_type="CAUSAL_LM",
+        )
+        model = get_peft_model(model, config)
+
+        random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(0)
+        _ = model(random_input)


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/peft/issues/600

As per title, this PR adds 8bit + 4bit support for `AdaptionPrompt` models. The fix is to infer the correct dtype by excluding the case where the weights are either an `torch.int8` (used in 8bit layers) or `torch.uint8` (used in 4bit layers) 

Adds also slow tests to test everything works correctly.

cc @pacman100 