### PR TITLE
Fix error using deepspeed zero2 + load_in_8bit + lora

### DIFF
--- a/src/peft/tuners/adalora/bnb.py
+++ b/src/peft/tuners/adalora/bnb.py
@@ -135,8 +135,9 @@ if is_bnb_4bit_available():
             requires_conversion = not torch.is_autocast_enabled()
             if requires_conversion:
                 expected_dtype = result.dtype
-                if x.dtype != torch.float32:
-                    x = x.float()
+                compute_dtype = lora_A.weight.dtype
+                if x.dtype != compute_dtype:
+                    x = x.to(compute_dtype)
 
             lora_A = self.lora_A[self.active_adapter]
             lora_B = self.lora_B[self.active_adapter]

--- a/src/peft/tuners/adalora/bnb.py
+++ b/src/peft/tuners/adalora/bnb.py
@@ -132,19 +132,19 @@ if is_bnb_4bit_available():
             # sure.
             result = result.clone()
 
-            requires_conversion = not torch.is_autocast_enabled()
-            if requires_conversion:
-                expected_dtype = result.dtype
-                compute_dtype = lora_A.weight.dtype
-                if x.dtype != compute_dtype:
-                    x = x.to(compute_dtype)
-
             lora_A = self.lora_A[self.active_adapter]
             lora_B = self.lora_B[self.active_adapter]
             lora_E = self.lora_E[self.active_adapter]
             dropout = self.lora_dropout[self.active_adapter]
             scaling = self.scaling[self.active_adapter]
             ranknum = self.ranknum[self.active_adapter] + 1e-5
+
+            requires_conversion = not torch.is_autocast_enabled()
+            if requires_conversion:
+                expected_dtype = result.dtype
+                compute_dtype = lora_A.weight.dtype
+                if x.dtype != compute_dtype:
+                    x = x.to(compute_dtype)
 
             output = dropout(x) @ (lora_A * lora_E).T @ lora_B.T
             if requires_conversion:

--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -75,8 +75,9 @@ if is_bnb_available():
             requires_conversion = not torch.is_autocast_enabled()
             if requires_conversion:
                 expected_dtype = result.dtype
-                if x.dtype != torch.float32:
-                    x = x.float()
+                compute_dtype = lora_A.weight.dtype
+                if x.dtype != compute_dtype:
+                    x = x.to(compute_dtype)
 
             output = lora_B(lora_A(dropout(x)))
             if requires_conversion:


### PR DESCRIPTION
running hf trainer with deepspeed/zero2, to train bf16 + load_in_8bit + lora/peft, the following error is observed:

> RuntimeError: expected scalar type Float but found BFloat16

poking around a debugger, i saw:

```
-> breakpoint()                                                                                                            
(Pdb) l                                                                                                                    
113         def forward(self, input: Tensor) -> Tensor:                                                                    
114             try:                                                                                                       
115                 return F.linear(input, self.weight, self.bias)                                                         
116             except Exception:                                                                                          
117                 import pdb                                                                                             
118  ->             breakpoint()                                                                                           
119                                                                                                                        
120         def extra_repr(self) -> str:                                                                                   
121             return 'in_features={}, out_features={}, bias={}'.format(                                                  
122                 self.in_features, self.out_features, self.bias is not None                                             
123             )                                                                                                          
(Pdb) input.dtype                                                                                                          
torch.float32                                                                                                              
(Pdb) self.weight.dtype                                                                                                    
torch.bfloat16                                                                                                             
(Pdb) up                                                                                                                   
> /home/tmm1/micromamba/envs/dev/lib/python3.10/site-packages/torch/nn/modules/module.py(1501)_call_impl()                 
-> return forward_call(*args, **kwargs)                                                                                    
(Pdb) up                                                                                                                   
> /home/tmm1/micromamba/envs/dev/lib/python3.10/site-packages/peft/tuners/lora.py(1167)forward()                           
-> output = lora_B(lora_A(dropout(x)))                                                                                     
(Pdb) l                                                                                                                    
1162                if requires_conversion:                                                                                
1163                    expected_dtype = result.dtype                                                                      
1164                    if x.dtype != torch.float32:                                                                       
1165                        x = x.float()                                                                                  
1166    
1167 ->             output = lora_B(lora_A(dropout(x)))
```

fixes https://github.com/OpenAccess-AI-Collective/axolotl/issues/473

to reproduce:

```
git clone https://github.com/OpenAccess-AI-Collective/axolotl
cd axolotl
pip install -e .
accelerate launch scripts/finetune.py examples/llama-2/lora.yml --deepspeed=deepspeed/zero2.json
```

cc @TimDettmers 
