### PR TITLE
Adding support for RoBERTa layers_transform in COMMON_LAYERS_PATTERN

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -241,7 +241,7 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "mpt": ["Wqkv"],
 }
 
-COMMON_LAYERS_PATTERN = ["layers", "h", "block", "blocks", 'layer']
+COMMON_LAYERS_PATTERN = ["layers", "h", "block", "blocks", "layer"]
 
 TRANSFORMERS_MODELS_TO_ADALORA_TARGET_MODULES_MAPPING = {
     "t5": ["q", "k", "v", "o", "wi", "wo"],

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -241,7 +241,7 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "mpt": ["Wqkv"],
 }
 
-COMMON_LAYERS_PATTERN = ["layers", "h", "block", "blocks"]
+COMMON_LAYERS_PATTERN = ["layers", "h", "block", "blocks", 'layer']
 
 TRANSFORMERS_MODELS_TO_ADALORA_TARGET_MODULES_MAPPING = {
     "t5": ["q", "k", "v", "o", "wi", "wo"],


### PR DESCRIPTION
### Description

This pull request aims to enhance the `COMMON_LAYERS_PATTERN` in order to support RoBERTa's `layers_transform` feature. Currently, the key format for RoBERTa layers is as follows: `roberta.encoder.layer.0.attention.self.query`. By adding the term 'layer' to the `COMMON_LAYERS_PATTERN`, we ensure compatibility and enable the transformation of RoBERTa layers.

### Changes Made

- Updated the `COMMON_LAYERS_PATTERN` by including the term 'layer' to accommodate RoBERTa's key format.
