### PR TITLE
[`core` / FEAT] Allow loading from meta device

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -210,7 +210,7 @@ class LoraModel(BaseTuner):
         if hasattr(child, "bias"):
             new_module.bias = child.bias
 
-        if new_module.bias.device.type == "meta":
+        if hasattr(new_module, "bias") and new_module.bias is not None and new_module.bias.device.type == "meta":
             set_module_to_device(new_module, child, "bias")
             meta_loading = True
 

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -46,6 +46,7 @@ from .other import (
     infer_device,
     get_auto_gptq_quant_linear,
     get_quantization_config,
+    set_module_to_device,
 )
 from .hub_utils import hub_file_exists
 from .save_and_load import get_peft_model_state_dict, set_peft_model_state_dict, load_peft_weights


### PR DESCRIPTION
# What does this PR do?

This PR enables to handle weights pre-loaded on the meta device for faster initialization. We'll leave it to users and developpers responsibility to dispatch the adapter weights through utility methods from accelerate such as `set_module_tensor_to_device`

The PR is perfectly backward compatible - but still facing some slow intiialization issues - will investigate more so putting it as draft

Related to: https://github.com/huggingface/diffusers/pull/5151#issuecomment-1741177923