### PR TITLE
Fix Conv1D merge error for IA3

### DIFF
--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -74,6 +74,7 @@ class Linear(nn.Linear, IA3Layer):
         out_features: int,
         fan_in_fan_out: bool = False,  # Set this to True if the layer to replace stores weight like (fan_in, fan_out)
         is_feedforward: bool = False,  # Set to True if the layer is treated as a feedforward layer
+        is_target_conv_1d_layer: bool = False,  # whether target module is a conv1d layer. useful while unloading later
         **kwargs,
     ) -> None:
         init_ia3_weights = kwargs.pop("init_ia3_weights", True)
@@ -87,6 +88,8 @@ class Linear(nn.Linear, IA3Layer):
         self.fan_in_fan_out = fan_in_fan_out
         if fan_in_fan_out:
             self.weight.data = self.weight.data.T
+
+        self.is_target_conv_1d_layer = is_target_conv_1d_layer
 
         nn.Linear.reset_parameters(self)
         self.update_layer(adapter_name, init_ia3_weights)

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -150,6 +150,7 @@ class IA3Model(BaseTuner):
                 in_features, out_features = (
                     target.weight.ds_shape if hasattr(target.weight, "ds_shape") else target.weight.shape
                 )
+                kwargs["is_target_conv_1d_layer"] = True  # useful for unloading later
                 if not kwargs["fan_in_fan_out"]:
                     warnings.warn(
                         "fan_in_fan_out is set to False but the target module is `Conv1D`. "
@@ -330,7 +331,10 @@ class IA3Model(BaseTuner):
                 )
             else:
                 bias = target.bias is not None
-                new_module = torch.nn.Linear(target.in_features, target.out_features, bias=bias)
+                if getattr(target, "is_target_conv_1d_layer", False):
+                    new_module = Conv1D(target.out_features, target.in_features)
+                else:
+                    new_module = torch.nn.Linear(target.in_features, target.out_features, bias=bias)
 
             target.merge(safe_merge=safe_merge)
             self._replace_module(parent, target_name, new_module, target)

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -86,26 +86,26 @@ TEST_CASES = [
         {"target_modules": ["lin0"], "modules_to_save": ["lin1"], "feedforward_modules": ["lin0"]},
     ),
     # TODO: There are errors when trying to merge Conv1D, hence skipping them for now
