### PR TITLE
TST: add test about loading custom models

### DIFF
--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import tempfile
 import unittest
 
 import torch
@@ -22,7 +23,7 @@ from parameterized import parameterized
 from torch import nn
 from transformers.pytorch_utils import Conv1D
 
-from peft import LoraConfig, get_peft_model
+from peft import LoraConfig, PeftModel, get_peft_model
 
 from .testing_common import PeftCommonTester
 
@@ -187,17 +188,17 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         pass
 
     @parameterized.expand(TEST_CASES)
-    def test_training_customs(self, test_name, model_id, config_cls, config_kwargs):
+    def test_training_custom_models(self, test_name, model_id, config_cls, config_kwargs):
         self._test_training(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(TEST_CASES)
-    def test_training_customs_layer_indexing(self, test_name, model_id, config_cls, config_kwargs):
+    def test_training_custom_models_layer_indexing(self, test_name, model_id, config_cls, config_kwargs):
         # At the moment, layer indexing only works when layer names conform to a specific pattern, which is not
         # guaranteed here. Therefore, this test is not performed.
         pass
 
     @parameterized.expand(TEST_CASES)
-    def test_training_customs_gradient_checkpointing(self, test_name, model_id, config_cls, config_kwargs):
+    def test_training_custom_models_gradient_checkpointing(self, test_name, model_id, config_cls, config_kwargs):
         self._test_training_gradient_checkpointing(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(TEST_CASES)
@@ -242,6 +243,45 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
                 # target_modules and modules_to_save _are_ updated
                 self.assertFalse(torch.allclose(param_before, param_after, atol=tol, rtol=tol))
             else:
+                self.assertTrue(torch.allclose(param_before, param_after, atol=tol, rtol=tol))
+
+    @parameterized.expand(TEST_CASES)
+    def test_parameters_after_loading_model(self, test_name, model_id, config_cls, config_kwargs):
+        # An explicit test that when loading a trained model, the parameters are loaded correctly
+        # see issue #808
+        X = self.prepare_inputs_for_testing()
+        model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config)
+        model.train()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.5)
+
+        # train at least 3 steps for all parameters to be updated (probably this is required because of symmetry
+        # breaking of some LoRA layers that are initialized with constants)
+        for _ in range(3):
+            optimizer.zero_grad()
+            y_pred = model(**X)
+            loss = y_pred.sum()
+            loss.backward()
+            optimizer.step()
+
+        tol = 1e-4
+        params_before = dict(model.named_parameters())
+        # note: no need to sanity check if parameters were updated at all, this
+        # is already covered in the previous test
+
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            model.save_pretrained(tmp_dirname)
+            model_from_pretrained = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+            model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
+            params_after = dict(model_from_pretrained.named_parameters())
+
+            self.assertEqual(params_before.keys(), params_after.keys())
+            for name, param_before in params_before.items():
+                param_after = params_after[name]
                 self.assertTrue(torch.allclose(param_before, param_after, atol=tol, rtol=tol))
 
     @parameterized.expand(TEST_CASES)


### PR DESCRIPTION
Prompted by #808, I added a test that shows that loading a trained custom model works as expected.

I only added this to custom models because it involves a few steps of training and I didn't want to slow down tests too much. LMK if this should be added to all tests.

In addition, I renamed some custom model tests which had strange names (probably caused by an overeager query-replace).