### PR TITLE
ENH Allow compile GH action to run on torch nightly

### DIFF
--- a/.github/workflows/torch_compile_tests.yml
+++ b/.github/workflows/torch_compile_tests.yml
@@ -8,6 +8,10 @@ on:
       branch:
         description: 'Branch to test on'
         required: true
+      pytorch_nightly:
+        description: 'Whether to use PyTorch nightly (true/false)'
+        required: false
+        default: false
 
 jobs:
   run_tests_with_compile:
@@ -18,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -27,7 +32,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test]
+          python -m pip install .[test]
+          if [ "${{ github.event.inputs.pytorch_nightly }}" = "true" ]; then
+            python -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/test/cpu
+          fi
       - name: Test compile with pytest
         run: |
           echo "PEFT_DEBUG_WITH_TORCH_COMPILE=$PEFT_DEBUG_WITH_TORCH_COMPILE"


### PR DESCRIPTION
If the action is triggered with `nightly=true`, the nightly PyTorch version will be installed.

Also, added a line that *may* enable the action to run on forks, not sure if it'll work but it shouldn't hurt either.