### PR TITLE
Combine multiple (IA)^3 Adapters and delete (IA)^3 adapters

### DIFF
--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -165,7 +165,6 @@ class Linear(nn.Linear, IA3Layer):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         dtype = previous_dtype = x.dtype
-
         if self.disable_adapters:
             if self.merged:
                 self.unmerge()

--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -34,7 +34,6 @@ class IA3Layer(BaseTunerLayer):
         out_features: int,
         is_feedforward: bool,
     ):
-        self.scaling = {}
         self.ia3_l = nn.ParameterDict({})
         # Mark the weight as unmerged
         self._disable_adapters = False

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -27,9 +27,9 @@ from peft.utils import (
     TRANSFORMERS_MODELS_TO_IA3_FEEDFORWARD_MODULES_MAPPING,
     TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING,
     ModulesToSaveWrapper,
+    _freeze_adapter,
     _get_submodules,
     _is_valid_match,
-    _freeze_adapter,
 )
 
 from .layer import Conv2d, IA3Layer, Linear
@@ -364,7 +364,6 @@ class IA3Model(BaseTuner):
                         f"Adapter {adapter_name} was active which is now deleted. Setting active adapter to {resetting_active_adapter}. "
                     )
                     target.set_adapter(resetting_active_adapter)
-
 
     def add_weighted_adapter(self, adapters, weights, adapter_name):
         """

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -29,7 +29,6 @@ from peft.utils import (
     ModulesToSaveWrapper,
     _freeze_adapter,
     _get_submodules,
-    _is_valid_match,
 )
 
 from .layer import Conv2d, IA3Layer, Linear

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -426,4 +426,4 @@ class IA3Model(BaseTuner):
                         current_adapter_ia3_l = target.ia3_l[adapter]
                     else:
                         continue
-                    target_ia3_l.data += current_adapter_ia3_l.data * weight * target.scaling[adapter]
+                    target_ia3_l.data += current_adapter_ia3_l.data * weight

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -354,12 +354,8 @@ class IA3Model(BaseTuner):
         for key in key_list:
             _, target, _ = _get_submodules(self.model, key)
             if isinstance(target, IA3Layer):
-                for attr in [
-                    "ia3_l",
-                    "scaling",
-                ]:
-                    if adapter_name in getattr(target, attr):
-                        getattr(target, attr).pop(adapter_name)
+                if adapter_name in target.ia3_l:
+                    target.ia3_l.pop(adapter_name)
                 if adapter_name in target.active_adapters:
                     resetting_active_adapter = (
                         list(self.peft_config.keys())[0] if len(self.peft_config) > 0 else "default"

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -816,7 +816,7 @@ class MultipleActiveAdaptersTester(unittest.TestCase):
         self.assertFalse(torch.allclose(adapter_1_output, combined_output, atol=1e-5))
         self.assertFalse(torch.allclose(adapter_2_output, combined_output, atol=1e-5))
 
-        if tuner_method == "lora" or tuner_method == "ia3":
+        if tuner_method == "lora":
             # create a weighted adapter combining both adapters and check that
             # its output is same as setting multiple active adapters
             peft_model.add_weighted_adapter(

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -816,7 +816,7 @@ class MultipleActiveAdaptersTester(unittest.TestCase):
         self.assertFalse(torch.allclose(adapter_1_output, combined_output, atol=1e-5))
         self.assertFalse(torch.allclose(adapter_2_output, combined_output, atol=1e-5))
 
-        if tuner_method == "lora":
+        if tuner_method == "lora" or tuner_method == "ia3":
             # create a weighted adapter combining both adapters and check that
             # its output is same as setting multiple active adapters
             peft_model.add_weighted_adapter(


### PR DESCRIPTION
### Problem
$(IA)^3$ models supports multiple adapters, however, there are a few missing features (compared to LoRA):
- Delete adapters: There is no method to delete an adapter from an `IA3Model`.
- Add Weighted Adapter: There is no method to add a weighted combination of multiple adapters.

### Solution
- Add a `delete_adapter` method based on the one in `LoraModel`.
- Add a `add_weighted_adapter` method based on the one in `LoraModel`. This method, however, is a simplified version of the LoRA one. As $(IA)^3$ injects trainable vectors, I have deleted both the `cat` and `svd` options.

### Other minor modifications
- I have deleted the `self.scaling` in `IA3Layer` as it was not used. I believe this was a leftover from the LoRA implementation this layer seems to be based on.

### Discussion
I have tested this locally using a simple script (see below) but I have not run any automated tests yet. What is the best way to test these changes?



<details>
  <summary>Test script</summary>

```py
import os

import datasets
import torch
from peft import PeftModel, PeftConfig
from transformers import (
    AutoModelForCausalLM,
    AutoTokenizer,
    BitsAndBytesConfig,
)

def run_model(
    output_dir: str,
    cache_dir: str,
    dataset_dir: str,
    peft_strategy: str,
):
    # Load dataset from the hub
    datasets.config.DOWNLOADED_DATASETS_PATH = dataset_dir

    tokenizer = AutoTokenizer.from_pretrained(
        "meta-llama/Llama-2-7b-hf", cache_dir=cache_dir
    )

    quantization_config = BitsAndBytesConfig(load_in_8bit=True)

    config = PeftConfig.from_pretrained(os.path.join(output_dir, peft_strategy, "general"))

    model = AutoModelForCausalLM.from_pretrained(
        config.base_model_name_or_path,
        torch_dtype=torch.float,
        quantization_config=quantization_config,
        # device_map="auto",
        cache_dir=cache_dir,
    )

    model = PeftModel.from_pretrained(model, os.path.join(output_dir, peft_strategy, "general"))
    model.load_adapter(os.path.join(output_dir, peft_strategy, "code"), "code")
    model.load_adapter(os.path.join(output_dir, peft_strategy, "creative"), "creative")

    model.add_weighted_adapter(["code", "creative"], [0.5, 0.5], "code_creative")
    model.set_adapter("code_creative")

    prompt = f"""
    ### Input:
    What is the capital of Spain?

    ### Response:
    """

    input_ids = tokenizer(
        prompt, return_tensors="pt", truncation=True
    ).input_ids.cuda()

    outputs = model.generate(
        input_ids=input_ids,
        max_new_tokens=500,
        do_sample=True,
        top_p=0.9,
        temperature=0.9,
    )

    print(
        f"Response: \n{tokenizer.batch_decode(outputs.detach().cpu().numpy(), skip_special_tokens=True)[0][len(prompt):]}"
    )


if __name__ == "__main__":
    run_model(
        output_dir="/path/to/output",
        cache_dir="/path/to/cache",
        dataset_dir="/path/to/dataset",
        peft_strategy = 'ia3',
    )
```

</details>