### PR TITLE
MNT: Refactor tuner forward methods for simplicity

### DIFF
--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -460,7 +460,7 @@ class SVDLinear(nn.Linear, AdaLoraLayer):
         if self.active_adapter not in self.lora_A.keys():
             return self._linear(x)
 
-        # FIXME: SVDLinear does not convert dtype, unlike lora linear, is that correct?
+        # TODO: SVDLinear does not convert dtype, unlike lora linear, is that correct?
         if self.disable_adapters:
             if self.r[self.active_adapter] > 0 and self.merged:
                 self.unmerge()
@@ -651,9 +651,9 @@ class SVDQuantLinear(torch.nn.Module, AdaLoraLayer):
         ranknum = self.ranknum[self.active_adapter] + 1e-5
 
         output = (dropout(x) @ (lora_A * lora_E).T @ lora_B.T) * scaling / ranknum
-        # FIXME: here, the dtype conversion is applied on the *whole
-        # expression*, not the intermediate result, unlike for SVDLinear8bitLT
-        # and SVDLinear4bit, is that correct?
+        # TODO: here, the dtype conversion is applied on the *whole expression*,
+        # not the intermediate result, unlike for SVDLinear8bitLT and
+        # SVDLinear4bit, is that correct?
         if requires_conversion:
             output = output.to(expected_dtype)
         result = result + output

--- a/src/peft/tuners/adalora.py
+++ b/src/peft/tuners/adalora.py
@@ -585,7 +585,13 @@ if is_bnb_4bit_available():
             ):
                 return result
 
-            # FIXME: is it correct that we don't clone here but we clone in lora Linear4bit?
+            # As per Tim Dettmers, for 4bit, we need to defensively clone here.
+            # The reason is that in some cases, an error can occur that backprop
+            # does not work on a manipulated view. This issue may be solved with
+            # newer PyTorch versions but this would need extensive testing to be
+            # sure.
+            result = result.clone()
+
             requires_conversion = not torch.is_autocast_enabled()
             if requires_conversion:
                 expected_dtype = result.dtype

--- a/src/peft/tuners/ia3.py
+++ b/src/peft/tuners/ia3.py
@@ -436,7 +436,7 @@ class Linear(nn.Linear, IA3Layer):
             ia3_scaling = self.ia3_l[self.active_adapter].flatten()
             if self.is_feedforward:
                 x = x.to(dtype)
-                # FIXME self.weight.dtype can be != self.ia3_l[self.active_adapter].dtype
+                # TODO: self.weight.dtype can be != self.ia3_l[self.active_adapter].dtype
                 # e.g. bf16 vs fp32. Is that okay?
                 interm = (x * ia3_scaling).to(self.weight.dtype)
                 result = self._linear(interm)

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -475,8 +475,8 @@ class LoraModel(BaseTuner):
                     kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = True
             else:
                 raise ValueError(
-                    f"Target module {target} is not supported. "
-                    f"Currently, only `torch.nn.Linear` and `Conv1D` are supported."
+                    f"Target module {target} is not supported. Currently, only the following modules are supported: "
+                    "`torch.nn.Linear`, `torch.nn.Embedding`, `torch.nn.Conv2d`, `transformers.pytorch_utils.Conv1D`."
                 )
             new_module = Linear(adapter_name, in_features, out_features, bias=bias, **kwargs)
 

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -970,7 +970,7 @@ class Embedding(nn.Embedding, LoraLayer):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if self.active_adapter not in self.lora_A.keys():
+        if self.active_adapter not in self.lora_embedding_A.keys():
             return self._embed(x)
 
         # FIXME: no dtype conversion here, unlike in Linear, is that correct?

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -973,7 +973,7 @@ class Embedding(nn.Embedding, LoraLayer):
         if self.active_adapter not in self.lora_embedding_A.keys():
             return self._embed(x)
 
-        # FIXME: no dtype conversion here, unlike in Linear, is that correct?
+        # TODO: no dtype conversion here, unlike in Linear, is that correct?
         if self.disable_adapters:
             if (self.r[self.active_adapter] > 0) and self.merged:
                 self.unmerge()
@@ -1204,8 +1204,13 @@ if is_bnb_4bit_available():
             ):
                 return result
 
