### PR TITLE
ENH Remove redundant initialization layer calls

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -210,7 +210,8 @@ class LoraModel(BaseTuner):
     @staticmethod
     def _replace_module(parent, child_name, new_module, child):
         setattr(parent, child_name, new_module)
-        # TODO: need to set requires grad?
+        # It's not necessary to set requires_grad here, as that is handled by
+        # _mark_only_adapters_as_trainable
         new_module.weight = child.weight
         if hasattr(child, "bias"):
             new_module.bias = child.bias

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -210,10 +210,10 @@ class LoraModel(BaseTuner):
     @staticmethod
     def _replace_module(parent, child_name, new_module, child):
         setattr(parent, child_name, new_module)
+        # TODO: need to set requires grad?
         new_module.weight = child.weight
         if hasattr(child, "bias"):
-            if child.bias is not None:
-                new_module.bias = child.bias
+            new_module.bias = child.bias
 
         if getattr(child, "state", None) is not None:
             new_module.state = child.state

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -368,3 +368,16 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
     @parameterized.expand(TEST_CASES)
     def test_adding_multiple_adapters_with_bias_raises(self, test_name, model_id, config_cls, config_kwargs):
         self._test_adding_multiple_adapters_with_bias_raises(model_id, config_cls, config_kwargs)
+
+
+class TestRepr(unittest.TestCase):
+    """Tests related to the repr of adapted models"""
+    def test_repr_lora(self):
+        config = LoraConfig(target_modules=["lin0"])
+        model = get_peft_model(MLP(), config)
+        print_output = repr(model.model.lin0)
+        self.assertTrue(print_output.startswith("Linear"))
+        self.assertTrue("in_features=10, out_features=20" in print_output)
+        self.assertTrue("lora_A" in print_output)
+        self.assertTrue("lora_B" in print_output)
+        self.assertTrue("default" in print_output)

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -372,6 +372,7 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
 
 class TestRepr(unittest.TestCase):
     """Tests related to the repr of adapted models"""
+
     def test_repr_lora(self):
         config = LoraConfig(target_modules=["lin0"])
         model = get_peft_model(MLP(), config)


### PR DESCRIPTION
See discussion in #872 

## Description

This is an attempt at speeding up initialization of LoRA layers. As mentioned in [this comment](https://github.com/huggingface/peft/pull/872#issuecomment-1698899931), it seems that we currently create the weights of the linear layer that is to be adapted with LoRA twice (!), only to override it later by the original weights of the target layer. This PR attempts to remove that redundancy.

Before this can be merged, there should be a thorough study of potential implications, since this could be BC breaking if we miss something, and the impact on initialization speed should be measured.

## Road not taken

I think an even cleaner design would be to pass the target module to the LoRA layer, so that the LoRA layer can hold a reference to it. During `forward`, it would call `self.original_module.forward(x)`, then add the LoRA stuff on top. When unloading, we would just return the `original_module` instead of having to create a completely new `nn.Linear`.

Note that this approach is basically already implemented for [`QuantLinear`](https://github.com/huggingface/peft/blob/0b2f950cc212dd8acda983760c0aba2bf4872a00/src/peft/tuners/lora/gptq.py#L35). However, I think making that change on `Linear` would indeed break BC because it would not allow to load existing weights (correct me if I'm wrong), so I didn't explore that approach further.