### PR TITLE
GPTQ Integration

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -39,7 +39,7 @@ RUN source activate peft && \
     git+https://github.com/huggingface/accelerate \
     peft[test]@git+https://github.com/huggingface/peft
 
-RUN python3 -m pip install --no-cache-dir bitsandbytes
+RUN python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq
 
 # Stage 2
 FROM nvidia/cuda:11.3.1-devel-ubuntu20.04 AS build-image

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -26,3 +26,7 @@ def is_bnb_4bit_available():
     import bitsandbytes as bnb
 
     return hasattr(bnb.nn, "Linear4bit")
+
+
+def is_auto_gptq_available():
+    return importlib.util.find_spec("auto_gptq") is not None

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -30,3 +30,7 @@ def is_bnb_4bit_available():
 
 def is_auto_gptq_available():
     return importlib.util.find_spec("auto_gptq") is not None
+
+
+def is_optimum_available():
+    return importlib.util.find_spec("optimum") is not None

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -321,7 +321,11 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         r"""
         Prepares the model for gradient checkpointing if necessary
         """
-        if not (getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)):
+        if not (
+            getattr(model, "is_loaded_in_8bit", False)
+            or getattr(model, "is_loaded_in_4bit", False)
+            or getattr(model, "is_gptq_quantized")
+        ):
             if hasattr(model, "enable_input_require_grads"):
                 model.enable_input_require_grads()
             elif hasattr(model, "get_input_embeddings"):

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -324,7 +324,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if not (
             getattr(model, "is_loaded_in_8bit", False)
             or getattr(model, "is_loaded_in_4bit", False)
-            or getattr(model, "is_gptq_quantized", False)
+            or getattr(model, "is_quantized", False)
         ):
             if hasattr(model, "enable_input_require_grads"):
                 model.enable_input_require_grads()

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -324,7 +324,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if not (
             getattr(model, "is_loaded_in_8bit", False)
             or getattr(model, "is_loaded_in_4bit", False)
-            or getattr(model, "is_gptq_quantized")
+            or getattr(model, "is_gptq_quantized", False)
         ):
             if hasattr(model, "enable_input_require_grads"):
                 model.enable_input_require_grads()

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -611,7 +611,6 @@ if is_auto_gptq_available():
             AdaLoraLayer.__init__(
                 self, in_features=quant_linear_module.infeatures, out_features=quant_linear_module.outfeatures
             )
-            self.weight = quant_linear_module.qweight
             self.quant_linear_module = quant_linear_module
             init_lora_weights = kwargs.pop("init_lora_weights", True)
             self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -131,7 +131,6 @@ class AdaLoraModel(LoraModel):
                 and hasattr(self.model, "config")
                 and hasattr(self.model.config, "quantization_config")
             ):
