### PR TITLE
DOC: Section on common issues encountered with PEFT

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -6,6 +6,8 @@
     title: Quicktour
   - local: install
     title: Installation
+  - local: common_issues
+    title: Common issues
 
 - title: Task guides
   sections:

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -6,8 +6,6 @@
     title: Quicktour
   - local: install
     title: Installation
-  - local: common_issues
-    title: Common issues
 
 - title: Task guides
   sections:
@@ -38,6 +36,8 @@
     title: PEFT low level API
   - local: developer_guides/contributing
     title: Contributing to PEFT
+  - local: developer_guides/troubleshooting
+    title: Troubleshooting
 
 - title: 🤗 Accelerate integrations
   sections:

--- a/docs/source/common_issues.mdx
+++ b/docs/source/common_issues.mdx
@@ -14,22 +14,22 @@ specific language governing permissions and limitations under the License.
 
 If you encounter any issue when using PEFT, please check the following list of common issues and their solutions.
 
-## I used or modified an existing example but it does not work
+## Examples don't work
 
-Please ensure that the versions of packages you use are up-to-date. Examples often rely on the most recent versions being used. In particular, check the version of the following packages:
+Examples often rely on the most recent package versions, so please ensure they're up-to-date. In particular, check the version of the following packages:
 
 - `peft`
 - `transformers`
 - `accelerate`
 - `torch`
 
-In general, you can update the version of your package by running this command inside your Python environment:
+In general, you can update the package version by running this command inside your Python environment:
 
 ```bash
 python -m pip install -U <package_name>
 ```
 
-Especially for PEFT, it may be useful to install the package from source:
+Installing PEFT from source is useful for keeping up with the latest developments:
 
 ```bash
 python -m pip install git+https://github.com/huggingface/peft
@@ -43,7 +43,7 @@ There can be several reasons for this. Please check one of the proposed solution
 
 If your model outputs are not exactly the same as previously, there could be an issue with random elements. For example, when the model uses dropout, please ensure that it is in `.eval()` mode. If you use `.generate()` on a language model, there could be random sampling, so obtaining the same result requires a random seed to be set. Finally, if you used quantization and merged the weights, small deviations are expected due to rounding errors.
 
-### Correctly loading the model
+### Incorrectly loaded model
 
 Please ensure that you load the model correctly. The loading code should look like this:
 
@@ -57,11 +57,13 @@ peft_model = PeftModel.from_pretrained(base_model, peft_model_id)
 
 A common mistake we see is users trying to load a _trained_ model using `get_peft_model`, which is incorrect.
 
-### Use of models with randomly initialized layers
+### Randomly initialized layers
 
-For some tasks, it is important to correctly configure `modules_to_save` in the config to take into account randomly initialized layers. As an example, if you use LoRA to fine-tune a language model for sequence classification, this is necessary. The reason for that is that transformers adds a classification head on top of the model, which is randomly initialized. Therefore, if you do not add this layer to `modules_to_save`, the classification head will not be saved. Then, next time you load the model, you get a _different_ randomly initialized classification head, resulting in completely different results.
+For some tasks, it is important to correctly configure `modules_to_save` in the config to account for randomly initialized layers. 
 
-In PEFT, we try to correctly guess the `modules_to_save` if you provide the `task_type` argument in the config. This should work for transformers models that follow the standard naming scheme. Still, we cannot guarantee that all models do so, which is why users should always double check.
+As an example, this is necessary if you use LoRA to fine-tune a language model for sequence classification because 🤗 Transformers adds a randomly initialized classification head on top of the model. If you do not add this layer to `modules_to_save`, the classification head won't be saved. The next time you load the model, you'll get a _different_ randomly initialized classification head, resulting in completely different results.
+
+In PEFT, we try to correctly guess the `modules_to_save` if you provide the `task_type` argument in the config. This should work for transformers models that follow the standard naming scheme. It is always a good idea to double check though because we can't guarantee all models follow the naming scheme.
 
 When you load a transformers model that has randomly initialized layers, you should see a warning along the lines of:
 

--- a/docs/source/common_issues.mdx
+++ b/docs/source/common_issues.mdx
@@ -1,0 +1,77 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Common issues encountered when using PEFT
+
+If you encounter any issue when using PEFT, please check the following list of common issues and their solutions.
+
+## I used or modified an existing example but it does not work
+
+Please ensure that the versions of packages you use are up-to-date. Examples often rely on the most recent versions being used. In particular, check the version of the following packages:
+
+- `peft`
+- `transformers`
+- `accelerate`
+- `torch`
+
+In general, you can update the version of your package by running this command inside your Python environment:
+
+```bash
+python -m pip install -U <package_name>
+```
+
+Especially for PEFT, it may be useful to install the package from source:
+
+```bash
+python -m pip install git+https://github.com/huggingface/peft
+```
+
+## I successfully trained a model but when I load it, I get bad results
+
+There can be several reasons for this. Please check one of the proposed solutions below.
+
+### Random deviations
+
+If your model outputs are not exactly the same as previously, there could be an issue with random elements. For example, when the model uses dropout, please ensure that it is in `.eval()` mode. If you use `.generate()` on a language model, there could be random sampling, so obtaining the same result requires a random seed to be set. Finally, if you used quantization and merged the weights, small deviations are expected due to rounding errors.
+
+### Correctly loading the model
+
+Please ensure that you load the model correctly. The loading code should look like this:
+
+```python
+from peft import PeftModel, PeftConfig
+
+base_model = ...  # to load the base model, use the same code as when you trained it
+config = PeftConfig.from_pretrained(peft_model_id)
+peft_model = PeftModel.from_pretrained(base_model, peft_model_id)
+```
+
+A common mistake we see is users trying to load a _trained_ model using `get_peft_model`, which is incorrect.
+
+### Use of models with randomly initialized layers
+
+For some tasks, it is important to correctly configure `modules_to_save` in the config to take into account randomly initialized layers. As an example, if you use LoRA to fine-tune a language model for sequence classification, this is necessary. The reason for that is that transformers adds a classification head on top of the model, which is randomly initialized. Therefore, if you do not add this layer to `modules_to_save`, the classification head will not be saved. Then, next time you load the model, you get a _different_ randomly initialized classification head, resulting in completely different results.
+
+In PEFT, we try to correctly guess the `modules_to_save` if you provide the `task_type` argument in the config. This should work for transformers models that follow the standard naming scheme. Still, we cannot guarantee that all models do so, which is why users should always double check.
+
+When you load a transformers model that has randomly initialized layers, you should see a warning along the lines of:
+
+```
+Some weights of <MODEL> were not initialized from the model checkpoint at <ID> and are newly initialized: [<LAYER_NAMES>].
+You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
+```
+
+The mentioned layers should be added to `modules_to_save` in the config to avoid the described problem.
+
+### None of the above helped
+
+If you checked all of the previous points and still have issues with loading your model, please check the issues on GitHub at https://github.com/huggingface/peft/issues and open a new one if none match your problem. As always when opening an issue, it helps a lot if you provide a minimal code example that reproduces the issue. Also, please report if the loaded model performs at the same level as the model did before fine-tuning, if it performs at a random level, or if it is only slightly worse than expected. This information helps us identify the problem more quickly.

--- a/docs/source/developer_guides/troubleshooting.mdx
+++ b/docs/source/developer_guides/troubleshooting.mdx
@@ -10,7 +10,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Common issues encountered when using PEFT
+# Troubleshooting
 
 If you encounter any issue when using PEFT, please check the following list of common issues and their solutions.
 
@@ -35,17 +35,23 @@ Installing PEFT from source is useful for keeping up with the latest development
 python -m pip install git+https://github.com/huggingface/peft
 ```
 