-            # FIXME: is it correct that we clone here but not for int8?
+            # As per Tim Dettmers, for 4bit, we need to defensively clone here.
+            # The reason is that in some cases, an error can occur that backprop
+            # does not work on a manipulated view. This issue may be solved with
+            # newer PyTorch versions but this would need extensive testing to be
+            # sure.
             result = result.clone()
+
             lora_A = self.lora_A[self.active_adapter]
             lora_B = self.lora_B[self.active_adapter]
             dropout = self.lora_dropout[self.active_adapter]
@@ -1255,7 +1260,7 @@ class QuantLinear(torch.nn.Module, LoraLayer):
         ):
             return result
 
-        # FIXME: is it correct that we clone here but not for int8?
+        # TODO: is cloning really needed here?
         result = result.clone()
 
         lora_A = self.lora_A[self.active_adapter]

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -150,8 +150,8 @@ class LoraLayer(BaseTunerLayer):
         self.lora_dropout.update(nn.ModuleDict({adapter_name: lora_dropout_layer}))
         # Actual trainable parameters
         if r > 0:
-            self.lora_A.update(nn.ModuleDict({adapter_name: nn.Linear(self.in_features, r, bias=False)}))
-            self.lora_B.update(nn.ModuleDict({adapter_name: nn.Linear(r, self.out_features, bias=False)}))
+            self.lora_A[adapter_name] = nn.Linear(self.in_features, r, bias=False)
+            self.lora_B[adapter_name] = nn.Linear(r, self.out_features, bias=False)
             self.scaling[adapter_name] = lora_alpha / r
         if init_lora_weights:
             self.reset_lora_parameters(adapter_name)
@@ -165,18 +165,14 @@ class LoraLayer(BaseTunerLayer):
         else:
             lora_dropout_layer = nn.Identity()
 
-        self.lora_dropout.update(nn.ModuleDict({adapter_name: lora_dropout_layer}))
+        self.lora_dropout[adapter_name] = lora_dropout_layer
         # Actual trainable parameters
         if r > 0:
             kernel_size = self.kwargs["kernel_size"]
             stride = self.kwargs["stride"]
             padding = self.kwargs["padding"]
-            self.lora_A.update(
-                nn.ModuleDict({adapter_name: nn.Conv2d(self.in_features, r, kernel_size, stride, padding, bias=False)})
-            )
-            self.lora_B.update(
-                nn.ModuleDict({adapter_name: nn.Conv2d(r, self.out_features, (1, 1), (1, 1), bias=False)})
-            )
+            self.lora_A[adapter_name] = nn.Conv2d(self.in_features, r, kernel_size, stride, padding, bias=False)
+            self.lora_B[adapter_name] = nn.Conv2d(r, self.out_features, (1, 1), (1, 1), bias=False)
             self.scaling[adapter_name] = lora_alpha / r
         if init_lora_weights:
             self.reset_lora_parameters(adapter_name)
@@ -190,13 +186,13 @@ class LoraLayer(BaseTunerLayer):
         else:
             lora_dropout_layer = nn.Identity()
 
-        self.lora_dropout.update(nn.ModuleDict({adapter_name: lora_dropout_layer}))
+        self.lora_dropout[adapter_name] = lora_dropout_layer
         # Actual trainable parameters
         if r > 0:
             weight_A = torch.randn((r, self.in_features), dtype=self.weight.dtype, device=self.weight.device)
             weight_B = torch.randn((self.out_features, r), dtype=self.weight.dtype, device=self.weight.device)
-            self.lora_embedding_A.update(nn.ParameterDict({adapter_name: nn.Parameter(weight_A)}))
-            self.lora_embedding_B.update(nn.ParameterDict({adapter_name: nn.Parameter(weight_B)}))
+            self.lora_embedding_A[adapter_name] = nn.Parameter(weight_A)
+            self.lora_embedding_B[adapter_name] = nn.Parameter(weight_B)
             self.scaling[adapter_name] = lora_alpha / r
         if init_lora_weights:
             self.reset_lora_parameters(adapter_name)
@@ -844,7 +840,7 @@ class Linear(nn.Linear, LoraLayer):
         fan_in_fan_out: bool = False,  # Set this to True if the layer to replace stores weight like (fan_in, fan_out)
         is_target_conv_1d_layer: bool = False,
         **kwargs,
