### PR TITLE
Fix `PeftModel.disable_adapter`

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -368,14 +368,14 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         Disables the adapter module.
         """
         try:
-            if isinstance(self.peft_config, PromptLearningConfig):
+            if isinstance(self.peft_config[self.active_adapter], PromptLearningConfig):
                 old_forward = self.forward
                 self.forward = self.base_model.forward
             else:
                 self.base_model.disable_adapter_layers()
             yield
         finally:
-            if isinstance(self.peft_config, PromptLearningConfig):
+            if isinstance(self.peft_config[self.active_adapter], PromptLearningConfig):
                 self.forward = old_forward
             else:
                 self.base_model.enable_adapter_layers()


### PR DESCRIPTION
According to the init method, `self.peft_config` is always a dict. It'll be something like `{"default": PeftConfig Instance}`.
https://github.com/huggingface/peft/blob/f5352f08c593503a442f4438e1c7e648377b6a4b/src/peft/peft_model.py#L97-L113

Therefore, existing `disable_adapter` method is checking the wrong item. It should check `self.peft_config["default"]` instead of `self.peft_config`
https://github.com/huggingface/peft/blob/f5352f08c593503a442f4438e1c7e648377b6a4b/src/peft/peft_model.py#L366-L381