-                print(self.model.config.quantization_config)
                 desc_act = self.model.config.quantization_config.desc_act
                 group_size = self.model.config.quantization_config.group_size
                 AutoGPTQQuantLinear = dynamically_import_QuantLinear(

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers.pytorch_utils import Conv1D
-from transformers.utils.quantization_config import QuantizationMethod
 
 from ..import_utils import is_bnb_4bit_available, is_bnb_available
 from ..utils import (
@@ -200,7 +199,7 @@ class AdaLoraModel(LoraModel):
             "loaded_in_4bit": loaded_in_4bit,
         }
 
-        quantization_config = get_quantization_config(self.model, method=QuantizationMethod.GPTQ)
+        quantization_config = get_quantization_config(self.model, method="gptq")
         if quantization_config is not None:
             kwargs["gptq_quantization_config"] = quantization_config
 

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -629,7 +629,6 @@ class SVDQuantLinear(torch.nn.Module, AdaLoraLayer):
         self.active_adapter = adapter_name
 
     def forward(self, x: torch.Tensor):
-        print(torch.is_autocast_enabled())
         result = self.quant_linear_module(x)
 
         if self.disable_adapters or self.active_adapter not in self.lora_A.keys():

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers.pytorch_utils import Conv1D
+from transformers.utils.quantization_config import QuantizationMethod
 
 from ..import_utils import is_auto_gptq_available, is_bnb_4bit_available, is_bnb_available
 from ..utils import (
@@ -126,7 +127,7 @@ class AdaLoraModel(LoraModel):
             from auto_gptq.utils.import_utils import dynamically_import_QuantLinear
 
             if (
-                getattr(self.model, "is_gptq_quantized", False)
+                getattr(self.model, "quantization_method", None) == QuantizationMethod.GPTQ
                 and hasattr(self.model, "config")
                 and hasattr(self.model.config, "quantization_config")
             ):

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -197,8 +197,12 @@ class AdaLoraModel(LoraModel):
             "loaded_in_8bit": loaded_in_8bit,
             "loaded_in_4bit": loaded_in_4bit,
         }
-        if hasattr(self.model, "config") and hasattr(self.model.config, "quantization_config") and getattr(self.model, "quantization_method", None) == QuantizationMethod.GPTQ:
-            kwargs['gptq_quantization_config'] = self.model.config.quantization_config
+        if (
+            hasattr(self.model, "config")
+            and hasattr(self.model.config, "quantization_config")
+            and getattr(self.model, "quantization_method", None) == QuantizationMethod.GPTQ
+        ):
+            kwargs["gptq_quantization_config"] = self.model.config.quantization_config
 
         # If it is not a LoraLayer, create a new module, else update it with new adapters
         if not isinstance(target, AdaLoraLayer):
@@ -217,6 +221,7 @@ class AdaLoraModel(LoraModel):
     def _create_new_module(lora_config, adapter_name, target, **kwargs):
         if is_auto_gptq_available():
             from auto_gptq.utils.import_utils import dynamically_import_QuantLinear
+
             gptq_quantization_config = kwargs.pop("gptq_quantization_config", None)
             if gptq_quantization_config is not None:
                 desc_act = gptq_quantization_config.desc_act
@@ -258,7 +263,7 @@ class AdaLoraModel(LoraModel):
             new_module = SVDLinear4bit(
                 adapter_name, target.in_features, target.out_features, bias=bias, **fourbit_kwargs
             )
-        elif (is_auto_gptq_available() and AutoGPTQQuantLinear is not None and isinstance(target, AutoGPTQQuantLinear)):
+        elif is_auto_gptq_available() and AutoGPTQQuantLinear is not None and isinstance(target, AutoGPTQQuantLinear):
             new_module = SVDQuantLinear(adapter_name, target, **kwargs)
             target.weight = target.qweight
         else:

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -133,8 +133,14 @@ class AdaLoraModel(LoraModel):
             ):
                 desc_act = self.model.config.quantization_config.desc_act
                 group_size = self.model.config.quantization_config.group_size
+                bits = self.model.config.quantization_config.bits
+                disable_exllama = self.model.config.quantization_config.disable_exllama
                 AutoGPTQQuantLinear = dynamically_import_QuantLinear(
-                    use_triton=False, desc_act=desc_act, group_size=group_size
+                    use_triton=False,
+                    desc_act=desc_act,
+                    group_size=group_size,
+                    bits=bits,
+                    disable_exllama=disable_exllama,
                 )
             else:
                 AutoGPTQQuantLinear = None

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -124,13 +124,20 @@ class AdaLoraModel(LoraModel):
     def _find_and_replace(self, adapter_name):
         if is_auto_gptq_available():
             from auto_gptq.utils.import_utils import dynamically_import_QuantLinear
-            if getattr(self.model, "is_gptq_quantized", False) and hasattr(self.model,"config") and hasattr(self.model.config,"quantization_config") :
+
+            if (
+                getattr(self.model, "is_gptq_quantized", False)
+                and hasattr(self.model, "config")
+                and hasattr(self.model.config, "quantization_config")
+            ):
                 print(self.model.config.quantization_config)
                 desc_act = self.model.config.quantization_config.desc_act
                 group_size = self.model.config.quantization_config.group_size
-                AutoGPTQQuantLinear = dynamically_import_QuantLinear(use_triton=False, desc_act=desc_act, group_size=group_size)
+                AutoGPTQQuantLinear = dynamically_import_QuantLinear(
+                    use_triton=False, desc_act=desc_act, group_size=group_size
+                )
             else:
-                AutoGPTQQuantLinear = None  
+                AutoGPTQQuantLinear = None
         lora_config = self.peft_config[adapter_name]
         loaded_in_8bit = getattr(self.model, "is_loaded_in_8bit", False)
         loaded_in_4bit = getattr(self.model, "is_loaded_in_4bit", False)
@@ -192,7 +199,11 @@ class AdaLoraModel(LoraModel):
                         new_module = SVDLinear4bit(
                             adapter_name, target.in_features, target.out_features, bias=bias, **fourbit_kwargs
                         )
