### PR TITLE
Fix seq2seq prompt tuning (#439)

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1091,7 +1091,8 @@ class PeftModelForSeq2SeqLM(PeftModel):
             prefix_attention_mask = torch.ones(batch_size, peft_config.num_virtual_tokens).to(
                 decoder_attention_mask.device
             )
-            decoder_attention_mask = torch.cat((prefix_attention_mask, decoder_attention_mask), dim=1)
+            if peft_config.peft_type not in [PeftType.PROMPT_TUNING, PeftType.P_TUNING]:
+                decoder_attention_mask = torch.cat((prefix_attention_mask, decoder_attention_mask), dim=1)
 
         if kwargs.get("position_ids", None) is not None:
             warnings.warn("Position ids are not supported for parameter efficient tuning. Ignoring position ids.")


### PR DESCRIPTION
The problem is that for prompt tuning, the decoder attention mask is extended as if the prompt was in the decoder (whereas it is in the encoder). So the decoder attention mask was too long. Feel free to propose better ways to fix the problem if my solution is not ideal (I'm not an expert).

See #439 for a code snippet that reproduces the problem.