### PR TITLE
[`Feature`] Save only selected adapters for LoRA

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -35,7 +35,7 @@ from .tuners import (
     PromptEncoderConfig,
     PromptTuningConfig,
 )
-from .utils import PromptLearningConfig
+from .utils import PromptLearningConfig, _prepare_prompt_learning_config
 
 
 if TYPE_CHECKING:
@@ -73,48 +73,6 @@ def get_peft_config(config_dict: Dict[str, Any]):
     """
 
     return PEFT_TYPE_TO_CONFIG_MAPPING[config_dict["peft_type"]](**config_dict)
-
-
-def _prepare_prompt_learning_config(peft_config: PeftConfig, model_config: Dict[str, Any]):
-    if peft_config.num_layers is None:
-        if "num_hidden_layers" in model_config:
-            num_layers = model_config["num_hidden_layers"]
-        elif "num_layers" in model_config:
-            num_layers = model_config["num_layers"]
-        elif "n_layer" in model_config:
-            num_layers = model_config["n_layer"]
-        else:
-            raise ValueError("Please specify `num_layers` in `peft_config`")
-        peft_config.num_layers = num_layers
-
-    if peft_config.token_dim is None:
-        if "hidden_size" in model_config:
-            token_dim = model_config["hidden_size"]
-        elif "n_embd" in model_config:
-            token_dim = model_config["n_embd"]
-        elif "d_model" in model_config:
-            token_dim = model_config["d_model"]
-        else:
-            raise ValueError("Please specify `token_dim` in `peft_config`")
-        peft_config.token_dim = token_dim
-
-    if peft_config.num_attention_heads is None:
-        if "num_attention_heads" in model_config:
-            num_attention_heads = model_config["num_attention_heads"]
-        elif "n_head" in model_config:
-            num_attention_heads = model_config["n_head"]
-        elif "num_heads" in model_config:
-            num_attention_heads = model_config["num_heads"]
-        elif "encoder_attention_heads" in model_config:
-            num_attention_heads = model_config["encoder_attention_heads"]
-        else:
-            raise ValueError("Please specify `num_attention_heads` in `peft_config`")
-        peft_config.num_attention_heads = num_attention_heads
-
-    if getattr(peft_config, "encoder_hidden_size", None) is None:
-        setattr(peft_config, "encoder_hidden_size", peft_config.token_dim)
-
-    return peft_config
 
 
 def get_peft_model(model: PreTrainedModel, peft_config: PeftConfig, adapter_name: str = "default") -> PeftModel:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -145,7 +145,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         if selected_adapters is None:
             selected_adapters = list(self.peft_config.keys())
-        elif selected_adapters is not None:
+        else:
             if any(
                 selected_adapter_name not in list(self.peft_config.keys())
                 for selected_adapter_name in selected_adapters
@@ -155,8 +155,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     f" {list(self.peft_config.keys())} - got {selected_adapters}."
                 )
 
-        for adapter_name, peft_config in self.peft_config.items():
-            if adapter_name in selected_adapters:
+        for adapter_name in selected_adapters:
+            peft_config = self.peft_config[adapter_name]
                 # save only the trainable weights
                 output_state_dict = get_peft_model_state_dict(
                     self, state_dict=kwargs.get("state_dict", None), adapter_name=adapter_name

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -157,35 +157,33 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         for adapter_name in selected_adapters:
             peft_config = self.peft_config[adapter_name]
-                # save only the trainable weights
-                output_state_dict = get_peft_model_state_dict(
-                    self, state_dict=kwargs.get("state_dict", None), adapter_name=adapter_name
-                )
-                output_dir = (
-                    os.path.join(save_directory, adapter_name) if adapter_name != "default" else save_directory
-                )
-                os.makedirs(output_dir, exist_ok=True)
+            # save only the trainable weights
+            output_state_dict = get_peft_model_state_dict(
+                self, state_dict=kwargs.get("state_dict", None), adapter_name=adapter_name
+            )
+            output_dir = os.path.join(save_directory, adapter_name) if adapter_name != "default" else save_directory
+            os.makedirs(output_dir, exist_ok=True)
 
-                if safe_serialization:
-                    safe_save_file(
-                        output_state_dict,
-                        os.path.join(output_dir, SAFETENSORS_WEIGHTS_NAME),
-                        metadata={"format": "pt"},
-                    )
-                else:
-                    torch.save(output_state_dict, os.path.join(output_dir, WEIGHTS_NAME))
+            if safe_serialization:
+                safe_save_file(
+                    output_state_dict,
+                    os.path.join(output_dir, SAFETENSORS_WEIGHTS_NAME),
+                    metadata={"format": "pt"},
+                )
+            else:
+                torch.save(output_state_dict, os.path.join(output_dir, WEIGHTS_NAME))
 
-                # save the config and change the inference mode to `True`
-                if peft_config.base_model_name_or_path is None:
-                    peft_config.base_model_name_or_path = (
-                        self.base_model.__dict__.get("name_or_path", None)
-                        if isinstance(peft_config, PromptLearningConfig)
-                        else self.base_model.model.__dict__.get("name_or_path", None)
-                    )
-                inference_mode = peft_config.inference_mode
-                peft_config.inference_mode = True
-                peft_config.save_pretrained(output_dir)
-                peft_config.inference_mode = inference_mode
+            # save the config and change the inference mode to `True`
+            if peft_config.base_model_name_or_path is None:
+                peft_config.base_model_name_or_path = (
+                    self.base_model.__dict__.get("name_or_path", None)
+                    if isinstance(peft_config, PromptLearningConfig)
+                    else self.base_model.model.__dict__.get("name_or_path", None)
+                )
+            inference_mode = peft_config.inference_mode
+            peft_config.inference_mode = True
+            peft_config.save_pretrained(output_dir)
+            peft_config.inference_mode = inference_mode
 
     @classmethod
     def from_pretrained(

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -140,8 +140,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         """
         if os.path.isfile(save_directory):
             raise ValueError(f"Provided path ({save_directory}) should be a directory, not a file")
