### PR TITLE
Fix lora creation

### DIFF
--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -63,7 +63,7 @@ class PeftConfigMixin(PushToHubMixin):
         output_dict = asdict(self)
         # converting set type to list
         for key in output_dict.keys():
-            if type(output_dict[key], set):
+            if isinstance(output_dict[key], set):
                 value = output_dict.pop(key)
                 output_dict[key] = list(value)
 

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -61,6 +61,12 @@ class PeftConfigMixin(PushToHubMixin):
         auto_mapping_dict = kwargs.pop("auto_mapping_dict", None)
 
         output_dict = asdict(self)
+        # converting set type to list
+        for key in output_dict.keys():
+            if type(output_dict[key], set):
+                value = output_dict.pop(key)
+                output_dict[key] = list(value)
+
         output_path = os.path.join(save_directory, CONFIG_NAME)
 
         # Add auto mapping details for custom models.

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -62,9 +62,8 @@ class PeftConfigMixin(PushToHubMixin):
 
         output_dict = asdict(self)
         # converting set type to list
-        for key in list(output_dict.keys()):
-            if isinstance(output_dict[key], set):
-                value = output_dict.pop(key)
+        for key, value in output_dict.items():
+            if isinstance(value, set):
                 output_dict[key] = list(value)
 
         output_path = os.path.join(save_directory, CONFIG_NAME)

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -62,7 +62,7 @@ class PeftConfigMixin(PushToHubMixin):
 
         output_dict = asdict(self)
         # converting set type to list
-        for key in output_dict.keys():
+        for key in list(output_dict.keys()):
             if isinstance(output_dict[key], set):
                 value = output_dict.pop(key)
                 output_dict[key] = list(value)

