### PR TITLE
Combining coverage reports

### DIFF
--- a/.github/workflows/testing-combined-coverage.yml
+++ b/.github/workflows/testing-combined-coverage.yml
@@ -1,9 +1,9 @@
 name: testing combining cov reports
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "*/20 * * * *"
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/testing-combined-coverage.yml
+++ b/.github/workflows/testing-combined-coverage.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -e .[test]
       - name: Test with pytest
         run: |
-          python -m pytest tests/test_config.py $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
+          python -m pytest tests/test_config.py
 
       - name: Disambiguate coverage filename
         run: mv .coverage ".coverage-config_${{ matrix.os }}_${{ matrix.python-version }}"
@@ -60,7 +60,7 @@ jobs:
           pip install -e .[test]
       - name: Test with pytest
         run: |
-          python -m pytest tests/test_stablediffusion.py $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
+          python -m pytest tests/test_stablediffusion.py
 
       - name: Disambiguate coverage filename
         run: mv .coverage ".coverage-stablediffusion_${{ matrix.os }}_${{ matrix.python-version }}"

--- a/.github/workflows/testing-combined-coverage.yml
+++ b/.github/workflows/testing-combined-coverage.yml
@@ -31,12 +31,14 @@ jobs:
           python -m pytest tests/test_config.py
 
       - name: Disambiguate coverage filename
-        run: mv .coverage ".coverage-config_${{ matrix.os }}_${{ matrix.python-version }}"
+        run: |
+          mv .coverage ".coverage-config_${{ matrix.os }}_${{ matrix.python-version }}"
+          ls -la .coverage*
       - name: Upload coverage data
         uses: actions/upload-artifact@v3
         with:
           name: coverage-data
-          path: .coverage.*
+          path: ".coverage-config_${{ matrix.os }}_${{ matrix.python-version }}"
 
   tests-stablediffusion:
     strategy:
@@ -63,12 +65,14 @@ jobs:
           python -m pytest tests/test_stablediffusion.py
 
       - name: Disambiguate coverage filename
-        run: mv .coverage ".coverage-stablediffusion_${{ matrix.os }}_${{ matrix.python-version }}"
+        run: |
+          mv .coverage ".coverage-stablediffusion_${{ matrix.os }}_${{ matrix.python-version }}"
+          ls -la .coverage*
       - name: Upload coverage data
         uses: actions/upload-artifact@v3
         with:
           name: coverage-data
-          path: .coverage.*
+          path: ".coverage-stablediffusion_${{ matrix.os }}_${{ matrix.python-version }}"
 
   coverage:
     # adopted from https://github.com/bentoml/OpenLLM/blob/77cb8516b6c19ce059b6e1baf7594e01d9a8dc60/.github/workflows/ci.yml#L32
@@ -97,7 +101,9 @@ jobs:
         with:
           name: coverage-data
       - name: Combine coverage data
-        run: coverage combine .coverage-*
+        run: |
+          ls -la .coverage*
+          coverage combine .coverage*
 
       - name: Export coverage reports
         run: |

--- a/.github/workflows/testing-combined-coverage.yml
+++ b/.github/workflows/testing-combined-coverage.yml
@@ -2,7 +2,6 @@ name: testing combining cov reports
 
 on:
   push:
