### PR TITLE
fix(pep561): include packaging type information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     url="https://github.com/huggingface/peft",
     package_dir={"": "src"},
     packages=find_packages("src"),
+    package_data={"peft": ["py.typed"]},
     entry_points={},
     python_requires=">=3.8.0",
     install_requires=[


### PR DESCRIPTION
This is an oversight on my end, that i forgot peft still relies on setup.py

PEP561 indicates that we need to add package_data to indicate the package is typed

See https://peps.python.org/pep-0561/#packaging-type-information

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
