### PR TITLE
FIX: Removes warnings about unknown pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,7 @@ doctest_optionflags = [
 
 [tool.pytest.ini_options]
 addopts = "--cov=src/peft --cov-report=term-missing"
+markers = [
+    "single_gpu_tests: tests that run on a single GPU",
+    "multi_gpu_tests: tests that run on multiple GPUs",
+]


### PR DESCRIPTION
This is a low prio PR but it solves an annoyance.

Right now, when running tests, the output is spammed by messages like:

> PytestUnknownMarkWarning: Unknown pytest.mark.multi_gpu_tests - is this a typo? ...

This makes it more difficult to see the actually relevant information. This PR fixes this by registering the two pytest markers we use, thus removing the warnings.