-                    elif is_auto_gptq_available() and AutoGPTQQuantLinear is not None and isinstance(target,AutoGPTQQuantLinear):
+                    elif (
+                        is_auto_gptq_available()
+                        and AutoGPTQQuantLinear is not None
+                        and isinstance(target, AutoGPTQQuantLinear)
+                    ):
                         new_module = SVDQuantLinear(adapter_name, target, **kwargs)
                         target.weight = target.qweight
                     elif isinstance(target, (nn.ModuleList, nn.ModuleDict)):

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -156,7 +156,7 @@ class IA3Model(torch.nn.Module):
                 "You can install it with `pip install bitsandbytes`."
             )
         is_gptq_quantized = getattr(self.model, "is_gptq_quantized", False)
-        if not is_gptq_quantized:
+        if is_gptq_quantized:
             raise NotImplementedError("GPTQ quantization is not supported for IA3 yet.")
 
     def _create_new_module(self, ia3_config, adapter_name, target, is_feedforward):

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -22,7 +22,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers.pytorch_utils import Conv1D
-from transformers.utils.quantization_config import QuantizationMethod
 
 from ..config import PeftConfig
 from ..import_utils import is_bnb_available

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -155,6 +155,9 @@ class IA3Model(torch.nn.Module):
                 "To use (IA)^3 with 8-bit quantization, please install the `bitsandbytes` package. "
                 "You can install it with `pip install bitsandbytes`."
             )
+        is_gptq_quantized = getattr(self.model, "is_gptq_quantized", False)
+        if not is_gptq_quantized:
+            raise NotImplementedError("GPTQ quantization is not supported for IA3 yet.")
 
     def _create_new_module(self, ia3_config, adapter_name, target, is_feedforward):
         kwargs = {

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -22,6 +22,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers.pytorch_utils import Conv1D
+from transformers.utils.quantization_config import QuantizationMethod
 
 from ..import_utils import is_bnb_available
 from ..utils import (
@@ -155,7 +156,7 @@ class IA3Model(torch.nn.Module):
                 "To use (IA)^3 with 8-bit quantization, please install the `bitsandbytes` package. "
                 "You can install it with `pip install bitsandbytes`."
             )
-        is_gptq_quantized = getattr(self.model, "is_gptq_quantized", False)
+        is_gptq_quantized = getattr(self.model, "quantization_method", None) == QuantizationMethod.GPTQ
         if is_gptq_quantized:
             raise NotImplementedError("GPTQ quantization is not supported for IA3 yet.")
 

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -24,7 +24,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from tqdm import tqdm
 from transformers.pytorch_utils import Conv1D
-from transformers.utils.quantization_config import QuantizationMethod
 
 from ..config import PeftConfig
 from ..import_utils import is_bnb_4bit_available, is_bnb_available
@@ -340,7 +339,7 @@ class LoraModel(BaseTuner):
         kwargs["loaded_in_4bit"] = optionnal_kwargs.pop("loaded_in_4bit", False)
         kwargs["bias"] = bias
 
-        quantization_config = get_quantization_config(self.model, method=QuantizationMethod.GPTQ)
+        quantization_config = get_quantization_config(self.model, method="gptq")
         if quantization_config is not None:
             kwargs["gptq_quantization_config"] = quantization_config
 
@@ -556,7 +555,7 @@ class LoraModel(BaseTuner):
     def _unload_and_optionally_merge(self, merge=True, progressbar: bool = False):
         if getattr(self.model, "is_loaded_in_8bit", False) or getattr(self.model, "is_loaded_in_4bit", False):
             raise ValueError("Cannot merge LORA layers when the model is loaded in 8-bit mode")
-        if getattr(self.model, "quantization_method", None) == QuantizationMethod.GPTQ:
+        if getattr(self.model, "quantization_method", None) == "gptq":
             raise ValueError("Cannot merge LORA layers when the model is gptq quantized")
 
         key_list = [key for key, _ in self.model.named_modules() if "lora" not in key]

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -338,8 +338,12 @@ class LoraModel(BaseTuner):
         kwargs["loaded_in_4bit"] = optionnal_kwargs.pop("loaded_in_4bit", False)
         kwargs["bias"] = bias
 
-        if hasattr(self.model, "config") and hasattr(self.model.config, "quantization_config") and getattr(self.model, "quantization_method", None) == QuantizationMethod.GPTQ:
-            kwargs['gptq_quantization_config'] = self.model.config.quantization_config
+        if (
+            hasattr(self.model, "config")
+            and hasattr(self.model.config, "quantization_config")
+            and getattr(self.model, "quantization_method", None) == QuantizationMethod.GPTQ
+        ):
+            kwargs["gptq_quantization_config"] = self.model.config.quantization_config
 
         # TODO: better deal with that
         if isinstance(target, LoraLayer) and isinstance(target, torch.nn.Conv2d):
@@ -414,6 +418,7 @@ class LoraModel(BaseTuner):
     def _create_new_module(lora_config, adapter_name, target, **kwargs):
         if is_auto_gptq_available():
             from auto_gptq.utils.import_utils import dynamically_import_QuantLinear
+
             gptq_quantization_config = kwargs.pop("gptq_quantization_config", None)
             if gptq_quantization_config is not None:
                 desc_act = gptq_quantization_config.desc_act

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -248,8 +248,14 @@ class LoraModel(torch.nn.Module):
             ):
                 desc_act = self.model.config.quantization_config.desc_act
                 group_size = self.model.config.quantization_config.group_size
