### PR TITLE
[`core`] Add `adapter_name` in `get_peft_model`

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -103,7 +103,7 @@ def _prepare_prompt_learning_config(peft_config, model_config):
     return peft_config
 
 
-def get_peft_model(model, peft_config) -> PeftModel:
+def get_peft_model(model, peft_config, adapter_name="default") -> PeftModel:
     """
     Returns a Peft model object from a model and a config.
 
@@ -116,7 +116,7 @@ def get_peft_model(model, peft_config) -> PeftModel:
     if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys() and not isinstance(
         peft_config, PromptLearningConfig
     ):
-        return PeftModel(model, peft_config)
+        return PeftModel(model, peft_config, adapter_name=adapter_name)
     if isinstance(peft_config, PromptLearningConfig):
         peft_config = _prepare_prompt_learning_config(peft_config, model_config)
-    return MODEL_TYPE_TO_PEFT_MODEL_MAPPING[peft_config.task_type](model, peft_config)
+    return MODEL_TYPE_TO_PEFT_MODEL_MAPPING[peft_config.task_type](model, peft_config, adapter_name=adapter_name)

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -70,6 +70,10 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
         self._test_model_attr(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_adapter_name(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_adapter_name(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_prepare_for_training_parametrized(self, test_name, model_id, config_cls, config_kwargs):
         self._test_prepare_for_training(model_id, config_cls, config_kwargs)
 

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -63,6 +63,10 @@ class PeftEncoderDecoderModelTester(unittest.TestCase, PeftCommonTester):
         self._test_model_attr(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_adapter_name(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_adapter_name(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_prepare_for_training_parametrized(self, test_name, model_id, config_cls, config_kwargs):
         self._test_prepare_for_training(model_id, config_cls, config_kwargs)
 

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -157,6 +157,21 @@ class PeftCommonTester:
         self.assertTrue(hasattr(model, "from_pretrained"))
         self.assertTrue(hasattr(model, "push_to_hub"))
 
+    def _test_adapter_name(self, model_id, config_cls, config_kwargs):
+        model = self.transformers_class.from_pretrained(model_id)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config, adapter_name="test-adapter")
+        correctly_converted = False
+        for n, _ in model.named_parameters():
+            if "test-adapter" in n:
+                correctly_converted = True
+                break
+
+        self.assertTrue(correctly_converted)
+
     def _test_prepare_for_training(self, model_id, config_cls, config_kwargs):
         model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
         config = config_cls(


### PR DESCRIPTION
# What does this PR do? 

Fixes https://github.com/huggingface/peft/issues/597

We should add the possibility to users to pass the adapter name when calling `get_peft_model` for a smoother UX

Added also some nice CI tests

cc @pacman100 