### PR TITLE
FIX: bug resulting in config copies not working

### DIFF
--- a/src/peft/utils/config.py
+++ b/src/peft/utils/config.py
@@ -55,12 +55,8 @@ class PeftConfigMixin(PushToHubMixin):
     """
     peft_type: Optional[PeftType] = field(default=None, metadata={"help": "The type of PEFT model."})
 
-    @property
-    def __dict__(self):
-        return asdict(self)
-
     def to_dict(self):
-        return self.__dict__
+        return asdict(self)
 
     def save_pretrained(self, save_directory, **kwargs):
         r"""
@@ -78,7 +74,7 @@ class PeftConfigMixin(PushToHubMixin):
 
         os.makedirs(save_directory, exist_ok=True)
 
-        output_dict = self.__dict__
+        output_dict = asdict(self)
         output_path = os.path.join(save_directory, CONFIG_NAME)
 
         # save it

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import copy
 import os
+import pickle
 import tempfile
 import unittest
 
@@ -97,11 +99,9 @@ class PeftConfigTester(unittest.TestCase, PeftConfigTestMixin):
         r"""
         Test if the config can be correctly converted to a dict using:
         - to_dict
-        - __dict__
         """
         for config_class in self.all_config_classes:
             config = config_class()
-            self.assertEqual(config.to_dict(), config.__dict__)
             self.assertTrue(isinstance(config.to_dict(), dict))
 
     def test_from_pretrained_cache_dir(self):
@@ -133,3 +133,24 @@ class PeftConfigTester(unittest.TestCase, PeftConfigTestMixin):
 
                 config_from_pretrained = config_class.from_pretrained(tmp_dirname)
                 self.assertEqual(config.to_dict(), config_from_pretrained.to_dict())
+
+    def test_config_copy(self):
+        # see https://github.com/huggingface/peft/issues/424
+        for config_class in self.all_config_classes:
+            config = config_class()
+            copied = copy.copy(config)
+            self.assertEqual(config.to_dict(), copied.to_dict())
+
+    def test_config_deepcopy(self):
+        # see https://github.com/huggingface/peft/issues/424
+        for config_class in self.all_config_classes:
+            config = config_class()
+            copied = copy.deepcopy(config)
+            self.assertEqual(config.to_dict(), copied.to_dict())
+
+    def test_config_pickle_roundtrip(self):
+        # see https://github.com/huggingface/peft/issues/424
+        for config_class in self.all_config_classes:
+            config = config_class()
+            copied = pickle.loads(pickle.dumps(config))
+            self.assertEqual(config.to_dict(), copied.to_dict())


### PR DESCRIPTION
Resolves #424

The bug was caused by `__dict__` being overwritten to return a copy of the `dataclass` as dict. This can lead to unpredictable behavior, as shown in the issue. This fix removes the `__dict__` property and preservers the original behavior where needed.

All three added tests would fail without the fix.