### PR TITLE
FIX: Embedding LoRA weights are initialized randomly

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -90,7 +90,12 @@ class LoraConfig(PeftConfig):
     )
     init_lora_weights: bool = field(
         default=True,
-        metadata={"help": "Whether to initialize the weights of the Lora layers."},
+        metadata={
+            "help": (
+                "Whether to initialize the weights of the Lora layers with their default initialization. Don't change "
+                "this setting, except if you know exactly what you're doing."
+            ),
+        },
     )
     layers_to_transform: Optional[Union[List, int]] = field(
         default=None,
@@ -596,12 +601,10 @@ class LoraLayer:
         self.lora_dropout.update(nn.ModuleDict({adapter_name: lora_dropout_layer}))
         # Actual trainable parameters
         if r > 0:
-            self.lora_embedding_A.update(
-                nn.ParameterDict({adapter_name: nn.Parameter(self.weight.new_zeros((r, self.in_features)))})
-            )
-            self.lora_embedding_B.update(
-                nn.ParameterDict({adapter_name: nn.Parameter(self.weight.new_zeros((self.out_features, r)))})
-            )
+            weight_A = torch.randn((r, self.in_features), dtype=self.weight.dtype, device=self.weight.device)
+            weight_B = torch.randn((self.out_features, r), dtype=self.weight.dtype, device=self.weight.device)
+            self.lora_embedding_A.update(nn.ParameterDict({adapter_name: nn.Parameter(weight_A)}))
+            self.lora_embedding_B.update(nn.ParameterDict({adapter_name: nn.Parameter(weight_B)}))
             self.scaling[adapter_name] = lora_alpha / r
         if init_lora_weights:
             self.reset_lora_parameters(adapter_name)


### PR DESCRIPTION
As discussed internally.

When `init_lora_weights=False`, embedding LoRA weights were initialized as all zeros, resulting in LoRA becoming an identity transform. This is inconsistent with other module types, where `init_lora_weights=False` results in random initialization and thus a non-identity operation.

As `init_lora_weights=False` is just for internal testing, users should not be affected by this change. In fact, I updated the doc of this parameter to - hopefully - better reflect this.

There is no direct test for this change. However, there are tests in #676 that will fail without this fix, so it is tested indirectly.