### PR TITLE
MNT: Run tests that were skipped previously

### DIFF
--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -168,11 +168,6 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
 
     @parameterized.expand(TEST_CASES)
     def test_merge_layers(self, test_name, model_id, config_cls, config_kwargs):
-        # for embeddings, even with init_lora_weights=False, the LoRA embeddings weights are still initialized to
-        # perform the identity transform, thus the test would fail.
-        if config_kwargs["target_modules"] == ["emb"]:
-            return
-
         config_kwargs = config_kwargs.copy()
         config_kwargs["init_lora_weights"] = False
         self._test_merge_layers(model_id, config_cls, config_kwargs)


### PR DESCRIPTION
Some tests were skipped because of an issue with how LoRA weights were initialized for embeddings. This issue has been fixed for some time now, so the tests no longer need to be skipped.