### PR TITLE
DOC: Remove loralib requirements from examples, a few small fixes

### DIFF
--- a/docs/source/task_guides/clm-prompt-tuning.mdx
+++ b/docs/source/task_guides/clm-prompt-tuning.mdx
@@ -85,6 +85,7 @@ dataset = dataset.map(
     batched=True,
     num_proc=1,
 )
+dataset["train"][0]
 {"Tweet text": "@HMRCcustomers No this is my first job", "ID": 0, "Label": 2, "text_label": "no complaint"}
 ```
 

--- a/docs/source/task_guides/image_classification_lora.mdx
+++ b/docs/source/task_guides/image_classification_lora.mdx
@@ -26,7 +26,7 @@ For more information on LoRA, please refer to the [original LoRA paper](https://
 Install the libraries required for model training:
 
 ```bash
-!pip install transformers accelerate evaluate datasets loralib peft -q
+!pip install transformers accelerate evaluate datasets peft -q
 ```
 
 Check the versions of all required libraries to make sure you are up to date:

--- a/docs/source/task_guides/semantic_segmentation_lora.mdx
+++ b/docs/source/task_guides/semantic_segmentation_lora.mdx
@@ -26,7 +26,7 @@ For more information on LoRA, please refer to the [original LoRA paper](https://
 Install the libraries required for model training:
 
 ```bash
-!pip install transformers accelerate evaluate datasets loralib peft -q
+!pip install transformers accelerate evaluate datasets peft -q
 ```
 
 ## Authenticate to share your model

--- a/docs/source/task_guides/seq2seq-prefix-tuning.mdx
+++ b/docs/source/task_guides/seq2seq-prefix-tuning.mdx
@@ -28,6 +28,7 @@ from peft import get_peft_config, get_peft_model, get_peft_model_state_dict, Pre
 from datasets import load_dataset
 from torch.utils.data import DataLoader
 from tqdm import tqdm
+import torch
 import os
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/examples/causal_language_modeling/requirements.txt
+++ b/examples/causal_language_modeling/requirements.txt
@@ -1,6 +1,5 @@
 transformers
 accelerate
-loralib
 evaluate
 deepspeed
 tqdm

--- a/examples/conditional_generation/requirements.txt
+++ b/examples/conditional_generation/requirements.txt
@@ -1,6 +1,5 @@
 transformers
 accelerate
-loralib
 evaluate
 deepspeed
 tqdm

--- a/examples/image_classification/image_classification_peft_lora.ipynb
+++ b/examples/image_classification/image_classification_peft_lora.ipynb
@@ -61,7 +61,7 @@
     }
    ],
    "source": [
-    "!pip install transformers accelerate evaluate datasets loralib git+https://github.com/huggingface/peft -q"
+    "!pip install transformers accelerate evaluate datasets git+https://github.com/huggingface/peft -q"
    ]
   },
   {

--- a/examples/int8_training/Finetune_flan_t5_large_bnb_peft.ipynb
+++ b/examples/int8_training/Finetune_flan_t5_large_bnb_peft.ipynb
@@ -71,7 +71,7 @@
     }
    ],
    "source": [
-    "!pip install -q bitsandbytes datasets accelerate loralib\n",
+    "!pip install -q bitsandbytes datasets accelerate\n",
     "!pip install -q git+https://github.com/huggingface/transformers.git@main git+https://github.com/huggingface/peft.git@main"
    ]
   },

--- a/examples/int8_training/Finetune_opt_bnb_peft.ipynb
+++ b/examples/int8_training/Finetune_opt_bnb_peft.ipynb
@@ -59,7 +59,7 @@
     }
    ],
    "source": [
-    "!pip install -q bitsandbytes datasets accelerate loralib\n",
+    "!pip install -q bitsandbytes datasets accelerate\n",
     "!pip install -q git+https://github.com/huggingface/transformers.git@main git+https://github.com/huggingface/peft.git"
    ]
   },

--- a/examples/int8_training/peft_bnb_whisper_large_v2_training.ipynb
+++ b/examples/int8_training/peft_bnb_whisper_large_v2_training.ipynb
@@ -64,7 +64,7 @@
     "!pip install evaluate>=0.30\n",
     "!pip install jiwer\n",
     "!pip install gradio\n",
-    "!pip install -q bitsandbytes datasets accelerate loralib\n",
+    "!pip install -q bitsandbytes datasets accelerate\n",
     "!pip install -q git+https://github.com/huggingface/transformers.git@main git+https://github.com/huggingface/peft.git@main"
    ]
   },

--- a/examples/lora_dreambooth/requirements.txt
+++ b/examples/lora_dreambooth/requirements.txt
@@ -1,6 +1,5 @@
 transformers
 accelerate
-loralib
 evaluate
 tqdm
 datasets

--- a/examples/semantic_segmentation/semantic_segmentation_peft_lora.ipynb
+++ b/examples/semantic_segmentation/semantic_segmentation_peft_lora.ipynb
@@ -38,7 +38,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install transformers accelerate evaluate datasets loralib git+https://github.com/huggingface/peft -q"
+    "!pip install transformers accelerate evaluate datasets git+https://github.com/huggingface/peft -q"
    ]
   },
   {

--- a/examples/sequence_classification/requirements.txt
+++ b/examples/sequence_classification/requirements.txt
@@ -1,6 +1,5 @@
 transformers
 accelerate
-loralib
 evaluate
 tqdm
 datasets

--- a/examples/token_classification/requirements.txt
+++ b/examples/token_classification/requirements.txt
@@ -1,6 +1,5 @@
 transformers
 accelerate
-loralib
 evaluate
 tqdm
 datasets


### PR DESCRIPTION
- As discussed, `loralib` is no longer required, so the examples from the docs have been updated to no longer require `loralib` as dependencies
- In one example, a missing `torch` import was added
- In another example, a missing line was added (output of that line is shown, but not the line itself)

Note: Some diffs that GH shows look spurious to me, as there was no change there. Not sure what is going on.