### PR TITLE
Fix subfolder issue

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -517,7 +517,11 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             self.add_adapter(adapter_name, peft_config)
 
         # load weights if any
-        path = os.path.join(model_id, kwargs["subfolder"]) if kwargs.get("subfolder", None) is not None else model_id
+        path = (
+            os.path.join(model_id, hf_hub_download_kwargs["subfolder"])
+            if hf_hub_download_kwargs.get("subfolder", None) is not None
+            else model_id
+        )
 
         if os.path.exists(os.path.join(path, SAFETENSORS_WEIGHTS_NAME)):
             filename = os.path.join(path, SAFETENSORS_WEIGHTS_NAME)

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+# Copyright 2023-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from transformers import AutoModelForCausalLM
+
+from peft import PeftConfig, PeftModel
+
+
+PEFT_MODELS_TO_TEST = [("peft-internal-testing/test-lora-subfolder", "test")]
+
+
+class PeftHubFeaturesTester(unittest.TestCase):
+    def test_subfolder(self):
+        r"""
+        Test if subfolder argument works as expected
+        """
+        for model_id, subfolder in PEFT_MODELS_TO_TEST:
+            config = PeftConfig.from_pretrained(model_id, subfolder=subfolder)
+
+            model = AutoModelForCausalLM.from_pretrained(
+                config.base_model_name_or_path,
+            )
+            model = PeftModel.from_pretrained(model, model_id, subfolder=subfolder)
+
+            self.assertTrue(isinstance(model, PeftModel))


### PR DESCRIPTION
Fixes https://github.com/huggingface/peft/issues/718

in the PR #712 , I forgot to properly deal with `subfolder` argument, in fact they will appear in `hf_hub_download_kwargs` as `subfolder` is in the signature of `hf_hub_download` method

cc @pacman100 @BenjaminBossan 

Added also a nice CI test