### PR TITLE
[`core`] Better hub kwargs management

### DIFF
--- a/src/peft/utils/config.py
+++ b/src/peft/utils/config.py
@@ -164,10 +164,10 @@ class PeftConfigMixin(PushToHubMixin):
     def _get_peft_type(
         cls,
         model_id,
-        subfolder: Optional[str] = None,
-        revision: Optional[str] = None,
-        cache_dir: Optional[str] = None,
+        **hf_hub_download_kwargs,
     ):
+        subfolder = hf_hub_download_kwargs.get("subfolder", None)
+
         path = os.path.join(model_id, subfolder) if subfolder is not None else model_id
 
         if os.path.isfile(os.path.join(path, CONFIG_NAME)):
@@ -175,7 +175,9 @@ class PeftConfigMixin(PushToHubMixin):
         else:
             try:
                 config_file = hf_hub_download(
-                    model_id, CONFIG_NAME, subfolder=subfolder, revision=revision, cache_dir=cache_dir
+                    model_id,
+                    CONFIG_NAME,
+                    **hf_hub_download_kwargs,
                 )
             except Exception:
                 raise ValueError(f"Can't find '{CONFIG_NAME}' at '{model_id}'")


### PR DESCRIPTION
# What does this PR do?

Currently the Hub kwargs are not correctly managed if one passes explicit key word arguments to `PeftModel.from_pretrained` the model loading fails. This is because some key word arguments are duplicated across the `hf_hub_download` method and the current kwargs that are passed.
in this PR, I propose to refactor things a bit and make a better kwargs managed of hub-related methods. Note that some arguments such as `use_auth_token` are not in the `hf_hub_download` signature, thus needs a special care for handling them.

Encountered this issue while working on https://github.com/huggingface/transformers/pull/24827

cc @pacman100 @BenjaminBossan 