### PR TITLE
Fix unbound error in ia3.py

### DIFF
--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -532,6 +532,7 @@ if is_bnb_available():
             self.is_feedforward = is_feedforward
 
         def forward(self, x: torch.Tensor):
+            result = None
             if self.disable_adapters or self.active_adapter not in self.ia3_l.keys():
                 return super().forward(x)
             else:

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -547,6 +547,6 @@ if is_bnb_available():
                 expected_dtype = result.dtype
                 result = result * ia3_scaling
 
-            if requires_conversion:
-                result = result.to(expected_dtype)
+                if requires_conversion:
+                    result = result.to(expected_dtype)
             return result

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -532,24 +532,21 @@ if is_bnb_available():
             self.is_feedforward = is_feedforward
 
         def forward(self, x: torch.Tensor):
-            result = None
-            if self.disable_adapters or self.active_adapter not in self.ia3_l.keys():
+            if self.disable_adapters or (self.active_adapter not in self.ia3_l.keys()):
                 return super().forward(x)
+
+            requires_conversion = (not torch.is_autocast_enabled()) and (x.dtype != torch.float32)
+            if requires_conversion:
+                x = x.float()
+
+            ia3_scaling = self.ia3_l[self.active_adapter].flatten()
+            if self.is_feedforward:
+                result = super().forward(x * ia3_scaling)
             else:
-                if not torch.is_autocast_enabled():
-                    if x.dtype != torch.float32:
-                        x = x.float()
-                    if self.is_feedforward:
-                        result = super().forward(x * self.ia3_l[self.active_adapter].flatten())
-                    else:
-                        result = super().forward(x)
-                        expected_dtype = result.dtype
-                        result = (result * self.ia3_l[self.active_adapter].flatten()).to(expected_dtype)
-                else:
-                    if self.is_feedforward:
-                        result = super().forward(x * self.ia3_l[self.active_adapter].flatten())
-                    else:
-                        if result is None:
-                            result = super().forward(x)
-                        result = result * self.ia3_l[self.active_adapter].flatten()
+                result = super().forward(x)
+                expected_dtype = result.dtype
+                result = result * ia3_scaling
+
+            if requires_conversion:
+                result = result.to(expected_dtype)
             return result


### PR DESCRIPTION
Fixes an unbound error relating to local variable "result" being referenced prior to being assigned, which arises during fine-tuning using a model loaded in 8-bit, while using Flash Attention (in my case, 2.0.4) and training in BF16 or FP16.

I have no experience nor formal education in computer programming, so apologies if this is redundant or incorrect. Based on the deductive testing the unbound error was caused by loading a model in 8-bit (using Bitsandbytes 41.0) while training in BF16 or FP16 as required by Flash Attention 2. Adding these two lines fixed the unbound error and did not seem to break anything else. The added text is simply a catch-all for where the code does not execute an if-block which assigns a value to result before reaching the current line 551.