-    ):
+    ) -> None:
         init_lora_weights = kwargs.pop("init_lora_weights", True)
 
         nn.Linear.__init__(self, in_features, out_features, **kwargs)
@@ -861,7 +857,7 @@ class Linear(nn.Linear, LoraLayer):
         self.active_adapter = adapter_name
         self.is_target_conv_1d_layer = is_target_conv_1d_layer
 
-    def merge(self):
+    def merge(self) -> None:
         if self.active_adapter not in self.lora_A.keys():
             return
         if self.merged:
@@ -871,7 +867,7 @@ class Linear(nn.Linear, LoraLayer):
             self.weight.data += self.get_delta_weight(self.active_adapter)
             self.merged = True
 
-    def unmerge(self):
+    def unmerge(self) -> None:
         if self.active_adapter not in self.lora_A.keys():
             return
         if not self.merged:
@@ -881,7 +877,7 @@ class Linear(nn.Linear, LoraLayer):
             self.weight.data -= self.get_delta_weight(self.active_adapter)
             self.merged = False
 
-    def get_delta_weight(self, adapter):
+    def get_delta_weight(self, adapter) -> torch.Tensor:
         return (
             transpose(
                 self.lora_B[adapter].weight @ self.lora_A[adapter].weight,
@@ -890,30 +886,32 @@ class Linear(nn.Linear, LoraLayer):
             * self.scaling[adapter]
         )
 
-    def forward(self, x: torch.Tensor):
-        previous_dtype = x.dtype
+    def _linear(self, input: torch.Tensor) -> torch.Tensor:
+        return F.linear(input, transpose(self.weight, self.fan_in_fan_out), bias=self.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         if self.active_adapter not in self.lora_A.keys():
-            return F.linear(x, transpose(self.weight, self.fan_in_fan_out), bias=self.bias)
+            return self._linear(x)
+
+        previous_dtype = x.dtype
+
         if self.disable_adapters:
-            if self.r[self.active_adapter] > 0 and self.merged:
+            if (self.r[self.active_adapter] > 0) and self.merged:
                 self.unmerge()
-            result = F.linear(x, transpose(self.weight, self.fan_in_fan_out), bias=self.bias)
-        elif self.r[self.active_adapter] > 0 and not self.merged:
-            result = F.linear(x, transpose(self.weight, self.fan_in_fan_out), bias=self.bias)
-
-            x = x.to(self.lora_A[self.active_adapter].weight.dtype)
-
-            result += (
-                self.lora_B[self.active_adapter](
-                    self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
-                )
-                * self.scaling[self.active_adapter]
-            )
+            result = self._linear(x)
+        elif (self.r[self.active_adapter] == 0) or self.merged:
+            result = self._linear(x)
         else:
-            result = F.linear(x, transpose(self.weight, self.fan_in_fan_out), bias=self.bias)
+            lora_A = self.lora_A[self.active_adapter]
+            lora_B = self.lora_B[self.active_adapter]
+            dropout = self.lora_dropout[self.active_adapter]
+            scaling = self.scaling[self.active_adapter]
+
+            result = self._linear(x)
+            x = x.to(lora_A.weight.dtype)
+            result += lora_B(lora_A(dropout(x))) * scaling
 
         result = result.to(previous_dtype)
-
         return result
 
 
@@ -928,7 +926,7 @@ class Embedding(nn.Embedding, LoraLayer):
         lora_alpha: int = 1,
         lora_dropout: float = 0.0,
         **kwargs,
-    ):
+    ) -> None:
         init_lora_weights = kwargs.pop("init_lora_weights", True)
 
         nn.Embedding.__init__(self, num_embeddings, embedding_dim, **kwargs)