+                bits = self.model.config.quantization_config.bits
+                disable_exllama = self.model.config.quantization_config.disable_exllama
                 AutoGPTQQuantLinear = dynamically_import_QuantLinear(
-                    use_triton=False, desc_act=desc_act, group_size=group_size
+                    use_triton=False,
+                    desc_act=desc_act,
+                    group_size=group_size,
+                    bits=bits,
+                    disable_exllama=disable_exllama,
                 )
             else:
                 AutoGPTQQuantLinear = None

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -24,7 +24,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers.pytorch_utils import Conv1D
 
-from ..import_utils import is_bnb_4bit_available, is_bnb_available
+from ..import_utils import is_auto_gptq_available, is_bnb_4bit_available, is_bnb_available
 from ..utils import (
     CLAMP_QUANTILE,
     COMMON_LAYERS_PATTERN,
@@ -237,6 +237,8 @@ class LoraModel(torch.nn.Module):
         return target_module_found
 
     def _create_new_module(self, lora_config, adapter_name, target):
+        if is_auto_gptq_available():
+            import auto_gptq.nn_modules.qlinear as auto_gptq_nn
         bias = hasattr(target, "bias") and target.bias is not None
         kwargs = {
             "r": lora_config.r,
@@ -271,6 +273,8 @@ class LoraModel(torch.nn.Module):
                 }
             )
             new_module = Linear4bit(adapter_name, target.in_features, target.out_features, bias=bias, **fourbit_kwargs)
+        elif is_auto_gptq_available() and isinstance(target, auto_gptq_nn.GeneralQuantLinear):
+            new_module = GeneralQuantLinear(adapter_name, target, **kwargs)
         elif isinstance(target, torch.nn.Embedding):
             embedding_kwargs = kwargs.copy()
             embedding_kwargs.pop("fan_in_fan_out", None)
@@ -1167,3 +1171,116 @@ if is_bnb_available():
                         )
                     result += output
                 return result
