### PR TITLE
[`core`] Stronger import of bnb

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -13,13 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
-import sys
-
-
-if sys.version_info[0] < 3.8:
-    _is_python_greater_3_8 = False
-else:
-    _is_python_greater_3_8 = True
 
 
 def is_bnb_available():
@@ -27,12 +20,9 @@ def is_bnb_available():
 
 
 def is_bnb_4bit_available():
-    if _is_python_greater_3_8:
-        from importlib.metadata import version
+    if not is_bnb_available():
+        return False
 
-        bnb_version = version("bitsandbytes")
-    else:
-        from pkg_resources import get_distribution
+    import bitsandbytes as bnb
 
-        bnb_version = get_distribution("bitsandbytes").version
-    return bnb_version >= "0.39.0"
+    return hasattr(bnb.nn, "Linear4bit")


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/peft/issues/603 

Instead of checking the version of bnb we should introduce a stronger check to make sure the 4bit layers cannot be imported to avoid corner cases such as the one described on the issue

cc @pacman100 