### PR TITLE
fix lora layer init

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -75,7 +75,10 @@ class LoraLayer(BaseTunerLayer):
         weight = getattr(self, "weight", None)
         if weight is not None:
             # the layer is already completely initialized, this is an update
-            self.to(weight.device, dtype=weight.dtype)
+            if weight.dtype.is_floating_point or weight.dtype.is_complex:
+                self.to(weight.device, dtype=weight.dtype)
+            else:
+                self.to(weight.device)
 
     def update_layer_conv2d(self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights):
         self.r[adapter_name] = r


### PR DESCRIPTION
# What does this PR do ?

This PR fixes the [CI](https://github.com/huggingface/peft/actions/runs/6167094166/job/16737542434), and more precisely a test about gptq. The problem was that we were updating the dtype the lora layers with the dtype of the GPTQ layer weights. However, the dtype is uint8 which is not a floating point or complex. Bnb don't have that issue as the weight dtype at initialization is torch.float32. 

PS: Other tests are failing (`StableDiffusionModelTester`) but not related to this PR 