### PR TITLE
[WIP] FIX: setting requires_grad on adapter layers

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -618,8 +618,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if adapter_name not in self.peft_config:
             raise ValueError(f"Adapter {adapter_name} not found.")
         self.active_adapter = adapter_name
-        if not self.peft_config[adapter_name].is_prompt_learning:
-            self.base_model.set_adapter(adapter_name)
+        # TODO: should add check which model can set adapter
+        self.base_model.set_adapter(adapter_name)
         _set_adapter(self, adapter_name)
 
     @property

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -81,6 +81,8 @@ class BaseTuner(nn.Module, ABC):
                 # user is adding a dict of PeftConfigs
                 self.peft_config.update(peft_config)
 
+        self.active_adapter = adapter_name
+
         # transformers models have a .config attribute, whose presence is assumed later on
         if not hasattr(self, "config"):
             self.config = {"model_type": "custom"}

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -153,9 +153,19 @@ class ModulesToSaveWrapper(torch.nn.Module):
         super().__init__()
         self.original_module = module_to_save
         self.modules_to_save = torch.nn.ModuleDict({})
+        self._active_adapter = adapter_name
+        self._disable_adapters = False
         self.update(adapter_name)
-        self.active_adapter = adapter_name
-        self.disable_adapters = False
+
+    @property
+    def disable_adapters(self) -> bool:
+        # use a property to ensure that disable_adapters is not set directly, instead use the enable_adapters method
+        return self._disable_adapters
+
+    @property
+    def active_adapter(self) -> str:
+        # use a property to ensure that active_adapter is not set directly, instead use the set_adapter method
+        return self._active_adapter
 
     def update(self, adapter_name):
         self.modules_to_save.update(torch.nn.ModuleDict({adapter_name: copy.deepcopy(self.original_module)}))
@@ -165,6 +175,10 @@ class ModulesToSaveWrapper(torch.nn.Module):
             new_hook = self._create_new_hook(old_hook)
             remove_hook_from_module(self.modules_to_save[adapter_name])
             add_hook_to_module(self.modules_to_save[adapter_name], new_hook)
+
+        self.original_module.requires_grad_(False)
+        if adapter_name == self.active_adapter:
+            self.modules_to_save[adapter_name].requires_grad_(True)
 
     def _create_new_hook(self, old_hook):
         r"""
@@ -184,6 +198,40 @@ class ModulesToSaveWrapper(torch.nn.Module):
         if self.disable_adapters or (self.active_adapter not in self.modules_to_save):
             return self.original_module(*args, **kwargs)
         return self.modules_to_save[self.active_adapter](*args, **kwargs)
+
+    def enable_adapters(self, enabled: bool):
+        """Toggle the enabling and disabling of adapters
+
+        Takes care of setting the requires_grad flag for the adapter weights.
+
+        Args:
+            enabled (bool): True to enable adapters, False to disable adapters
+        """
+        if self._disable_adapters is not enabled:
+            # already in the desired state, do nothing
+            return
+
+        if enabled:
+            self.original_module.requires_grad_(False)
+            self.modules_to_save[self.active_adapter].requires_grad_(True)
+            self._disable_adapters = False
+        else:
+            self.original_module.requires_grad_(True)
+            self.modules_to_save.requires_grad_(False)
+            self._disable_adapters = True
+
+    def set_adapter(self, adapter_name: str):
+        """Set the active adapter
+
+        Args:
+            adapter_name (str): The name of the adapter to set as active
+        """
+        if adapter_name not in self.modules_to_save:
+            raise ValueError(f"Adapter {adapter_name} not found in {self.modules_to_save.keys()}")
+
+        self.modules_to_save[self.active_adapter].requires_grad_(False)
+        self.modules_to_save[adapter_name].requires_grad_(True)
+        self._active_adapter = adapter_name
 
 
 def _get_submodules(model, key):
@@ -207,16 +255,17 @@ def _set_trainable(model, adapter_name):
             parent, target, target_name = _get_submodules(model, key)
             if isinstance(target, ModulesToSaveWrapper):
                 target.update(adapter_name)
+                target.set_adapter(target.active_adapter)
             else:
-                for param in target.parameters():
-                    param.requires_grad = True
-                setattr(parent, target_name, ModulesToSaveWrapper(target, adapter_name))
+                new_module = ModulesToSaveWrapper(target, adapter_name)
+                new_module.set_adapter(adapter_name)
+                setattr(parent, target_name, new_module)
 
 
 def _set_adapter(model, adapter_name):
     for module in model.modules():
         if isinstance(module, ModulesToSaveWrapper):
-            module.active_adapter = adapter_name
+            module.set_adapter(adapter_name)
 
 
 def _prepare_prompt_learning_config(peft_config, model_config):

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -207,14 +207,14 @@ class PeftCommonTester:
         dummy_input = self.prepare_inputs_for_testing()
         dummy_output = model.get_input_embeddings()(dummy_input["input_ids"])
 
-        self.assertTrue(not dummy_output.requires_grad)
+        self.assertFalse(dummy_output.requires_grad)
 
         # load with `prepare_model_for_int8_training`
         model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
         model = prepare_model_for_int8_training(model)
 
         for param in model.parameters():
-            self.assertTrue(not param.requires_grad)
+            self.assertFalse(param.requires_grad)
 
         config = config_cls(
             base_model_name_or_path=model_id,


### PR DESCRIPTION
This is an alternative to #900, resolves #899.

Thanks @passaglia for figuring out the underlying issue.

## Description

Currently, we don't handle setting `requires_grad` on adapter layers really well. The main issue is that it can be set to `True` on adapter parameters that are not being used, e.g. the `original_module` in `ModulesToSaveWrapper` or inactive adapters in LoRA.

Normally, this is not a big issue, except maybe if we want to correctly count the number of trainable parameters. However, when training with `DistributedDataParallel`, this results in errors, as PyTorch thinks that all parameters with `requires_grad=True` should participate in the loss computation, but those mentioned parameters don't. For that reason, training with DDP currently errors when using `modules_to_save` or multiple adapters.

## Implementation

This turned out to be more complicated than I initially thought. The logic for setting `requires_grad` is all over the place, it was hard to encapsulate the logic and I only succeeded partially. As is, this PR is more complex than the one it tries to supersede, #900, but it is also "more correct".

Tests were added to check whether `requires_grad` is set correctly. There are (so far) no tests for whether DDP indeed works, they could be added with multi-GPU. I did, however, test an early stage of this PR with DDP and setting `requires_grad` correctly will indeed fix the DDP error.

## DONE/TODO

- [x] ModulesToSaveWrapper
- [x] LoRA
- [ ] IA³
- [ ] AdaLora

Since some tuners are not implemented yet, tests are expected to fail. Check the new tests at the bottom of `test_custom.py`, those should pass. I have not measured if this change adds a significant overhead when switching adapters.