### PR TITLE
TST: Add GH action to run unit tests with torch.compile

### DIFF
--- a/.github/workflows/torch_compile_tests.yml
+++ b/.github/workflows/torch_compile_tests.yml
@@ -1,0 +1,34 @@
+name: torch compile tests
+
+# see peft/tests/__init__.py
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to test on'
+        required: true
+
+jobs:
+  run_tests_with_compile:
+    runs-on: ubuntu-latest
+    env:
+      PEFT_DEBUG_WITH_TORCH_COMPILE: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Test compile with pytest
+        run: |
+          git status
+          make test

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,19 @@
+import os
+
+
+if os.environ.get("PEFT_DEBUG_WITH_TORCH_COMPILE") == "1":
+    # This is a hack purely for debugging purposes. If the environment variable PEFT_DEBUG_WITH_TORCH_COMPILE is set to
+    # 1, get_peft_model() will return a compiled model. This way, all unit tests that use peft.get_peft_model() will
+    # use a compiled model. See .github/workflows/torch_compile_tests.yml.
+    import torch
+
+    import peft
+    from peft.mapping import get_peft_model as get_peft_model_original
+
+    def get_peft_model_new(*args, **kwargs):
+        """Make get_peft_model() return a compiled model."""
+        peft_model = get_peft_model_original(*args, **kwargs)
+        peft_model = torch.compile(peft_model)
+        return peft_model
+
+    peft.get_peft_model = get_peft_model_new


### PR DESCRIPTION
The GitHub action works by setting an environment variable `PEFT_DEBUG_WITH_TORCH_COMPILE=1`. This causes the tests to run with torch.compile if `get_peft_model` is being used. The action is triggered manually and requires to indicate the branch to run it on.

Once this PR is merged, the action should be listed [here](https://github.com/huggingface/peft/actions). Unfortunately, I don't think we can really test this before merging into main. I did, however, add a similar action to a [toy repo](https://github.com/BenjaminBossan/mops/blob/main/.github/workflows/manual_trigger.yml) where it works. To instead run tests with `torch.compile` locally, just use the normal test command with the env var set to 1, e.g. `PEFT_DEBUG_WITH_TORCH_COMPILE=1 make test`.

With this action, we should be able to incrementally add support for torch.compile in PEFT without disrupting the existing tests. Once we fully support torch.compile, we can think about adding to the tests by default and to remove the code from this PR.