### PR TITLE
[`Patch`] patch trainable params for 4bit layers

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -383,9 +383,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 prompts = prompt_encoder(prompt_tokens)
             return prompts
 
-    def print_trainable_parameters(self):
-        """
-        Prints the number of trainable parameters in the model.
+    def get_nb_trainable_parameters(self):
+        r"""
+        Returns the number of trainable parameters and number of all parameters in the model.
         """
         trainable_params = 0
         all_param = 0
@@ -404,6 +404,15 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             all_param += num_params
             if param.requires_grad:
                 trainable_params += num_params
+
+        return trainable_params, all_param
+
+    def print_trainable_parameters(self):
+        """
+        Prints the number of trainable parameters in the model.
+        """
+        trainable_params, all_param = self.get_nb_trainable_parameters()
+
         print(
             f"trainable params: {trainable_params:,d} || all params: {all_param:,d} || trainable%: {100 * trainable_params / all_param}"
         )

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -119,12 +119,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if getattr(model, "is_gradient_checkpointing", True):
             model = self._prepare_model_for_gradient_checkpointing(model)
 
-        # the `pretraining_tp` is set for some models to simulate Tensor Parallelism during inference to avoid
-        # numerical differences, https://github.com/pytorch/pytorch/issues/76232 - to avoid any unexpected
-        # behavior we disable that in this line.
-        if hasattr(self.base_model, "disable_pretraining_tp") and hasattr(self.config, "pretraining_tp"):
-            model.disable_pretraining_tp()
-
     def save_pretrained(
         self,
         save_directory: str,

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -60,6 +60,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         torch.cuda.empty_cache()
         gc.collect()
 
+    # Borrowed from: https://stackoverflow.com/questions/33767627/python-write-unittest-for-console-print
     @pytest.fixture(autouse=True)
     def _pass_fixtures(self, capsys):
         self.capsys = capsys


### PR DESCRIPTION
# What does this PR do?

Currently the total number of parameters displayed by `print_trainable_parameters` is incorrect for 4bit base models. Due to the design of `Params4bit` modules, one needs to multiply the number of parameters of these modules by 2 to get the correct number of params.

Script to reproduce:

```python
from transformers import AutoModelForCausalLM, BitsAndBytesConfig
import torch
from peft import get_peft_model, LoraConfig

model_id = "facebook/opt-125m"

bnb_config = BitsAndBytesConfig(
        load_in_4bit=True,
        bnb_4bit_quant_type="nf4",
        bnb_4bit_compute_dtype=torch.float16,
        bnb_4bit_use_double_quant=True,
    )
model = AutoModelForCausalLM.from_pretrained(model_id, quantization_config=bnb_config,
                                            device_map={"":0})

peft_config = LoraConfig(
    r=8,
)

model = get_peft_model(model, peft_config)

model.print_trainable_parameters()
```

cc @pacman100 @BenjaminBossan 