### PR TITLE
[`Llama2`] Add disabling TP behavior

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -119,6 +119,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if getattr(model, "is_gradient_checkpointing", True):
             model = self._prepare_model_for_gradient_checkpointing(model)
 
+        # the `pretraining_tp` is set for some models to simulate Tensor Parallelism during inference to avoid
+        # numerical differences, https://github.com/pytorch/pytorch/issues/76232 - to avoid any unexpected
+        # behavior we disable that in this line.
         if hasattr(self.base_model, "disable_pretraining_tp") and hasattr(self.config, "pretraining_tp"):
             model.disable_pretraining_tp()
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -119,6 +119,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if getattr(model, "is_gradient_checkpointing", True):
             model = self._prepare_model_for_gradient_checkpointing(model)
 
+        if hasattr(self.base_model, "disable_pretraining_tp") and hasattr(self.config, "pretraining_tp"):
+            model.disable_pretraining_tp()
+
     def save_pretrained(
         self,
         save_directory: str,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -122,8 +122,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         # the `pretraining_tp` is set for some models to simulate Tensor Parallelism during inference to avoid
         # numerical differences, https://github.com/pytorch/pytorch/issues/76232 - to avoid any unexpected
         # behavior we disable that in this line.
-        if hasattr(self.base_model, "disable_pretraining_tp") and hasattr(self.config, "pretraining_tp"):
-            model.disable_pretraining_tp()
+        if hasattr(self.base_model, "config") and hasattr(self.base_model.config, "pretraining_tp"):
+            self.base_model.config.pretraining_tp = 1
 
     def save_pretrained(
         self,


### PR DESCRIPTION
Fixes #726 

This PR is on par with https://github.com/huggingface/transformers/pull/24906

Currently the TP paradigm that is supported by transformers, technically is not really a real Tensor Parallelism paradigm but rather a simulation of TP by manually splitting the layers into chunks and concatenating the results.

The motivation of that implementation is to mimic the TP paradigm that was used during pre-training of these models, as slicing weight tensors and input leads to slight numerical differences: https://github.com/pytorch/pytorch/issues/76232 

I would argue that this might be not that important for training as the model will be fine-tuned, thus the weights of the model will be adapted accordingly. 

cc @pacman100 @BenjaminBossan 

I propose to properly support TP in the future once this is properly implemented, currently the TP that is in place is more a patch to match the logits of the original implementation