### PR TITLE
Merge lora module to 8bit model

### DIFF
--- a/src/peft/tuners/lora.py
+++ b/src/peft/tuners/lora.py
@@ -1293,7 +1293,8 @@ if is_bnb_4bit_available():
                 return
             if self.r[self.active_adapter] > 0:
                 warnings.warn(
-                    "Merge lora module to 4-bit linear may get different generations due to rounding errors."
+                    "Merge lora module to 4-bit linear may get different generations due to rounding errors. \n\
+                    You would better to use torch.inference_mode for inference due to the gradient issue."
                 )
                 # Refer to https://gist.github.com/ChrisHayduk/1a53463331f52dca205e55982baf9930
                 kwargs = self.weight.__dict__
@@ -1310,7 +1311,8 @@ if is_bnb_4bit_available():
                 return
             if self.r[self.active_adapter] > 0:
                 warnings.warn(
-                    "Unmerge lora module to 4-bit linear may get different generations due to rounding errors."
+                    "Unmerge lora module to 4-bit linear may get different generations due to rounding errors. \n\
+                    You would better to use torch.inference_mode for inference due to the gradient issue."
                 )
                 kwargs = self.weight.__dict__
                 lora_data = self.get_delta_weight(self.active_adapter)

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -362,6 +362,38 @@ class PeftGPUCommonTests(unittest.TestCase):
     @require_torch_gpu
     @pytest.mark.single_gpu_tests
     @require_bitsandbytes
+    def test_8bit_merge_lora(self):
+        torch.manual_seed(1000)
+        model = AutoModelForCausalLM.from_pretrained(
+            "/home/bitsandbytes/hf_home/hub/models--facebook--opt-125m/snapshots/3d2b5f275bdf882b8775f902e1bfdb790e2cfc32/",
+            load_in_8bit=True,
+        )
+        config = LoraConfig(
+            r=8,
+            init_lora_weights=False,
+        )
+        model = get_peft_model(model, config)
+
+        random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
+        with torch.inference_mode():
+            out_before_merge = model.generate(random_input, max_new_tokens=1)
+
+        model.merge_and_unload("default")
+        with torch.inference_mode():
+            out_after_merge = model.generate(random_input, max_new_tokens=1)
+
+        self.assertTrue(torch.equal(out_before_merge, out_after_merge))
+        self.assertTrue(isinstance(model, PeftModel))
+        self.assertTrue(
+            isinstance(model.base_model.model.model.decoder.layers[0].self_attn.q_proj, bnb.nn.Linear8bitLt)
+        )
+        self.assertTrue(
+            isinstance(model.base_model.model.model.decoder.layers[0].self_attn.v_proj, bnb.nn.Linear8bitLt)
+        )
+
+    @require_torch_gpu
+    @pytest.mark.single_gpu_tests
+    @require_bitsandbytes
     def test_4bit_merge_lora(self):
         torch.manual_seed(3000)
         bnb_config = BitsAndBytesConfig(

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -365,7 +365,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_8bit_merge_lora(self):
         torch.manual_seed(1000)
         model = AutoModelForCausalLM.from_pretrained(
-            "/home/bitsandbytes/hf_home/hub/models--facebook--opt-125m/snapshots/3d2b5f275bdf882b8775f902e1bfdb790e2cfc32/",
+            "facebook/opt-125m",
             load_in_8bit=True,
         )
         config = LoraConfig(


### PR DESCRIPTION
Hi @younesbelkada @pacman100 @BenjaminBossan @TimDettmers .

Relate to [851](https://github.com/huggingface/peft/pull/851). I found a way to merge 8bit model.

BitsandBytes can only dequantize the int MatMul result. Therefore, I use an identify matrix to multiply the 8-bit weight, so the result is equal to the original weight after dequantization.

The test script is also attached
```python
torch.manual_seed(1024)
model_origin = AutoModelForCausalLM.from_pretrained(
            "facebook/opt-125m",)
model = AutoModelForCausalLM.from_pretrained(
            "facebook/opt-125m",
            load_in_8bit=True,
        )
model = prepare_model_for_kbit_training(model)
print(model)
random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
print(model_origin(random_input.clone().to(model_origin.device)).logits)

config = LoraConfig(
    r=8,
    init_lora_weights=False,
    target_modules=["k_proj", "v_proj", "q_proj", "out_proj", "fc1", "fc2"]
)
model = get_peft_model(model, config)
print(model)
with torch.inference_mode():
    out_before_merge = model(random_input)
    print(out_before_merge.logits)

model = model.merge_and_unload("default")
print(model)
with torch.inference_mode():
    out_after_merge = model(random_input)
    print(out_after_merge.logits)
```

The result should be
```
tensor([[[-4.8259, -4.8183,  0.9898,  ..., -4.9119, -4.9100, -4.8111],
         [-3.5888, -3.5779,  0.9716,  ..., -3.7284, -3.6713, -3.7122],
         [-3.6172, -3.6078,  0.8687,  ..., -3.7570, -3.6960, -3.7456],
         [-3.5690, -3.5609,  0.7098,  ..., -3.7097, -3.6471, -3.6961],
         [-3.6113, -3.6041,  0.6201,  ..., -3.7497, -3.6936, -3.7288],
         [-3.7012, -3.6957,  0.5803,  ..., -3.8397, -3.7881, -3.8144]]],
       device='cuda:0')

tensor([[[-4.7348, -4.7283,  1.1155,  ..., -4.8248, -4.8206, -4.7260],
         [-3.5906, -3.5802,  0.9311,  ..., -3.7292, -3.6703, -3.7129],
         [-3.6750, -3.6668,  0.8512,  ..., -3.8123, -3.7480, -3.7943],
         [-3.6069, -3.5996,  0.7566,  ..., -3.7426, -3.6845, -3.7268],
         [-3.6024, -3.5957,  0.7001,  ..., -3.7365, -3.6801, -3.7149],
         [-3.7372, -3.7322,  0.5553,  ..., -3.8741, -3.8224, -3.8415]]],
       device='cuda:0')
```
We can see that the difference between the two logits is really small.

Would you please help me review it? Thx!