### PR TITLE
fix crash when using torch.nn.DataParallel for LORA inference

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -63,7 +63,6 @@ class BaseTuner(nn.Module, ABC):
         super().__init__()
 
         self.model = model
-        self.forward = self.model.forward
 
         # For advanced developpers, if you want to attach multiple adapters to your
         # model, just add a `peft_config` dict attribute to your model.
@@ -84,6 +83,9 @@ class BaseTuner(nn.Module, ABC):
 
         # Copy the peft_config in the injected model.
         self.model.peft_config = self.peft_config
+
+    def forward(self, *args: Any, **kwargs: Any):
+        return self.model.forward(*args, **kwargs)
 
     @abstractmethod
     def _prepare_adapter_config(self, peft_config: PeftConfig, model_config: dict) -> PeftConfig:


### PR DESCRIPTION
 Load the Lora model
inference_model = PeftModel.from_pretrained(inference_model, peft_model_id)
inference_model = torch.nn.DataParallel(inference_model)
inference_model.to(device)
inference_model.eval()

just the use the inference mode to inference. and the issue could be reproduce.
calltrace like
Original Traceback (most recent call last):
  File "/mnt/disk1/wangyi/miniconda3/envs/alpaca/lib/python3.9/site-packages/torch/nn/parallel/parallel_apply.py", line 64, in _worker
    output = module(*input, **kwargs)
  File "/mnt/disk1/wangyi/miniconda3/envs/alpaca/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/mnt/disk3/wangyi/peft/src/peft/peft_model.py", line 720, in forward
    return self.base_model(
  File "/mnt/disk1/wangyi/miniconda3/envs/alpaca/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/mnt/disk3/wangyi/transformers/src/transformers/models/roberta/modeling_roberta.py", line 1196, in forward
    outputs = self.roberta(
  File "/mnt/disk1/wangyi/miniconda3/envs/alpaca/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/mnt/disk3/wangyi/transformers/src/transformers/models/roberta/modeling_roberta.py", line 837, in forward
    embedding_output = self.embeddings(
  File "/mnt/disk1/wangyi/miniconda3/envs/alpaca/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/mnt/disk3/wangyi/transformers/src/transformers/models/roberta/modeling_roberta.py", line 125, in forward
    inputs_embeds = self.word_embeddings(input_ids)
  File "/mnt/disk1/wangyi/miniconda3/envs/alpaca/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/mnt/disk1/wangyi/miniconda3/envs/alpaca/lib/python3.9/site-packages/torch/nn/modules/sparse.py", line 162, in forward
    return F.embedding(
  File "/mnt/disk1/wangyi/miniconda3/envs/alpaca/lib/python3.9/site-packages/torch/nn/functional.py", line 2210, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:1! (when checking argument for argument index in method wrapper_CUDA__index_select)