### PR TITLE
Fix broken docker images

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -42,7 +42,7 @@ RUN source activate peft && \
 RUN python3 -m pip install --no-cache-dir bitsandbytes
 
 # Stage 2
-FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image
+FROM nvidia/cuda:11.3.1-devel-ubuntu20.04 AS build-image
 COPY --from=compile-image /opt/conda /opt/conda
 ENV PATH /opt/conda/bin:$PATH
 


### PR DESCRIPTION
The new release of bitsandbytes dropped the support for CUDA 11.2 and 11.6: https://github.com/TimDettmers/bitsandbytes/commit/ae7cd6ad147e67c3d5c4a681ef573c92fc5dd9de 
The nightly runner having cuda 11.6 installed as discussed internally let's use the cuda11.3 image on our docker images 

cc @BenjaminBossan @pacman100 

Can confirm the import of bitsandbytes works at least as expected with this new image