### PR TITLE
[`tests`] add transformers & diffusers integration tests

### DIFF
--- a/.github/workflows/integrations_tests.yml
+++ b/.github/workflows/integrations_tests.yml
@@ -6,10 +6,6 @@ on:
       branch:
         description: 'Branch to test on'
         required: true
-      pytorch_nightly:
-        description: 'Whether to test integration tests (diffusers + transformers)'
-        required: false
-        default: false
 
 jobs:
   run_transformers_integration_tests_main:
@@ -60,7 +56,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[test]
-          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git log
+          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git rev-parse HEAD
 
       - name: Test transformers integration
         run: |

--- a/.github/workflows/integrations_tests.yml
+++ b/.github/workflows/integrations_tests.yml
@@ -1,0 +1,37 @@
+name: integration tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to test on'
+        required: true
+      pytorch_nightly:
+        description: 'Whether to test integration tests (diffusers + transformers)'
+        required: false
+        default: false
+
+jobs:
+  run_transformers_integration_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[test]
+          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/
+          python -m pip install ".[dev]"
+
+      - name: Test transformers integration
+        run: |
+          RUN_SLOW=1 pytest tests/peft_integration/test_peft_integration.py

--- a/.github/workflows/integrations_tests.yml
+++ b/.github/workflows/integrations_tests.yml
@@ -8,7 +8,10 @@ on:
         required: true
 
 jobs:
-  run_transformers_integration_tests_main:
+  run_transformers_integration_tests:
+    strategy:
+      matrix:
+        transformers-version: ['main', 'latest']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,38 +33,20 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[test]
           cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git log
-          python -m pip install ".[dev]"
+          if [ "${{ matrix.transformers-version }}" == "main" ]; then
+              pip install -e ".[dev]"
+          else
+              echo "Nothing to do as transformers latest already installed"
+          fi
 
       - name: Test transformers integration
         run: |
           RUN_SLOW=1 pytest tests/peft_integration/test_peft_integration.py
-  run_transformers_integration_tests_release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: "pip"
-          cache-dependency-path: "setup.py"
-      - name: print environment variables
-        run: |
-          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
-          echo "env.CI_SHA = ${{ env.CI_SHA }}"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install .[test]
-          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git rev-parse HEAD
-
-      - name: Test transformers integration
-        run: |
-          RUN_SLOW=1 pytest tests/peft_integration/test_peft_integration.py
-  run_diffusers_integration_tests_main:
+  run_diffusers_integration_tests:
+    strategy:
+      matrix:
+        # For now diffusers integration is not on PyPI
+        diffusers-version: ['main']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +68,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install .[test]
           cd .. && git clone https://github.com/huggingface/diffusers.git && cd diffusers/ && git log
-          python -m pip install ".[dev]"
+          if [ "${{ matrix.diffusers-version }}" == "main" ]; then
+              pip install -e ".[dev]"
+          else
+              echo "Nothing to do as diffusers latest already installed"
+          fi
 
       - name: Test diffusers integration
         run: |

--- a/.github/workflows/integrations_tests.yml
+++ b/.github/workflows/integrations_tests.yml
@@ -12,7 +12,7 @@ on:
         default: false
 
 jobs:
-  run_transformers_integration_tests:
+  run_transformers_integration_tests_main:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,17 +25,21 @@ jobs:
           python-version: "3.10"
           cache: "pip"
           cache-dependency-path: "setup.py"
+      - name: print environment variables
+        run: |
+          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[test]
-          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/
+          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git log
           python -m pip install ".[dev]"
 
       - name: Test transformers integration
         run: |
           RUN_SLOW=1 pytest tests/peft_integration/test_peft_integration.py
-  run_diffusers_integration_tests:
+  run_transformers_integration_tests_release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,11 +52,41 @@ jobs:
           python-version: "3.10"
           cache: "pip"
           cache-dependency-path: "setup.py"
+      - name: print environment variables
+        run: |
+          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[test]
-          cd .. && git clone https://github.com/huggingface/diffusers.git && cd diffusers/
+          cd .. && git clone https://github.com/huggingface/transformers.git && cd transformers/ && git log
+
+      - name: Test transformers integration
+        run: |
+          RUN_SLOW=1 pytest tests/peft_integration/test_peft_integration.py
+  run_diffusers_integration_tests_main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: print environment variables
+        run: |
+          echo "env.CI_BRANCH = ${{ env.CI_BRANCH }}"
+          echo "env.CI_SHA = ${{ env.CI_SHA }}"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[test]
+          cd .. && git clone https://github.com/huggingface/diffusers.git && cd diffusers/ && git log
           python -m pip install ".[dev]"
 
       - name: Test diffusers integration

--- a/.github/workflows/integrations_tests.yml
+++ b/.github/workflows/integrations_tests.yml
@@ -35,3 +35,26 @@ jobs:
       - name: Test transformers integration
         run: |
           RUN_SLOW=1 pytest tests/peft_integration/test_peft_integration.py
+  run_diffusers_integration_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[test]
+          cd .. && git clone https://github.com/huggingface/diffusers.git && cd diffusers/
+          python -m pip install ".[dev]"
+
+      - name: Test diffusers integration
+        run: |
+          pytest tests/lora/test_lora_layers_peft.py


### PR DESCRIPTION
Adds a workflow to manually run PEFT integration of transformers and diffusers tests to make sure new PRs will not break those integrations

cc @BenjaminBossan @pacman100 