### PR TITLE
Add base model metadata to model card

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -17,14 +17,12 @@ from __future__ import annotations
 
 import inspect
 import os
-import re
 import warnings
 from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Union
 
 import torch
-import yaml
 from accelerate import dispatch_model, infer_auto_device_map
 from accelerate.hooks import AlignDevicesHook, add_hook_to_module, remove_hook_from_submodules
 from accelerate.utils import get_balanced_memory
@@ -656,12 +654,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         """
 
         filename = os.path.join(output_dir, "README.md")
-        
-        card = (
-            ModelCard.load(filename)
-            if os.path.exists(filename)
-            else ModelCard.from_template(ModelCardData())
-        )
+
+        card = ModelCard.load(filename) if os.path.exists(filename) else ModelCard.from_template(ModelCardData())
 
         card.data["library_name"] = "peft"
         model_config = self.config

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -30,7 +30,6 @@ from .other import (
     WEIGHTS_NAME,
     SAFETENSORS_WEIGHTS_NAME,
     _set_trainable,
-    add_library_to_model_card,
     bloom_model_postprocess_past_key_value,
     prepare_model_for_int8_training,
     prepare_model_for_kbit_training,

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import copy
 import inspect
-import os
 import warnings
 from typing import Optional
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -39,31 +39,6 @@ def infer_device():
     return torch_device
 
 
-# Add or edit model card to have `library_name: peft`
-def add_library_to_model_card(output_dir):
-    if os.path.exists(os.path.join(output_dir, "README.md")):
-        with open(os.path.join(output_dir, "README.md"), "r") as f:
-            lines = f.readlines()
-        # check if the first line is `---`
-        if len(lines) > 0 and lines[0].startswith("---"):
-            for i, line in enumerate(lines[1:]):
-                # check if line starts with `library_name`, if yes, update it
-                if line.startswith("library_name"):
-                    lines[i + 1] = "library_name: peft\n"
-                    break
-                elif line.startswith("---"):
-                    # insert `library_name: peft` before the last `---`
-                    lines.insert(i + 1, "library_name: peft\n")
-                    break
-        else:
-            lines = ["---\n", "library_name: peft\n", "---\n"] + lines
-    else:
-        lines = ["---\n", "library_name: peft\n", "---\n"]
-    # write the lines back to README.md
-    with open(os.path.join(output_dir, "README.md"), "w") as f:
-        f.writelines(lines)
-
-
 # needed for prefix-tuning of bloom model
 def bloom_model_postprocess_past_key_value(past_key_values):
     past_key_values = torch.cat(past_key_values)


### PR DESCRIPTION
Resolves #938

This PR adds the base model metadata, if present, to the model card.

On top of this, the code for creating the model card has been refactored to use the huggingface_hub classes instead of doing ad hoc parsing and writing. A consequence of this is that if no model card exists, the default template will now be used, with a lot of placeholder text.

LMK if this is not desired.

ping @davanstrien @osanseviero 