### PR TITLE
[skip ci] [WIP] Refactor of adapter layers

### DIFF
--- a/alt/base.py
+++ b/alt/base.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any
+
+from torch import nn
+
+
+@dataclass
+class AdapterConfig:
+    target_modules: str | list[str] | None = field(
+        default=None,
+        metadata={
+            "help": "List of module names or regex expression of the module names to replace with Lora."
+            "For example, ['q', 'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$' "
+        },
+    )
+
+    modules_to_save: list[str] = field(
+        default_factory=list,
+        metadata={
+            "help": "List of modules apart from LoRA layers to be set as trainable and saved in the final checkpoint. "
+            "For example, in Sequence Classification or Token Classification tasks, "
+            "the final layer `classifier/score` are randomly initialized and as such need to be trainable and saved."
+        },
+    )
+
+
+class AdapterLayer(nn.Module):
+    def __init__(self, base_module: nn.Module) -> None:
+        super().__init__()
+        self.base_module = base_module  # TODO rename to base_layer
+
+        self.active: bool = True
+        self.merged: bool = False
+        self.reset_params()
+        self.reset_device()
+
+    @classmethod
+    def from_config(cls, config: AdapterConfig, base_module: nn.Module) -> AdapterLayer:
+        raise NotImplementedError
+
+    def set_active(self, active: bool) -> None:
+        self.active = active
+
+    def reset_params(self) -> None:
+        raise NotImplementedError
+
+    def reset_device(self) -> None:
+        raise NotImplementedError
+
+    def reset_requires_grad(self) -> None:
+        raise NotImplementedError
+
+    def merge(self) -> None:
+        raise NotImplementedError
+
+    def unmerge(self) -> None:
+        raise NotImplementedError
+
+    def _pre_forward(self, *args, **kwargs):
+        return args, kwargs
+
+    def forward(self, *args, **kwargs) -> Any:
+        args, kwargs = self._pre_forward(*args, **kwargs)
+        output = self.base_module(*args, **kwargs)
+        return self._post_forward(output, *args, **kwargs)
+
+    def _post_forward(self, output, *args, **kwargs):
+        return output
+
+
+class ModulesToSaveWrapper(AdapterLayer):
+    def reset_params(self) -> None:
+        self.new_module = copy.deepcopy(self.base_module)
+
+    def reset_device(self) -> None:
+        pass
+
+    def reset_requires_grad(self) -> None:
+        self.base_module.requires_grad_(False)
+        self.new_module.requires_grad_(True)
+
+    def merge(self) -> None:
+        if self.merged:
+            return
+
+        self.base_module, self.new_module = self.new_module, self.base_module
+        self.merged = True
+
+    def unmerge(self) -> None:
+        if not self.merged:
+            return
+
+        self.base_module, self.new_module = self.new_module, self.base_module
+        self.merged = False
+
+    def forward(self, *args, **kwargs) -> Any:
+        args, kwargs = self._pre_forward(*args, **kwargs)
+
+        if self.active is self.merged:
+            output = self.base_module(*args, **kwargs)
+        else:
+            output = self.new_module(*args, **kwargs)
+
+        return self._post_forward(output, *args, **kwargs)

