### PR TITLE
[`Auto`] Support `AutoPeftModel` for custom HF models

### DIFF
--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -120,7 +120,23 @@ If you have saved your adapter locally or on the Hub, you can leverage the `Auto
 + peft_model = AutoPeftModelForCausalLM.from_pretrained("ybelkada/opt-350m-lora")
 ```
 
-Currently, supported auto classes are: `AutoPeftModelForCausalLM`, `AutoPeftModelForSequenceClassification`, `AutoPeftModelForSeq2SeqLM`, `AutoPeftModelForTokenClassification`, `AutoPeftModelForQuestionAnswering` and `AutoPeftModelForFeatureExtraction`.
+Currently, supported auto classes are: `AutoPeftModelForCausalLM`, `AutoPeftModelForSequenceClassification`, `AutoPeftModelForSeq2SeqLM`, `AutoPeftModelForTokenClassification`, `AutoPeftModelForQuestionAnswering` and `AutoPeftModelForFeatureExtraction`. For other tasks (e.g. Whisper, StableDiffusion), you can load the model with:
+
+```diff
+- from peft import PeftModel, PeftConfig, AutoPeftModel
++ from peft import AutoPeftModel
+- from transformers import WhisperForConditionalGeneration
+
+- model_id = "smangrul/openai-whisper-large-v2-LORA-colab"
+
+peft_model_id = "smangrul/openai-whisper-large-v2-LORA-colab"
+- peft_config = PeftConfig.from_pretrained(peft_model_id)
+- model = WhisperForConditionalGeneration.from_pretrained(
+-     peft_config.base_model_name_or_path, load_in_8bit=True, device_map="auto"
+- )
+- model = PeftModel.from_pretrained(model, peft_model_id)
++ model = AutoPeftModel.from_pretrained(peft_model_id)
+```
 
 ## Next steps
 

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -20,6 +20,7 @@
 __version__ = "0.4.0.dev0"
 
 from .auto import (
+    AutoPeftModel,
     AutoPeftModelForCausalLM,
     AutoPeftModelForSequenceClassification,
     AutoPeftModelForSeq2SeqLM,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -160,7 +160,22 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 )
             inference_mode = peft_config.inference_mode
             peft_config.inference_mode = True
-            peft_config.save_pretrained(output_dir)
+
+            if peft_config.task_type is None:
+                # deal with auto mapping
+                base_model_class = self._get_base_model_class(
+                    is_prompt_tuning=isinstance(peft_config, PromptLearningConfig)
+                )
+                parent_library = base_model_class.__module__
+
+                auto_mapping_dict = {
+                    "base_model_class": base_model_class.__name__,
+                    "parent_library": parent_library,
+                }
+            else:
+                auto_mapping_dict = None
+
+            peft_config.save_pretrained(output_dir, auto_mapping_dict=auto_mapping_dict)
             peft_config.inference_mode = inference_mode
 
     @classmethod
@@ -372,6 +387,14 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         Forward pass of the model.
         """
         return self.get_base_model()(*args, **kwargs)
+
+    def _get_base_model_class(self, is_prompt_tuning=False):
+        """
+        Returns the base model class.
+        """
+        if not is_prompt_tuning:
+            return self.base_model.model.__class__
+        return self.base_model.__class__
 
     @contextmanager
     def disable_adapter(self):

--- a/src/peft/utils/config.py
+++ b/src/peft/utils/config.py
@@ -56,6 +56,9 @@ class PeftConfigMixin(PushToHubMixin):
         peft_type (Union[[`~peft.utils.config.PeftType`], `str`]): The type of Peft method to use.
     """
     peft_type: Optional[PeftType] = field(default=None, metadata={"help": "The type of PEFT model."})
+    auto_mapping: Optional[dict] = field(
+        default=None, metadata={"help": "An auto mapping dict to help retrieve the base model class if needed."}
+    )
 
     def to_dict(self):
         return asdict(self)
@@ -75,9 +78,14 @@ class PeftConfigMixin(PushToHubMixin):
             raise AssertionError(f"Provided path ({save_directory}) should be a directory, not a file")
 
         os.makedirs(save_directory, exist_ok=True)
+        auto_mapping_dict = kwargs.pop("auto_mapping_dict", None)
 
         output_dict = asdict(self)
         output_path = os.path.join(save_directory, CONFIG_NAME)
+
+        # Add auto mapping details for custom models.
+        if auto_mapping_dict is not None:
+            output_dict["auto_mapping"] = auto_mapping_dict
 
         # save it
         with open(output_path, "w") as writer:


### PR DESCRIPTION
# What does this PR do? 

Extends the recent PR: #694 by adding the support for all HF models: whisper, sd, etc.

The logic is as follows:
- Since if a user trains a model with `task_type=None`, it must be a custom model, we add to the peft config dictionary a new field termed as `auto_mapping`, responsible of storing all required information for retrieving back this class: https://huggingface.co/ybelkada/whisper-lora-test-auto-mapping/blob/main/adapter_config.json#L2 
- For users that want to register whisper/ sd etc models in the future to be compatible with `AutoPeftModel` they need to load the model from the Hub and push it again

Current API: 

```diff
- from peft import PeftModel, PeftConfig, AutoPeftModel
+ from peft import AutoPeftModel
- from transformers import WhisperForConditionalGeneration

- model_id = "smangrul/openai-whisper-large-v2-LORA-colab"

peft_model_id = "smangrul/openai-whisper-large-v2-LORA-colab"
- peft_config = PeftConfig.from_pretrained(peft_model_id)
- model = WhisperForConditionalGeneration.from_pretrained(
-     peft_config.base_model_name_or_path, load_in_8bit=True, device_map="auto"
- )
- model = PeftModel.from_pretrained(model, peft_model_id)
+ model = AutoPeftModel.from_pretrained(peft_model_id)
```

Added tests for Whisper, will add a test for SD models as well

cc @BenjaminBossan @pacman100 