### PR TITLE
Proposal: Use more of pytest features

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,7 +40,7 @@ ALL_CONFIG_CLASSES = (
 class TestPeftConfig:
     @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
     def test_methods_exist(self, config_class):
-        r""" Test if all configs have the expected methods. Here we test """
+        r"""Test if all configs have the expected methods. Here we test"""
         config = config_class()
         methods_expected = ["to_dict", "save_pretrained", "from_pretrained", "from_json_file"]
         for method in methods_expected:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import tempfile
-import unittest
+
+import pytest
 
 from peft import (
     AdaptionPromptConfig,
@@ -26,110 +26,97 @@ from peft import (
 )
 
 
-PEFT_MODELS_TO_TEST = [("lewtun/tiny-random-OPTForCausalLM-delta", "v1")]
+# list of (model_id, revision)
+ALL_MODELS = [("lewtun/tiny-random-OPTForCausalLM-delta", "v1")]
+ALL_CONFIG_CLASSES = (
+    LoraConfig,
+    PromptEncoderConfig,
+    PrefixTuningConfig,
+    PromptTuningConfig,
+    AdaptionPromptConfig,
+)
 
 
-class PeftConfigTestMixin:
-    all_config_classes = (
-        LoraConfig,
-        PromptEncoderConfig,
-        PrefixTuningConfig,
-        PromptTuningConfig,
-        AdaptionPromptConfig,
-    )
+class TestPeftConfig:
+    @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
+    def test_methods_exist(self, config_class):
+        r""" Test if all configs have the expected methods. Here we test """
+        config = config_class()
+        methods_expected = ["to_dict", "save_pretrained", "from_pretrained", "from_json_file"]
+        for method in methods_expected:
+            assert hasattr(config, method)
 
+    @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
+    def test_task_type(self, config_class):
+        # assert this will not fail
+        config_class(task_type="test")
 
-class PeftConfigTester(unittest.TestCase, PeftConfigTestMixin):
-    def test_methods(self):
-        r"""
-        Test if all configs have the expected methods. Here we test
-        - to_dict
-        - save_pretrained
-        - from_pretrained
-        - from_json_file
-        """
-        # test if all configs have the expected methods
-        for config_class in self.all_config_classes:
-            config = config_class()
-            self.assertTrue(hasattr(config, "to_dict"))
-            self.assertTrue(hasattr(config, "save_pretrained"))
-            self.assertTrue(hasattr(config, "from_pretrained"))
-            self.assertTrue(hasattr(config, "from_json_file"))
-
-    def test_task_type(self):
-        for config_class in self.all_config_classes:
-            # assert this will not fail
-            _ = config_class(task_type="test")
-
-    def test_from_pretrained(self):
+    @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
+    @pytest.mark.parametrize("peft_model", ALL_MODELS)
+    def test_from_pretrained(self, config_class, peft_model):
         r"""
         Test if the config is correctly loaded using:
         - from_pretrained
         """
-        for config_class in self.all_config_classes:
-            for model_name, revision in PEFT_MODELS_TO_TEST:
-                # Test we can load config from delta
-                _ = config_class.from_pretrained(model_name, revision=revision)
+        model_name, revision = peft_model
+        # Test we can load config from delta
+        config_class.from_pretrained(model_name, revision=revision)
 
-    def test_save_pretrained(self):
+    @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
+    def test_save_pretrained(self, config_class, tmp_path):
         r"""
         Test if the config is correctly saved and loaded using
         - save_pretrained
         """
-        for config_class in self.all_config_classes:
-            config = config_class()
-            with tempfile.TemporaryDirectory() as tmp_dirname:
-                config.save_pretrained(tmp_dirname)
+        config = config_class()
+        config.save_pretrained(tmp_path)
 
-                config_from_pretrained = config_class.from_pretrained(tmp_dirname)
-                self.assertEqual(config.to_dict(), config_from_pretrained.to_dict())
+        config_from_pretrained = config_class.from_pretrained(tmp_path)
+        assert config.to_dict() == config_from_pretrained.to_dict()
 
-    def test_from_json_file(self):
-        for config_class in self.all_config_classes:
-            config = config_class()
-            with tempfile.TemporaryDirectory() as tmp_dirname:
-                config.save_pretrained(tmp_dirname)
+    @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
+    def test_from_json_file(self, config_class, tmp_path):
+        config = config_class()
+        config.save_pretrained(tmp_path)
 
-                config_from_json = config_class.from_json_file(os.path.join(tmp_dirname, "adapter_config.json"))
-                self.assertEqual(config.to_dict(), config_from_json)
+        config_from_json = config_class.from_json_file(tmp_path / "adapter_config.json")
+        assert config.to_dict() == config_from_json
 
-    def test_to_dict(self):
+    @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
+    def test_to_dict(self, config_class):
         r"""
         Test if the config can be correctly converted to a dict using:
         - to_dict
         - __dict__
         """
-        for config_class in self.all_config_classes:
-            config = config_class()
-            self.assertEqual(config.to_dict(), config.__dict__)
-            self.assertTrue(isinstance(config.to_dict(), dict))
+        config = config_class()
+        assert config.to_dict() == config.__dict__
+        assert isinstance(config.to_dict(), dict)
 
-    def test_from_pretrained_cache_dir(self):
+    @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
+    @pytest.mark.parametrize("peft_model", ALL_MODELS)
+    def test_from_pretrained_cache_dir(self, config_class, peft_model, tmp_path):
         r"""
         Test if the config is correctly loaded with extra kwargs
         """
-        with tempfile.TemporaryDirectory() as tmp_dirname:
-            for config_class in self.all_config_classes:
-                for model_name, revision in PEFT_MODELS_TO_TEST:
-                    # Test we can load config from delta
-                    _ = config_class.from_pretrained(model_name, revision=revision, cache_dir=tmp_dirname)
+        model_name, revision = peft_model
+        # Test we can load config from delta
+        config_class.from_pretrained(model_name, revision=revision, cache_dir=tmp_path)
 
-    def test_from_pretrained_cache_dir_remote(self):
+    def test_from_pretrained_cache_dir_remote(self, tmp_path):
         r"""
         Test if the config is correctly loaded with a checkpoint from the hub
         """
-        with tempfile.TemporaryDirectory() as tmp_dirname:
-            _ = PeftConfig.from_pretrained("ybelkada/test-st-lora", cache_dir=tmp_dirname)
-            self.assertTrue("models--ybelkada--test-st-lora" in os.listdir(tmp_dirname))
+        PeftConfig.from_pretrained("ybelkada/test-st-lora", cache_dir=tmp_path)
+        assert "models--ybelkada--test-st-lora" in os.listdir(tmp_path)
 
-    def test_set_attributes(self):
+    @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
+    def test_set_attributes(self, config_class, tmp_path):
         # manually set attributes and check if they are correctly written
-        for config_class in self.all_config_classes:
-            config = config_class(peft_type="test")
+        config = config_class(peft_type="test")
 
-            # save pretrained
-            with tempfile.TemporaryDirectory() as tmp_dirname:
-                config.save_pretrained(tmp_dirname)
+        # save pretrained
+        config.save_pretrained(tmp_path)
 
-                config_from_pretrained = config_class.from_pretrained(tmp_dirname)
-                self.assertEqual(config.to_dict(), config_from_pretrained.to_dict())
+        config_from_pretrained = config_class.from_pretrained(tmp_path)
+        assert config.to_dict() == config_from_pretrained.to_dict()


### PR DESCRIPTION
As discussed in our meeting, I wanted to propose to use more pytest features for testing instead of relying on unittest.

To demonstrate the changes, I rewrote `test_config.py` (took only ~30 min). As you can see (side-by-side view is best), there are no substantial changes, the core logic is exactly the same. Test coverage is also 100% identical. But there are a few advantages:

- Using `pytest.mark.parametrize` instead of looping in the tests leads to less nesting
- Also, so far, if the first element in the loop fails, the next test cases are not tested, but with `parametrize`, they are still tested because they are separate tests
- Allows to use simple `assert a == b`, instead of `self.assertEqual(a, b)` etc.
- Use pytest fixture `tmp_path` instead of `TemporaryDirectory` to save a few keystrokes and nesting

Some of the more useful features of pytest, such as writing fixtures, are not even used here.

Regarding ease of use for outside contributors, I think it's a draw, some things are easier, some require a bit of pytest knowledge to understand. At least according to Google trends, pytest seems to be more popular than unittest, though, so I would expect more contributors to have existing knowledge of pytest.

My proposal would be to make use of more of the pytest features from here on out. I'm *not* proposing to do a complete rewrite just for the sake of rewriting. Instead, when the tests are being worked on (e.g. the items from the roadmap), we can add more pytest features bit by bit.

Let me know what you think.

*google trends on pytest vs unittest*

![image](https://github.com/huggingface/peft/assets/6229650/c595926d-e308-4097-aa55-a8ee600199ce)