### PR TITLE
Add tqdm to adapter inject

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -18,6 +18,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Union
 
+import tqdm
 from torch import nn
 
 from ..config import PeftConfig
@@ -204,7 +205,7 @@ class BaseTuner(nn.Module, ABC):
 
         peft_config = self._prepare_adapter_config(peft_config, model_config)
 
-        for key in key_list:
+        for key in tqdm.tqdm(key_list, desc="Injecting adapter layers"):
             if not self._check_target_module_exists(peft_config, key):
                 continue
 


### PR DESCRIPTION
# What does this PR do

This PR adds `tqdm` to `inject_adapter` function.  This is helpful as adding adapter could be very slow for LLM. 
e.g., up to 40 seconds for LLama-2-7b depending on machines, far more longer than loading  its checkpoint shards(which has tqdm to show progress).

Hope this is useful for others too. 