--- a/src/peft/tuners/ia3/config.py
+++ b/src/peft/tuners/ia3/config.py
@@ -72,3 +72,9 @@ class IA3Config(PeftConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.IA3
+        self.target_modules = (
+            set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
+        )
+        self.feedforward_modules = (
+            set(self.feedforward_modules) if isinstance(self.feedforward_modules, list) else self.feedforward_modules
+        )

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -22,13 +22,12 @@ import torch
 from transformers.pytorch_utils import Conv1D
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
-from peft.tuners.tuners_utils import BaseTuner
+from peft.tuners.tuners_utils import BaseTuner, check_target_module_exists
 from peft.utils import (
     TRANSFORMERS_MODELS_TO_IA3_FEEDFORWARD_MODULES_MAPPING,
     TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING,
     ModulesToSaveWrapper,
     _get_submodules,
-    _is_valid_match,
 )
 
 from .layer import IA3Layer, Linear
@@ -40,9 +39,7 @@ if is_bnb_available():
     from .bnb import Linear8bitLt
 
 if is_bnb_4bit_available():
-    import bitsandbytes as bnb
-
-    from .bnb import Linear4bit, Linear8bitLt
+    from .bnb import Linear4bit
 
 
 class IA3Model(BaseTuner):
@@ -158,11 +155,7 @@ class IA3Model(BaseTuner):
 
     @staticmethod
     def _check_target_module_exists(ia3_config, key):
-        if isinstance(ia3_config.target_modules, str):
-            target_module_found = re.fullmatch(ia3_config.target_modules, key)
-        else:
-            target_module_found = any(_is_valid_match(key, target_key) for target_key in ia3_config.target_modules)
-        return target_module_found
+        return check_target_module_exists(ia3_config, key)
 
     def _mark_only_adapters_as_trainable(self) -> None:
         for n, p in self.model.named_parameters():

--- a/src/peft/tuners/loha/config.py
+++ b/src/peft/tuners/loha/config.py
@@ -121,3 +121,6 @@ class LoHaConfig(PeftConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.LOHA
+        self.target_modules = (
+            set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
+        )

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -118,4 +118,6 @@ class LoraConfig(PeftConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.LORA
-        self.target_modules = set(self.target_modules) if type(self.target_modules, list) else self.target_modules
+        self.target_modules = (
+            set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
+        )

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -121,7 +121,3 @@ class LoraConfig(PeftConfig):
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
         )
-        target_modules_regex = ""
-        for module in self.target_modules:
-            target_modules_regex += f"(.*{module}$)|"
-        self.target_modules_regex = target_modules_regex[:-1]

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -118,3 +118,4 @@ class LoraConfig(PeftConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.LORA
+        self.target_modules = set(self.target_modules) if type(self.target_modules, list) else self.target_modules

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -121,3 +121,7 @@ class LoraConfig(PeftConfig):
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
         )
+        target_modules_regex = ""
+        for module in self.target_modules:
+            target_modules_regex += f"(.*{module}$)|"
+        self.target_modules_regex = target_modules_regex[:-1]

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -500,12 +500,12 @@ class LoraModel(BaseTuner):
                     "all adapter configs should follow the same target modules type. "
                     "Combining adapters with `target_modules` type being a mix of list and string is not supported."
                 )
-            if target_modules_type == list:
+            if target_modules_type == set:
                 new_target_modules |= set(self.peft_config[adapter].target_modules)
             else:
                 new_target_modules += f"({self.peft_config[adapter].target_modules})|"
 
-        new_target_modules = list(new_target_modules) if target_modules_type == list else new_target_modules[:-1]
+        new_target_modules = new_target_modules if target_modules_type == set else new_target_modules[:-1]
 
         self.peft_config[adapter_name] = replace(
             self.peft_config[adapters[0]],

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -493,7 +493,7 @@ class LoraModel(BaseTuner):
             raise ValueError(f"Invalid combination_type: {combination_type}")
 
         target_modules_type = type(self.peft_config[adapters[0]].target_modules)
-        new_target_modules = set() if target_modules_type == list else ""
+        new_target_modules = set() if target_modules_type == set else ""
         for adapter in adapters:
             if type(self.peft_config[adapter].target_modules) != target_modules_type:
                 raise ValueError(

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -505,7 +505,7 @@ class LoraModel(BaseTuner):
             else:
                 new_target_modules += f"({self.peft_config[adapter].target_modules})|"
 
-        new_target_modules = new_target_modules if target_modules_type == set else new_target_modules[:-1]
+        new_target_modules = list(new_target_modules) if target_modules_type == set else new_target_modules[:-1]
 
         self.peft_config[adapter_name] = replace(
             self.peft_config[adapters[0]],

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -12,10 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import operator
 import re
 import warnings
 from dataclasses import asdict, replace
 from enum import Enum
+from functools import reduce
 from itertools import chain
 
 import torch
@@ -494,20 +496,23 @@ class LoraModel(BaseTuner):
         else:
             raise ValueError(f"Invalid combination_type: {combination_type}")
 
-        target_modules_type = type(self.peft_config[adapters[0]].target_modules)
-        new_target_modules = set() if target_modules_type == set else ""
-        for adapter in adapters:
-            if type(self.peft_config[adapter].target_modules) != target_modules_type:
-                raise ValueError(
-                    "all adapter configs should follow the same target modules type. "
-                    "Combining adapters with `target_modules` type being a mix of list and string is not supported."
-                )
-            if target_modules_type == set:
-                new_target_modules |= self.peft_config[adapter].target_modules
-            else:
-                new_target_modules += f"({self.peft_config[adapter].target_modules})|"
+        target_module_types = [type(self.peft_config[adapter].target_modules) for adapter in adapters]
+        if not target_module_types:
+            raise ValueError(f"Found no adapter matching the names in {adapters}")
+        if len(set(target_module_types)) > 1:
+            raise ValueError(
+                "all adapter configs should follow the same target modules type. "
+                "Combining adapters with `target_modules` type being a mix of list/set and string is not supported."
+            )
 
-        new_target_modules = list(new_target_modules) if target_modules_type == set else new_target_modules[:-1]
+        if target_module_types[0] == str:
+            new_target_modules = "|".join(f"({self.peft_config[adapter].target_modules})" for adapter in adapters)
+        elif target_module_types[0] == set:
+            new_target_modules = reduce(
+                operator.or_, (self.peft_config[adapter].target_modules for adapter in adapters)
+            )
+        else:
+            raise TypeError(f"Invalid type {target_module_types[0]} found in target_modules")
 
         self.peft_config[adapter_name] = replace(
             self.peft_config[adapters[0]],

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -501,7 +501,7 @@ class LoraModel(BaseTuner):
                     "Combining adapters with `target_modules` type being a mix of list and string is not supported."
                 )
             if target_modules_type == set:
-                new_target_modules |= set(self.peft_config[adapter].target_modules)
+                new_target_modules |= self.peft_config[adapter].target_modules
             else:
                 new_target_modules += f"({self.peft_config[adapter].target_modules})|"
 

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -358,7 +358,9 @@ class LoraModel(BaseTuner):
         if peft_config.target_modules is None:
             if model_config["model_type"] not in TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING:
                 raise ValueError("Please specify `target_modules` in `peft_config`")
-            peft_config.target_modules = TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING[model_config["model_type"]]
+            peft_config.target_modules = set(
+                TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING[model_config["model_type"]]
+            )
         return peft_config
 
     def _unload_and_optionally_merge(self, merge=True, progressbar: bool = False):

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -359,9 +359,9 @@ def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
     if isinstance(config.target_modules, str):
         target_module_found = re.fullmatch(config.target_modules, key)
     else:
-        target_module_found = key in config.target_modules
-        if not target_module_found:
-            target_module_found = any(key.endswith(f".{target_key}") for target_key in config.target_modules)
+        target_module_found = key in config.target_modules or any(
+            key.endswith(f".{target_key}") for target_key in config.target_modules
+        )
         is_using_layer_indexes = getattr(config, "layers_to_transform", None) is not None
         layer_indexing_pattern = getattr(config, "layers_pattern", None)
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -359,9 +359,9 @@ def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
     if isinstance(config.target_modules, str):
         target_module_found = re.fullmatch(config.target_modules, key)
     else:
-        target_module_found = key in config.target_modules or re.fullmatch(config.target_modules_regex, key)
-        # if not target_module_found:
-        #     target_module_found = any(key.endswith(f".{target_key}") for target_key in config.target_modules)
+        target_module_found = key in config.target_modules
+        if not target_module_found:
+            target_module_found = any(key.endswith(f".{target_key}") for target_key in config.target_modules)
         is_using_layer_indexes = getattr(config, "layers_to_transform", None) is not None
         layer_indexing_pattern = getattr(config, "layers_pattern", None)
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -359,9 +359,9 @@ def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
     if isinstance(config.target_modules, str):
         target_module_found = re.fullmatch(config.target_modules, key)
     else:
-        target_module_found = key in config.target_modules
-        if not target_module_found:
-            target_module_found = any(key.endswith(f".{target_key}") for target_key in config.target_modules)
+        target_module_found = key in config.target_modules or re.fullmatch(config.target_modules_regex, key)
+        # if not target_module_found:
+        #     target_module_found = any(key.endswith(f".{target_key}") for target_key in config.target_modules)
         is_using_layer_indexes = getattr(config, "layers_to_transform", None) is not None
         layer_indexing_pattern = getattr(config, "layers_pattern", None)
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -359,9 +359,9 @@ def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
     if isinstance(config.target_modules, str):
         target_module_found = re.fullmatch(config.target_modules, key)
     else:
-        target_module_found = any(re.match(f".*\.{target_key}$", key) for target_key in config.target_modules) or any(
-            target_key == key for target_key in config.target_modules
-        )
+        target_module_found = key in config.target_modules
+        if not target_module_found:
+            target_module_found = any(key.endswith(f".{target_key}") for target_key in config.target_modules)
         is_using_layer_indexes = getattr(config, "layers_to_transform", None) is not None
         layer_indexing_pattern = getattr(config, "layers_pattern", None)
 


### PR DESCRIPTION
### What does this PR do?
1. Makes the injecting of LoRA layers faster. The previous way of checking `target_module_found` was the bottleneck. This PR fixes that.

This help the PR https://github.com/huggingface/diffusers/pull/5151 when loading large SD-XL model. The time to load the lora ckpts went down from ~120 seconds to ~2 seconds.

![Screenshot 2023-10-04 at 6 38 05 PM](https://github.com/huggingface/peft/assets/13534540/d8b375e9-153d-49ff-a5cd-1ad3d97fc40b)

