### PR TITLE
Patched lora tuner init to allow example 1 code in docstring to run

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -179,7 +179,8 @@ class LoraModel(torch.nn.Module):
         super().__init__()
         self.model = model
         self.forward = self.model.forward
-        self.peft_config = config
+        self.peft_config = {}
+        self.peft_config[adapter_name] = config
         self.add_adapter(adapter_name, self.peft_config[adapter_name])
 
         # transformers models have a .config attribute, whose presence is assumed later on


### PR DESCRIPTION
Currently peft_config[adapter_name] will throw an error since peft_config is a PeftConfig object. Need to pass it as a dictionary. Following get_peft_model usage,I've did a similar adaptation to allow for quick code running like in the first example in the docstring of LoraModel.