### PR TITLE
FIX: Issue with params that have to ignored for DDP

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import math
 import warnings

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -118,7 +118,9 @@ class LoraLayer(BaseTunerLayer):
         # See issue 899.
         ddp_params_and_buffers_to_ignore: set[str] = set()
 
-        inactive_adapters = set(self.lora_A) | set(self.lora_B) | set(self.lora_embedding_A) | set(self.lora_embedding_B)
+        inactive_adapters = (
+            set(self.lora_A) | set(self.lora_B) | set(self.lora_embedding_A) | set(self.lora_embedding_B)
+        )
         if not self.disable_adapters:
             # there is an active adapter, it should not be ignored
             inactive_adapters -= {self.active_adapter}
@@ -137,6 +139,7 @@ class LoraLayer(BaseTunerLayer):
             ddp_params_and_buffers_to_ignore |= set(iter_params(inactive_adapter, "lora_embedding_B"))
 
         return ddp_params_and_buffers_to_ignore
+
 
 # Below code is based on https://github.com/microsoft/LoRA/blob/main/loralib/layers.py
 # and modified to work with PyTorch FSDP

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -374,6 +374,7 @@ class DdpParamsToIgnoreTester(unittest.TestCase):
     would be overkill.
 
     """
+
     def test_ddp_params_and_buffers_to_ignore_modules_to_save_none(self):
         config = LoraConfig(target_modules=["lin0"])
         peft_model = get_peft_model(MLP(), config)
@@ -401,7 +402,8 @@ class DdpParamsToIgnoreTester(unittest.TestCase):
         with peft_model.disable_adapter():
             params_and_buffers_to_ignore = peft_model._ddp_params_and_buffers_to_ignore
         expected = {
-            "base_model.model.lin1.modules_to_save.default.weight", "base_model.model.lin1.modules_to_save.default.bias"
+            "base_model.model.lin1.modules_to_save.default.weight",
+            "base_model.model.lin1.modules_to_save.default.bias",
         }
         # we check for subset because we're not interested in checking the ignored lora layers in this test
         self.assertTrue(expected.issubset(params_and_buffers_to_ignore))

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -723,7 +723,7 @@ class PeftCommonTester:
             # AdaLora does not support adding more than 1 adapter
             return
 
-        adapter_list = ["adapter1", "adapter_2", "adapter_3"]
+        adapter_list = ["adapter_1", "adapter_2", "adapter_3"]
         weight_list = [0.5, 1.5, 1.5]
         model = self.transformers_class.from_pretrained(model_id)
         config = config_cls(


### PR DESCRIPTION
Resolves #899

## Description

When using PyTorch `DistributedDataParallel`, there is an error if DDP wraps parameters that are not participating in the calculation of the loss. This is annoying, as we often have those types of parameters, e.g.:

- `ModulesToSaveWrapper` has a copy of the original weights
- When using multiple adapters, with only one being active

This PR aims at fixing this issue by exposing an attribute (actually: `property`) called `_ddp_params_and_buffers_to_ignore`. DDP uses this attribute to ignore the given parameters, making the error disappear.

## Implementation

Please let me know if there is a better way to implement this. The current solution has a few drawbacks:

Besides having to do this in the first place, it is also annoying that we have to implement this for all tuner layers, as they can differ when it comes to what parameters to ignore (we don't have a consistent naming scheme).

Also, our unit tests cannot cover this directly, as DDP requires a multi-gpu setup. Instead, the test is only for the existence, and correct value, of the `_ddp_params_and_buffers_to_ignore` attribute. Writing a proper DDP test would require more effort but should be feasible.

We also rely on a private attribute here, so there is a danger of this breaking with future PyTorch releases.

## DONE/TODO:

- [x] ModulesToSaveWrapper
- [x] LoRA
- [ ] IA³
- [ ] AdaLora