### PR TITLE
Fixed LoraConfig alpha modification on add_weighted_adapter

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -15,7 +15,7 @@
 import math
 import re
 import warnings
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
@@ -450,8 +450,9 @@ class LoraModel(torch.nn.Module):
     def add_weighted_adapter(self, adapters, weights, adapter_name):
         if len({self.peft_config[adapter].r for adapter in adapters}) != 1:
             raise ValueError("All adapters must have the same r value")
-        self.peft_config[adapter_name] = self.peft_config[adapters[0]]
-        self.peft_config[adapter_name].lora_alpha = self.peft_config[adapters[0]].r
+        self.peft_config[adapter_name] = replace(
+            self.peft_config[adapters[0]], lora_alpha=self.peft_config[adapters[0]].r
+        )
         self._find_and_replace(adapter_name)
         mark_only_lora_as_trainable(self.model, self.peft_config[adapter_name].bias)
         _freeze_adapter(self.model, adapter_name)

--- a/tests/test_stablediffusion.py
+++ b/tests/test_stablediffusion.py
@@ -115,7 +115,6 @@ class StableDiffusionModelTester(TestCase, PeftCommonTester):
         # Images are in uint8 drange, so use large atol
         self.assertTrue(np.allclose(peft_output, merged_output, atol=1.0))
 
-
     @parameterized.expand(
         PeftStableDiffusionTestConfigManager.get_grid_parameters(
             {
@@ -139,5 +138,7 @@ class StableDiffusionModelTester(TestCase, PeftCommonTester):
         model.unet.add_weighted_adapter([unet_adapter_name], [0.5], "weighted_adapter_test")
 
         # Assert that base adapters config did not change
-        self.assertTrue(asdict(text_encoder_adapter_config) == asdict(model.text_encoder.peft_config[text_encoder_adapter_name]))        
-        self.assertTrue(asdict(unet_adapter_config) == asdict(model.unet.peft_config[unet_adapter_name]))        
+        self.assertTrue(
+            asdict(text_encoder_adapter_config) == asdict(model.text_encoder.peft_config[text_encoder_adapter_name])
+        )
+        self.assertTrue(asdict(unet_adapter_config) == asdict(model.unet.peft_config[unet_adapter_name]))


### PR DESCRIPTION
Hi!

Currently adding a weighted adapter rewrites base lora alpha value like this:

```python
import torch
from diffusers import StableDiffusionPipeline
from peft import get_peft_model
from peft.tuners.lora import LoraConfig

pipe = StableDiffusionPipeline.from_pretrained(
    "runwayml/stable-diffusion-v1-5",
    torch_dtype=torch.float16
).to("cuda")

config = LoraConfig(
    r=8,
    lora_alpha=32,
    target_modules=["to_q"]
)

pipe.unet = get_peft_model(pipe.unet, config)

print(pipe.unet.peft_config)
# {'default': LoraConfig(
# peft_type=<PeftType.LORA: 'LORA'>, base_model_name_or_path=None,
# revision=None, task_type=None, inference_mode=False, r=8, target_modules=['to_q']
# lora_alpha=32, lora_dropout=0.0, fan_in_fan_out=False, bias='none', modules_to_save=None,
# init_lora_weights=True, layers_to_transform=None, layers_pattern=None)}

pipe.unet.add_weighted_adapter(["default"], [0.5], "default_05")
print(pipe.unet.peft_config)
# {'default': LoraConfig(
# peft_type=<PeftType.LORA: 'LORA'>, base_model_name_or_path=None,
# revision=None, task_type=None, inference_mode=False, r=8, target_modules=['to_q'],
# lora_alpha=8, lora_dropout=0.0, fan_in_fan_out=False, bias='none', modules_to_save=None,
# init_lora_weights=True, layers_to_transform=None, layers_pattern=None),
# 'default_05': LoraConfig(
# peft_type=<PeftType.LORA: 'LORA'>, base_model_name_or_path=None,
# revision=None, task_type=None, inference_mode=False, r=8, target_modules=['to_q'],
# lora_alpha=8, lora_dropout=0.0, fan_in_fan_out=False, bias='none', modules_to_save=None,
# init_lora_weights=True, layers_to_transform=None, layers_pattern=None)}
```

This PR just fixes this small issue.

@pacman100 your review is kindly appreciated.