### PR TITLE
Use device_map to load adapters weight onto specified device

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -551,10 +551,13 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     )
 
         if use_safetensors:
-            adapters_weights = safe_load_file(filename, device=kwargs.get("device_map", "cuda" if torch.cuda.is_available() else "cpu"))
+            adapters_weights = safe_load_file(
+                filename, device=kwargs.get("device_map", "cuda" if torch.cuda.is_available() else "cpu")
+            )
         else:
             adapters_weights = torch.load(
-                filename, map_location=kwargs.get("device_map", torch.device("cuda" if torch.cuda.is_available() else "cpu"))
+                filename,
+                map_location=kwargs.get("device_map", torch.device("cuda" if torch.cuda.is_available() else "cpu")),
             )
 
         # load the weights into the model

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -551,10 +551,10 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     )
 
         if use_safetensors:
-            adapters_weights = safe_load_file(filename, device="cuda" if torch.cuda.is_available() else "cpu")
+            adapters_weights = safe_load_file(filename, device=kwargs.get("device_map", "cuda" if torch.cuda.is_available() else "cpu"))
         else:
             adapters_weights = torch.load(
-                filename, map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu")
+                filename, map_location=kwargs.get("device_map", torch.device("cuda" if torch.cuda.is_available() else "cpu"))
             )
 
         # load the weights into the model


### PR DESCRIPTION
When loading adapters weight with `PeftModel.from_pretrained(...)` method (https://github.com/huggingface/peft/blob/main/src/peft/peft_model.py#L553-L558), it will load the weights on the first visible cuda device, which might not always be ideal considering GPU memory allocation and management.

If a `device_map` variable (i.e. ` torch.device("cuda:2") is passed to `from_pretrained(...)` as kwargs, it can be used to ensure the weights are loaded to the specified device.