-## I successfully trained a model but when I load it, I get bad results
+## Bad results from a loaded PEFT model
 
-There can be several reasons for this. Please check one of the proposed solutions below.
+There can be several reasons for getting a poor result from a loaded PEFT model, which are listed below. If you're still unable to troubleshoot the problem, see if anyone else had a similar [issue](https://github.com/huggingface/peft/issues) on GitHub, and if you can't find any, open a new issue.
+
+When opening an issue, it helps a lot if you provide a minimal code example that reproduces the issue. Also, please report if the loaded model performs at the same level as the model did before fine-tuning, if it performs at a random level, or if it is only slightly worse than expected. This information helps us identify the problem more quickly.
 
 ### Random deviations
 
-If your model outputs are not exactly the same as previously, there could be an issue with random elements. For example, when the model uses dropout, please ensure that it is in `.eval()` mode. If you use `.generate()` on a language model, there could be random sampling, so obtaining the same result requires a random seed to be set. Finally, if you used quantization and merged the weights, small deviations are expected due to rounding errors.
+If your model outputs are not exactly the same as previous runs, there could be an issue with random elements. For example:
+
+1. please ensure it is in `.eval()` mode, which is important, for instance, if the model uses dropout
+2. if you use [`~transformers.GenerationMixin.generate`] on a language model, there could be random sampling, so obtaining the same result requires setting a random seed
+3. if you used quantization and merged the weights, small deviations are expected due to rounding errors
 
 ### Incorrectly loaded model
 
-Please ensure that you load the model correctly. The loading code should look like this:
+Please ensure that you load the model correctly. A common error is trying to load a _trained_ model with `get_peft_model`, which is incorrect. Instead, the loading code should look like this:
 
 ```python
 from peft import PeftModel, PeftConfig
@@ -54,8 +60,6 @@ base_model = ...  # to load the base model, use the same code as when you traine
 config = PeftConfig.from_pretrained(peft_model_id)
 peft_model = PeftModel.from_pretrained(base_model, peft_model_id)
 ```
-
-A common mistake we see is users trying to load a _trained_ model using `get_peft_model`, which is incorrect.
 
 ### Randomly initialized layers
 
@@ -73,7 +77,3 @@ You should probably TRAIN this model on a down-stream task to be able to use it 
 ```
 
 The mentioned layers should be added to `modules_to_save` in the config to avoid the described problem.
-
-### None of the above helped
-
-If you checked all of the previous points and still have issues with loading your model, please check the issues on GitHub at https://github.com/huggingface/peft/issues and open a new one if none match your problem. As always when opening an issue, it helps a lot if you provide a minimal code example that reproduces the issue. Also, please report if the loaded model performs at the same level as the model did before fine-tuning, if it performs at a random level, or if it is only slightly worse than expected. This information helps us identify the problem more quickly.


### PR DESCRIPTION
So far, this section contains two issues, not using latest package versions and issues with loading PEFT models. This is based on what I feel are issues that are commonly brought up.

If this is helpful, I think in the future, we should sections on common issues with quantization, correcting wrong expectations about memory use and runtime performance, etc., which I feel often come up.

Also, let me know if I should move the section to a different part of the docs.