### PR TITLE
FEAT: Add fp16 + cpu merge support

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -262,7 +262,7 @@ class Linear(nn.Linear, LoraLayer):
 
         # In case users wants to merge the adapter weights that are in
         # float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
-        # float16.
+        # float16 because the `@` and matmul operation in general is not supported in torch + cpu + fp16.
         cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
 
         weight_A = self.lora_A[adapter].weight
@@ -384,7 +384,7 @@ class Embedding(nn.Embedding, LoraLayer):
 
         # In case users wants to merge the adapter weights that are in
         # float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
-        # float16.
+        # float16 because the `@` and matmul operation in general is not supported in torch + cpu + fp16.
         cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
 
         weight_A = self.lora_embedding_A[adapter]
@@ -523,7 +523,7 @@ class Conv2d(nn.Conv2d, LoraLayer):
 
         # In case users wants to merge the adapter weights that are in
         # float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
-        # float16.
+        # float16 because the `@` and matmul operation in general is not supported in torch + cpu + fp16.
         cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
 
         weight_A = self.lora_A[adapter].weight

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -250,13 +250,37 @@ class Linear(nn.Linear, LoraLayer):
                 self.weight.data -= self.get_delta_weight(active_adapter)
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
-        return (
-            transpose(
-                self.lora_B[adapter].weight @ self.lora_A[adapter].weight,
-                self.fan_in_fan_out,
-            )
-            * self.scaling[adapter]
-        )
+        """
+        Compute the delta weight for the given adapter. In case users wants to merge the adapter weights that are in
+        float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
+        float16.
+
+        Args:
+            adapter (str):
+                The name of the adapter for which the delta weight should be computed.
+        """
+        device = self.lora_B[adapter].weight.device
+        dtype = self.lora_B[adapter].weight.dtype
+
+        cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
+
+        weight_A = self.lora_A[adapter].weight
+        weight_B = self.lora_B[adapter].weight
+
+        if cast_to_fp32:
+            weight_A = weight_A.float()
+            weight_B = weight_B.float()
+
+        output_tensor = transpose(weight_B @ weight_A, self.fan_in_fan_out) * self.scaling[adapter]
+
+        if cast_to_fp32:
+            output_tensor = output_tensor.to(dtype=dtype)
+
+            # cast back the weights
+            self.lora_A[adapter].weight.data = weight_A.to(dtype)
+            self.lora_B[adapter].weight.data = weight_B.to(dtype)
+
+        return output_tensor
 
     def _linear(self, input: torch.Tensor) -> torch.Tensor:
         return F.linear(input, transpose(self.weight, self.fan_in_fan_out), bias=self.bias)
@@ -347,7 +371,37 @@ class Embedding(nn.Embedding, LoraLayer):
                 self.weight.data -= self.get_delta_weight(active_adapter)
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
-        return transpose(self.lora_embedding_B[adapter] @ self.lora_embedding_A[adapter], True) * self.scaling[adapter]
+        """
+        Compute the delta weight for the given adapter. In case users wants to merge the adapter weights that are in
+        float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
+        float16.
+
+        Args:
+            adapter (str):
+                The name of the adapter for which the delta weight should be computed.
+        """
+        device = self.lora_embedding_B[adapter].weight.device
+        dtype = self.lora_embedding_A[adapter].weight.dtype
+
+        cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
+
+        weight_A = self.lora_embedding_A[adapter].weight
+        weight_B = self.lora_embedding_B[adapter].weight
+
+        if cast_to_fp32:
+            weight_A = weight_A.float()
+            weight_B = weight_B.float()
+
+        output_tensor = transpose(weight_B @ weight_A, True) * self.scaling[adapter]
+
+        if cast_to_fp32:
+            output_tensor = output_tensor.to(dtype=dtype)
+
+            # cast back the weights
+            self.lora_embedding_A[adapter].weight.data = weight_A.to(dtype)
+            self.lora_embedding_B[adapter].weight.data = weight_B.to(dtype)
+
+        return output_tensor
 
     def _embed(self, input: torch.Tensor, weight: Optional[torch.Tensor] = None) -> torch.Tensor:
         weight = self.weight if weight is None else weight