--- a/alt/construction.py
+++ b/alt/construction.py
@@ -1,0 +1,68 @@
+"""Function and classes that construct an adapter from a config"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Iterator
+
+from torch import nn
+
+from base import AdapterConfig, AdapterLayer
+from ia3 import IA3Config, LinearIA3Layer
+from lora import EmbeddingLoraLayer, LinearLoraLayer, LoraConfig
+
+
+def _get_selection_strategy(config: AdapterConfig, base_model: nn.Module) -> Any:  # TODO
+    if isinstance(config.target_modules, str):
+        return _regex_selection_strategy(config, base_model)
+    if isinstance(config.target_modules, list):
+        return _list_match_selection_strategy(config, base_model)
+    raise ValueError("TODO")
+
+
+def _regex_selection_strategy(config: AdapterConfig, base_model: nn.Module) -> Iterator[tuple[str, Any]]:
+    assert isinstance(config.target_modules, str)
+    for name, _ in base_model.named_modules():
+        if re.fullmatch(config.target_modules, name):
+            yield name, None
+
+
+def _list_match_selection_strategy(config: AdapterConfig, base_model: nn.Module) -> Iterator[tuple[str, Any]]:
+    assert isinstance(config.target_modules, list)
+    assert isinstance(config.target_modules[0], str)
+    for name, _ in base_model.named_modules():
+        if any(name.endswith(key) for key in config.target_modules):
+            yield name, None
+
+
+def _get_adaptation_strategy(
+    config: AdapterConfig, layer_specific_args: Any | None
+) -> Callable[[nn.Module, str], AdapterLayer]:
+    # TODO: more complex strategies, e.g. allowing to provide user defined layers
+    # as replacement layers, or even mixing things up, like:
+    # - one is LoRA layer with r=8, another with r=16
+    # - one is LoRA layer, another is IA³ layer
+    if layer_specific_args is None:
+        return _OneToOneMappingStrategy(config)
+    raise ValueError("TODO")
+
+
+class _OneToOneMappingStrategy:
+    # TODO could be partial-ed function
+    def __init__(self, config: AdapterConfig) -> None:
+        self.config = config
+
+    def __call__(self, base_model: nn.Module, name: str) -> AdapterLayer:
+        layer = getattr(base_model, name)
+
+        if isinstance(layer, nn.Linear):
+            if isinstance(self.config, LoraConfig):
+                return LinearLoraLayer.from_config(self.config, layer)
+            if isinstance(self.config, IA3Config):
+                return LinearIA3Layer.from_config(self.config, layer)
+
+        if isinstance(layer, nn.Embedding):
+            if isinstance(self.config, LoraConfig):
+                return EmbeddingLoraLayer.from_config(self.config, layer)
+
+        raise TypeError(f"Could not find a suitable adapter layer for {type(layer)} and config {type(self.config)}")

--- a/alt/ia3.py
+++ b/alt/ia3.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from base import AdapterConfig, AdapterLayer
+from torch import nn
+
+
+@dataclass
+class IA3Config(AdapterConfig):
+    pass
+
+
+class LinearIA3Layer(AdapterLayer):
+    @classmethod
+    def from_config(cls, config: AdapterConfig, base_module: nn.Module) -> LinearIA3Layer:
+        return cls(base_module)
+
+    def reset_device(self) -> None:
+        self.to(self.base_module.weight.device)  # type: ignore
+
+    def reset_params(self) -> None:
+        if not isinstance(self.base_module, nn.Linear):
+            raise ValueError(f"{self.__class__.__name__} must be applied to an nn.Linear layer")
+        self.ia3_weight = nn.Parameter(torch.ones_like(self.base_module.weight[:1]))
+
+    def reset_requires_grad(self) -> None:
+        self.base_module.requires_grad_(False)
+        self.ia3_weight.requires_grad_(True)
+
+    def _pre_forward(self, X, *args, **kwargs):
+        if self.merged or not self.active:
+            return (X,) + args, kwargs
+
+        return (X * self.ia3_weight,) + args, kwargs
+
+    def merge(self) -> None:
+        if self.merged:
+            return
+
+        self.base_module.weight.data *= self.ia3_weight
+        #self.base_module.weight.data = torch.mul(self.base_module.weight.data, self.ia3_weight.data)
+        self.merged = True
+
+    def unmerge(self) -> None:
+        if not self.merged:
+            return
+
+        self.base_module.weight.data /= self.ia3_weight
+        #self.base_module.weight.data = torch.div(self.base_module.weight.data, self.ia3_weight.data + 1e-8)
+        self.merged = False

--- a/alt/lora.py
+++ b/alt/lora.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import torch
+from base import AdapterConfig, AdapterLayer
+from torch import nn
+from torch.nn import functional as F
+
+
+@dataclass
+class LoraConfig(AdapterConfig):
+    r: int = field(default=8, metadata={"help": "Lora attention dimension"})
+
+    def __post_init__(self) -> None:
+        if isinstance(self.target_modules, list):
+            assert len(self.target_modules) >= 1
+        assert self.r > 0
+
+
+class LoraLayer(AdapterLayer):
+    def __init__(self, base_module: nn.Module, r: int = 8) -> None:
+        if r <= 0:
+            raise ValueError("TODO")
+
+        self.r = r
+        super().__init__(base_module)
+
+    @classmethod
+    def from_config(cls, config: AdapterConfig, base_module: nn.Module) -> LoraLayer:
+        r = getattr(config, "r", None)
+        assert isinstance(r, int)
+        return cls(base_module, r=r)
+
+    def reset_device(self) -> None:
+        self.to(self.base_module.weight.device)  # type: ignore
+
+    def reset_requires_grad(self) -> None:
+        self.base_module.requires_grad_(False)
+        self.lora_A.requires_grad_(True)
+        self.lora_B.requires_grad_(True)
+
+    def _post_forward(self, output, x):
+        if self.merged or not self.active:
+            return output
+
+        lora_output = self.lora_B(self.lora_A(x))
+        return output + lora_output
+
+    def merge(self) -> None:
+        if self.merged:
+            return
+
+        delta_weight = self.get_delta_weight()
+        self.base_module.weight.data += delta_weight
+        self.merged = True
+
+    def unmerge(self) -> None:
+        if not self.merged:
+            return
+
+        delta_weight = self.get_delta_weight()
+        self.base_module.weight.data -= delta_weight
+        self.merged = False
+
+    def get_delta_weight(self) -> torch.Tensor:
+        raise NotImplementedError
+
+
+class LinearLoraLayer(LoraLayer):
+    def reset_params(self) -> None:
+        if not isinstance(self.base_module, nn.Linear):
+            raise ValueError(f"{self.__class__.__name__} must be applied to an nn.Linear layer")
+
+        self.lora_A = nn.Linear(self.base_module.in_features, self.r, bias=False)
+        self.lora_B = nn.Linear(self.r, self.base_module.out_features, bias=False)
+        nn.init.zeros_(self.lora_B.weight)
+
+    def get_delta_weight(self) -> torch.Tensor:
+        return self.lora_B.weight @ self.lora_A.weight  # type: ignore
+
+
+class EmbeddingLoraLayer(LoraLayer):
+    def reset_params(self) -> None:
+        if not isinstance(self.base_module, nn.Embedding):
+            raise ValueError(f"{self.__class__.__name__} must be applied to an nn.Embedding layer")
+
+        self.lora_A = nn.Embedding(
+            self.base_module.num_embeddings,
+            self.r,
+            padding_idx=self.base_module.padding_idx,
+            max_norm=self.base_module.max_norm,
+            norm_type=self.base_module.norm_type,
+            scale_grad_by_freq=self.base_module.scale_grad_by_freq,
+            sparse=self.base_module.sparse,
+            device=self.base_module.weight.device,
+            dtype=self.base_module.weight.dtype,
+        )
+        self.lora_B = nn.Linear(self.r, self.base_module.embedding_dim, bias=False)
+        nn.init.zeros_(self.lora_B.weight)
+
+    def get_delta_weight(self) -> torch.Tensor:
+        return self.lora_A.weight @ self.lora_B.weight.T

--- a/alt/test_alt.py
+++ b/alt/test_alt.py
@@ -1,0 +1,387 @@
+import copy
+from functools import partial
+
+import pytest
+import torch
+from ia3 import IA3Config, LinearIA3Layer
+from lora import LoraConfig, LinearLoraLayer
+from torch import nn
+from wrapper import AdapterWrapper
+
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin0 = nn.Linear(10, 300)
+        self.relu = nn.ReLU()
+        self.drop = nn.Dropout(0.5)
+        self.lin1 = nn.Linear(300, 1)
+
+    def forward(self, X):
+        X = self.lin0(X)
+        X = self.relu(X)
+        X = self.drop(X)
+        X = self.lin1(X)
+        return X
+
+
+class EmbModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.emb = nn.Embedding(10, 300)
+        self.relu = nn.ReLU()
+        self.drop = nn.Dropout(0.5)
+        self.lin1 = nn.Linear(300, 1)
+
+    def forward(self, X):
+        X = self.emb(X)
+        X = self.relu(X)
+        X = self.drop(X)
+        X = self.lin1(X).squeeze(-1)
+        return X
+
+
+TEST_CASES = [
+    (MLP, LoraConfig(target_modules="lin0")),
+    (MLP, LoraConfig(target_modules="lin1")),
+    (MLP, LoraConfig(target_modules=["lin0"])),
+    (MLP, LoraConfig(target_modules=["lin0", "lin1"])),
+    (MLP, LoraConfig(target_modules=["lin0"], modules_to_save=["lin1"])),
+
+    (EmbModel, LoraConfig(target_modules="emb")),
+    (EmbModel, LoraConfig(target_modules="lin1")),
+    (EmbModel, LoraConfig(target_modules=["emb"])),
+    (EmbModel, LoraConfig(target_modules=["emb", "lin1"])),
+    (EmbModel, LoraConfig(target_modules=["emb"], modules_to_save=["lin1"])),
+
+    (MLP, IA3Config(target_modules="lin0")),
+    (MLP, IA3Config(target_modules="lin1")),
+    (MLP, IA3Config(target_modules=["lin0"])),
+    (MLP, IA3Config(target_modules=["lin0", "lin1"])),
+    (MLP, IA3Config(target_modules=["lin0"], modules_to_save=["lin1"])),
+]
+
+
+def get_prefix_from_config(config):
+    # used to identify if a parameter is an adapter parameter
+    prefix = {
+        LoraConfig: "lora",
+        IA3Config: "ia3",
+    }[type(config)]
+    return prefix
+
+
+class TestAltLora:
+    device = "cpu"
+
+    @pytest.fixture(autouse=True, params=["cpu", "cuda:0"])
+    def set_device(self, request):
+        if request.param == "cuda:0":
+            if not torch.cuda.is_available():
+                pytest.skip(reason="device is not CUDA-capble")
+        self.device = request.param
+
+    def get_data(self, model_cls):
+        if model_cls == MLP:
+            X = torch.rand(9, 10)
+            y = torch.rand(9, 1)
+        elif model_cls == EmbModel:
+            X = torch.randint(0, 10, (9, 1))
+            y = torch.rand(9, 1)
+        X, y = X.to(self.device), y.to(self.device)
+        return X, y
+
+    def get_peft_model(self, model_cls, config, **kwargs):
+        torch.manual_seed(0)
+        model = model_cls()
+        peft_model = AdapterWrapper.from_config(model, config, **kwargs)
+        peft_model = peft_model.to(self.device).eval()
+        return peft_model
+
+    def fit(self, model, X, y, epochs=3):
+        torch.manual_seed(0)
+        model.train()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+        # train at least 3 steps for all parameters to be updated (probably this is required because of symmetry
+        # breaking of some layers that are initialized with constants)
+        for _ in range(3):
+            optimizer.zero_grad()
+            y_pred = model(X)
+            loss = nn.functional.mse_loss(y_pred, y)
+            loss.backward()
+            optimizer.step()
+
+        model.eval()
+
+    @pytest.mark.parametrize("model_cls, config", TEST_CASES)
+    def test_applying_lora_does_not_change_output(self, model_cls, config):
+        X, _ = self.get_data(model_cls)
+        model = model_cls().to(self.device).eval()
+        output_base = model(X)
+
+        peft_model = AdapterWrapper.from_config(model, config)
+        output_peft = peft_model(X)
+
+        torch.testing.assert_close(output_base, output_peft)
+
+    @pytest.mark.parametrize("model_cls, config", TEST_CASES)
+    def test_training_changes_output(self, model_cls, config):
+        X, y = self.get_data(model_cls)
+        peft_model = self.get_peft_model(model_cls, config)
+
+        output_base = peft_model.model(X)
+        output_before = peft_model(X)
+        torch.testing.assert_close(output_base, output_before)
+
+        self.fit(peft_model, X, y)
+        output_after = peft_model(X)
+        assert not torch.allclose(output_before, output_after)
+
+    @pytest.mark.parametrize("model_cls, config", TEST_CASES)
+    def test_only_adapter_layers_are_updated(self, model_cls, config):
+        X, y = self.get_data(model_cls)
+        peft_model = self.get_peft_model(model_cls, config)
+        params_before = {k: v.clone().detach() for k, v in peft_model.named_parameters()}
+        self.fit(peft_model, X, y)
+        params_after = dict(peft_model.named_parameters())
+
+        assert params_before.keys() == params_after.keys()
+
+        prefix = get_prefix_from_config(config)
+        for key, param_before in params_before.items():
+            param_after = params_after[key]
+            is_adapter_param = prefix in key
+            is_module_to_save = any(key.startswith(m2s + ".new_module") for m2s in config.modules_to_save)
+            if is_adapter_param or is_module_to_save:
+                assert not torch.allclose(param_before, param_after)
+                assert param_after.requires_grad
+            else:
+                torch.testing.assert_close(param_before, param_after)
+                assert not param_after.requires_grad
+
+    @pytest.mark.parametrize("model_cls, config", TEST_CASES)
+    @pytest.mark.parametrize("merge", [True, False])
+    def test_unload(self, model_cls, config, merge):
+        X, y = self.get_data(model_cls)
+        peft_model = self.get_peft_model(model_cls, config)
+        output_before = peft_model(X)
+        self.fit(peft_model, X, y)
+
+        if merge:
+            peft_model.merge_adapter()
+
+        model = peft_model.unload()
+        output_unloaded = model(X)
+        torch.testing.assert_close(output_before, output_unloaded)
+
+    @pytest.mark.parametrize("model_cls, config", TEST_CASES)
+    @pytest.mark.parametrize("merge", [True, False])
+    def test_merge_and_unload(self, model_cls, config, merge):
+        X, y = self.get_data(model_cls)
+        peft_model = self.get_peft_model(model_cls, config)
+
+        self.fit(peft_model, X, y)
+        output_after = peft_model(X)
+
+        if merge:
+            peft_model.merge_adapter()
+        model = peft_model.merge_and_unload()
+        output_unloaded = model(X)
+        torch.testing.assert_close(output_after, output_unloaded)
+
+    @pytest.mark.parametrize("model_cls, config", TEST_CASES)
+    def test_merge_unmerge(self, model_cls, config):
+        X, y = self.get_data(model_cls)
+        peft_model = self.get_peft_model(model_cls, config)
+
+        self.fit(peft_model, X, y)
+        output_after = peft_model(X)
+
+        peft_model.merge_adapter()
+        output_merged = peft_model(X)
+        torch.testing.assert_close(output_after, output_merged)
+
+        peft_model.unmerge_adapter()
+        output_unmerged = peft_model(X)
+        torch.testing.assert_close(output_after, output_unmerged)
+
+    @pytest.mark.parametrize("model_cls, config", TEST_CASES)
+    def test_multiple_adapters_only_active_one_is_updated(self, model_cls, config):
+        X, y = self.get_data(model_cls)
+
+        config_A = config
+        config_B = copy.copy(config)
+        peft_model = self.get_peft_model(model_cls, config_B, adapter_name="adapter-B")
+        # config B is the active adapter
+
+        peft_model.add_adapter_from_config(config_A, "adapter-A")
+        # config A is now the active adapter
+
+        params_A_before = {
+            k: v.clone().detach() for k, v in peft_model._adapter_registry["adapter-A"].named_adapter_parameters()
+        }
+        params_B_before = {
+            k: v.clone().detach() for k, v in peft_model._adapter_registry["adapter-B"].named_adapter_parameters()
+        }
+        self.fit(peft_model, X, y, epochs=3)
+        params_A_after = dict(peft_model._adapter_registry["adapter-A"].named_adapter_parameters())
+        params_B_after = dict(peft_model._adapter_registry["adapter-B"].named_adapter_parameters())
+
+        prefix = get_prefix_from_config(config)
+        # adapter layers for A should have changed
+        for key, param_before in params_A_before.items():
+            param_after = params_A_after[key]
+            is_adapter_param = prefix in key
+            is_module_to_save = key.startswith("new_module.")
+            if is_adapter_param or is_module_to_save:
+                assert param_after.requires_grad
+                assert not torch.allclose(param_before, param_after)
+            else:
+                assert not param_after.requires_grad
+                torch.testing.assert_allclose(param_before, param_after)
+
+        # all B layers should be the same
+        for key, param_before in params_B_before.items():
+            param_after = params_B_after[key]
+            torch.testing.assert_close(param_before, param_after)
+
+    @pytest.mark.parametrize("model_cls, config", TEST_CASES)
+    def test_multiple_adapters_output(self, model_cls, config):
+        X, y = self.get_data(model_cls)
+
+        config_A = config
+        config_B = copy.copy(config)
+        peft_model = self.get_peft_model(model_cls, config_B, adapter_name="adapter-B")
+        # config B is the active adapter
+
+        prefix = get_prefix_from_config(config)
+        grad_dict = {name: param.requires_grad for name, param in peft_model.named_parameters()}
+        grad_dict_expected = {name: (prefix in name) or ("new_module" in name) for name in grad_dict}
+        assert grad_dict == grad_dict_expected
+
+        peft_model.add_adapter_from_config(config_A, "adapter-A")
+        # config_A is now the active adapter
+        grad_dict = {name: param.requires_grad for name, param in peft_model.named_parameters()}
+        assert grad_dict == grad_dict_expected
+
+        output_A_1 = peft_model(X)
+
+        peft_model.set_adapter("adapter-B")
+        grad_dict = {name: param.requires_grad for name, param in peft_model.named_parameters()}
+        assert grad_dict == grad_dict_expected
+        self.fit(peft_model, X, y, epochs=10)  # different number of epochs to ensure different weights
+        output_B_1 = peft_model(X)
+
+        # first, ensure that the two adapters produce different outputs
+        assert not torch.allclose(output_A_1, output_B_1)
+
+        # going back to A should produce the same A output as before
+        peft_model.set_adapter("adapter-A")
+        grad_dict = {name: param.requires_grad for name, param in peft_model.named_parameters()}
+        assert grad_dict == grad_dict_expected
+        output_A_2 = peft_model(X)
+        torch.testing.assert_close(output_A_1, output_A_2)
+
+        # going back to B should produce the same B output as before
+        peft_model.set_adapter("adapter-B")
+        grad_dict = {name: param.requires_grad for name, param in peft_model.named_parameters()}
+        assert grad_dict == grad_dict_expected
+        output_B_2 = peft_model(X)
+        torch.testing.assert_close(output_B_1, output_B_2)
+
+        # delete the currently active adapter => adapter A should be active now
+        peft_model.delete_adapter("adapter-B")
+        output_A_3 = peft_model(X)
+        torch.testing.assert_close(output_A_1, output_A_3)
+
+        # deleting B again raises a KeyError
+        with pytest.raises(KeyError):
+            peft_model.delete_adapter("adapter-B")
+        # trying to delete A, which is the last adapter, raises a ValueError
+        with pytest.raises(ValueError):
+            peft_model.delete_adapter("adapter-A")
+
+    def test_mixing_adaptations_parameters_works(self):
+        X, y = self.get_data(MLP)
+        model = MLP().to(self.device).eval()
+        output_base = model(X)
+
+        peft_model = AdapterWrapper(model)
+        peft_model.add_adapter()
+
+        lin_lora_0 = partial(LinearLoraLayer, r=4)
+        peft_model.add_adapter_layer("lin0", lin_lora_0)
+        lin_lora_1 = partial(LinearLoraLayer, r=5)
+        peft_model.add_adapter_layer("lin1", lin_lora_1)
+        output_peft = peft_model(X)
+
+        torch.testing.assert_close(output_base, output_peft)
+        self.fit(peft_model, X, y)
+
+        output_after = peft_model(X)
+        assert not torch.allclose(output_peft, output_after)
+
+        lora_layers = [layer for layer in peft_model.modules() if isinstance(layer, LinearLoraLayer)]
+        assert len(lora_layers) == 2
+        assert lora_layers[0].lora_A.out_features == 4
+        assert lora_layers[0].lora_B.in_features == 4
+        assert lora_layers[1].lora_A.out_features == 5
+        assert lora_layers[1].lora_B.in_features == 5
+
+        peft_model.delete_adapter_layer("lin0")
+        output_deleted = peft_model(X)
+        assert not torch.allclose(output_after, output_deleted)
+
+        lora_layers = [layer for layer in peft_model.modules() if isinstance(layer, LinearLoraLayer)]
+        assert len(lora_layers) == 1
+        assert lora_layers[0].lora_A.out_features == 5
+        assert lora_layers[0].lora_B.in_features == 5
+
+    def test_mixing_adaptations_types_works(self):
+        X, y = self.get_data(MLP)
+        model = MLP().to(self.device).eval()
+        output_base = model(X)
+
+        peft_model = AdapterWrapper(model)
+        peft_model.add_adapter()
+
+        lin_lora = partial(LinearLoraLayer, r=4)
+        peft_model.add_adapter_layer("lin0", lin_lora)
+        lin_ia3 = LinearIA3Layer
+        peft_model.add_adapter_layer("lin1", lin_ia3)
+        output_peft = peft_model(X)
+
+        torch.testing.assert_close(output_base, output_peft)
+        self.fit(peft_model, X, y)
+
+        output_after = peft_model(X)
+        assert not torch.allclose(output_peft, output_after)
+
+        lora_layers = [layer for layer in peft_model.modules() if isinstance(layer, LinearLoraLayer)]
+        assert len(lora_layers) == 1
+        assert lora_layers[0].lora_A.out_features == 4
+        assert lora_layers[0].lora_B.in_features == 4
+
+        ia3_layers = [layer for layer in peft_model.modules() if isinstance(layer, LinearIA3Layer)]
+        assert len(ia3_layers) == 1
+        assert ia3_layers[0].ia3_weight.shape == (1, 300)
+
+    def test_nesting_adaptations_types_raises(self):
+        X, y = self.get_data(MLP)
+        model = MLP().to(self.device).eval()
+
+        peft_model = AdapterWrapper(model)
+        peft_model.add_adapter()
+
+        # trying to apply IA³ to a Lora layer should raise an error
+        lin_lora = partial(LinearLoraLayer, r=4)
+        peft_model.add_adapter_layer("lin0", lin_lora)
+        lin_ia3 = LinearIA3Layer
+
+        with pytest.raises(ValueError):
+            peft_model.add_adapter_layer("lin0", lin_ia3)
+
+    @pytest.mark.skip(reason="TODO")
+    def test_wrong_module_names_raises(self):
+        pass

--- a/alt/wrapper.py
+++ b/alt/wrapper.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from typing import Iterator, Type
+
+import torch
+from base import AdapterConfig, AdapterLayer, ModulesToSaveWrapper
+from construction import _get_adaptation_strategy, _get_selection_strategy
+from torch import nn
+
+
+class Adapter:
+    def __init__(self, model: nn.Module, name: str):
+        self.model = model
+        self.name = name
+        self._adapter_layers: dict[str, AdapterLayer] = {}
+
+    def _apply(self) -> None:
+        for name, new_layer in self._adapter_layers.items():
+            self._replace_layer(self.model, name, new_layer)
+        self._reset_requires_grad()
+
+    def _unapply(self) -> None:
+        for name, layer in self._adapter_layers.items():
+            self._replace_layer(self.model, name, layer.base_module)
+
+    def _replace_layer(self, base_model: nn.Module, name: str, new_layer: nn.Module) -> None:
+        # TODO: deal with ModuleList, ModuleDict
+        old_layer = getattr(base_model, name, None)
+        if old_layer is None:
+            raise AttributeError("TODO")
+
+        if old_layer is new_layer:
+            return
+
+        if isinstance(old_layer, AdapterLayer) and isinstance(new_layer, AdapterLayer):
+            raise ValueError("Trying to replace an adapter layer with another adapter layer")
+
+        if getattr(base_model, name) is not new_layer:
+            setattr(base_model, name, new_layer)
+
+    def _reset_requires_grad(self) -> None:
+        for layer in self._adapter_layers.values():
+            layer.reset_requires_grad()
+
+    def _merge(self) -> None:
+        for layer in self._adapter_layers.values():
+            layer.merge()
+
+    def _unmerge(self) -> None:
+        for layer in self._adapter_layers.values():
+            layer.unmerge()
+
+    def _add_layer(self, name: str, layer: AdapterLayer | Type[AdapterLayer]) -> None:
+        if not isinstance(layer, nn.Module):
+            # layer is not (fully) iniitalized, initialize it here
+            if not hasattr(self.model, name):
+                raise AttributeError("TODO")
+            old_layer = getattr(self.model, name)
+            layer = layer(old_layer)
+
+        self._adapter_layers[name] = layer
+        self._replace_layer(self.model, name, layer)
+
+    def _delete_layer(self, name: str) -> None:
+        existing_names = self._adapter_layers.keys()
+        if name not in existing_names:
+            raise KeyError(f"Adapter layer {name} does not exist, existing layers: {existing_names}")
+
+        adapter_layer = self._adapter_layers.pop(name)
+        assert isinstance(adapter_layer, AdapterLayer)
+        self._replace_layer(self.model, name, adapter_layer.base_module)
+
+    def named_adapter_parameters(self) -> Iterator[tuple[str, torch.Tensor]]:
+        for layer in self._adapter_layers.values():
+            yield from layer.named_parameters()
+
+    def adapter_parameters(self) -> Iterator[torch.Tensor]:
+        for _, param in self.named_adapter_parameters():
+            yield param
+
+
+class AdapterWrapper(nn.Module):
+    ##################
+    # INITIALIZATION #
+    ##################
+
+    def __init__(self, model: nn.Module, config: AdapterConfig | None = None) -> None:
+        super().__init__()
+        self.model = model
+        self.config = config
+
+        self._active_adapter_name: str | None = None
+        self._adapter_registry: dict[str, Adapter] = {}
+
+    @property
+    def active_adapter(self) -> Adapter | None:
+        # this can return None if no adapter is active yet
+        if self._active_adapter_name is None:
+            return None
+        return self._adapter_registry.get(self._active_adapter_name)
+
+    def reset_base_model(self) -> None:
+        self.model.requires_grad_(False)
+
+        if self.active_adapter is not None:
+            self.unmerge_adapter()
+            self.active_adapter._unapply()
+
+    #####################
+    # HANDLING ADAPTERS #
+    #####################
+
+    def add_adapter(self, adapter_name: str = "default") -> None:
+        if adapter_name in self._adapter_registry:
+            raise KeyError("TODO")
+
+        self.reset_base_model()
+        self._active_adapter_name = adapter_name
+        adapter = Adapter(self.model, name=adapter_name)
+        self._adapter_registry[adapter_name] = adapter
+        adapter._apply()
+
+    def set_adapter(self, adapter_name: str) -> None:
+        if adapter_name == self._active_adapter_name:
+            return
+
+        if adapter_name not in self._adapter_registry:
+            raise KeyError("TODO")
+
+        self.reset_base_model()
+        self._active_adapter_name = adapter_name
+        if self.active_adapter is not None:
+            # note: should never be None at this point but mypy doesn't understand that
+            self.active_adapter._apply()
+
+    def delete_adapter(self, adapter_name: str) -> None:
+        if adapter_name not in self._adapter_registry:
+            raise KeyError("TODO")
+
+        if len(self._adapter_registry) == 1:
+            # TODO: probably not needed, should work without adapter
+            raise ValueError("Cannot delete last adapter")
+
+        is_active_adapter = adapter_name == self._active_adapter_name
+        if is_active_adapter:
+            self.unmerge_adapter()
+            # we know there must be a key != currently active adapter because of the check above
+            guess_next_adapter = next(k for k in self._adapter_registry if k != adapter_name)
+            self.set_adapter(guess_next_adapter)
+
+        del self._adapter_registry[adapter_name]
+
+    def add_adapter_layer(self, name: str, layer: AdapterLayer | Type[AdapterLayer]) -> None:
+        """Add an adapter layer to the active adapter."""
+        if self.active_adapter is None:
+            raise ValueError("There is no active adapter, create it first by calling .add_adapter")
+
+        self.active_adapter._add_layer(name, layer)
+        self.active_adapter._apply()
+
+    def delete_adapter_layer(self, name: str) -> None:
+        """Delete an adapter layer from the active adapter."""
+        if self.active_adapter is None:
+            raise ValueError("There is no active adapter")
+
+        self.active_adapter._delete_layer(name)
+
+    def _unload_and_optionally_merge(self, merge: bool) -> nn.Module:
+        adapter = self.active_adapter
+        if adapter is None:
+            return self.model
+
+        if merge:
+            adapter._merge()
+        else:
+            adapter._unmerge()
+
+        # remove the adapter layers
+        adapter._unapply()
+        return self.model
+
+    def merge_adapter(self) -> None:
+        if self.active_adapter is not None:
+            self.active_adapter._merge()
+
+    def unmerge_adapter(self) -> None:
+        if self.active_adapter is not None:
+            self.active_adapter._unmerge()
+
+    def unload(self) -> nn.Module:
+        return self._unload_and_optionally_merge(merge=False)
+
+    def merge_and_unload(self) -> nn.Module:
+        return self._unload_and_optionally_merge(merge=True)
+
+    def activate_adapter(self) -> None:
+        # TODO
+        pass
+
+    def deactivate_adapter(self) -> None:
+        # TODO
+        pass
+
+    ########################
+    # CREATION FROM CONFIG #
+    ########################
+
+    def add_adapter_from_config(self, config: AdapterConfig, adapter_name: str = "default") -> AdapterWrapper:
+        self.add_adapter(adapter_name)
+
+        selection_strategy = _get_selection_strategy(config, self.model)
+        any_match = False
+        for name, layer_specific_args in selection_strategy:
+            any_match = True
+            adaptation_strategy = _get_adaptation_strategy(config, layer_specific_args)
+            new_layer = adaptation_strategy(self.model, name)
+            self.add_adapter_layer(name, new_layer)
+
+        if not any_match:
+            raise ValueError("Could not find any matching layers for the given config")
+
+        modules_to_save = config.modules_to_save or []
+        for name in modules_to_save:
+            self.add_adapter_layer(name, ModulesToSaveWrapper)
+
+        return self
+
+    @classmethod
+    def from_config(cls, model: nn.Module, config: AdapterConfig, adapter_name: str = "default") -> AdapterWrapper:
+        wrapper = cls(model, config=config)
+        wrapper.add_adapter_from_config(config, adapter_name)
+        return wrapper
+
+    ##################################
+    # EXPOSING METHODS OF BASE MODEL #
+    ##################################
+
+    def forward(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
+
+    def generate(self, *args, **kwargs):
+        return self.model.generate(*args, **kwargs)
+
+    def parameters(self):
+        return self.model.parameters()
+
+    def named_parameters(self):
+        return self.model.named_parameters()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ doctest_optionflags = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/peft --cov-report=term-missing"
+addopts = "--cov=src/peft --cov=alt/ --cov-report=term-missing"
 markers = [
     "single_gpu_tests: tests that run on a single GPU",
     "multi_gpu_tests: tests that run on multiple GPUs",


### PR DESCRIPTION
This is a draft for a refactor adapter layers. I'll explain in more details in the weekly. Right now, LoRA and IA³ are implemented (though only a subset of features). Prompt tuning is out of scope.

Some things that have were with this refactor:

- adapter handling:
  - handling of different adapters not delegated to `LoraLayer` et al, instead, handling of adapters is delegated to the wrapper class, which needs to know about this anyway
  - => makes adapter layers simpler as they need not know about different adapters
  - => responsibilities are better defined, e.g. there is a single source of truth for what adapter is currently active
  - => generic adapter wrapper class works for all adapters, no more necessity for `IAModel`, `LoraModel` etc.

- separation of concerns for the design of adapter layer
  - there is a clearly defined base class
  - => makes it clear what child classes need to implement, e.g. weight initialization lives on child classes, not parent

- adapter layers keep reference to original layer
  - currently, the original layer is "dissolved" when it's passed to the adapter layer
  - => now, unloading is just a matter of returning that reference, no more construction of new layers (which is error prone -- were all parameters passed correctly?)
  - => the original forward method of the layer is preserved and can be called, no more `F.linear(x, transpose(self.weight, self.fan_in_fan_out), bias=self.bias)` etc., just do `self.base_module(*args, **kwargs)`

- groundwork for more flexible initialization of adapters
  - => enables more fine-grained control of how adapter layers are initialized, e.g. - LoRA layers with different values for the `r` parameter - mixing LoRA and IA³ - replacing layer by type (e.g. all `Linear` layers) instead of by name
  - => enables users to provide their own adapter layers => turns peft more into a library instead of a "model zoo" for fine-tuning techniques
  - but: representing all these options in a declarative way in a single json-serializable config may not be possible (however, the original options should still work)