### PR TITLE
[minor bugfix] prevent lora Linear4bit from sneakily changing compute_dtype to float32

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -1106,7 +1106,7 @@ if is_bnb_available():
                     in_features,
                     out_features,
                     bias=kwargs.get("bias", True),
-                    compute_dtype=kwargs.get("compute_dtype", torch.float32),
+                    compute_dtype=kwargs.get("compute_dtype", None),
                     compress_statistics=kwargs.get("compress_statistics", True),
                     quant_type=kwargs.get("quant_type", "nf4"),
                 )


### PR DESCRIPTION
__Problem:__ if you load a 4-bit model in fp16 precision, it runs fast; if you convert it to LoRA it runs much slower even with disable_adapters. However, if you manually set compute_dtype of each layer, the issue goes away. This happens because peft sneakily changes how Linear4bit handles default compute dtype.

Minimalistic example of the problem : https://colab.research.google.com/drive/1ZEWVihanF0DAPFDrWOqpDOBYXa81bOfj

By default, bitsandbytes.nn.Linear4bit has [compute_dtype](https://github.com/TimDettmers/bitsandbytes/blob/67475257a96b792f9b66e71892dab90f7a60ed87/bitsandbytes/nn/modules.py#L207), which [defaults to None](compute_dtype=None). The default value means "same as input type" -- for instance, in fp16.

Currently, peft intercepts the compute_dtype=None and forces it to be float32, which can be significantly slower, especially for inference with pretrained adapters.


__Suggested solution:__ it would be more intuitive if peft kept the default compute_dtype behavior from bitsandbytes.

__Disclaimer:__ there could be some legitimate reason why PEFT decided to deviate from transfomers default behavior in this way for some niche scenario that I didn't know about. Do not trust me. All I'm saying is that it's a bit unexpected why peft implicitly leaves performance on the table for half-precision models and hides this from the user.
