### PR TITLE
[`core`] PEFT refactor + introducing `create_and_replace` public method

### DIFF
--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -28,7 +28,13 @@ from .auto import (
     AutoPeftModelForQuestionAnswering,
     AutoPeftModelForFeatureExtraction,
 )
-from .mapping import MODEL_TYPE_TO_PEFT_MODEL_MAPPING, PEFT_TYPE_TO_CONFIG_MAPPING, get_peft_config, get_peft_model
+from .mapping import (
+    MODEL_TYPE_TO_PEFT_MODEL_MAPPING,
+    PEFT_TYPE_TO_CONFIG_MAPPING,
+    get_peft_config,
+    get_peft_model,
+    create_and_replace,
+)
 from .peft_model import (
     PeftModel,
     PeftModelForCausalLM,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -537,50 +537,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 peft_config.inference_mode = not is_trainable
             self.add_adapter(adapter_name, peft_config)
 
-        # load weights if any
-        path = (
-            os.path.join(model_id, hf_hub_download_kwargs["subfolder"])
-            if hf_hub_download_kwargs.get("subfolder", None) is not None
-            else model_id
-        )
-
-        if os.path.exists(os.path.join(path, SAFETENSORS_WEIGHTS_NAME)):
-            filename = os.path.join(path, SAFETENSORS_WEIGHTS_NAME)
-            use_safetensors = True
-        elif os.path.exists(os.path.join(path, WEIGHTS_NAME)):
-            filename = os.path.join(path, WEIGHTS_NAME)
-            use_safetensors = False
-        else:
-            has_remote_safetensors_file = hub_file_exists(
-                model_id,
-                SAFETENSORS_WEIGHTS_NAME,
-                revision=hf_hub_download_kwargs.get("revision", None),
-                repo_type=hf_hub_download_kwargs.get("repo_type", None),
-            )
-            use_safetensors = has_remote_safetensors_file
-
-            if has_remote_safetensors_file:
-                # Priority 1: load safetensors weights
-                filename = hf_hub_download(
-                    model_id,
-                    SAFETENSORS_WEIGHTS_NAME,
-                    **hf_hub_download_kwargs,
-                )
-            else:
-                try:
-                    filename = hf_hub_download(model_id, WEIGHTS_NAME, **hf_hub_download_kwargs)
-                except EntryNotFoundError:
-                    raise ValueError(
-                        f"Can't find weights for {model_id} in {model_id} or in the Hugging Face Hub. "
-                        f"Please check that the file {WEIGHTS_NAME} or {SAFETENSORS_WEIGHTS_NAME} is present at {model_id}."
-                    )
-
-        if use_safetensors:
-            adapters_weights = safe_load_file(filename, device="cuda" if torch.cuda.is_available() else "cpu")
-        else:
-            adapters_weights = torch.load(
-                filename, map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu")
-            )
+        adapters_weights = self._get_peft_state_dict(model_id, **hf_hub_download_kwargs)
 
         # load the weights into the model
         load_result = set_peft_model_state_dict(self, adapters_weights, adapter_name=adapter_name)
@@ -647,6 +604,55 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
     @property
     def active_peft_config(self):
         return self.peft_config[self.active_adapter]
+
+    @staticmethod
+    def _get_peft_state_dict(model_id, **hf_hub_download_kwargs):
+        # load weights if any
+        path = (
+            os.path.join(model_id, hf_hub_download_kwargs["subfolder"])
+            if hf_hub_download_kwargs.get("subfolder", None) is not None
+            else model_id
+        )
+
+        if os.path.exists(os.path.join(path, SAFETENSORS_WEIGHTS_NAME)):
+            filename = os.path.join(path, SAFETENSORS_WEIGHTS_NAME)
+            use_safetensors = True
+        elif os.path.exists(os.path.join(path, WEIGHTS_NAME)):
+            filename = os.path.join(path, WEIGHTS_NAME)
+            use_safetensors = False
+        else:
+            has_remote_safetensors_file = hub_file_exists(
+                model_id,
+                SAFETENSORS_WEIGHTS_NAME,
+                revision=hf_hub_download_kwargs.get("revision", None),
+                repo_type=hf_hub_download_kwargs.get("repo_type", None),
+            )
+            use_safetensors = has_remote_safetensors_file
+
+            if has_remote_safetensors_file:
+                # Priority 1: load safetensors weights
+                filename = hf_hub_download(
+                    model_id,
+                    SAFETENSORS_WEIGHTS_NAME,
+                    **hf_hub_download_kwargs,
+                )
+            else:
+                try:
+                    filename = hf_hub_download(model_id, WEIGHTS_NAME, **hf_hub_download_kwargs)
+                except EntryNotFoundError:
+                    raise ValueError(
+                        f"Can't find weights for {model_id} in {model_id} or in the Hugging Face Hub. "
+                        f"Please check that the file {WEIGHTS_NAME} or {SAFETENSORS_WEIGHTS_NAME} is present at {model_id}."
+                    )
+
+        if use_safetensors:
+            adapters_weights = safe_load_file(filename, device="cuda" if torch.cuda.is_available() else "cpu")
+        else:
+            adapters_weights = torch.load(
+                filename, map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            )
+
+        return adapters_weights
 
     def create_or_update_model_card(self, output_dir: str):
         """

--- a/src/peft/tuners/__init__.py
+++ b/src/peft/tuners/__init__.py
@@ -24,3 +24,9 @@ from .adalora import AdaLoraConfig, AdaLoraModel
 from .p_tuning import PromptEncoder, PromptEncoderConfig, PromptEncoderReparameterizationType
 from .prefix_tuning import PrefixEncoder, PrefixTuningConfig
 from .prompt_tuning import PromptEmbedding, PromptTuningConfig, PromptTuningInit
+
+TUNERS_MAPPING = {
+    "LORA": LoraModel,
+    "IA3": IA3Model,
+    "ADALORA": AdaLoraModel,
+}


### PR DESCRIPTION
# What does this PR do ?

Refactors a bit the internals of some PEFT models (making some methods static, etc.) and introduces a new method `create_and_replace` for users that want to pass a bare model, a peft config to inject adapters in-place into the model. 
These changes are totally BC with the previous PEFT versions.

This PR makes things easier for the PEFT integration in transformers https://github.com/huggingface/transformers/pull/25077 

cc @pacman100 @BenjaminBossan 