### PR TITLE
Fix missing tokenizer attribute in test

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -111,6 +111,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
     def setUp(self):
         self.seq2seq_model_id = "google/flan-t5-base"
         self.causal_lm_model_id = "facebook/opt-6.7b"
+        self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
         self.audio_model_id = "openai/whisper-large"
 
     def tearDown(self):


### PR DESCRIPTION
This should hopefully fix the error in `test_causal_lm_training_mutli_gpu_4bit` (see e.g. [here](https://github.com/huggingface/peft/actions/runs/6346369912/job/17239765704)). I haven't tested it, as it's multi GPU.