### PR TITLE
Add progressbar unload/merge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "pyyaml",
         "torch>=1.13.0",
         "transformers",
+        "tqdm",
         "accelerate",
         "safetensors",
     ],

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -624,7 +624,7 @@ class LoraModel(torch.nn.Module):
                     )
                     target.active_adapter = resetting_active_adapter
 
-    def merge_and_unload(self, progressbar: bool = True):
+    def merge_and_unload(self, progressbar: bool = False):
         r"""
         This method merges the LoRa layers into the base model. This is needed if someone wants to use the base model
         as a standalone model.

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -22,8 +22,8 @@ from typing import List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers.pytorch_utils import Conv1D
 from tqdm import tqdm
+from transformers.pytorch_utils import Conv1D
 
 from ..import_utils import is_bnb_4bit_available, is_bnb_available
 from ..utils import (
@@ -55,6 +55,7 @@ class LoraConfig(PeftConfig):
         lora_dropout (`float`): The dropout probability for Lora layers.
         fan_in_fan_out (`bool`): Set this to True if the layer to replace stores weight like (fan_in, fan_out).
         For example, gpt-2 uses `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`.:
+            
         bias (`str`): Bias type for Lora. Can be 'none', 'all' or 'lora_only'. If 'all' or 'lora_only', the
             corresponding biases will be updated during training. Be aware that this means that, even when disabling
             the adapters, the model will not produce the same output as the base model would have without adaptation.

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -460,7 +460,7 @@ class LoraModel(torch.nn.Module):
             peft_config.target_modules = TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING[model_config["model_type"]]
         return peft_config
 
-    def _unload_and_optionally_merge(self, merge=True, progressbar: bool = True):
+    def _unload_and_optionally_merge(self, merge=True, progressbar: bool = False):
         if getattr(self.model, "is_loaded_in_8bit", False) or getattr(self.model, "is_loaded_in_4bit", False):
             raise ValueError("Cannot merge LORA layers when the model is loaded in 8-bit mode")
 

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -54,8 +54,8 @@ class LoraConfig(PeftConfig):
         lora_alpha (`int`): The alpha parameter for Lora scaling.
         lora_dropout (`float`): The dropout probability for Lora layers.
         fan_in_fan_out (`bool`): Set this to True if the layer to replace stores weight like (fan_in, fan_out).
-        For example, gpt-2 uses `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`.:
-            
+            For example, gpt-2 uses `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set
+            to `True`.
         bias (`str`): Bias type for Lora. Can be 'none', 'all' or 'lora_only'. If 'all' or 'lora_only', the
             corresponding biases will be updated during training. Be aware that this means that, even when disabling
             the adapters, the model will not produce the same output as the base model would have without adaptation.


### PR DESCRIPTION
Adds an optional progressbar when merge_and_unloading a model to indicate to users that the code is not "hanging" but actually still doing something. The progress bar is enabled by default but can be disabled.

TQDM has been explicitly added to the requirements, although it is probably already installed as dependency of the other libraries like torch or transformers.

closes #667 