### PR TITLE
add docs chatbot v0

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -18,6 +18,21 @@ Recent state-of-the-art PEFT techniques achieve performance comparable to that o
 
 PEFT is seamlessly integrated with 🤗 Accelerate for large-scale models leveraging DeepSpeed and [Big Model Inference](https://huggingface.co/docs/accelerate/usage_guides/big_modeling).
 
+<div class="block dark:hidden">
+	<iframe 
+        src="https://smangrul-peft-docs-qa-chatbot.hf.space?__theme=light"
+        width="850"
+        height="1600"
+    ></iframe>
+</div>
+<div class="hidden dark:block">
+    <iframe 
+        src="https://smangrul-peft-docs-qa-chatbot.hf.space?__theme=dark"
+        width="850"
+        height="1600"
+    ></iframe>
+</div>
+
 <div class="mt-10">
   <div class="w-full flex flex-col space-y-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-y-4 md:gap-x-5">
     <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="quicktour"


### PR DESCRIPTION
### What does this PR do?
1. Adding Retrieval Augmented Generation based QA Chatbot wrt PEFT documentation. Based on the internal discussions to make hf.co/docs more chatty and easier for users. This is V0 and will need several improvements.

Highlights:
1. Uses 3 models:
    a. Bi-encoder `intfloat/e5-large-v2` for semantic search to retrieve relevant chunks. Runs on CPU during inference.
    b. Cross-encoder `cross-encoder/ms-marco-MiniLM-L-12-v2` for reranking the retrieved relevant chunks. Runs on CPU during inference.
    c. LlamaV2 70B `meta-llama/Llama-2-7b-chat-hf` via inference endpoints using Philipp's easyllm client+TGI

Current limitations:
1. The scraping and embeddings aren't being updated. We need to setup a pipeline to scrape the docs and generate index in a timely manner, maybe once every week or once every 2 weeks.
3. The embeddings of chunks and the chunks pandas df should be loaded from some remote location instead of being clubbed with the gradio app.