### PR TITLE
Add adapter error handling

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import copy
 import inspect
 import os
 import warnings
@@ -110,7 +109,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if not peft_config.is_prompt_learning:
             self.peft_config[adapter_name] = peft_config
             cls = PEFT_TYPE_TO_MODEL_MAPPING[peft_config.peft_type]
-            self.base_model = cls(self.base_model, copy.copy(peft_config), adapter_name)
+            self.base_model = cls(self.base_model, self.peft_config.copy(), adapter_name)
             self.set_additional_trainable_modules(peft_config, adapter_name)
         else:
             self.add_adapter(adapter_name, peft_config)
@@ -480,7 +479,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             )
 
         self.peft_config[adapter_name] = peft_config
-        self.base_model.peft_config[adapter_name] = peft_config
 
         try:
             if peft_config.is_prompt_learning:
@@ -494,10 +492,12 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             elif peft_config.is_adaption_prompt:
                 self.base_model.add_adapter(adapter_name, peft_config)
             else:
+                self.base_model.peft_config[adapter_name] = peft_config
                 self.base_model.inject_adapter(self, adapter_name)
         except Exception:  # somthing went wrong, roll back
             del self.peft_config[adapter_name]
-            del self.base_model.peft_config[adapter_name]
+            if hasattr(self.base_model, "peft_config"):
+                del self.base_model.peft_config[adapter_name]
             raise
 
         self.set_additional_trainable_modules(peft_config, adapter_name)

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -130,7 +130,7 @@ class AdaLoraModel(LoraModel):
         - **peft_config** ([`AdaLoraConfig`]): The configuration of the AdaLora model.
     """
 
-    def __init__(self, model, config: AdaLoraConfig, adapter_name: str):
+    def __init__(self, model, config, adapter_name):
         super().__init__(model, config, adapter_name)
 
         traininable_mode_counter = 0

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -160,7 +160,7 @@ class IA3Model(BaseTuner):
         - **peft_config** ([`ia3Config`]): The configuration of the (IA)^3 model.
     """
 
-    def __init__(self, model, config: IA3Config, adapter_name: str):
+    def __init__(self, model, config, adapter_name):
         super().__init__(model, config, adapter_name)
 
     @staticmethod

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -133,6 +133,7 @@ class IA3Model(BaseTuner):
     Args:
         model ([`~transformers.PreTrainedModel`]): The model to be adapted.
         config ([`IA3Config`]): The configuration of the (IA)^3 model.
+        adapter_name (`str`): The name of the adapter, defaults to `"default"`.
 
     Returns:
         `torch.nn.Module`: The (IA)^3 model.
@@ -159,7 +160,7 @@ class IA3Model(BaseTuner):
         - **peft_config** ([`ia3Config`]): The configuration of the (IA)^3 model.
     """
 
-    def __init__(self, model, config, adapter_name):
+    def __init__(self, model, config: IA3Config, adapter_name: str):
         super().__init__(model, config, adapter_name)
 
     @staticmethod

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -219,6 +219,7 @@ class LoraModel(BaseTuner):
     Args:
         model ([`~transformers.PreTrainedModel`]): The model to be adapted.
         config ([`LoraConfig`]): The configuration of the Lora model.
+        adapter_name (`str`): The name of the adapter, defaults to `"default"`.
 
     Returns:
         `torch.nn.Module`: The Lora model.
@@ -268,8 +269,23 @@ class LoraModel(BaseTuner):
         - **peft_config** ([`LoraConfig`]): The configuration of the Lora model.
     """
 
-    def __init__(self, model, config, adapter_name):
+    def __init__(self, model, config: LoraConfig, adapter_name: str) -> None:
         super().__init__(model, config, adapter_name)
+
+    def _check_new_adapter_config(self, config: LoraConfig) -> None:
+        """
+        A helper method to check the config when a new adapter is being added.
+
+        Raise a ValueError if there is something wrong with the config or if it conflicts with existing adapters.
+
+        """
+        # TODO: there should be a check if any of the existing adapters actually has bias != "none", or else the check
+        # does not fully correspond to the error message.
+        if (len(self.peft_config) > 1) and (config.bias != "none"):
+            raise ValueError(
+                f"{self.__class__.__name__} supports only 1 adapter with bias. When using multiple adapters, "
+                "set bias to 'none' for all adapters."
+            )
 
     @staticmethod
     def _check_target_module_exists(lora_config, key):

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -269,7 +269,7 @@ class LoraModel(BaseTuner):
         - **peft_config** ([`LoraConfig`]): The configuration of the Lora model.
     """
 
-    def __init__(self, model, config: LoraConfig, adapter_name: str) -> None:
+    def __init__(self, model, config, adapter_name) -> None:
         super().__init__(model, config, adapter_name)
 
     def _check_new_adapter_config(self, config: LoraConfig) -> None:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 import logging
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Union
 
 from torch import nn
 
@@ -59,7 +59,7 @@ class BaseTuner(nn.Module, ABC):
             The model configuration object, it should be a dictionary of `str` to `Any` objects.
     """
 