-        os.makedirs(save_directory, exist_ok=True)
-        self.create_or_update_model_card(save_directory)
 
         if selected_adapters is None:
             selected_adapters = list(self.peft_config.keys())
@@ -154,6 +152,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     f"You passed an invalid `selected_adapters` arguments, current supported adapter names are"
                     f" {list(self.peft_config.keys())} - got {selected_adapters}."
                 )
+
+        os.makedirs(save_directory, exist_ok=True)
+        self.create_or_update_model_card(save_directory)
 
         for adapter_name in selected_adapters:
             peft_config = self.peft_config[adapter_name]

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -144,6 +144,15 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         if selected_adapters is None:
             selected_adapters = list(self.peft_config.keys())
+        elif selected_adapters is not None:
+            if any(
+                selected_adapter_name not in list(self.peft_config.keys())
+                for selected_adapter_name in selected_adapters
+            ):
+                raise ValueError(
+                    f"You passed an invalid `selected_adapters` arguments, current supported adapter names are"
+                    f" {list(self.peft_config.keys())} - got {selected_adapters}."
+                )
 
         for adapter_name, peft_config in self.peft_config.items():
             if adapter_name in selected_adapters:

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -39,6 +39,7 @@ from .other import (
     _set_adapter,
     _freeze_adapter,
     ModulesToSaveWrapper,
+    _prepare_prompt_learning_config,
 )
 from .hub_utils import hub_file_exists
 from .save_and_load import get_peft_model_state_dict, set_peft_model_state_dict

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -178,6 +178,48 @@ def _set_adapter(model, adapter_name):
             module.active_adapter = adapter_name
 
 
