### PR TITLE
Typo in clm-prompt-tuning.mdx

### DIFF
--- a/docs/source/task_guides/clm-prompt-tuning.mdx
+++ b/docs/source/task_guides/clm-prompt-tuning.mdx
@@ -159,7 +159,7 @@ Create a [`DataLoader`](https://pytorch.org/docs/stable/data.html#torch.utils.da
 
 ```py
 train_dataset = processed_datasets["train"]
-eval_dataset = processed_datasets["train"]
+eval_dataset = processed_datasets["test"]
 
 
 train_dataloader = DataLoader(


### PR DESCRIPTION
A typo sets train_dataset and eval_dataset to the same split. "train_dataset = processed_datasets["train"]
eval_dataset = processed_datasets["train"]"
Might be confusing in the guide. The evaluation split is called "test".