### PR TITLE
Calling prepare_model_for_kbit_training if you aren't quantizing the model can freeze all parameters when doing LoRA training

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -72,6 +72,7 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
             The loaded model from `transformers`
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
+    
     for name, param in model.named_parameters():
         # freeze base model's layers
         param.requires_grad = False
@@ -99,7 +100,7 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
         if not any(p.requires_grad for p in model.parameters()):
             warnings.warn(
                 "This model has no trainable parameters: \
-                did you accidentally call prepare_model_for_kbit_training when your model was not quantized?",
+                did you accidentally call prepare_model_for_kbit_training when your model was not quantized?"
             )
     return model
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -95,7 +95,13 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
 
         # enable gradient checkpointing for memory efficiency
         model.gradient_checkpointing_enable()
-
+    else:
+         # check to see if the model has any parameters that are trainable
+        if len([p for p in model.parameters() if p.requires_grad]) == 0:
+            warnings.warn(
+                "This model has no trainable parameters: did you accidentally call prepare_model_for_kbit_training when your model was not quantized?",
+                Warning
+            )
     return model
 
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -96,12 +96,10 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
         # enable gradient checkpointing for memory efficiency
         model.gradient_checkpointing_enable()
     else:
-        # check to see if the model has any parameters that are trainable
-        if not any(p.requires_grad for p in model.parameters()):
-            warnings.warn(
-                "This model has no trainable parameters: \
-                did you accidentally call prepare_model_for_kbit_training when your model was not quantized?"
-            )
+        warnings.warn(
+            "This model has no trainable parameters: \
+            did you accidentally call prepare_model_for_kbit_training when your model was not quantized?"
+        )
     return model
 
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -72,11 +72,6 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
             The loaded model from `transformers`
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
-    if not loaded_in_kbit:
-        warnings.warn(
-            "You are not quantizing the model, This function is going to freeze all of the base model's parameters. If you are going to train a new LoRA adapter, there may be no parameters with requires_grad=True.",
-            Warning
-        )
     for name, param in model.named_parameters():
         # freeze base model's layers
         param.requires_grad = False
@@ -101,10 +96,10 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
         model.gradient_checkpointing_enable()
     else:
          # check to see if the model has any parameters that are trainable
-        if len([p for p in model.parameters() if p.requires_grad]) == 0:
+        if not any(p.requires_grad for p in model.parameters()):
             warnings.warn(
-                "This model has no trainable parameters: did you accidentally call prepare_model_for_kbit_training when your model was not quantized?",
-                Warning
+                "This model has no trainable parameters: \
+                did you accidentally call prepare_model_for_kbit_training when your model was not quantized?",
             )
     return model
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -72,7 +72,11 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
             The loaded model from `transformers`
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
-
+    if not loaded_in_kbit:
+        warnings.warn(
+            "You are not quantizing the model, This function is going to freeze all of the base model's parameters. If you are going to train a new LoRA adapter, there may be no parameters with requires_grad=True.",
+            Warning
+        )
     for name, param in model.named_parameters():
         # freeze base model's layers
         param.requires_grad = False

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -72,7 +72,7 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
             The loaded model from `transformers`
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
-    
+
     for name, param in model.named_parameters():
         # freeze base model's layers
         param.requires_grad = False

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -96,7 +96,7 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
         # enable gradient checkpointing for memory efficiency
         model.gradient_checkpointing_enable()
     else:
-         # check to see if the model has any parameters that are trainable
+        # check to see if the model has any parameters that are trainable
         if not any(p.requires_grad for p in model.parameters()):
             warnings.warn(
                 "This model has no trainable parameters: \


### PR DESCRIPTION
Hi! I am still trying to track down the exact failure condition, but it seems that if you aren't 8bit or 4bit quantizing the model, then calling prepare_model_for_kbit_training freezes all the weights in the model and training will fail with the error

`warnings.warn("None of the inputs have requires_grad=True. Gradients will be None")`

```
model = AutoModelForCausalLM.from_pretrained(
        model_args.model_name_or_path,
        load_in_8bit=False,
        load_in_4bit=False,
        device_map=device_map,
    )
model = prepare_model_for_kbit_training(model)

trainable_params = [p for p in model.parameters() if p.requires_grad]
if len(trainable_params) == 0:
    print("No trainable parameters in the model.")

config = LoraConfig(
    r=model_args.lora_r,
    lora_alpha=model_args.lora_alpha,
    target_modules=model_args.lora_target_modules,
    lora_dropout= model_args.lora_dropout,
    bias="none",
    task_type="CAUSAL_LM",
)
model = get_peft_model(model, config)
for n, p in model.named_parameters():
    print(f"{n}: {p.requires_grad}")
```

Seems like there should at least be a warning message if you call prepare_model_for_kbit_training but didn't set `load_in_8bit` or `load_in_4bit` to True?