### PR TITLE
Require Python version >= 3.8

### DIFF
--- a/docs/source/install.mdx
+++ b/docs/source/install.mdx
@@ -12,13 +12,13 @@ specific language governing permissions and limitations under the License.
 
 # Installation
 
-Before you start, you will need to setup your environment, install the appropriate packages, and configure 🤗 PEFT. 🤗 PEFT is tested on **Python 3.7+**.
+Before you start, you will need to setup your environment, install the appropriate packages, and configure 🤗 PEFT. 🤗 PEFT is tested on **Python 3.8+**.
 
-🤗 PEFT is available on pypi, as well as GitHub:
+🤗 PEFT is available on PyPI, as well as GitHub:
 
-## pip 
+## PyPI
 
-To install 🤗 PEFT from pypi:
+To install 🤗 PEFT from PyPI:
 
 ```bash
 pip install peft

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     entry_points={},
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     install_requires=[
         "numpy>=1.17",
         "packaging>=20.0",
@@ -55,7 +55,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
 )


### PR DESCRIPTION
I would suggest to drop support for Python 3.7. It is end-of-life since yesterday and wasn't tested in CI anyway. If you feel like we should not require 3.8+, feel free to close the PR.

Again, the diff view from GH shows spurious changes. Seems to be an issue with mdx?