### PR TITLE
Enh speed up init emb conv2d

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -43,6 +43,18 @@ class LoraLayer(BaseTunerLayer):
         self.out_features = out_features
         self.kwargs = kwargs
 
+    def _init_empty_weights(self, cls, *args, **kwargs) -> None:
+        # A helper method that allows to initialize the layer of the given class without spending time to initialize the
+        # model weights. The implementation is inspired by
+        # https://pytorch.org/docs/stable/generated/torch.nn.utils.skip_init.html but this function cannot be used
+        # directly.
+        # Instead of this approach, it would be possible to bypass the __init__ of the class but that runs the risk of
+        # omitting important logic inside that __init__.
+        kwargs = kwargs.copy()
+        final_device = kwargs.pop('device', 'cpu')
+        cls.__init__(self, *args, device="meta", **kwargs)
+        self.to_empty(device=final_device)
+
     def update_layer(self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights):
         self.r[adapter_name] = r
         self.lora_alpha[adapter_name] = lora_alpha
@@ -63,7 +75,7 @@ class LoraLayer(BaseTunerLayer):
         weight = getattr(self, "weight", None)
         if weight is not None:
             # the layer is already completely initialized, this is an update
-            self.to(weight.device)
+            self.to(weight.device, dtype=weight.dtype)
 
     def update_layer_conv2d(self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights):
         self.r[adapter_name] = r
@@ -84,7 +96,11 @@ class LoraLayer(BaseTunerLayer):
             self.scaling[adapter_name] = lora_alpha / r
         if init_lora_weights:
             self.reset_lora_parameters(adapter_name)
-        self.to(self.weight.device)
+
+        weight = getattr(self, "weight", None)
+        if weight is not None:
+            # the layer is already completely initialized, this is an update
+            self.to(self.weight.device, dtype=weight.dtype)
 
     def update_layer_embedding(self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights):
         self.r[adapter_name] = r
@@ -97,14 +113,18 @@ class LoraLayer(BaseTunerLayer):
         self.lora_dropout[adapter_name] = lora_dropout_layer
         # Actual trainable parameters
         if r > 0:
-            weight_A = torch.randn((r, self.in_features), dtype=self.weight.dtype, device=self.weight.device)
-            weight_B = torch.randn((self.out_features, r), dtype=self.weight.dtype, device=self.weight.device)
+            weight_A = torch.randn((r, self.in_features))
+            weight_B = torch.randn((self.out_features, r))
             self.lora_embedding_A[adapter_name] = nn.Parameter(weight_A)
             self.lora_embedding_B[adapter_name] = nn.Parameter(weight_B)
             self.scaling[adapter_name] = lora_alpha / r
         if init_lora_weights:
             self.reset_lora_parameters(adapter_name)
-        self.to(self.weight.device)
+
+        weight = getattr(self, "weight", None)
+        if weight is not None:
+            # the layer is already completely initialized, this is an update
+            self.to(self.weight.device, dtype=weight.dtype)
 
     def reset_lora_parameters(self, adapter_name):
         if adapter_name in self.lora_A.keys():
@@ -145,6 +165,8 @@ class Linear(nn.Linear, LoraLayer):
         # this gets the init from nn.Linear's super perspective, i.e.
         # nn.Module.__init__, which should always be called
         super(nn.Linear, self).__init__()
+        # Note that we don't use self._init_empty_weights() for Linear because it is a bit slower and the benefit of
+        # added robustness is not big enough for Linear.
 
         LoraLayer.__init__(self, in_features=in_features, out_features=out_features)
         # Freezing the pre-trained weight matrix
@@ -226,13 +248,8 @@ class Embedding(nn.Embedding, LoraLayer):
         **kwargs,
     ) -> None:
         init_lora_weights = kwargs.pop("init_lora_weights", True)
-
-        nn.Embedding.__init__(self, num_embeddings, embedding_dim, **kwargs)
+        self._init_empty_weights(nn.Embedding, num_embeddings, embedding_dim, **kwargs)
         LoraLayer.__init__(self, in_features=num_embeddings, out_features=embedding_dim)
-
-        self.weight.requires_grad = False
-
-        nn.Embedding.reset_parameters(self)
         self.update_layer_embedding(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
         self.active_adapter = adapter_name
 
@@ -306,8 +323,8 @@ class Conv2d(nn.Conv2d, LoraLayer):
         **kwargs,
     ) -> None:
         init_lora_weights = kwargs.pop("init_lora_weights", True)
+        self._init_empty_weights(nn.Conv2d, in_channels, out_channels, kernel_size, stride=stride, padding=padding)
 
-        nn.Conv2d.__init__(self, in_channels, out_channels, kernel_size, stride, padding)
         LoraLayer.__init__(
             self,
             in_features=in_channels,
@@ -316,10 +333,7 @@ class Conv2d(nn.Conv2d, LoraLayer):
             stride=stride,
             padding=padding,
         )
-        # Freezing the pre-trained weight matrix
-        self.weight.requires_grad = False
 