+def _prepare_prompt_learning_config(peft_config, model_config):
+    if peft_config.num_layers is None:
+        if "num_hidden_layers" in model_config:
+            num_layers = model_config["num_hidden_layers"]
+        elif "num_layers" in model_config:
+            num_layers = model_config["num_layers"]
+        elif "n_layer" in model_config:
+            num_layers = model_config["n_layer"]
+        else:
+            raise ValueError("Please specify `num_layers` in `peft_config`")
+        peft_config.num_layers = num_layers
+
+    if peft_config.token_dim is None:
+        if "hidden_size" in model_config:
+            token_dim = model_config["hidden_size"]
+        elif "n_embd" in model_config:
+            token_dim = model_config["n_embd"]
+        elif "d_model" in model_config:
+            token_dim = model_config["d_model"]
+        else:
+            raise ValueError("Please specify `token_dim` in `peft_config`")
+        peft_config.token_dim = token_dim
+
+    if peft_config.num_attention_heads is None:
+        if "num_attention_heads" in model_config:
+            num_attention_heads = model_config["num_attention_heads"]
+        elif "n_head" in model_config:
+            num_attention_heads = model_config["n_head"]
+        elif "num_heads" in model_config:
+            num_attention_heads = model_config["num_heads"]
+        elif "encoder_attention_heads" in model_config:
+            num_attention_heads = model_config["encoder_attention_heads"]
+        else:
+            raise ValueError("Please specify `num_attention_heads` in `peft_config`")
+        peft_config.num_attention_heads = num_attention_heads
+
+    if getattr(peft_config, "encoder_hidden_size", None) is None:
+        setattr(peft_config, "encoder_hidden_size", peft_config.token_dim)
+
+    return peft_config
+
+
 def fsdp_auto_wrap_policy(model):
     import functools
     import os

--- a/tests/test_adaption_prompt.py
+++ b/tests/test_adaption_prompt.py
@@ -159,6 +159,56 @@ class AdaptionPromptTester(TestCase, PeftCommonTester):
             # check if `config.json` is not present
             self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "config.json")))
 
