### PR TITLE
add lora target modules for stablelm models

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -452,6 +452,7 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "btlm": ["c_proj", "c_attn"],
     "codegen": ["qkv_proj"],
     "mistral": ["q_proj", "v_proj"],
+    "stablelm": ["q_proj", "v_proj"],
 }
 
 TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING = {


### PR DESCRIPTION
i was able to load a model with `get_peft_model` method that takes `LoraConfig` object which has ["q_proj", "v_proj"] for its `target_modules` parameter. 