### PR TITLE
chore(style): fix F401 on __init__

### DIFF
--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -1,7 +1,3 @@
-# flake8: noqa
-# There's no way to ignore "F401 '...' imported but unused" warnings in this
-# module, but to preserve other warnings. So, don't check this module at all.
-
 # coding=utf-8
 # Copyright 2023-present the HuggingFace Inc. team.
 #
@@ -20,52 +16,137 @@
 __version__ = "0.5.0.dev0"
 
 from .auto import (
-    AutoPeftModel,
-    AutoPeftModelForCausalLM,
-    AutoPeftModelForSequenceClassification,
-    AutoPeftModelForSeq2SeqLM,
-    AutoPeftModelForTokenClassification,
-    AutoPeftModelForQuestionAnswering,
-    AutoPeftModelForFeatureExtraction,
+    AutoPeftModel as AutoPeftModel,
 )
-from .mapping import MODEL_TYPE_TO_PEFT_MODEL_MAPPING, PEFT_TYPE_TO_CONFIG_MAPPING, get_peft_config, get_peft_model
+from .auto import (
+    AutoPeftModelForCausalLM as AutoPeftModelForCausalLM,
+)
+from .auto import (
+    AutoPeftModelForFeatureExtraction as AutoPeftModelForFeatureExtraction,
+)
+from .auto import (
+    AutoPeftModelForQuestionAnswering as AutoPeftModelForQuestionAnswering,
+)
+from .auto import (
+    AutoPeftModelForSeq2SeqLM as AutoPeftModelForSeq2SeqLM,
+)
+from .auto import (
+    AutoPeftModelForSequenceClassification as AutoPeftModelForSequenceClassification,
+)
+from .auto import (
+    AutoPeftModelForTokenClassification as AutoPeftModelForTokenClassification,
+)
+from .mapping import (
+    MODEL_TYPE_TO_PEFT_MODEL_MAPPING as MODEL_TYPE_TO_PEFT_MODEL_MAPPING,
+)
+from .mapping import (
+    PEFT_TYPE_TO_CONFIG_MAPPING as PEFT_TYPE_TO_CONFIG_MAPPING,
+)
+from .mapping import (
+    get_peft_config as get_peft_config,
+)
+from .mapping import (
+    get_peft_model as get_peft_model,
+)
 from .peft_model import (
-    PeftModel,
-    PeftModelForCausalLM,
-    PeftModelForSeq2SeqLM,
-    PeftModelForSequenceClassification,
-    PeftModelForTokenClassification,
-    PeftModelForQuestionAnswering,
-    PeftModelForFeatureExtraction,
+    PeftModel as PeftModel,
+)
+from .peft_model import (
+    PeftModelForCausalLM as PeftModelForCausalLM,
+)
+from .peft_model import (
+    PeftModelForFeatureExtraction as PeftModelForFeatureExtraction,
+)
+from .peft_model import (
+    PeftModelForQuestionAnswering as PeftModelForQuestionAnswering,
+)
+from .peft_model import (
+    PeftModelForSeq2SeqLM as PeftModelForSeq2SeqLM,
+)
+from .peft_model import (
+    PeftModelForSequenceClassification as PeftModelForSequenceClassification,
+)
+from .peft_model import (
+    PeftModelForTokenClassification as PeftModelForTokenClassification,
 )
 from .tuners import (
-    AdaptionPromptConfig,
-    AdaptionPromptModel,
-    LoraConfig,
-    LoraModel,
-    IA3Config,
-    IA3Model,
-    AdaLoraConfig,
-    AdaLoraModel,
-    PrefixEncoder,
-    PrefixTuningConfig,
-    PromptEmbedding,
-    PromptEncoder,
-    PromptEncoderConfig,
-    PromptEncoderReparameterizationType,
-    PromptTuningConfig,
-    PromptTuningInit,
+    AdaLoraConfig as AdaLoraConfig,
+)
+from .tuners import (
+    AdaLoraModel as AdaLoraModel,
+)
+from .tuners import (
+    AdaptionPromptConfig as AdaptionPromptConfig,
+)
+from .tuners import (
+    AdaptionPromptModel as AdaptionPromptModel,
+)
+from .tuners import (
+    IA3Config as IA3Config,
+)
+from .tuners import (
+    IA3Model as IA3Model,
+)
+from .tuners import (
+    LoraConfig as LoraConfig,
+)
+from .tuners import (
+    LoraModel as LoraModel,
+)
+from .tuners import (
+    PrefixEncoder as PrefixEncoder,
+)
+from .tuners import (
+    PrefixTuningConfig as PrefixTuningConfig,
+)
+from .tuners import (
+    PromptEmbedding as PromptEmbedding,
+)
+from .tuners import (
+    PromptEncoder as PromptEncoder,
+)
+from .tuners import (
+    PromptEncoderConfig as PromptEncoderConfig,
+)
+from .tuners import (
+    PromptEncoderReparameterizationType as PromptEncoderReparameterizationType,
+)
+from .tuners import (
+    PromptTuningConfig as PromptTuningConfig,
+)
+from .tuners import (
+    PromptTuningInit as PromptTuningInit,
 )
 from .utils import (
-    TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING,
-    PeftConfig,
-    PeftType,
-    PromptLearningConfig,
-    TaskType,
-    bloom_model_postprocess_past_key_value,
-    get_peft_model_state_dict,
-    prepare_model_for_int8_training,
-    prepare_model_for_kbit_training,
-    set_peft_model_state_dict,
-    shift_tokens_right,
+    TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING as TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING,
+)
+from .utils import (
+    PeftConfig as PeftConfig,
+)
+from .utils import (
+    PeftType as PeftType,
+)
+from .utils import (
+    PromptLearningConfig as PromptLearningConfig,
+)
+from .utils import (
+    TaskType as TaskType,
+)
+from .utils import (
+    bloom_model_postprocess_past_key_value as bloom_model_postprocess_past_key_value,
+)
+from .utils import (
+    get_peft_model_state_dict as get_peft_model_state_dict,
+)
+from .utils import (
+    prepare_model_for_int8_training as prepare_model_for_int8_training,
+)
+from .utils import (
+    prepare_model_for_kbit_training as prepare_model_for_kbit_training,
+)
+from .utils import (
+    set_peft_model_state_dict as set_peft_model_state_dict,
+)
+from .utils import (
+    shift_tokens_right as shift_tokens_right,
 )


### PR DESCRIPTION
Alias imports is a workaround for F401 warning

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
