### PR TITLE
Install correct PyTorch nightly in GH action

### DIFF
--- a/.github/workflows/torch_compile_tests.yml
+++ b/.github/workflows/torch_compile_tests.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[test]
           if [ "${{ github.event.inputs.pytorch_nightly }}" = "true" ]; then
-            python -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/test/cpu
+            python -m pip install --upgrade --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
           fi
       - name: Test compile with pytest
         run: |


### PR DESCRIPTION
For the GH action about running torch.compile, when using the nightly options, install from the correct index (used to be test, now is nightly).