+    def test_save_pretrained_selected_adapters(self) -> None:
+        seed = 420
+        torch.manual_seed(seed)
+        model = LlamaForCausalLM(self._create_test_llama_config())
+        config = AdaptionPromptConfig(adapter_layers=2, adapter_len=4, task_type="CAUSAL_LM")
+        model = get_peft_model(model, config)
+        model = model.to(self.torch_device)
+
+        new_adapter_config = AdaptionPromptConfig(adapter_layers=2, adapter_len=4, task_type="CAUSAL_LM")
+        model.add_adapter("new_adapter", new_adapter_config)
+
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            model.save_pretrained(tmp_dirname)
+
+            torch.manual_seed(seed)
+            model_from_pretrained = LlamaForCausalLM(self._create_test_llama_config())
+            model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
+
+            model_from_pretrained.load_adapter(tmp_dirname, "new_adapter")
+
+            # check if the state dicts are equal
+            state_dict = get_peft_model_state_dict(model)
+            state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained)
+
+            # check if same keys
+            self.assertEqual(state_dict.keys(), state_dict_from_pretrained.keys())
+
+            # Check that the number of saved parameters is 4 -- 2 layers of (tokens and gate).
+            self.assertEqual(len(list(state_dict.keys())), 4)
+
+            # check if tensors equal
+            for key in state_dict.keys():
+                self.assertTrue(
+                    torch.allclose(
+                        state_dict[key].to(self.torch_device), state_dict_from_pretrained[key].to(self.torch_device)
+                    )
+                )
+
+            # check if `adapter_model.bin` is present
+            self.assertTrue(os.path.exists(os.path.join(tmp_dirname, "adapter_model.bin")))
+
+            # check if `adapter_config.json` is present
+            self.assertTrue(os.path.exists(os.path.join(tmp_dirname, "adapter_config.json")))
+
+            # check if `pytorch_model.bin` is not present
+            self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "pytorch_model.bin")))
+
+            # check if `config.json` is not present
+            self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "config.json")))
+
     def test_generate(self) -> None:
         model = LlamaForCausalLM(self._create_test_llama_config())
         config = AdaptionPromptConfig(adapter_layers=2, adapter_len=4, task_type="CAUSAL_LM")

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -82,6 +82,10 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
         self._test_save_pretrained(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_save_pretrained_selected_adapters(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_save_pretrained_selected_adapters(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_from_pretrained_config_construction(self, test_name, model_id, config_cls, config_kwargs):
         self._test_from_pretrained_config_construction(model_id, config_cls, config_kwargs)
 

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -68,6 +68,10 @@ class PeftEncoderDecoderModelTester(unittest.TestCase, PeftCommonTester):
         self._test_save_pretrained(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_save_pretrained_selected_adapters(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_save_pretrained_selected_adapters(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_from_pretrained_config_construction(self, test_name, model_id, config_cls, config_kwargs):
         self._test_from_pretrained_config_construction(model_id, config_cls, config_kwargs)
 

--- a/tests/test_feature_extraction_models.py
+++ b/tests/test_feature_extraction_models.py
@@ -85,6 +85,10 @@ class PeftFeatureExtractionModelTester(unittest.TestCase, PeftCommonTester):
         self._test_save_pretrained(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_save_pretrained_selected_adapters(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_save_pretrained_selected_adapters(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_from_pretrained_config_construction(self, test_name, model_id, config_cls, config_kwargs):
         self._test_from_pretrained_config_construction(model_id, config_cls, config_kwargs)
 

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -285,6 +285,8 @@ class PeftCommonTester:
             model_from_pretrained = self.transformers_class.from_pretrained(model_id)
             model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
 
+            model_from_pretrained.load_adapter(tmp_dirname, "new_adapter")
+
             # check if the state dicts are equal
             state_dict = get_peft_model_state_dict(model)
             state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained)

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -263,6 +263,66 @@ class PeftCommonTester:
             # check if `config.json` is not present
             self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "config.json")))
 
+    def _test_save_pretrained_selected_adapters(self, model_id, config_cls, config_kwargs):
+        if config_cls not in (LoraConfig,):
+            return
+
+        model = self.transformers_class.from_pretrained(model_id)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config)
+        model = model.to(self.torch_device)
+
+        new_adapter_config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model.add_adapter("new_adapter", new_adapter_config)
+
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            model.save_pretrained(tmp_dirname)
+
+            model_from_pretrained = self.transformers_class.from_pretrained(model_id)
+            model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
+
+            # check if the state dicts are equal
+            state_dict = get_peft_model_state_dict(model)
+            state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained)
+
+            # check if same keys
+            self.assertEqual(state_dict.keys(), state_dict_from_pretrained.keys())
+
+            # check if tensors equal
+            for key in state_dict.keys():
+                self.assertTrue(
+                    torch.allclose(
+                        state_dict[key].to(self.torch_device), state_dict_from_pretrained[key].to(self.torch_device)
+                    )
+                )
+
+            # check if `adapter_model.bin` is present
+            self.assertTrue(os.path.exists(os.path.join(tmp_dirname, "adapter_model.bin")))
+
+            # check if `adapter_config.json` is present
+            self.assertTrue(os.path.exists(os.path.join(tmp_dirname, "adapter_config.json")))
+
+            # check if `pytorch_model.bin` is not present
+            self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "pytorch_model.bin")))
+
+            # check if `config.json` is not present
+            self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "config.json")))
+
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            model.save_pretrained(tmp_dirname, selected_adapters=["default"])
+
+            model_from_pretrained = self.transformers_class.from_pretrained(model_id)
+            model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
+
+            self.assertTrue("default" in model_from_pretrained.peft_config.keys())
+            self.assertTrue("new_adapter" not in model_from_pretrained.peft_config.keys())
+
     def _test_from_pretrained_config_construction(self, model_id, config_cls, config_kwargs):
         model = self.transformers_class.from_pretrained(model_id)
         config = config_cls(base_model_name_or_path=model_id, **config_kwargs)

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -264,9 +264,6 @@ class PeftCommonTester:
             self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "config.json")))
 
     def _test_save_pretrained_selected_adapters(self, model_id, config_cls, config_kwargs):
-        if config_cls not in (LoraConfig,):
-            return
-
         model = self.transformers_class.from_pretrained(model_id)
         config = config_cls(
             base_model_name_or_path=model_id,
@@ -279,6 +276,7 @@ class PeftCommonTester:
             base_model_name_or_path=model_id,
             **config_kwargs,
         )
+
         model.add_adapter("new_adapter", new_adapter_config)
 
         with tempfile.TemporaryDirectory() as tmp_dirname:


### PR DESCRIPTION
Fixes https://github.com/huggingface/peft/issues/699

This PR enables users to save selected adapters for all supported PEFT models.

The current API is as follows:

```python
peft_model.save_pretrained(dir, selected_adapters=["default", "adapter_1"])
```

Of course, this PR is totally backward compatible, is `selected_adapters` is not passed, it will select all available adapters by default.

cc @BenjaminBossan @pacman100 