### PR TITLE
TST: Fix broken save_pretrained tests

### DIFF
--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -36,6 +36,7 @@ from peft import (
 )
 from peft.tuners.lora import LoraLayer
 from peft.utils import _get_submodules, infer_device
+from .testing_utils import get_state_dict
 
 
 CONFIG_CLASSES = (
@@ -238,6 +239,14 @@ class PeftCommonTester:
         self.assertTrue(dummy_output.requires_grad)
 
     def _test_save_pretrained(self, model_id, config_cls, config_kwargs):
+        # ensure that the weights are randomly initialized
+        if issubclass(config_cls, LoraConfig):
+            config_kwargs = config_kwargs.copy()
+            config_kwargs["init_lora_weights"] = False
+        if issubclass(config_cls, IA3Config):
+            config_kwargs = config_kwargs.copy()
+            config_kwargs["init_ia3_weights"] = False
+
         model = self.transformers_class.from_pretrained(model_id)
         config = config_cls(
             base_model_name_or_path=model_id,
@@ -253,11 +262,15 @@ class PeftCommonTester:
             model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
 
             # check if the state dicts are equal
-            state_dict = get_peft_model_state_dict(model, unwrap_compiled=True)
-            state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained, unwrap_compiled=True)
-
-            # check if same keys
-            self.assertEqual(state_dict.keys(), state_dict_from_pretrained.keys())
+            if issubclass(config_cls, PromptEncoderConfig):
+                # For prompt encoding, the state_dict may contain EXTRA keys, so we don't test that keys are equal but
+                # that keys are a subset.
+                # TODO: is this expected?
+                state_dict = get_peft_model_state_dict(model, unwrap_compiled=True)
+                state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained, unwrap_compiled=True)
+            else:
+                state_dict = get_state_dict(model, unwrap_compiled=True)
+                state_dict_from_pretrained = get_state_dict(model_from_pretrained, unwrap_compiled=True)
 
             # check if tensors equal
             for key in state_dict.keys():
@@ -284,6 +297,14 @@ class PeftCommonTester:
             # AdaLora does not support adding more than 1 adapter
             return
 
+        # ensure that the weights are randomly initialized
+        if issubclass(config_cls, LoraConfig):
+            config_kwargs = config_kwargs.copy()
+            config_kwargs["init_lora_weights"] = False
+        if issubclass(config_cls, IA3Config):
+            config_kwargs = config_kwargs.copy()
+            config_kwargs["init_ia3_weights"] = False
+
         model = self.transformers_class.from_pretrained(model_id)
         config = config_cls(
             base_model_name_or_path=model_id,
@@ -305,11 +326,19 @@ class PeftCommonTester:
             model_from_pretrained = self.transformers_class.from_pretrained(model_id)
             model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
 
-            model_from_pretrained.load_adapter(tmp_dirname, "new_adapter")
+            new_adapter_dir = os.path.join(tmp_dirname, "new_adapter")
+            model_from_pretrained.load_adapter(new_adapter_dir, "new_adapter")
 
             # check if the state dicts are equal
-            state_dict = get_peft_model_state_dict(model, unwrap_compiled=True)
-            state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained, unwrap_compiled=True)
+            if issubclass(config_cls, PromptEncoderConfig):
+                # For prompt encoding, the state_dict may contain EXTRA keys, so we don't test that keys are equal but
+                # that keys are a subset.
+                # TODO: is this expected?
+                state_dict = get_peft_model_state_dict(model, unwrap_compiled=True)
+                state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained, unwrap_compiled=True)
+            else:
+                state_dict = get_state_dict(model, unwrap_compiled=True)
+                state_dict_from_pretrained = get_state_dict(model_from_pretrained, unwrap_compiled=True)
 
             # check if same keys
             self.assertEqual(state_dict.keys(), state_dict_from_pretrained.keys())