@@ -940,7 +938,7 @@ class Embedding(nn.Embedding, LoraLayer):
         self.update_layer_embedding(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
         self.active_adapter = adapter_name
 
-    def unmerge(self):
+    def unmerge(self) -> None:
         if not self.merged:
             warnings.warn("Already unmerged. Nothing to do.")
             return
@@ -948,7 +946,7 @@ class Embedding(nn.Embedding, LoraLayer):
             self.weight.data -= self.get_delta_weight(self.active_adapter)
             self.merged = False
 
-    def merge(self):
+    def merge(self) -> None:
         if self.merged:
             warnings.warn("Already merged. Nothing to do.")
             return
@@ -956,31 +954,42 @@ class Embedding(nn.Embedding, LoraLayer):
             self.weight.data += self.get_delta_weight(self.active_adapter)
             self.merged = True
 
-    def get_delta_weight(self, adapter):
+    def get_delta_weight(self, adapter) -> torch.Tensor:
         return transpose(self.lora_embedding_B[adapter] @ self.lora_embedding_A[adapter], True) * self.scaling[adapter]
 
-    def forward(self, x: torch.Tensor):
-        if self.disable_adapters:
-            if self.r[self.active_adapter] > 0 and self.merged:
-                self.unmerge()
-            return nn.Embedding.forward(self, x)
+    def _embed(self, input: torch.Tensor, weight: Optional[torch.Tensor] = None) -> torch.Tensor:
+        weight = self.weight if weight is None else weight
+        return F.embedding(
+            input,
+            weight,
+            padding_idx=self.padding_idx,
+            max_norm=self.max_norm,
+            norm_type=self.norm_type,
+            scale_grad_by_freq=self.scale_grad_by_freq,
+            sparse=self.sparse,
+        )
 
-        elif self.r[self.active_adapter] > 0 and not self.merged:
-            result = nn.Embedding.forward(self, x)
-            if self.r[self.active_adapter] > 0:
-                after_A = F.embedding(
-                    x,
-                    self.lora_embedding_A[self.active_adapter].T,
-                    self.padding_idx,
-                    self.max_norm,
-                    self.norm_type,
-                    self.scale_grad_by_freq,
-                    self.sparse,
-                )
-                result += (after_A @ self.lora_embedding_B[self.active_adapter].T) * self.scaling[self.active_adapter]
-            return result
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.active_adapter not in self.lora_A.keys():
+            return self._embed(x)
+
+        # FIXME: no dtype conversion here, unlike in Linear, is that correct?
+        if self.disable_adapters:
+            if (self.r[self.active_adapter] > 0) and self.merged:
+                self.unmerge()
+            result = self._embed(x)
+        elif (self.r[self.active_adapter] == 0) or self.merged:
+            result = self._embed(x)
         else:
-            return nn.Embedding.forward(self, x)
+            embedding_A = self.lora_embedding_A[self.active_adapter].T
+            embedding_B = self.lora_embedding_B[self.active_adapter].T
+            scaling = self.scaling[self.active_adapter]
+
+            result = self._embed(x)
+            after_A = self._embed(x, embedding_A)
+            result += (after_A @ embedding_B) * scaling
+
+        return result
 
 
 class Conv2d(nn.Conv2d, LoraLayer):
@@ -997,7 +1006,7 @@ class Conv2d(nn.Conv2d, LoraLayer):
         lora_alpha: int = 1,
         lora_dropout: float = 0.0,
         **kwargs,
-    ):
+    ) -> None:
         init_lora_weights = kwargs.pop("init_lora_weights", True)
 
         nn.Conv2d.__init__(self, in_channels, out_channels, kernel_size, stride, padding)
@@ -1016,7 +1025,7 @@ class Conv2d(nn.Conv2d, LoraLayer):
         self.update_layer_conv2d(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
         self.active_adapter = adapter_name
 
-    def merge(self):
+    def merge(self) -> None:
         if self.active_adapter not in self.lora_A.keys():
             return
         if self.merged:
@@ -1026,7 +1035,7 @@ class Conv2d(nn.Conv2d, LoraLayer):
             self.weight.data += self.get_delta_weight(self.active_adapter)
             self.merged = True
 
-    def unmerge(self):
+    def unmerge(self) -> None:
         if self.active_adapter not in self.lora_A.keys():
             return
         if not self.merged:
@@ -1036,7 +1045,7 @@ class Conv2d(nn.Conv2d, LoraLayer):
             self.weight.data -= self.get_delta_weight(self.active_adapter)
             self.merged = False
 
-    def get_delta_weight(self, adapter):
+    def get_delta_weight(self, adapter) -> torch.Tensor:
         # https://github.com/bmaltais/kohya_ss/blob/feb6728762a8f463d15ba936d189d4c3abfaa1ab/networks/lora.py#L117
         if self.weight.size()[2:4] == (1, 1):
             # conv2d 1x1
@@ -1053,63 +1062,40 @@ class Conv2d(nn.Conv2d, LoraLayer):
                 * self.scaling[adapter]
             )
 
