### PR TITLE
Fix IA3 config for Falcon models

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -471,9 +471,9 @@ TRANSFORMERS_MODELS_TO_IA3_FEEDFORWARD_MODULES_MAPPING = {
     "bert": ["output.dense"],
     "deberta-v2": ["output.dense"],
     "deberta": ["output.dense"],
-    "RefinedWeb": ["query_key_value"],
-    "RefinedWebModel": ["query_key_value"],
-    "falcon": ["query_key_value"],
+    "RefinedWeb": ["dense_4h_to_h"],
+    "RefinedWebModel": ["dense_4h_to_h"],
+    "falcon": ["dense_4h_to_h"],
 }
 
 COMMON_LAYERS_PATTERN = ["layers", "h", "block", "blocks", "layer"]

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -450,9 +450,9 @@ TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING = {
     "bert": ["key", "value", "output.dense"],
     "deberta-v2": ["key_proj", "value_proj", "output.dense"],
     "deberta": ["in_proj", "output.dense"],
-    "RefinedWebModel": ["query_key_value"],
-    "RefinedWeb": ["query_key_value"],
-    "falcon": ["query_key_value"],
+    "RefinedWebModel": ["query_key_value", "dense_4h_to_h"],
+    "RefinedWeb": ["query_key_value", "dense_4h_to_h"],
+    "falcon": ["query_key_value", "dense_4h_to_h"],
 }
 
 TRANSFORMERS_MODELS_TO_IA3_FEEDFORWARD_MODULES_MAPPING = {


### PR DESCRIPTION
# What does this PR do?
Minor changes to the default IA $^3$ config for Falcon models. IA $^3$ learned vectors are added to the second feedforward layer in the MLP block, and for falcon that would be `dense_4h_to_h` as seen [here](https://github.com/huggingface/transformers/blob/a5e6df82c00cb53ffe863008cbbedd813bcc508b/src/transformers/models/falcon/modeling_falcon.py#L744C21-L744C21).

