### PR TITLE
Add falcon to officially supported LoRA & IA3 modules

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -282,6 +282,7 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "gpt_bigcode": ["c_attn"],
     "mpt": ["Wqkv"],
     "RefinedWebModel": ["query_key_value"],
+    "RefinedWeb": ["query_key_value"],
     "falcon": ["query_key_value"],
 }
 
@@ -302,6 +303,7 @@ TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING = {
     "deberta-v2": ["key_proj", "value_proj", "output.dense"],
     "deberta": ["in_proj", "output.dense"],
     "RefinedWebModel": ["query_key_value"],
+    "RefinedWeb": ["query_key_value"],
     "falcon": ["query_key_value"],
 }
 
@@ -321,6 +323,7 @@ TRANSFORMERS_MODELS_TO_IA3_FEEDFORWARD_MODULES_MAPPING = {
     "bert": ["output.dense"],
     "deberta-v2": ["output.dense"],
     "deberta": ["output.dense"],
+    "RefinedWeb": ["query_key_value"],
     "RefinedWebModel": ["query_key_value"],
     "falcon": ["query_key_value"],
 }

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -281,6 +281,8 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "chatglm": ["query_key_value"],
     "gpt_bigcode": ["c_attn"],
     "mpt": ["Wqkv"],
+    "RefinedWebModel": ["query_key_value"],
+    "falcon": ["query_key_value"],
 }
 
 TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING = {

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -299,6 +299,8 @@ TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING = {
     "bert": ["key", "value", "output.dense"],
     "deberta-v2": ["key_proj", "value_proj", "output.dense"],
     "deberta": ["in_proj", "output.dense"],
+    "RefinedWebModel": ["query_key_value"],
+    "falcon": ["query_key_value"],
 }
 
 TRANSFORMERS_MODELS_TO_IA3_FEEDFORWARD_MODULES_MAPPING = {
@@ -317,6 +319,8 @@ TRANSFORMERS_MODELS_TO_IA3_FEEDFORWARD_MODULES_MAPPING = {
     "bert": ["output.dense"],
     "deberta-v2": ["output.dense"],
     "deberta": ["output.dense"],
+    "RefinedWebModel": ["query_key_value"],
+    "falcon": ["query_key_value"],
 }
 
 COMMON_LAYERS_PATTERN = ["layers", "h", "block", "blocks", "layer"]


### PR DESCRIPTION
as per title

@pacman100 @BenjaminBossan @abhishekkrthakur 

added also `RefinedWebModel` for backward compatiblity for models that use the first versions of Falcon. `falcon` stands for the model id of the falcon port in transformers

Note that 
- falcon 7b has the model_type termed as `RefinedWeb`: https://huggingface.co/tiiuae/falcon-7b/blob/main/config.json#L23
- falcon 40b has the model_type termed as `RefinedWebModel`: https://huggingface.co/tiiuae/falcon-40b/blob/main/config.json#L23