### PR TITLE
FIX: Error in forward of 4bit linear lora layer

### DIFF
--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -189,8 +189,6 @@ if is_bnb_4bit_available():
                     expected_dtype = result.dtype
                     x = x.to(lora_A.weight.dtype)
 
-                x = x.to(lora_A.weight.dtype)
-                result += lora_B(lora_A(dropout(x))) * scaling
                 output = lora_B(lora_A(dropout(x)))
                 if requires_conversion:
                     output = output.to(expected_dtype)


### PR DESCRIPTION
This was introduced during the refactoring of the `forward` function. It should now be fixed and be equivalent to the `forward` function before the refactoring:

https://github.com/huggingface/peft/blob/4df9c5a243194b03e703c1dd526d64163f9b4fd2/src/peft/tuners/lora.py#L1207-L1231

Bug reported by @jiqing-feng