### PR TITLE
Add pytest-cov for reporting test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # cpu version of pytorch
-          pip install .[test]
+          pip install -e .[test]
       - name: Test with pytest
         run: |
           make test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,6 @@ doctest_optionflags = [
     "ELLIPSIS",
     "NUMBER",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--cov=src/peft --cov-report=term-missing"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras = {}
 extras["quality"] = ["black ~= 22.0", "ruff>=0.0.241", "urllib3<=2.0.0"]
 extras["docs_specific"] = ["hf-doc-builder"]
 extras["dev"] = extras["quality"] + extras["docs_specific"]
-extras["test"] = extras["dev"] + ["pytest", "pytest-xdist", "parameterized", "datasets", "diffusers"]
+extras["test"] = extras["dev"] + ["pytest", "pytest-cov", "pytest-xdist", "parameterized", "datasets", "diffusers"]
 
 setup(
     name="peft",


### PR DESCRIPTION
As discussed, this adds line coverage to the tests. This will allow us to identify parts of the code that are missing coverage and make it easier to ensure newly added code is well covered.

At the moment, CI is not set up to report if new, uncovered code is being added. We could add codecov to the CI to get this functionality, but having 100% coverage for new code is not always desired, so it's debatable if it is needed.

Right now, there are multiple test commands (normal, single, multi GPU). For each individual command, the coverage report would only include the lines covered by that command, so the total coverage would be underreported. It is possible to [combine multiple coverage reports into a single report](https://coverage.readthedocs.io/en/stable/cmd.html#cmd-combine). However, I'm not sure if/how we can make this work, since the different commands are run by different actions, thus don't share the same environment.

Before merging, we should check if there is a slowdown in how fast the tests run. **Edit**: I compared the runtimes to those from #640 and there is no systematic change in the speed of the tests.

For devs: After merging the PR, you would have to `pip install pytest-cov` to run the tests locally.