### PR TITLE
Fix typo in custom_models.mdx

### DIFF
--- a/docs/source/developer_guides/custom_models.mdx
+++ b/docs/source/developer_guides/custom_models.mdx
@@ -72,7 +72,7 @@ This should print:
  ('seq.5', torch.nn.modules.activation.LogSoftmax)]
 ```
 
-Let's say we want to apply LoRA to the input layer and to the hidden layer, those are `'seq.0'` and `'seq.1'`. Moreover,
+Let's say we want to apply LoRA to the input layer and to the hidden layer, those are `'seq.0'` and `'seq.2'`. Moreover,
 let's assume we want to update the output layer without LoRA, that would be `'seq.4'`. The corresponding config would
 be:
 

--- a/docs/source/developer_guides/low_level_api.mdx
+++ b/docs/source/developer_guides/low_level_api.mdx
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 # PEFT as a utility library
 
 Let's cover in this section how you can leverage PEFT's low level API to inject trainable adapters into any `torch` module. 
-The development of this API has been motivated by the need for super users to not rely on modling classes that are exposed in PEFT library and still be able to use adapter methods such as LoRA, IA3 and AdaLoRA.
+The development of this API has been motivated by the need for super users to not rely on modeling classes that are exposed in PEFT library and still be able to use adapter methods such as LoRA, IA3 and AdaLoRA.
 
 ## Supported tuner types
 


### PR DESCRIPTION
I have made a correction in line 75 to maintain consistency with the subsequent code. The hidden layer should be labeled as 'seq.2' instead of 'seq.1'.