### PR TITLE
[`ModulesToSave`] add correct hook management for modules to save

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -153,7 +153,7 @@ class ModulesToSaveWrapper(torch.nn.Module):
         Creates a new hook based on the old hook. Use it only if you know what you are doing !
         """
         old_hook_cls = getattr(accelerate.hooks, old_hook.__class__.__name__)
-        old_hook_attr = {k: v for k, v in old_hook.__dict__.items()}
+        old_hook_attr = old_hook.__dict__
         filtered_old_hook_attr = {}
         old_hook_init_signature = inspect.signature(old_hook_cls.__init__)
         for k in old_hook_attr.keys():

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -12,12 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import copy
+import inspect
 import os
 import warnings
 
+import accelerate
 import torch
+from accelerate.hooks import add_hook_to_module, remove_hook_from_module
 
 
 # Add or edit model card to have `library_name: peft`
@@ -139,6 +141,26 @@ class ModulesToSaveWrapper(torch.nn.Module):
 
     def update(self, adapter_name):
         self.modules_to_save.update(torch.nn.ModuleDict({adapter_name: copy.deepcopy(self.original_module)}))
+
+        if hasattr(self.modules_to_save[adapter_name], "_hf_hook"):
+            old_hook = self.modules_to_save[adapter_name]._hf_hook
+            new_hook = self._create_new_hook(old_hook)
+            remove_hook_from_module(self.modules_to_save[adapter_name])
+            add_hook_to_module(self.modules_to_save[adapter_name], new_hook)
+
+    def _create_new_hook(self, old_hook):
+        r"""
+        Creates a new hook based on the old hook. Use it only if you know what you are doing !
+        """
+        old_hook_cls = getattr(accelerate.hooks, old_hook.__class__.__name__)
+        old_hook_attr = {k: v for k, v in old_hook.__dict__.items()}
+        filtered_old_hook_attr = {}
+        old_hook_init_signature = inspect.signature(old_hook_cls.__init__)
+        for k in old_hook_attr.keys():
+            if k in old_hook_init_signature.parameters:
+                filtered_old_hook_attr[k] = old_hook_attr[k]
+        new_hook = old_hook_cls(**filtered_old_hook_attr)
+        return new_hook
 
     def forward(self, *args, **kwargs):
         if self.disable_adapters or (self.active_adapter not in self.modules_to_save):

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -20,6 +20,7 @@ import torch
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForSeq2SeqLM,
+    AutoModelForSequenceClassification,
     AutoTokenizer,
     BitsAndBytesConfig,
     LlamaForCausalLM,
@@ -316,3 +317,40 @@ class PeftGPUCommonTests(unittest.TestCase):
 
         self.assertEqual(trainable_params, EXPECTED_TRAINABLE_PARAMS)
         self.assertEqual(all_params, EXPECTED_ALL_PARAMS)
+
+    @require_torch_gpu
+    @pytest.mark.single_gpu_tests
+    @require_bitsandbytes
+    def test_modules_to_save_grad(self):
+        model_id = "bigscience/bloomz-560m"
+        load_in_4bit = True
+
+        model = AutoModelForSequenceClassification.from_pretrained(
+            model_id,
+            load_in_4bit=load_in_4bit,
+            torch_dtype=torch.float32,
+        )
+
+        model = prepare_model_for_kbit_training(model)
+
+        config = LoraConfig(
+            r=16,
+            lora_alpha=16,
+            lora_dropout=0.05,
+            bias="none",
+            task_type="SEQ_CLS",
+        )
+
+        peft_model = get_peft_model(model, config)
+
+        lm_head = peft_model.base_model.model.score
+        original_module = lm_head.original_module
+        modules_to_save = lm_head.modules_to_save.default
+
+        inputs = torch.randn((1024))
+        o1 = lm_head(inputs)
+        o1.mean().backward()
+
+        self.assertTrue(modules_to_save.weight.requires_grad is True)
+        self.assertTrue(original_module.weight.grad is None)
+        self.assertTrue(modules_to_save.weight.grad is not None)


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/peft/issues/602 and the solution has been found out by @BenjaminBossan 
When loading the base model with accelerate, the old hooks were still attached to the new module, causing the `ModulesToSaveWrapper` module to call the previous forward method, leading to the gradients not being properly backpropagated to the right module.

A reproducible script shared by Benjamin:

```python
import torch
from peft import LoraConfig, TaskType, get_peft_model, prepare_model_for_kbit_training
from transformers import AutoTokenizer, AutoModelForSequenceClassification, set_seed
set_seed(123)

PRETRAIN = 'bigscience/bloomz-560m'
tokenizer = AutoTokenizer.from_pretrained(PRETRAIN)

load_in_4bit=True
device_map=None
should_resize_token_embeddings=False
should_prepare_model_for_kbit_training=True

model = AutoModelForSequenceClassification.from_pretrained(
    PRETRAIN,
    load_in_4bit=load_in_4bit,
    torch_dtype=torch.float32,
    device_map=device_map,
)
if should_prepare_model_for_kbit_training:
    model = prepare_model_for_kbit_training(model)

config = LoraConfig(
    r=16,
    lora_alpha=16,
    lora_dropout=0.05,
    bias="none",
    task_type=TaskType.SEQ_CLS,
)

peft_model = get_peft_model(model, config)
if should_resize_token_embeddings:
    model.resize_token_embeddings(len(tokenizer))

lm_head = peft_model.base_model.model.score
original_module = lm_head.original_module
modules_to_save = lm_head.modules_to_save.default

inputs = torch.randn((1024))
o1 = lm_head(inputs)
o1.mean().backward()

assert modules_to_save.weight.requires_grad is True
assert original_module.weight.grad is None
assert modules_to_save.weight.grad is not None
```

The fix is to create a fresh new copy of the previous hook to keep the same attributes, remove the old hook and attach that new hook to the module. 

cc @BenjaminBossan @pacman100 