### PR TITLE
FIX: Disabling adapter works with modules_to_save

### DIFF
--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -303,6 +303,8 @@ class IA3Model(torch.nn.Module):
         for module in self.model.modules():
             if isinstance(module, IA3Layer):
                 module.disable_adapters = False if enabled else True
+            elif isinstance(module, ModulesToSaveWrapper):
+                module.disable_adapter = False if enabled else True
 
     def enable_adapter_layers(self):
         self._set_adapter_layers(enabled=True)

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -304,7 +304,7 @@ class IA3Model(torch.nn.Module):
             if isinstance(module, IA3Layer):
                 module.disable_adapters = False if enabled else True
             elif isinstance(module, ModulesToSaveWrapper):
-                module.disable_adapter = False if enabled else True
+                module.disable_adapters = False if enabled else True
 
     def enable_adapter_layers(self):
         self._set_adapter_layers(enabled=True)

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -397,7 +397,7 @@ class LoraModel(torch.nn.Module):
             if isinstance(module, LoraLayer):
                 module.disable_adapters = False if enabled else True
             elif isinstance(module, ModulesToSaveWrapper):
-                module.disable_adapter = False if enabled else True
+                module.disable_adapters = False if enabled else True
 
     def enable_adapter_layers(self):
         self._set_adapter_layers(enabled=True)

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -396,6 +396,8 @@ class LoraModel(torch.nn.Module):
         for module in self.model.modules():
             if isinstance(module, LoraLayer):
                 module.disable_adapters = False if enabled else True
+            elif isinstance(module, ModulesToSaveWrapper):
+                module.disable_adapter = False if enabled else True
 
     def enable_adapter_layers(self):
         self._set_adapter_layers(enabled=True)

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -135,12 +135,13 @@ class ModulesToSaveWrapper(torch.nn.Module):
         self.modules_to_save = torch.nn.ModuleDict({})
         self.update(adapter_name)
         self.active_adapter = adapter_name
+        self.disable_adapter = False
 
     def update(self, adapter_name):
         self.modules_to_save.update(torch.nn.ModuleDict({adapter_name: copy.deepcopy(self.original_module)}))
 
     def forward(self, *args, **kwargs):
-        if self.active_adapter not in self.modules_to_save:
+        if self.disable_adapter or (self.active_adapter not in self.modules_to_save):
             return self.original_module(*args, **kwargs)
         return self.modules_to_save[self.active_adapter](*args, **kwargs)
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -135,13 +135,13 @@ class ModulesToSaveWrapper(torch.nn.Module):
         self.modules_to_save = torch.nn.ModuleDict({})
         self.update(adapter_name)
         self.active_adapter = adapter_name
-        self.disable_adapter = False
+        self.disable_adapters = False
 
     def update(self, adapter_name):
         self.modules_to_save.update(torch.nn.ModuleDict({adapter_name: copy.deepcopy(self.original_module)}))
 
     def forward(self, *args, **kwargs):
-        if self.disable_adapter or (self.active_adapter not in self.modules_to_save):
+        if self.disable_adapters or (self.active_adapter not in self.modules_to_save):
             return self.original_module(*args, **kwargs)
         return self.modules_to_save[self.active_adapter](*args, **kwargs)
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -35,6 +35,16 @@ TEST_CASES = [
     ("Vanilla MLP 2", "MLP", LoraConfig, {"target_modules": ["lin0"]}),
     ("Vanilla MLP 3", "MLP", LoraConfig, {"target_modules": ["lin1"]}),
     ("Vanilla MLP 4", "MLP", LoraConfig, {"target_modules": ["lin0", "lin1"]}),
+    ("Vanilla MLP 5", "MLP", LoraConfig, {"target_modules": ["lin0"], "modules_to_save": ["lin1"]}),
+    (
+        "Vanilla MLP 6",
+        "MLP",
+        LoraConfig, {
+            "target_modules": ["lin0"],
+            "lora_alpha": 4,
+            "lora_dropout": 0.1,
+        },
+    ),
     ("Embedding + transformers Conv1D 1", "EmbConv1D", LoraConfig, {"target_modules": ["conv1d"]}),
     ("Embedding + transformers Conv1D 2", "EmbConv1D", LoraConfig, {"target_modules": ["emb"]}),
     ("Embedding + transformers Conv1D 3", "EmbConv1D", LoraConfig, {"target_modules": ["emb", "conv1d"]}),
@@ -227,7 +237,8 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         self.assertEqual(params_before.keys(), params_after.keys())
         for name, param_before in params_before.items():
             param_after = params_after[name]
-            if "lora_" in name:
+            if ("lora_" in name) or ("modules_to_save" in name):
+                # target_modules and modules_to_save _are_ updated
                 self.assertFalse(torch.allclose(param_before, param_after, atol=tol, rtol=tol))
             else:
                 self.assertTrue(torch.allclose(param_before, param_after, atol=tol, rtol=tol))
@@ -262,5 +273,9 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         with model.disable_adapter():
             outputs_disabled = model(**X)
 
+        # check that after leaving the disable_adapter context, everything is enabled again
+        outputs_enabled_after_disable = model(**X)
+
         self.assertFalse(torch.allclose(outputs_before, outputs_after))
         self.assertTrue(torch.allclose(outputs_before, outputs_disabled))
+        self.assertTrue(torch.allclose(outputs_after, outputs_enabled_after_disable))

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -39,7 +39,8 @@ TEST_CASES = [
     (
         "Vanilla MLP 6",
         "MLP",
-        LoraConfig, {
+        LoraConfig,
+        {
             "target_modules": ["lin0"],
             "lora_alpha": 4,
             "lora_dropout": 0.1,

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -467,7 +467,7 @@ class PeftCommonTester:
         loss.backward()
         parameter_prefix = "ia3" if config_cls == IA3Config else "lora"
         for n, param in model.named_parameters():
-            if parameter_prefix in n:
+            if (parameter_prefix in n) or ("modules_to_save" in n):
                 self.assertIsNotNone(param.grad)
             else:
                 self.assertIsNone(param.grad)


### PR DESCRIPTION
Resolves #493

For LoRA and IA³, there was a bug that even even using the `disable_adapter` context, if the module was listed in `modules_to_save`, the updated weights would be used instead of the original weights. This meant that `disable_adapter` would not return the same results as the base model without adaptation. This PR fixes the issue and provides a test.

Note: I tried to adjust AdaLoRA too, since it seemed that the same reasoning should apply there. However, I think that AdaLoRA does not really support disabling adapters at all. E.g. there is no `disable_adapter_layers` method. Therefore, AdaLoRA was not changed.