+
+
+# Ugly solution
+if is_auto_gptq_available():
+
+    class GeneralQuantLinear(torch.nn.Linear, LoraLayer):
+        def __init__(
+            self,
+            adapter_name,
+            quant_linear_module,
+            r: int = 0,
+            lora_alpha: int = 1,
+            lora_dropout: float = 0.0,
+            **kwargs,
+        ):
+            torch.nn.Linear.__init__(
+                self, in_features=quant_linear_module.in_features, out_features=quant_linear_module.out_features
+            )
+            LoraLayer.__init__(
+                self, in_features=quant_linear_module.in_features, out_features=quant_linear_module.out_features
+            )
+
+            self.weight.requires_grad = False
+            self.quant_linear_module = quant_linear_module
+            self.weight = self.quant_linear_module.weight
+            self.bias = self.quant_linear_module.bias
+            init_lora_weights = kwargs.pop("init_lora_weights", True)
+            self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
+            self.active_adapter = adapter_name
+
+        def forward(self, x: torch.Tensor):
+            result = self.quant_linear_module(x)
+            if self.disable_adapters or self.active_adapter not in self.lora_A.keys():
+                return result
+            elif self.r[self.active_adapter] > 0:
+                result = result.clone()
+                if not torch.is_autocast_enabled():
+                    expected_dtype = result.dtype
+                    x = x.to(self.lora_A[self.active_adapter].weight.dtype)
+                    output = (
+                        self.lora_B[self.active_adapter](
+                            self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
+                        ).to(expected_dtype)
+                        * self.scaling[self.active_adapter]
+                    )
+                else:
+                    output = (
+                        self.lora_B[self.active_adapter](
+                            self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
+                        )
+                        * self.scaling[self.active_adapter]
+                    )
+                result += output
+            return result
+
+        # TODO: Check if it is better as suggested by users https://github.com/PanQiWei/AutoGPTQ/pull/102
+        # def reset_lora_parameters(self, adapter_name):
+        #     if adapter_name in self.lora_A.keys():
+        #         torch.nn.init.xavier_uniform_(self.lora_A[adapter_name].weight)
+        #         torch.nn.init.zeros_(self.lora_B[adapter_name].weight)
+
+
+# # Pb circular import issue when importing prepare_model_for_kbit_training (-> get_peft -> lora -> auto_gptq -> get_peft )
+# if is_auto_gptq_available():
+#     import auto_gptq.nn_modules.qlinear as auto_gptq_nn
+#     class GeneralQuantLinear(auto_gptq_nn.GeneralQuantLinear, LoraLayer):
+#         def __init__(
+#             self,
+#             adapter_name,
+#             quant_linear_module,
+#             r: int = 0,
+#             lora_alpha: int = 1,
+#             lora_dropout: float = 0.0,
+#             **kwargs,
+#         ):
+#             auto_gptq_nn.GeneralQuantLinear.__init__(self, quant_linear_module)
+#             LoraLayer.__init__(self, in_features=quant_linear_module.in_features, out_features=quant_linear_module.out_features)
+
+#             self.weight.requires_grad = False
+#             init_lora_weights = kwargs.pop("init_lora_weights", True)
+#             self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
+#             self.active_adapter = adapter_name
+
+#         def forward(self, x: torch.Tensor):
+#             result = super().forward(x)
+#             if self.disable_adapters or self.active_adapter not in self.lora_A.keys():
+#                 return result
+#             elif self.r[self.active_adapter] > 0:
+#                 result = result.clone()
+#                 if not torch.is_autocast_enabled():
+#                     expected_dtype = result.dtype
+#                     x = x.to(self.lora_A[self.active_adapter].weight.dtype)
+#                     output = (
+#                         self.lora_B[self.active_adapter](
+#                             self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
+#                         ).to(expected_dtype)
+#                         * self.scaling[self.active_adapter]
+#                     )
+#                 else:
+#                     output = (
+#                         self.lora_B[self.active_adapter](
+#                             self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
+#                         )
+#                         * self.scaling[self.active_adapter]
+#                     )
+#                 result += output
+#             return result
+
+#         # TODO: Check if it is better as suggested by users https://github.com/PanQiWei/AutoGPTQ/pull/102
+#         # def reset_lora_parameters(self, adapter_name):
+#         #     if adapter_name in self.lora_A.keys():
+#         #         torch.nn.init.xavier_uniform_(self.lora_A[adapter_name].weight)
+#         #         torch.nn.init.zeros_(self.lora_B[adapter_name].weight)

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -246,7 +246,6 @@ class LoraModel(torch.nn.Module):
                 and hasattr(self.model, "config")
                 and hasattr(self.model.config, "quantization_config")
             ):