@@ -455,21 +509,48 @@ class Conv2d(nn.Conv2d, LoraLayer):
                 self.weight.data -= self.get_delta_weight(active_adapter)
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
+        """
+        Compute the delta weight for the given adapter. In case users wants to merge the adapter weights that are in
+        float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
+        float16.
+
+        Args:
+            adapter (str):
+                The name of the adapter for which the delta weight should be computed.
+        """
+        device = self.lora_B[adapter].weight.device
+        dtype = self.lora_A[adapter].weight.dtype
+
+        cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
+
+        if cast_to_fp32:
+            weight_A = self.lora_A[adapter].weight.float()
+            weight_B = self.lora_B[adapter].weight.float()
+
         # https://github.com/bmaltais/kohya_ss/blob/feb6728762a8f463d15ba936d189d4c3abfaa1ab/networks/lora.py#L117
         if self.weight.size()[2:4] == (1, 1):
             # conv2d 1x1
-            return (
-                self.lora_B[adapter].weight.squeeze(3).squeeze(2) @ self.lora_A[adapter].weight.squeeze(3).squeeze(2)
-            ).unsqueeze(2).unsqueeze(3) * self.scaling[adapter]
+            output_tensor = (weight_B.squeeze(3).squeeze(2) @ weight_A.squeeze(3).squeeze(2)).unsqueeze(2).unsqueeze(
+                3
+            ) * self.scaling[adapter]
         else:
             # conv2d 3x3