-    # (
-    #     "transformers Conv1D 1 IA3",
-    #     "EmbConv1D",
-    #     IA3Config,
-    #     {"target_modules": ["conv1d"], "feedforward_modules": ["conv1d"]},
-    # ),
-    # (
-    #     "transformers Conv1D 2 IA3",
-    #     "EmbConv1D",
-    #     IA3Config,
-    #     {"target_modules": ["conv1d", "lin0"], "feedforward_modules": ["conv1d", "lin0"]},
-    # ),
-    # (
-    #     "transformers Conv1D 1 IA3",
-    #     "EmbConv1D",
-    #     IA3Config,
-    #     {"target_modules": ["conv1d"], "feedforward_modules": ["conv1d"], "modules_to_save": ["lin1"]},
-    # ),
-    # ("Conv2d 1 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": []}),
-    # ("Conv2d 2 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": ["conv2d"]}),
+    (
+        "transformers Conv1D 1 IA3",
+        "EmbConv1D",
+        IA3Config,
+        {"target_modules": ["conv1d"], "feedforward_modules": ["conv1d"]},
+    ),
+    (
+        "transformers Conv1D 2 IA3",
+        "EmbConv1D",
+        IA3Config,
+        {"target_modules": ["conv1d", "lin0"], "feedforward_modules": ["conv1d", "lin0"]},
+    ),
+    (
+        "transformers Conv1D 1 IA3",
+        "EmbConv1D",
+        IA3Config,
+        {"target_modules": ["conv1d"], "feedforward_modules": ["conv1d"], "modules_to_save": ["lin1"]},
+    ),
+    ("Conv2d 1 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": []}),
+    ("Conv2d 2 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": ["conv2d"]}),
     (
         "Conv2d 3 IA3",
         "Conv2d",
@@ -557,11 +557,15 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         # check that after leaving the disable_adapter context, everything is enabled again
         outputs_enabled_after_disable = model(**X)
 
-        atol, rtol = 1e-5, 1e-5  # merging introduces some numerical instability
-        if issubclass(config_cls, IA3Config):  # IA³ introduces more instability
-            atol, rtol = 1e-3, 1e-3
+        atol, rtol = 1e-5, 1e-5  # tolerances higher than defaults since merging introduces some numerical instability
 
+        # check that there is a difference in results after training
         self.assertFalse(torch.allclose(outputs_before, outputs_after, atol=atol, rtol=rtol))
+
+        # change atol and rtol for IA3 for the merge related checks, since the merge introduces more instability
+        # for IA3
+        if issubclass(config_cls, IA3Config):
+            atol, rtol = 1e-3, 1e-3
         self.assertTrue(torch.allclose(outputs_before, outputs_disabled, atol=atol, rtol=rtol))
         self.assertTrue(torch.allclose(outputs_after, outputs_enabled_after_disable, atol=atol, rtol=rtol))
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -85,7 +85,6 @@ TEST_CASES = [
         IA3Config,
         {"target_modules": ["lin0"], "modules_to_save": ["lin1"], "feedforward_modules": ["lin0"]},
     ),
-    # TODO: There are errors when trying to merge Conv1D, hence skipping them for now
     (
         "transformers Conv1D 1 IA3",
         "EmbConv1D",
@@ -104,14 +103,15 @@ TEST_CASES = [
         IA3Config,
         {"target_modules": ["conv1d"], "feedforward_modules": ["conv1d"], "modules_to_save": ["lin1"]},
     ),
-    ("Conv2d 1 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": []}),
-    ("Conv2d 2 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": ["conv2d"]}),
-    (
-        "Conv2d 3 IA3",
-        "Conv2d",
-        IA3Config,
-        {"target_modules": ["conv2d", "lin0"], "feedforward_modules": []},
-    ),
+    # TODO: fix these tests, preferably without hacking about tolerance values
+    # ("Conv2d 1 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": []}),
+    # ("Conv2d 2 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": ["conv2d"]}),
+    # (
+    #     "Conv2d 3 IA3",
+    #     "Conv2d",
+    #     IA3Config,
+    #     {"target_modules": ["conv2d", "lin0"], "feedforward_modules": []},
+    # ),
     (
         "Conv2d 4 IA3",
         "Conv2d",
@@ -533,9 +533,9 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         outputs_before = model(**X)
 
         model.train()
-        # EmbConv1D is slow to learn for some reason
-        lr = 0.01 if model_id != "EmbConv1D" else 1.0
-        optimizer = torch.optim.SGD(model.parameters(), lr=lr)
+        lr = 0.01
+        # Adam optimizer since SGD isn't great for small models with IA3 + Conv1D
+        optimizer = torch.optim.Adam(model.parameters(), lr=lr)
 
         # train at least 3 steps for all parameters to be updated (probably this is required because of symmetry
         # breaking of some LoRA layers that are initialized with constants)
@@ -558,15 +558,16 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         outputs_enabled_after_disable = model(**X)
 
         atol, rtol = 1e-5, 1e-5  # tolerances higher than defaults since merging introduces some numerical instability
+        # if issubclass(config_cls, IA3Config) and model_id == "Conv2d": # try to avoid this
+        #     atol, rtol = 1e-3, 1e-3
 
         # check that there is a difference in results after training
         self.assertFalse(torch.allclose(outputs_before, outputs_after, atol=atol, rtol=rtol))
 
-        # change atol and rtol for IA3 for the merge related checks, since the merge introduces more instability
-        # for IA3
-        if issubclass(config_cls, IA3Config):
-            atol, rtol = 1e-3, 1e-3
+        # check that disabling adapters gives the same results as before training
         self.assertTrue(torch.allclose(outputs_before, outputs_disabled, atol=atol, rtol=rtol))
+
+        # check that enabling + disabling adapters does not change the results
         self.assertTrue(torch.allclose(outputs_after, outputs_enabled_after_disable, atol=atol, rtol=rtol))
 
     @parameterized.expand(TEST_CASES)

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -103,15 +103,14 @@ TEST_CASES = [
         IA3Config,
         {"target_modules": ["conv1d"], "feedforward_modules": ["conv1d"], "modules_to_save": ["lin1"]},
     ),
-    # TODO: fix these tests, preferably without hacking about tolerance values
-    # ("Conv2d 1 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": []}),
-    # ("Conv2d 2 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": ["conv2d"]}),
-    # (
-    #     "Conv2d 3 IA3",
-    #     "Conv2d",
-    #     IA3Config,
-    #     {"target_modules": ["conv2d", "lin0"], "feedforward_modules": []},
-    # ),
+    ("Conv2d 1 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": []}),
+    ("Conv2d 2 IA3", "Conv2d", IA3Config, {"target_modules": ["conv2d"], "feedforward_modules": ["conv2d"]}),
+    (
+        "Conv2d 3 IA3",
+        "Conv2d",
+        IA3Config,
+        {"target_modules": ["conv2d", "lin0"], "feedforward_modules": []},
+    ),
     (
         "Conv2d 4 IA3",
         "Conv2d",
@@ -558,8 +557,9 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         outputs_enabled_after_disable = model(**X)
 
         atol, rtol = 1e-5, 1e-5  # tolerances higher than defaults since merging introduces some numerical instability
-        # if issubclass(config_cls, IA3Config) and model_id == "Conv2d": # try to avoid this
-        #     atol, rtol = 1e-3, 1e-3
+
+        if issubclass(config_cls, IA3Config) and model_id == "Conv2d":  # more instability with Conv2d + IA3
+            atol, rtol = 1e-3, 1e-3
 
         # check that there is a difference in results after training
         self.assertFalse(torch.allclose(outputs_before, outputs_after, atol=atol, rtol=rtol))


### PR DESCRIPTION
# What does this PR do?

Fixes the error after merging a Conv1D layer, as described in https://github.com/huggingface/peft/pull/972#issue-1915881305 . Currently, PEFT subclasses nn.Linear and injects trainable parameters. For Conv1D layers, we use `fan_in_fan_out` to make note of the fact that the weights need to be transposed for correct behaviour. Thus, this Linear layer has to be converted back into a Conv1D layer when you merge and convert back into the base model, but this wasn't happening before with IA3. This meant that the base model returned by `merge_and_unload` had all Conv1D layers replaced by Linear layers. I've used the LoRA implementation as a reference to fix this, and added a flag `is_target_conv1d_layer` to IA3's Linear layer. @BenjaminBossan I've simply uncommented all your tests for Conv1D merging, they seem comprehensive for now.

 Also, there was an error being raised with `test_disable_adapters_with_merging`  for IA3 - the `assertFalse` checks were failing because the tolerance used was too high. The high tolerance makes sense for the merge related checks, because IA3 introduces instability since you lose some information when the vectors are multiplied with the weights.  Now, the `assertFalse` check is for successful training. The outputs before and after a few training steps are gonna be very close to each other, so adding a high tolerance for `torch.allclose` leads to a True output i.e it says that the outputs before and after training are indeed close to each other, and the `assertFalse` fails. I think we should use the same tolerance for IA3 as for LoRA, so I've made that change. All tests pass now.