### PR TITLE
FIX: issues with (un)merging multiple LoRA and IA³ adapters

### DIFF
--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -100,6 +100,7 @@ class Linear(nn.Linear, IA3Layer):
                 self.weight = transpose(self.weight, self.fan_in_fan_out)
                 self.weight.data = torch.mul(self.weight.data, self.ia3_l[active_adapter].data)
                 self.weight = transpose(self.weight, self.fan_in_fan_out)
+                self.merged_adapters.append(active_adapter)
                 self.merged = True
 
     def unmerge(self) -> None:
@@ -108,7 +109,8 @@ class Linear(nn.Linear, IA3Layer):
             return
 
         warnings.warn("Unmerge result can be inaccurate for (IA)^3.")
-        for active_adapter in self.active_adapters:
+        while len(self.merged_adapters) > 0:
+            active_adapter = self.merged_adapters.pop()
             if active_adapter in self.ia3_l.keys():
                 self.weight = transpose(self.weight, self.fan_in_fan_out)
                 # divide by (IA)^3 vector. Add tolerace to avoid division by zero

--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -214,6 +214,7 @@ if is_bnb_4bit_available():
                 lora_data = self.get_delta_weight(active_adapter)
                 w_data = bnb.functional.dequantize_4bit(self.weight.data, self.weight.quant_state) + lora_data
                 self.weight = bnb.nn.Params4bit(w_data.to("cpu"), requires_grad=False, **kwargs).to(self.weight.device)
+                self.merged_adapters.append(active_adapter)
                 self.merged = True
 
         def unmerge(self):


### PR DESCRIPTION
This should resolve the failing slow test `test_4bit_merge_and_disable_lora` (see e.g. [here](https://github.com/huggingface/peft/actions/runs/6346369912/job/17239765575)).

While investigating, I also noticed that merging multiple adapters was not correct for IA³. I added a test that should catch this bug and provided a fix for it too. However, the test does not check IA³ at the moment because the test parameters do not contain IA³. For this, #972 needs to be merged too, which adds IA³ to the test parameters.

Note: I did some small fixes on the tests to avoid exploding/vanishing gradients, as they made it difficult to find the right tolerance for comparing outputs.