### PR TITLE
Fixed LoRA conversion for kohya_ss

### DIFF
--- a/examples/lora_dreambooth/convert_kohya_ss_sd_lora_to_peft.py
+++ b/examples/lora_dreambooth/convert_kohya_ss_sd_lora_to_peft.py
@@ -39,8 +39,8 @@ def get_modules_names(
             for child_name, child_module in module.named_modules():
                 if len(child_name) == 0:
                     continue
-                is_linear = child_module.__class__.__name__ == "Linear"
-                is_conv2d = child_module.__class__.__name__ == "Conv2d"
+                is_linear = isinstance(child_module, nn.Linear)
+                is_conv2d = isinstance(child_module, nn.Conv2d)
 
                 if (is_linear and module.__class__.__name__ in target_replace_modules_linear) or (
                     is_conv2d and module.__class__.__name__ in target_replace_modules_conv2d


### PR DESCRIPTION
diffusers have recently replaced Conv2d and Linear layers with [LoraCompatibleConv](https://github.com/huggingface/diffusers/blob/9800cc5ece794f8e63b61fb21e8f3197a88bc00f/src/diffusers/models/lora.py#L103) and [LoraCompatibleLinear](https://github.com/huggingface/diffusers/blob/9800cc5ece794f8e63b61fb21e8f3197a88bc00f/src/diffusers/models/lora.py#L170).

This pull request fixes wrong conversion of kohya_ss trained LoRAs. It should be better to determine whether module is Linear or Conv2d block based on class inheritance, not based on its name.

@BenjaminBossan @pacman100 your review is kindly appreciated.