### PR TITLE
Make base_model.peft_config single source of truth

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -510,7 +510,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 f"Found {self.peft_type} and {peft_config.peft_type}."
             )
 
-
         try:
             if peft_config.is_prompt_learning:
                 self.peft_config[adapter_name] = peft_config

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -510,10 +510,10 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 f"Found {self.peft_type} and {peft_config.peft_type}."
             )
 
-        self.peft_config[adapter_name] = peft_config
 
         try:
             if peft_config.is_prompt_learning:
+                self.peft_config[adapter_name] = peft_config
                 if hasattr(self.config, "to_dict"):
                     dict_config = self.config.to_dict()
                 else:
@@ -524,9 +524,11 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             elif peft_config.is_adaption_prompt:
                 self.base_model.add_adapter(adapter_name, peft_config)
             else:
+                self.peft_config[adapter_name] = peft_config
                 self.base_model.inject_adapter(self, adapter_name)
         except Exception:  # somthing went wrong, roll back
-            del self.peft_config[adapter_name]
+            if adapter_name in self.peft_config:
+                del self.peft_config[adapter_name]
             raise
 
         self.set_additional_trainable_modules(peft_config, adapter_name)


### PR DESCRIPTION
Resolves #802

For the problem description, please check the mentioned issue.

I went with solution 2, i.e. making the `base_model.peft_config` the "single source of truth" for the PEFT configuration. That way, we minimize the risk of diverging configurations.

This does not apply for prompt learning, where we don't have a `peft_config` on the base model (which is just the normal model, not a PEFT class).

For adaption prompt, I had to make a small change, renaming `self._configs` to `self.peft_config` to be consistent with the other tuners. It also differs by using the name `configs` in its `__init__` signature, in contrast to `config`, as all others do. I was tempted to rename it, but it would technically be backwards compatibility breaking (but PEFT code wouldn't be affected, as we pass it positionally). LMK if I should rename it.

I added a setter for `peft_config` but from my testing, it isn't being used. It's only there for completeness.