-    def forward(self, x: torch.Tensor):
+    def _conv2d(self, input: torch.Tensor) -> torch.Tensor:
+        return F.conv2d(
+            input,
+            self.weight,
+            bias=self.bias,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.active_adapter not in self.lora_A.keys():
+            return self._conv2d(x)
+
         previous_dtype = x.dtype
 
-        if self.active_adapter not in self.lora_A.keys():
-            return F.conv2d(
-                x,
-                self.weight,
-                bias=self.bias,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=self.groups,
-            )
         if self.disable_adapters:
             if self.r[self.active_adapter] > 0 and self.merged:
                 self.unmerge()
-            result = F.conv2d(
-                x,
-                self.weight,
-                bias=self.bias,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=self.groups,
-            )
-        elif self.r[self.active_adapter] > 0 and not self.merged:
-            result = F.conv2d(
-                x,
-                self.weight,
-                bias=self.bias,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=self.groups,
-            )
-
-            x = x.to(self.lora_A[self.active_adapter].weight.dtype)
-
-            result += (
-                self.lora_B[self.active_adapter](
-                    self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
-                )
-                * self.scaling[self.active_adapter]
-            )
+            result = self._conv2d(x)
+        elif (self.r[self.active_adapter] == 0) or self.merged:
+            result = self._conv2d(x)
         else:
-            result = F.conv2d(
-                x,
-                self.weight,
-                bias=self.bias,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=self.groups,
-            )
+            lora_A = self.lora_A[self.active_adapter]
+            lora_B = self.lora_B[self.active_adapter]
+            dropout = self.lora_dropout[self.active_adapter]
+            scaling = self.scaling[self.active_adapter]
+
+            result = self._conv2d(x)
+            x = x.to(lora_A.weight.dtype)
+            result += lora_B(lora_A(dropout(x))) * scaling
 
         result = result.to(previous_dtype)
-
         return result
 
 
@@ -1126,7 +1112,7 @@ if is_bnb_available():
             lora_alpha: int = 1,
             lora_dropout: float = 0.0,
             **kwargs,
-        ):
+        ) -> None:
             bnb.nn.Linear8bitLt.__init__(
                 self,
                 in_features,
@@ -1145,90 +1131,97 @@ if is_bnb_available():
             self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
             self.active_adapter = adapter_name
 
-        def forward(self, x: torch.Tensor):
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            # note: logic differs from default Linear because merging is not supported
             result = super().forward(x)
 
-            if self.disable_adapters or self.active_adapter not in self.lora_A.keys():
+            if (
+                self.disable_adapters
+                or (self.active_adapter not in self.lora_A.keys())
+                or (self.r[self.active_adapter] == 0)
+            ):
                 return result
-            elif self.r[self.active_adapter] > 0:
-                if not torch.is_autocast_enabled():
-                    expected_dtype = result.dtype
 
-                    if x.dtype != torch.float32:
-                        x = x.float()
-                    output = (
-                        self.lora_B[self.active_adapter](
-                            self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
-                        ).to(expected_dtype)
-                        * self.scaling[self.active_adapter]
-                    )
-                else:
-                    output = (
-                        self.lora_B[self.active_adapter](
-                            self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
-                        )
-                        * self.scaling[self.active_adapter]
-                    )
-                result += output
+            lora_A = self.lora_A[self.active_adapter]
+            lora_B = self.lora_B[self.active_adapter]
+            dropout = self.lora_dropout[self.active_adapter]
+            scaling = self.scaling[self.active_adapter]
+
+            requires_conversion = not torch.is_autocast_enabled()
+            if requires_conversion:
+                expected_dtype = result.dtype
+                if x.dtype != torch.float32:
+                    x = x.float()
+
+            output = lora_B(lora_A(dropout(x)))
+            if requires_conversion:
+                output = output.to(expected_dtype)
+            output = output * scaling
+            result += output
             return result
 
-    if is_bnb_4bit_available():
 
-        class Linear4bit(bnb.nn.Linear4bit, LoraLayer):
-            # Lora implemented in a dense layer
-            def __init__(
+if is_bnb_4bit_available():
+
+    class Linear4bit(bnb.nn.Linear4bit, LoraLayer):
+        # Lora implemented in a dense layer
+        def __init__(
+            self,
+            adapter_name,
+            in_features,
+            out_features,
+            r: int = 0,
+            lora_alpha: int = 1,
+            lora_dropout: float = 0.0,
+            **kwargs,
+        ) -> None:
+            bnb.nn.Linear4bit.__init__(
                 self,
-                adapter_name,
                 in_features,
                 out_features,
-                r: int = 0,
-                lora_alpha: int = 1,
-                lora_dropout: float = 0.0,
-                **kwargs,
+                bias=kwargs.get("bias", True),
+                compute_dtype=kwargs.get("compute_dtype", torch.float32),
+                compress_statistics=kwargs.get("compress_statistics", True),
+                quant_type=kwargs.get("quant_type", "nf4"),
+            )
+            LoraLayer.__init__(self, in_features=in_features, out_features=out_features)
+
+            # Freezing the pre-trained weight matrix
+            self.weight.requires_grad = False
+
+            init_lora_weights = kwargs.pop("init_lora_weights", True)
+            self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
+            self.active_adapter = adapter_name
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            # note: logic differs from default Linear because merging is not supported
+            result = super().forward(x)
+
+            if (
+                self.disable_adapters
+                or (self.active_adapter not in self.lora_A.keys())
+                or (self.r[self.active_adapter] == 0)
             ):
-                bnb.nn.Linear4bit.__init__(
-                    self,
-                    in_features,
-                    out_features,
-                    bias=kwargs.get("bias", True),
-                    compute_dtype=kwargs.get("compute_dtype", torch.float32),
-                    compress_statistics=kwargs.get("compress_statistics", True),
-                    quant_type=kwargs.get("quant_type", "nf4"),
-                )
-                LoraLayer.__init__(self, in_features=in_features, out_features=out_features)
-
-                # Freezing the pre-trained weight matrix
-                self.weight.requires_grad = False
-
-                init_lora_weights = kwargs.pop("init_lora_weights", True)
-                self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
-                self.active_adapter = adapter_name
-
-            def forward(self, x: torch.Tensor):
-                result = super().forward(x)
-
-                if self.disable_adapters or self.active_adapter not in self.lora_A.keys():
-                    return result
-                elif self.r[self.active_adapter] > 0:
-                    result = result.clone()
-                    if not torch.is_autocast_enabled():
-                        expected_dtype = result.dtype
-                        x = x.to(self.lora_A[self.active_adapter].weight.dtype)
-                        output = (
-                            self.lora_B[self.active_adapter](
-                                self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
-                            ).to(expected_dtype)
-                            * self.scaling[self.active_adapter]
-                        )
-                    else:
-                        output = (
-                            self.lora_B[self.active_adapter](
-                                self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
-                            )
-                            * self.scaling[self.active_adapter]
-                        )
-                    result += output
                 return result
+
+            # FIXME: is it correct that we clone here but not for int8?
+            result = result.clone()
+            lora_A = self.lora_A[self.active_adapter]
+            lora_B = self.lora_B[self.active_adapter]
+            dropout = self.lora_dropout[self.active_adapter]
+            scaling = self.scaling[self.active_adapter]
+
+            requires_conversion = not torch.is_autocast_enabled()
+            if requires_conversion:
+                expected_dtype = result.dtype
+                x = x.to(lora_A.weight.dtype)
+
+            output = lora_B(lora_A(dropout(x)))
+            if requires_conversion:
+                output = output.to(expected_dtype)
+            output = output * scaling
+            result += output
+            return result
 
 
 class QuantLinear(torch.nn.Module, LoraLayer):
@@ -1252,28 +1245,34 @@ class QuantLinear(torch.nn.Module, LoraLayer):
         self.active_adapter = adapter_name
 
     def forward(self, x: torch.Tensor):
+        # note: logic differs from default Linear because merging is not supported
         result = self.quant_linear_module(x)
-        if self.disable_adapters or self.active_adapter not in self.lora_A.keys():
+
+        if (
+            self.disable_adapters
+            or (self.active_adapter not in self.lora_A.keys())
+            or (self.r[self.active_adapter] == 0)
+        ):
             return result
-        elif self.r[self.active_adapter] > 0:
-            result = result.clone()
-            if not torch.is_autocast_enabled():
-                expected_dtype = result.dtype
-                x = x.to(self.lora_A[self.active_adapter].weight.dtype)
-                output = (
-                    self.lora_B[self.active_adapter](
-                        self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
-                    ).to(expected_dtype)
-                    * self.scaling[self.active_adapter]
-                )
-            else:
-                output = (
-                    self.lora_B[self.active_adapter](
-                        self.lora_A[self.active_adapter](self.lora_dropout[self.active_adapter](x))
-                    )
-                    * self.scaling[self.active_adapter]
-                )
-            result += output
+
+        # FIXME: is it correct that we clone here but not for int8?
+        result = result.clone()
+
+        lora_A = self.lora_A[self.active_adapter]
+        lora_B = self.lora_B[self.active_adapter]
+        dropout = self.lora_dropout[self.active_adapter]
+        scaling = self.scaling[self.active_adapter]
+
+        requires_conversion = not torch.is_autocast_enabled()
+        if requires_conversion:
+            expected_dtype = result.dtype
+            x = x.to(lora_A.weight.dtype)
+
+        output = lora_B(lora_A(dropout(x)))
+        if requires_conversion:
+            output = output.to(expected_dtype)
+        output = output * scaling
+        result += output
         return result
 
     # TODO: Check if it is better as suggested by users https://github.com/PanQiWei/AutoGPTQ/pull/102

--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -1260,9 +1260,6 @@ class QuantLinear(torch.nn.Module, LoraLayer):
         ):
             return result
 
-        # TODO: is cloning really needed here?
-        result = result.clone()
-
         lora_A = self.lora_A[self.active_adapter]
         lora_B = self.lora_B[self.active_adapter]
         dropout = self.lora_dropout[self.active_adapter]

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -260,8 +260,8 @@ class BaseTunerLayer(ABC):
     """
     active_adapter = None
 
-    def merge(self):
+    def merge(self) -> None:
         raise NotImplementedError
 
-    def unmerge(self):
+    def unmerge(self) -> None:
         raise NotImplementedError


### PR DESCRIPTION
This is to be consistent with changes in #794

## Description

The `forward` methods of several tuner layers were partly unnecessarily nested, which made them harder to read and which can conceal bugs (as in #794). Therefore, these methods have been refactored to (hopefully) be as readable as possible. Moreover, the different methods are now coded as similar as possible between the different implementations.

On top of those changes, I made the following adjustments:

- added some type hints to the methods of the layers
- removed a comment about code being copied which I think is not necessary
- for the lora embedding layer, we sometimes used `F.embedding(...)` and sometimes `nn.Embedding.forward(self, ...)` -- now, we consistently use only `F.embedding(...)`
- for IA³ `Linear8bitLT`, apply dtype conversion regardless of whether `self.is_feedforward` is `True` or `False` (as discussed internally)
- for the definition of lora `Linear4bit`, we (implicitly) checked if bnb is available and if bnb 4bit is available, but it is enough to check the latter, as it calls the former internally -- now we only check the latter, saving us 1 level of indentation (note that the github diff view of that class is very messy, in fact I only unindented it and changed `forward`, the rest is identical!)
- a few times, `ModuleDict.update(<dict>)` is called when `<dict>` has only 1 single item -- I simplified this code to just assign that item, which is more readable and consistent with other nearby code
- in the LoRA `Embedding.forward` method, there was no check if the `active_adapter` is in the lora module dict keys or not, unlike the other layer types -- now I added the check
- the error message when no LoRA layer could be replaced was outdated, only mentioning `Linear` and `Conv1D`, I added the other supported layer types

## Comments

In general, I ensured that the changes I made in the forward methods result in the exact same outcome as previously. Please ensure that I achieved this while reviewing this PR. This is probably easier with a side-by-side diff view.

While working on this, I found that a lot of code is essentially duplicated, but I think we can accept that if we want to avoid adding too many layers of abstraction/indirection.

Moreover, I discovered multiple potential inconsistencies between the implementations:

- sometimes, dtypes are converted, sometimes not
- dtypes are not always converted on the same intermediate result
- sometimes, `result.clone()` is called, sometimes not

I have added a `# FIXME` comment each time I spotted those differences. Before merging, all those comments should be addressed. This either means that we fix the inconsistencies, or, if they are intended, we add a comment to explain why they are intended.