### PR TITLE
add the lora target modules for Mistral Models

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -451,6 +451,7 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "falcon": ["query_key_value"],
     "btlm": ["c_proj", "c_attn"],
     "codegen": ["qkv_proj"],
+    "mistral": ["q_proj", "v_proj"],
 }
 
 TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING = {


### PR DESCRIPTION
### What does this PR do?
1. Add the lora target modules for Mistral Models