-    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/testing-combined-coverage.yml
+++ b/.github/workflows/testing-combined-coverage.yml
@@ -1,0 +1,116 @@
+name: testing combining cov reports
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "*/20 * * * *"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+
+  tests-config:
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+        os: ["ubuntu-latest", "macos-latest"]
+    runs-on: ${{ matrix.os }}
+    name: tests-config-${{ matrix.os }}-${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # cpu version of pytorch
+          pip install -e .[test]
+      - name: Test with pytest
+        run: |
+          python -m pytest tests/test_config.py $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
+
+      - name: Disambiguate coverage filename
+        run: mv .coverage ".coverage-config_${{ matrix.os }}_${{ matrix.python-version }}"
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
+
+  tests-stablediffusion:
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10"]
+        os: ["ubuntu-latest", "macos-latest"]
+    runs-on: ${{ matrix.os }}
+    name: tests-stablediffusion-${{ matrix.os }}-${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # cpu version of pytorch
+          pip install -e .[test]
+      - name: Test with pytest
+        run: |
+          python -m pytest tests/test_stablediffusion.py $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
+
+      - name: Disambiguate coverage filename
+        run: mv .coverage ".coverage-stablediffusion_${{ matrix.os }}_${{ matrix.python-version }}"
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
+
+  coverage:
+    # adopted from https://github.com/bentoml/OpenLLM/blob/77cb8516b6c19ce059b6e1baf7594e01d9a8dc60/.github/workflows/ci.yml#L32
+    name: report-coverage
+    runs-on: ubuntu-latest
+    needs:
+      - tests-config
+      - tests-stablediffusion
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pytest-cov
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-data
+      - name: Combine coverage data
+        run: coverage combine .coverage-*
+
+      - name: Export coverage reports
+        run: |
+          coverage html --skip-covered --skip-empty
+
+      - name: Upload uncovered HTML report
+        uses: actions/upload-artifact@v3
+        with:
+          name: uncovered-html-report
+          path: htmlcov

--- a/.github/workflows/testing-combined-coverage.yml
+++ b/.github/workflows/testing-combined-coverage.yml
@@ -102,7 +102,6 @@ jobs:
           name: coverage-data
       - name: Combine coverage data
         run: |
-          ls -la .coverage*
           coverage combine .coverage*
 
       - name: Export coverage reports

--- a/.github/workflows/testing-combined-coverage.yml
+++ b/.github/workflows/testing-combined-coverage.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-cov
+          python -m pip install -e .[test]
 
       - name: Download coverage data
         uses: actions/download-artifact@v3

--- a/.github/workflows/testing-combined-coverage.yml
+++ b/.github/workflows/testing-combined-coverage.yml
@@ -5,11 +5,6 @@ on:
   schedule:
     - cron: "*/20 * * * *"
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-
 jobs:
 
   tests-config:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: tests
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: tests
 
 on:
   push:
-    branches: [main]
   pull_request:
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,6 @@ addopts = "--cov=src/peft --cov-report=term-missing"
 [tool.coverage.paths]
 source = [
     "src/peft/",
-    "*/site-packages"
+    "*/site-packages",
     "*/src/peft",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,10 @@ doctest_optionflags = [
 
 [tool.pytest.ini_options]
 addopts = "--cov=src/peft --cov-report=term-missing"
+
+[tool.coverage.paths]
+source = [
+    "src/peft/",
+    "*/site-packages"
+    "*/src/peft",
+]


### PR DESCRIPTION
As discussed in #634, we want to combine coverage reports for all tests to get a complete picture of the line coverage of the code base.

To test this, I didn't want to run the expensive GPU tests (which will probably not run on my fork anyway). Instead, I ran the normal tests, once for `test_config.py` and once for `test_stablediffusion.py`, and combined their reports. After a bit of tinkering, I got it to work.

The combined report can be downloaded [here](https://github.com/BenjaminBossan/peft/actions/runs/5423885728) by clicking on `uncovered-html-report`. From the downloaded zip file, open `index.html` and it should look like this:

![image](https://github.com/huggingface/peft/assets/6229650/df8cbe8f-5382-4a87-a0dd-42bb3bdece21)

Before continuing, I wanted to collect the feedback from @pacman100 and @younesbelkada on how to proceed. My suggestion:

1. Create a new PR (this one is just for demo purposes) 
2. Add the normal tests to the nightly run
3. Add job to combine and upload the reports from normal + GPU runs
4. Make the run trigger on push so that we don't have to wait 1 day for feedback (or would that be too expensive?)
5. Do something useful with the coverage report
6. Once everything passes, remove the push trigger, going back to just cron

Regarding point 5, downloading the report and inspecting it is somewhat cumbersome. What can we do to present it in a more useful fashion? Can it be uploaded to slack? Maybe @aarnphm can give some hints about how they do it.