-    def __init__(self, model, peft_config, adapter_name):
+    def __init__(self, model, peft_config: Union[PeftConfig, dict[str, PeftConfig]], adapter_name: str) -> None:
         super().__init__()
 
         self.model = model
@@ -74,7 +74,11 @@ class BaseTuner(nn.Module, ABC):
                 "Already found a `peft_config` attribute in the model. This will lead to having multiple adapters"
                 " in the model. Make sure to know what you are doing!"
             )
-            self.peft_config[adapter_name] = peft_config
+            if isinstance(peft_config, PeftConfig):
+                self.peft_config[adapter_name] = peft_config
+            else:
+                # user is adding a dict of PeftConfigs
+                self.peft_config.update(peft_config)
 
         # transformers models have a .config attribute, whose presence is assumed later on
         if not hasattr(self, "config"):
@@ -159,6 +163,15 @@ class BaseTuner(nn.Module, ABC):
         """
         ...
 
+    def _check_new_adapter_config(self, config: PeftConfig) -> None:
+        """
+        A helper method to check the config when a new adapter is being added.
+
+        Raise a ValueError if there is something wrong with the config or if it conflicts with existing adapters.
+
+        """
+        pass
+
     def inject_adapter(self, model: nn.Module, adapter_name: str):
         r"""
         Creates adapter layers and replaces the target modules with the adapter layers. This method is called under the
@@ -173,6 +186,10 @@ class BaseTuner(nn.Module, ABC):
                 The adapter name.
         """
         peft_config = self.peft_config[adapter_name]
+        # Note: If possible, all checks should be performed *at the start of this method*.
+        # This way, we can raise early if something goes wrong, without leaving the model
+        # in a bad (half-initialized) state.
+        self._check_new_adapter_config(peft_config)
 
         is_target_modules_in_base_model = False
         key_list = [key for key, _ in model.named_modules()]

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Union

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -324,3 +324,7 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         if bias_warning_was_given:
             # This is bad, there was a warning about the bias when there should not have been any.
             self.fail("There should be no warning when bias is set to 'none'")
+
+    @parameterized.expand(TEST_CASES)
+    def test_adding_multiple_adapters_with_bias_raises(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_adding_multiple_adapters_with_bias_raises(model_id, config_cls, config_kwargs)

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -144,6 +144,10 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
     def test_delete_adapter(self, test_name, model_id, config_cls, config_kwargs):
         self._test_delete_adapter(model_id, config_cls, config_kwargs)
 
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_adding_multiple_adapters_with_bias_raises(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_adding_multiple_adapters_with_bias_raises(model_id, config_cls, config_kwargs)
+
     @parameterized.expand(
         PeftTestConfigManager.get_grid_parameters(
             {

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -125,6 +125,10 @@ class PeftEncoderDecoderModelTester(unittest.TestCase, PeftCommonTester):
     def test_delete_adapter(self, test_name, model_id, config_cls, config_kwargs):
         self._test_delete_adapter(model_id, config_cls, config_kwargs)
 
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_adding_multiple_adapters_with_bias_raises(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_adding_multiple_adapters_with_bias_raises(model_id, config_cls, config_kwargs)
+
     @parameterized.expand(
         PeftTestConfigManager.get_grid_parameters(
             {

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -860,12 +860,14 @@ class PeftCommonTester:
         if not issubclass(config_cls, (LoraConfig, AdaLoraConfig)):
             return
 
-        model = self.transformers_class.from_pretrained(model_id)
+        config_kwargs = config_kwargs.copy()
         config_kwargs["bias"] = "all"
         config = config_cls(
             base_model_name_or_path=model_id,
             **config_kwargs,
         )
+
+        model = self.transformers_class.from_pretrained(model_id)
         model = get_peft_model(model, config, "adapter0")
         with self.assertRaises(ValueError):
             model.add_adapter("adapter1", replace(config, r=20))


### PR DESCRIPTION
When a user tries to add a 2nd adapter, Lora and AdaLora make some checks to ensure the new adapter is compatible with existing adapters. Currently, that check is performed halfway through the method. This means that if the check fails, the new adapter is partially applied, leaving the model in a bad state. The main purpose of this PR is to ensure that the model state is correct after such a failure is encountered.

Tests were added to catch this potential bug.

While working on this, I also made the following changes:

- Previously, the `peft_config` from the `PeftModel` was passed to the base model. This meant that sometimes, the base model would hold a reference to `PeftModel.peft_config`, but not always, as some base models would create new dicts. This is problematic, because some code would rely on the objects being the same. Now, they are never the same, leading to more consistency.
- I think that for Lora (but not AdaLora), the check if multiple adapters have biases (which is not supported) was accidentally removed by #749. It is added back in.
- Add some type annotations
- Extend docstrings to contain adapter_name