### PR TITLE
TST: Fix some tests that would fail with torch.compile

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -25,17 +25,23 @@ from .other import SAFETENSORS_WEIGHTS_NAME, WEIGHTS_NAME, infer_device
 from .peft_types import PeftType
 
 
-def get_peft_model_state_dict(model, state_dict=None, adapter_name="default"):
+def get_peft_model_state_dict(model, state_dict=None, adapter_name="default", unwrap_compiled=False):
     """
     Get the state dict of the Peft model.
 
     Args:
         model ([`PeftModel`]): The Peft model. When using torch.nn.DistributedDataParallel, DeepSpeed or FSDP,
-        the model should be the underlying model/unwrapped model (i.e. model.module).
+            the model should be the underlying model/unwrapped model (i.e. model.module).
         state_dict (`dict`, *optional*, defaults to `None`):
-            The state dict of the model. If not provided, the state dict of the model
-        will be used.
+            The state dict of the model. If not provided, the state dict of the passed model will be used.
+        adapter_name (`str`, *optional*, defaults to `"default"`):
+            The name of the adapter whose state dict should be returned.
+        unwrap_compiled (`bool`, *optional*, defaults to `False`):
+            Whether to unwrap the model if torch.compile was used.
     """
+    if unwrap_compiled:
+        model = getattr(model, "_orig_mod", model)
+
     config = model.peft_config[adapter_name]
     if state_dict is None:
         state_dict = model.state_dict()

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -26,6 +26,7 @@ from transformers.pytorch_utils import Conv1D
 from peft import LoraConfig, PeftModel, get_peft_model
 
 from .testing_common import PeftCommonTester
+from .testing_utils import get_state_dict
 
 
 # MLP is a vanilla FF network with only linear layers
@@ -264,7 +265,7 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
             optimizer.step()
 
         tol = 1e-4
-        params_before = dict(model.named_parameters())
+        params_before = get_state_dict(model)
         # note: no need to sanity check if parameters were updated at all, this
         # is already covered in the previous test
 
@@ -272,7 +273,7 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
             model.save_pretrained(tmp_dirname)
             model_from_pretrained = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
             model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
-            params_after = dict(model_from_pretrained.named_parameters())
+            params_after = get_state_dict(model_from_pretrained)
 
             self.assertEqual(params_before.keys(), params_after.keys())
             for name, param_before in params_before.items():

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -253,8 +253,8 @@ class PeftCommonTester:
             model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
 
             # check if the state dicts are equal
-            state_dict = get_peft_model_state_dict(model)
-            state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained)
+            state_dict = get_peft_model_state_dict(model, unwrap_compiled=True)
+            state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained, unwrap_compiled=True)
 
             # check if same keys
             self.assertEqual(state_dict.keys(), state_dict_from_pretrained.keys())
@@ -308,8 +308,8 @@ class PeftCommonTester:
             model_from_pretrained.load_adapter(tmp_dirname, "new_adapter")
 
             # check if the state dicts are equal
-            state_dict = get_peft_model_state_dict(model)
-            state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained)
+            state_dict = get_peft_model_state_dict(model, unwrap_compiled=True)
+            state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained, unwrap_compiled=True)
 
             # check if same keys
             self.assertEqual(state_dict.keys(), state_dict_from_pretrained.keys())

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -89,3 +89,12 @@ def temp_seed(seed: int):
         torch.random.set_rng_state(torch_state)
         if torch.cuda.is_available():
             torch.cuda.set_rng_state_all(torch_cuda_states)
+
+
+def get_state_dict(model, unwrap_compiled=True):
+    """
+    Get the state dict of a model. If the model is compiled, unwrap it first.
+    """
+    if unwrap_compiled:
+        model = getattr(model, "_orig_mod", model)
+    return model.state_dict()


### PR DESCRIPTION
Some tests would currently fail with `torch.compile`, not because there is anything wrong with how PEFT works with compiled models, but simply because of the way the tests are written. This is because when models are compiled, the keys of the state dict change. Tests have now been adapted to unwrap the compiled model first before getting the state dict.

Note that the mentioned issue does not affect saving and loading, because `save_pretrained` is already called on the original module, so there is no issue with mismatched keys.

While working on this, I also fixed the docstring of `get_peft_model_state_dict`.

Running the `torch.compile` tests against this branch failed, probably because it's a fork :-/ https://github.com/huggingface/peft/actions/runs/6238068686/job/16933091996