### PR TITLE
FIX: Warning when initializing prompt encoder

### DIFF
--- a/src/peft/tuners/p_tuning.py
+++ b/src/peft/tuners/p_tuning.py
@@ -143,9 +143,12 @@ class PromptEncoder(torch.nn.Module):
                 )
 
             elif self.encoder_type == PromptEncoderReparameterizationType.MLP:
-                warnings.warn(
-                    f"for {self.encoder_type}, the `encoder_num_layers` is ignored. Exactly 2 MLP layers are used."
-                )
+                encoder_num_layers_default = PromptEncoderConfig.encoder_num_layers
+                if config.encoder_num_layers != encoder_num_layers_default:
+                    warnings.warn(
+                        f"for {self.encoder_type}, the argument `encoder_num_layers` is ignored. "
+                        f"Exactly {encoder_num_layers_default} MLP layers are used."
+                    )
                 layers = [
                     torch.nn.Linear(self.input_size, self.hidden_size),
                     torch.nn.ReLU(),


### PR DESCRIPTION
This is low prio, just fixing an annoyance.

Right now, when the user initializes a prompt encoder with `MLP`, they get a warning that a certain argument, `encoder_num_layers`, is ignored, and there is no possible value for the argument that would stop the warning. Usually, warnings are for issues that something is (probably) going wrong, but here, everything is going as expected. Therefore, by default, I would not give this warning, thus avoiding users getting confused.

However, I would still give the warning if the user set the argument for `encoder_num_layers` explicitly to a different value. In that case, they expect the change to make a difference, but since the argument is ignored, their expectation is not met, which warrants a warning.

I didn't find a good place to put the unit test, so I put it into `test_config.py`. LMK if there is a better location.