@@ -324,15 +353,19 @@ class PeftCommonTester:
 
             # check if `adapter_model.bin` is present
             self.assertTrue(os.path.exists(os.path.join(tmp_dirname, "adapter_model.bin")))
+            self.assertTrue(os.path.exists(os.path.join(new_adapter_dir, "adapter_model.bin")))
 
             # check if `adapter_config.json` is present
             self.assertTrue(os.path.exists(os.path.join(tmp_dirname, "adapter_config.json")))
+            self.assertTrue(os.path.exists(os.path.join(new_adapter_dir, "adapter_config.json")))
 
             # check if `pytorch_model.bin` is not present
             self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "pytorch_model.bin")))
+            self.assertFalse(os.path.exists(os.path.join(new_adapter_dir, "pytorch_model.bin")))
 
             # check if `config.json` is not present
             self.assertFalse(os.path.exists(os.path.join(tmp_dirname, "config.json")))
+            self.assertFalse(os.path.exists(os.path.join(new_adapter_dir, "config.json")))
 
         with tempfile.TemporaryDirectory() as tmp_dirname:
             model.save_pretrained(tmp_dirname, selected_adapters=["default"])

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -36,6 +36,7 @@ from peft import (
 )
 from peft.tuners.lora import LoraLayer
 from peft.utils import _get_submodules, infer_device
+
 from .testing_utils import get_state_dict
 
 
@@ -263,8 +264,8 @@ class PeftCommonTester:
 
             # check if the state dicts are equal
             if issubclass(config_cls, PromptEncoderConfig):
-                # For prompt encoding, the state_dict may contain EXTRA keys, so we don't test that keys are equal but
-                # that keys are a subset.
+                # For prompt encoding, when loading the whole state_dict, there are differences, therefore, only load
+                # adapter-specific weights for comparison.
                 # TODO: is this expected?
                 state_dict = get_peft_model_state_dict(model, unwrap_compiled=True)
                 state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained, unwrap_compiled=True)
@@ -331,8 +332,8 @@ class PeftCommonTester:
 
             # check if the state dicts are equal
             if issubclass(config_cls, PromptEncoderConfig):
-                # For prompt encoding, the state_dict may contain EXTRA keys, so we don't test that keys are equal but
-                # that keys are a subset.
+                # For prompt encoding, when loading the whole state_dict, there are differences, therefore, only load
+                # adapter-specific weights for comparison.
                 # TODO: is this expected?
                 state_dict = get_peft_model_state_dict(model, unwrap_compiled=True)
                 state_dict_from_pretrained = get_peft_model_state_dict(model_from_pretrained, unwrap_compiled=True)


### PR DESCRIPTION
Resolves #968

As the linked issue mentions, the `test_save_pretrained_selected_adapters` test was broken because the 2nd adapter would load the weight of the default adapter, instead of its own weights. This was a pretty quick fix.

However, this made me wonder why the test was passing beforehand when it is loading the wrong weights, so I dug deeper (warning: rabbit hole!).

The first issue I encountered was that for IA³, we did not set `init_ia3_weights=False`. For this reason, all weights were set to `1.0`. Of course, in that case, it doesn't matter what weights are loaded, they're all the same. Therefore, I changed `init_ia3_weights=False`.

However, this still doesn't explain why this worked for LoRA, which, even without `init_lora_weights=True`, should have some completely random weights which cannot be the same.

The reason for that is that we used `get_peft_model_state_dict` to get the `state_dict` we used for comparison. This function only returns the weights of one of the adapters (in this case default), so the weights for the new adapter were never compared at all. Thus I changed this so that all weights are now compared.

However, this now caused the tests for prompt encoders to fail. For some reason, the `state_dict` from prompt encoding models is not the same after loading. At this point, I stopped investigating and just wrote an exception for prompt encoding to use `get_peft_model_state_dict` instead of comparing the whole `state_dict`. Any insights would be appreciated.

Finally, for completeness, I added some checks for the existence of the files of the new adapter.