-        nn.Conv2d.reset_parameters(self)
         self.update_layer_conv2d(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
         self.active_adapter = adapter_name
 

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -51,7 +51,7 @@ class LoraLayer(BaseTunerLayer):
         # Instead of this approach, it would be possible to bypass the __init__ of the class but that runs the risk of
         # omitting important logic inside that __init__.
         kwargs = kwargs.copy()
-        final_device = kwargs.pop('device', 'cpu')
+        final_device = kwargs.pop("device", "cpu")
         cls.__init__(self, *args, device="meta", **kwargs)
         self.to_empty(device=final_device)
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -368,12 +368,44 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
 class TestRepr(unittest.TestCase):
     """Tests related to the repr of adapted models"""
 
-    def test_repr_lora(self):
+    def test_repr_lora_linear(self):
         config = LoraConfig(target_modules=["lin0"])
         model = get_peft_model(MLP(), config)
         print_output = repr(model.model.lin0)
         self.assertTrue(print_output.startswith("Linear"))
         self.assertTrue("in_features=10, out_features=20" in print_output)
+        self.assertTrue("lora_A" in print_output)
+        self.assertTrue("lora_B" in print_output)
+        self.assertTrue("default" in print_output)
+
+    def test_repr_lora_embedding(self):
+        config = LoraConfig(target_modules=["emb"])
+        model = get_peft_model(ModelEmbConv1D(), config)
+        print_output = repr(model.model.emb)
+        self.assertTrue(print_output.startswith("Embedding"))
+        self.assertTrue("100, 5" in print_output)
+        self.assertTrue("lora_embedding_A" in print_output)
+        self.assertTrue("lora_embedding_B" in print_output)
+        self.assertTrue("default" in print_output)
+
+    def test_repr_lora_conv1d(self):
+        config = LoraConfig(target_modules=["conv1d"])
+        model = get_peft_model(ModelEmbConv1D(), config)
+        print_output = repr(model.model.conv1d)
+        self.assertTrue(print_output.startswith("Linear"))
+        self.assertTrue("in_features=5, out_features=1" in print_output)
+        self.assertTrue("lora_A" in print_output)
+        self.assertTrue("lora_B" in print_output)
+        self.assertTrue("default" in print_output)
+
+    def test_repr_lora_conv2d(self):
+        config = LoraConfig(target_modules=["conv2d"])
+        model = get_peft_model(ModelConv2D(), config)
+        print_output = repr(model.model.conv2d)
+        self.assertTrue(print_output.startswith("Conv2d"))
+        self.assertTrue("5, 10" in print_output)
+        self.assertTrue("kernel_size=(3, 3)" in print_output)
+        self.assertTrue("stride=(1, 1)" in print_output)
         self.assertTrue("lora_A" in print_output)
         self.assertTrue("lora_B" in print_output)
         self.assertTrue("default" in print_output)


### PR DESCRIPTION
Resolves part of #872

## Description

After getting faster initialization of the LoRA `Linear` layer, initialization of `Conv2d` and `Embedding` is now sped up.

## Implementation

The approach of how to achieve the speed up has slightly changed compared to last time. To refresh memory, in #887, we avoided the unnecessary initialization of the full weight matrix by completely skipping `nn.Linear.__init__`.

Although it is possible to do the same for `Embedding` and `Conv2d`, we run into some trouble here. The issue is that the `__init__` methods of these classes have quite a lot more arguments and some custom logic (i.e. not only `self.foo = foo` but more on top). If we wanted to skip `__init__` entirely, we would have to basically copy all of that into our code. Although that is possible, it is brittle (e.g. the logic could be different for different PyTorch versions or change over time).

For that reason, I opted to implement this differently, using a suggestion we had discussed earlier. The approach is to call `__init__` of the parent class but enforce empty weights (this is what `torch.nn.utils.skip_init` does, although we cannot use that function directly). This way, we can avoid having to copy the `__init__` code while still avoiding expensive initialization of the weights.

I did not change the code for `Linear` to also use this approach because the logic inside of `Linear.__init__` is quite simple (at least for now), so we are good here with the existing approach.

## Benchmark

I was curious how changing the approach for `Linear` would affect the initialization speed. Therefore, I ran the script from #872, 3 times each, with the current vs the new approach.

Current approach:

```
test 1 with model bert-base took 0.021 sec.
test 1 with model bert-base took 0.020 sec.
test 1 with model bert-base took 0.020 sec.
test 2 with model bloomz-1b7 took 0.030 sec.
test 2 with model bloomz-1b7 took 0.030 sec.
test 2 with model bloomz-1b7 took 0.030 sec.
```

New approach if applied to Linear:

```
test 1 with model bert-base took 0.038 sec.
test 1 with model bert-base took 0.039 sec.
test 1 with model bert-base took 0.038 sec.
test 2 with model bloomz-1b7 took 0.072 sec.
test 2 with model bloomz-1b7 took 0.048 sec.
test 2 with model bloomz-1b7 took 0.048 sec.
```

This shows that the new approach is indeed a bit slower than the existing one, though still a lot faster than what we had before. IMHO, I think we're safe to leave the code inside of `Linear` as is and benefit from the slightly better performance at the cost of slightly more fragile code. But please let me know if you prefer:

1. The new approach should also be applied to `Linear`
2. The existing approach should also be applied to `Embedding` and `Conv2d`