-                print(self.model.config.quantization_config)
                 desc_act = self.model.config.quantization_config.desc_act
                 group_size = self.model.config.quantization_config.group_size
                 AutoGPTQQuantLinear = dynamically_import_QuantLinear(

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -1191,7 +1191,6 @@ if is_auto_gptq_available():
             LoraLayer.__init__(
                 self, in_features=quant_linear_module.infeatures, out_features=quant_linear_module.outfeatures
             )
-            self.weight = quant_linear_module.qweight
             self.quant_linear_module = quant_linear_module
             init_lora_weights = kwargs.pop("init_lora_weights", True)
             self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -45,6 +45,8 @@ from .other import (
     _prepare_prompt_learning_config,
     _is_valid_match,
     infer_device,
+    get_auto_gptq_quant_linear,
+    get_quantization_config,
 )
 from .hub_utils import hub_file_exists
 from .save_and_load import get_peft_model_state_dict, set_peft_model_state_dict, load_peft_weights

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -72,17 +72,19 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
             The loaded model from `transformers`
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
+    is_gptq_quantized = getattr(model, "is_gptq_quantized", False)
 
     for name, param in model.named_parameters():
         # freeze base model's layers
         param.requires_grad = False
 
-    # cast all non INT8 parameters to fp32
-    for param in model.parameters():
-        if (param.dtype == torch.float16) or (param.dtype == torch.bfloat16):
-            param.data = param.data.to(torch.float32)
+    if not is_gptq_quantized:
+        # cast all non INT8 parameters to fp32
+        for param in model.parameters():
+            if (param.dtype == torch.float16) or (param.dtype == torch.bfloat16):
+                param.data = param.data.to(torch.float32)
 
-    if loaded_in_kbit and use_gradient_checkpointing:
+    if (loaded_in_kbit or is_gptq_quantized) and use_gradient_checkpointing:
         # For backward compatibility
         if hasattr(model, "enable_input_require_grads"):
             model.enable_input_require_grads()

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -22,7 +22,6 @@ import accelerate
 import torch
 from accelerate.hooks import add_hook_to_module, remove_hook_from_module
 from accelerate.utils import is_npu_available, is_xpu_available
-from transformers.utils.quantization_config import QuantizationMethod
 
 from ..import_utils import is_auto_gptq_available
 
@@ -90,8 +89,7 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
             The loaded model from `transformers`
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
-    is_gptq_quantized = getattr(model, "quantization_method", None) == QuantizationMethod.GPTQ
-
+    is_gptq_quantized = getattr(model, "quantization_method", None) == "gptq"
     for name, param in model.named_parameters():
         # freeze base model's layers
         param.requires_grad = False
@@ -330,7 +328,7 @@ def _get_batch_size(input_ids: Optional[torch.Tensor], inputs_embeds: Optional[t
     return batch_size
 
 
-def get_quantization_config(model: torch.nn.Module, method: QuantizationMethod):
+def get_quantization_config(model: torch.nn.Module, method: str):
     """
     Get the quantization config of the related quantization method
     """

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -62,6 +62,8 @@ def bloom_model_postprocess_past_key_value(past_key_values):
 
 
 def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
+    from transformers.utils.quantization_config import QuantizationMethod
+
     r"""
     This method wraps the entire protocol for preparing a model before running a training. This includes:
         1- Cast the layernorm in fp32 2- making output embedding layer require grads 3- Add the upcasting of the lm
@@ -72,7 +74,7 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
             The loaded model from `transformers`
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
-    is_gptq_quantized = getattr(model, "is_gptq_quantized", False)
+    is_gptq_quantized = getattr(model, "quantization_method", None) == QuantizationMethod.GPTQ
 
     for name, param in model.named_parameters():
         # freeze base model's layers

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -535,7 +535,10 @@ class PeftGPTQGPUTests(unittest.TestCase):
     """
 
     def setUp(self):
+        from transformers import GPTQConfig
+
         self.causal_lm_model_id = "marcsun13/opt-350m-gptq-4bit"
+        self.quantization_config = GPTQConfig(bits=4, disable_exllama=True)
         self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
 
     def tearDown(self):
@@ -545,7 +548,6 @@ class PeftGPTQGPUTests(unittest.TestCase):
         """
         gc.collect()
         torch.cuda.empty_cache()
-        gc.collect()
 
     @pytest.mark.single_gpu_tests
     def test_causal_lm_training(self):
@@ -558,6 +560,7 @@ class PeftGPTQGPUTests(unittest.TestCase):
                 self.causal_lm_model_id,
                 torch_dtype=torch.float16,
                 device_map="auto",
+                quantization_config=self.quantization_config,
             )
 
             model = prepare_model_for_kbit_training(model)
@@ -607,7 +610,10 @@ class PeftGPTQGPUTests(unittest.TestCase):
         """
 
         model = AutoModelForCausalLM.from_pretrained(
-            self.causal_lm_model_id, torch_dtype=torch.float16, device_map="auto"
+            self.causal_lm_model_id,
+            torch_dtype=torch.float16,
+            device_map="auto",
+            quantization_config=self.quantization_config,
         )
 
         model = prepare_model_for_kbit_training(model)
@@ -672,6 +678,7 @@ class PeftGPTQGPUTests(unittest.TestCase):
                 self.causal_lm_model_id,
                 torch_dtype=torch.float16,
                 device_map="auto",
+                quantization_config=self.quantization_config,
             )
 
             self.assertEqual(set(model.hf_device_map.values()), {0, 1})

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -45,7 +45,13 @@ from peft import (
     prepare_model_for_kbit_training,
 )
 
-from .testing_utils import require_bitsandbytes, require_torch_gpu, require_torch_multi_gpu
+from .testing_utils import (
+    require_auto_gptq,
+    require_bitsandbytes,
+    require_optimum,
+    require_torch_gpu,
+    require_torch_multi_gpu,
+)
 
 
 # A full testing suite that tests all the necessary features on GPU. The tests should
@@ -508,6 +514,202 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 tokenizer=processor.feature_extractor,
             )
 
+            trainer.train()
+
+            model.cpu().save_pretrained(tmp_dir)
+
+            self.assertTrue("adapter_config.json" in os.listdir(tmp_dir))
+            self.assertTrue("adapter_model.bin" in os.listdir(tmp_dir))
+
+            # assert loss is not None
+            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+
+
+@require_torch_gpu
+@require_auto_gptq
+@require_optimum
+class PeftGPTQGPUTests(unittest.TestCase):
+    r"""
+    GPTQ + peft tests
+    """
+
+    def setUp(self):
+        self.causal_lm_model_id = "marcsun13/opt-350m-gptq-4bit"
+        self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
+
+    def tearDown(self):
+        r"""
+        Efficient mechanism to free GPU memory after each test. Based on
+        https://github.com/huggingface/transformers/issues/21094
+        """
+        gc.collect()
+        torch.cuda.empty_cache()
+        gc.collect()
+
+    @pytest.mark.single_gpu_tests
+    def test_causal_lm_training(self):
+        r"""
+        Test the CausalLM training on a single GPU device. The test would simply fail if the adapters are not set
+        correctly.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = AutoModelForCausalLM.from_pretrained(
+                self.causal_lm_model_id,
+                torch_dtype=torch.float16,
+                device_map="auto",
+            )
+
+            model = prepare_model_for_kbit_training(model)
+            config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=["q_proj", "v_proj"],
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+            )
+            model = get_peft_model(model, config)
+
+            data = load_dataset("ybelkada/english_quotes_copy")
+            data = data.map(lambda samples: self.tokenizer(samples["quote"]), batched=True)
+
+            trainer = Trainer(
+                model=model,
+                train_dataset=data["train"],
+                args=TrainingArguments(
+                    per_device_train_batch_size=4,
+                    gradient_accumulation_steps=4,
+                    warmup_steps=2,
+                    max_steps=3,
+                    learning_rate=2e-4,
+                    fp16=True,
+                    logging_steps=1,
+                    output_dir=tmp_dir,
+                ),
+                data_collator=DataCollatorForLanguageModeling(self.tokenizer, mlm=False),
+            )
+            model.config.use_cache = False
+            trainer.train()
+
+            model.cpu().save_pretrained(tmp_dir)
+
+            self.assertTrue("adapter_config.json" in os.listdir(tmp_dir))
+            self.assertTrue("adapter_model.bin" in os.listdir(tmp_dir))
+
+            # assert loss is not None
+            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+
+    @pytest.mark.single_gpu_tests
+    def test_adalora_causalLM(self):
+        r"""
+        Tests the gptq training with adalora
+        """
+
+        model = AutoModelForCausalLM.from_pretrained(
+            self.causal_lm_model_id, torch_dtype=torch.float16, device_map="auto"
+        )
+
+        model = prepare_model_for_kbit_training(model)
+
+        peft_config = AdaLoraConfig(
+            init_r=6,
+            target_r=4,
+            tinit=50,
+            tfinal=100,
+            deltaT=5,
+            beta1=0.3,
+            beta2=0.3,
+            orth_reg_weight=0.2,
+            lora_alpha=32,
+            lora_dropout=0.05,
+            bias="none",
+            task_type="CAUSAL_LM",
+        )
+
+        model = get_peft_model(model, peft_config)
+
+        data = load_dataset("ybelkada/english_quotes_copy")
+        data = data.map(lambda samples: self.tokenizer(samples["quote"]), batched=True)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            trainer = Trainer(
+                model=model,
+                train_dataset=data["train"],
+                args=TrainingArguments(
+                    per_device_train_batch_size=4,
+                    gradient_accumulation_steps=4,
+                    warmup_steps=2,
+                    max_steps=3,
+                    learning_rate=2e-4,
+                    fp16=True,
+                    logging_steps=1,
+                    output_dir=tmp_dir,
+                ),
+                data_collator=DataCollatorForLanguageModeling(self.tokenizer, mlm=False),
+            )
+            model.config.use_cache = False
+            trainer.train()
+
+            model.cpu().save_pretrained(tmp_dir)
+
+            self.assertTrue("adapter_config.json" in os.listdir(tmp_dir))
+            self.assertTrue("adapter_model.bin" in os.listdir(tmp_dir))
+
+            # assert loss is not None
+            self.assertIsNotNone(trainer.state.log_history[-1]["train_loss"])
+
+    @pytest.mark.multi_gpu_tests
+    @require_torch_multi_gpu
+    def test_causal_lm_training_mutli_gpu(self):
+        r"""
+        Test the CausalLM training on a multi-GPU device. The test would simply fail if the adapters are not set
+        correctly.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = AutoModelForCausalLM.from_pretrained(
+                self.causal_lm_model_id,
+                torch_dtype=torch.float16,
+                device_map="auto",
+            )
+
+            self.assertEqual(set(model.hf_device_map.values()), {0, 1})
+
+            model = prepare_model_for_kbit_training(model)
+
+            setattr(model, "model_parallel", True)
+            setattr(model, "is_parallelizable", True)
+
+            config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=["q_proj", "v_proj"],
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+            )
+
+            model = get_peft_model(model, config)
+
+            data = load_dataset("Abirate/english_quotes")
+            data = data.map(lambda samples: self.tokenizer(samples["quote"]), batched=True)
+
+            trainer = Trainer(
+                model=model,
+                train_dataset=data["train"],
+                args=TrainingArguments(
+                    per_device_train_batch_size=4,
+                    gradient_accumulation_steps=4,
+                    warmup_steps=2,
+                    max_steps=3,
+                    learning_rate=2e-4,
+                    fp16=True,
+                    logging_steps=1,
+                    output_dir=tmp_dir,
+                ),
+                data_collator=DataCollatorForLanguageModeling(self.tokenizer, mlm=False),
+            )
+            model.config.use_cache = False
             trainer.train()
 
             model.cpu().save_pretrained(tmp_dir)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -18,6 +18,8 @@ from contextlib import contextmanager
 import numpy as np
 import torch
 
