### PR TITLE
TST: Cover checking requires_grad for Conv1D & Conv1d  for LoRA & IA³

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -116,6 +116,7 @@ class LoraLayer(BaseTunerLayer):
         if weight is not None:
             # the layer is already completely initialized, this is an update
             self.to(self.weight.device, dtype=weight.dtype)
+        # Note: set_adapter is called by the caller, not required here
 
     def update_layer_embedding(self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights):
         if r <= 0:
@@ -142,6 +143,7 @@ class LoraLayer(BaseTunerLayer):
         if weight is not None:
             # the layer is already completely initialized, this is an update
             self.to(self.weight.device, dtype=weight.dtype)
+        # Note: set_adapter is called by the caller, not required here
 
     def reset_lora_parameters(self, adapter_name):
         if adapter_name in self.lora_A.keys():


### PR DESCRIPTION
Extend test coverage to also cover checking `requires_grad` for `Conv1D` and `Conv2d` for LoRA and IA3, as well as `Embedding` for LoRA.

Note: I initially thought we had a bug, so I wrote these tests to fix the bug in TDD fashion. It turns out that there is no bug, but it's still good to have the tests, so here they are. I added a comment to the lines where I thought we had the bug.