-            return (
+            output_tensor = (
                 F.conv2d(
-                    self.lora_A[adapter].weight.permute(1, 0, 2, 3),
-                    self.lora_B[adapter].weight,
+                    weight_A.permute(1, 0, 2, 3),
+                    weight_B.weight,
                 ).permute(1, 0, 2, 3)
                 * self.scaling[adapter]
             )
+
+        if cast_to_fp32:
+            output_tensor = output_tensor.to(dtype=dtype)
+
+            # cast back the weights
+            self.lora_A[adapter].weight.data = weight_A.to(dtype)
+            self.lora_B[adapter].weight.data = weight_B.to(dtype)
+
+        return output_tensor
 
     def _conv2d(self, input: torch.Tensor) -> torch.Tensor:
         return F.conv2d(

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -251,9 +251,7 @@ class Linear(nn.Linear, LoraLayer):
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
         """
-        Compute the delta weight for the given adapter. In case users wants to merge the adapter weights that are in
-        float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
-        float16.
+        Compute the delta weight for the given adapter.
 
         Args:
             adapter (str):
@@ -262,6 +260,9 @@ class Linear(nn.Linear, LoraLayer):
         device = self.lora_B[adapter].weight.device
         dtype = self.lora_B[adapter].weight.dtype
 
+        # In case users wants to merge the adapter weights that are in
+        # float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
+        # float16.
         cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
 
         weight_A = self.lora_A[adapter].weight
@@ -372,9 +373,7 @@ class Embedding(nn.Embedding, LoraLayer):
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
         """
-        Compute the delta weight for the given adapter. In case users wants to merge the adapter weights that are in
-        float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
-        float16.
+        Compute the delta weight for the given adapter.
 
         Args:
             adapter (str):
@@ -383,6 +382,9 @@ class Embedding(nn.Embedding, LoraLayer):
         device = self.lora_embedding_B[adapter].device
         dtype = self.lora_embedding_A[adapter].dtype
 
+        # In case users wants to merge the adapter weights that are in
+        # float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
+        # float16.
         cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
 
         weight_A = self.lora_embedding_A[adapter]
@@ -510,9 +512,7 @@ class Conv2d(nn.Conv2d, LoraLayer):
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
         """
-        Compute the delta weight for the given adapter. In case users wants to merge the adapter weights that are in
-        float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
-        float16.
+        Compute the delta weight for the given adapter.
 
         Args:
             adapter (str):
@@ -521,6 +521,9 @@ class Conv2d(nn.Conv2d, LoraLayer):
         device = self.lora_B[adapter].weight.device
         dtype = self.lora_A[adapter].weight.dtype
 
+        # In case users wants to merge the adapter weights that are in
+        # float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
+        # float16.
         cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
 
         weight_A = self.lora_A[adapter].weight

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -316,17 +316,17 @@ class MockTransformerWrapper:
         # set the seed so that from_pretrained always returns the same model
         torch.manual_seed(0)
 
-        if torch_dtype is not None:
-            torch.set_default_dtype(torch_dtype)
+        if torch_dtype is None:
+            torch_dtype = torch.float32
 
         if model_id == "MLP":
-            return MLP()
+            return MLP().to(torch_dtype)
 
         if model_id == "EmbConv1D":
-            return ModelEmbConv1D()
+            return ModelEmbConv1D().to(torch_dtype)
 
         if model_id == "Conv2d":
-            return ModelConv2D()
+            return ModelConv2D().to(torch_dtype)
 
         raise ValueError(f"model_id {model_id} not implemented")
 

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -119,6 +119,10 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
         self._test_generate(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
+    def test_merge_layers_fp16(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_merge_layers_fp16(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
     def test_generate_half_prec(self, test_name, model_id, config_cls, config_kwargs):
         self._test_generate_half_prec(model_id, config_cls, config_kwargs)
 

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -443,7 +443,7 @@ class PeftCommonTester:
             **config_kwargs,
         )
         model = get_peft_model(model, config)
-        model = model.to(torch.float16)
+        model = model.to(device="cpu", dtype=torch.float16)
 
         model.eval()
 

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -443,7 +443,7 @@ class PeftCommonTester:
             **config_kwargs,
         )
         model = get_peft_model(model, config)
-        model = model.to(self.torch_device)
+        model = model.to(torch.float16)
 
         model.eval()
 

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -430,6 +430,26 @@ class PeftCommonTester:
             self.assertTrue(model_from_pretrained.peft_config["default"].inference_mode)
             self.assertIs(model_from_pretrained.peft_config["default"], config)
 
+    def _test_merge_layers_fp16(self, model_id, config_cls, config_kwargs):
+        if config_cls not in (LoraConfig,):
+            # Merge layers only supported for LoRA and IA³
+            return
+        if ("gpt2" in model_id.lower()) and (config_cls != LoraConfig):
+            self.skipTest("Merging GPT2 adapters not supported for IA³ (yet)")
+
+        model = self.transformers_class.from_pretrained(model_id, torch_dtype=torch.float16)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config)
+        model = model.to(self.torch_device)
+
+        model.eval()
+
+        # This should simply work
+        _ = model.merge_and_unload()
+
     def _test_merge_layers_nan(self, model_id, config_cls, config_kwargs):
         if config_cls not in (LoraConfig, IA3Config, AdaLoraConfig):
             # Merge layers only supported for LoRA and IA³


### PR DESCRIPTION
# What does this PR do?

Specifically addresses: https://github.com/huggingface/diffusers/pull/5151#pullrequestreview-1672087496 

Some users might want to perform `merge_and_unload` when the adapter weights being in fp16. 

In diffusers users are able to perform that as the lora weights are always upcasted to fp32: https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/lora.py#L257 before merging

Therefore I think we might need to support that usecase to avoid regressions in diffusers. 

I propose to perform the upcasting to fp32 only in the case adapter weights are on cpu and the dtype of the adapter weights are in fp16

Added also nice tests

cc @BenjaminBossan @pacman100 @patrickvonplaten @sayakpaul 