### PR TITLE
FIX: torch compile gh action installs pytest

### DIFF
--- a/.github/workflows/torch_compile_tests.yml
+++ b/.github/workflows/torch_compile_tests.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install .[test]
       - name: Test compile with pytest
         run: |
+          echo "PEFT_DEBUG_WITH_TORCH_COMPILE=$PEFT_DEBUG_WITH_TORCH_COMPILE"
           git status
           make test


### PR DESCRIPTION
There was a small mistake in the previous GH action because pytest was not being installed. This should fix it.