### PR TITLE
FIX stale.py uses timezone-aware datetime

### DIFF
--- a/scripts/stale.py
+++ b/scripts/stale.py
@@ -15,8 +15,9 @@
 Script to close stale issue. Taken in part from the AllenNLP repository.
 https://github.com/allenai/allennlp.
 """
-from datetime import datetime as dt
 import os
+from datetime import datetime as dt
+from datetime import timezone
 
 from github import Github
 
@@ -42,14 +43,14 @@ def main():
         last_comment = comments[0] if len(comments) > 0 else None
         if (
             last_comment is not None and last_comment.user.login == "github-actions[bot]"
-            and (dt.utcnow() - issue.updated_at).days > 7
-            and (dt.utcnow() - issue.created_at).days >= 30
+            and (dt.now(timezone.utc) - issue.updated_at).days > 7
+            and (dt.now(timezone.utc) - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
             issue.edit(state="closed")
         elif (
-            (dt.utcnow() - issue.updated_at).days > 23
-            and (dt.utcnow() - issue.created_at).days >= 30
+            (dt.now(timezone.utc) - issue.updated_at).days > 23
+            and (dt.now(timezone.utc) - issue.created_at).days >= 30
             and not any(label.name.lower() in LABELS_TO_EXEMPT for label in issue.get_labels())
         ):
             issue.create_comment(


### PR DESCRIPTION
At first, I was happy that we didn't have any stale issues anymore because I thought we became better at solving them. In reality, it's just an error with our `stale.py` script:

> can't subtract offset-naive and offset-aware datetimes

https://github.com/huggingface/peft/actions/runs/6497439325/job/17646562512

This is an attempt to fix the issue.

Notes:

1. I haven't tested it. But what is the worst that can happen (all issues and PRs being closed :D)??
2. I'm not sure why this suddenly happens, I suspect that PyGithub changed the return type of their `datetimes` to be timezone-aware.
3. If this works, other repos should also be updated (e.g. accelerate ping @muellerzr).
4. Alternatively, we could use the GH [stale action](https://github.com/actions/stale).