### PR TITLE
[`Docker`] Fix gptq dockerfile

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -39,12 +39,15 @@ RUN source activate peft && \
     git+https://github.com/huggingface/accelerate \
     peft[test]@git+https://github.com/huggingface/peft
 
-RUN python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq
-
 # Stage 2
-FROM nvidia/cuda:11.3.1-devel-ubuntu20.04 AS build-image
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 AS build-image
 COPY --from=compile-image /opt/conda /opt/conda
 ENV PATH /opt/conda/bin:$PATH
+
+RUN chsh -s /bin/bash
+SHELL ["/bin/bash", "-c"]
+RUN source activate peft && \ 
+    python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq
 
 # Install apt libs
 RUN apt-get update && \


### PR DESCRIPTION
Fixes the docker image build that is currently failing on main since the GPTQ PR

The build was failing because auto-gptq was trying to get installed before the cuda install which led to auto-gptq library throwing an error as it is not supported in non-CUDA envs. 

The fix is to simply move the install of auto-gptq after the CUDA related packages install, I have also bumped the cuda version to 11.8 

can confirm the docker build works locally with these changes