+from peft.import_utils import is_auto_gptq_available, is_optimum_available
+
 
 def require_torch_gpu(test_case):
     """
@@ -49,6 +51,20 @@ def require_bitsandbytes(test_case):
         return unittest.skip("test requires bitsandbytes")(test_case)
     else:
         return test_case
+
+
+def require_auto_gptq(test_case):
+    """
+    Decorator marking a test that requires auto-gptq. These tests are skipped when auto-gptq isn't installed.
+    """
+    return unittest.skipUnless(is_auto_gptq_available(), "test requires auto-gptq")(test_case)
+
+
+def require_optimum(test_case):
+    """
+    Decorator marking a test that requires optimum. These tests are skipped when optimum isn't installed.
+    """
+    return unittest.skipUnless(is_optimum_available(), "test requires optimum")(test_case)
 
 
 @contextmanager


### PR DESCRIPTION
# What does this PR do ? 
This PR adds the possibility to train lora + adalora adapters on top of GPTQ quantized model. 

### convert to peft model for training
```py
causal_lm_model_id = "marcsun13/opt-350m-gptq-4bit"
tokenizer  = AutoTokenizer.from_pretrained(causal_lm_model_id)
model = AutoModelForCausalLM.from_pretrained(
    causal_lm_model_id,
    torch_dtype=torch.float16,
    device_map="auto"
)
model = prepare_model_for_kbit_training(model)
config = LoraConfig(
      r=16,
      lora_alpha=32,
      target_modules=["q_proj", "v_proj"],
      lora_dropout=0.05,
      bias="none",
      task_type="CAUSAL_LM",
)
model = get_peft_model(model, config)
```
### save adapters after training 
```py
model.cpu().save_pretrained(save_dir)
```
### load saved adapters
```py
model = AutoModelForCausalLM.from_pretrained(
    causal_lm_model_id,
    torch_dtype=torch.float16,
    device_map="auto"
)
model = PeftModel.from_pretrained(model ,save_dir)# load saved adapters
```

### to do 
- [x] finetune llama2 
- [ ] merge after transformers PR (the doc PR test will then be fixed)