### PR TITLE
Fixed wrong construction of LoHa weights, updated adapters conversion script

### DIFF
--- a/src/peft/tuners/loha/layer.py
+++ b/src/peft/tuners/loha/layer.py
@@ -161,7 +161,7 @@ class LoHaLayer(BaseTunerLayer, nn.Module):
                 self.hada_t1[adapter_name],
                 self.hada_w1_a[adapter_name],
                 self.hada_w1_b[adapter_name],
-                self.hada_t1[adapter_name],
+                self.hada_t2[adapter_name],
                 self.hada_w2_a[adapter_name],
                 self.hada_w2_b[adapter_name],
                 scale=torch.tensor(self.scaling[adapter_name]),

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -144,6 +144,8 @@ TEST_CASES = [
     ),
     ("Conv2d 1 LOHA", "Conv2d", LoHaConfig, {"target_modules": ["conv2d"]}),
     ("Conv2d 2 LOHA", "Conv2d", LoHaConfig, {"target_modules": ["conv2d", "lin0"]}),
+    ("Conv2d 3 LOHA", "Conv2d", LoHaConfig, {"target_modules": ["conv2d"], "use_effective_conv2d": True}),
+    ("Conv2d 4 LOHA", "Conv2d", LoHaConfig, {"target_modules": ["conv2d", "lin0"], "use_effective_conv2d": True}),
 ]
 
 MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES = [


### PR DESCRIPTION
This PR addresses the issue I found with the current LoHa adapter implementation. Right now there is a bug that does not take into account hada_t2 parameter during delta weights [calculation](https://github.com/huggingface/peft/blob/aaa7e9f44a6405af819e721d7ee7fc6dd190c980/src/peft/tuners/loha/layer.py#L160) both in train and inference.

This bug also exists in the original implementation, so I've created a similar [PR](https://github.com/KohakuBlueleaf/LyCORIS/pull/115) to fix it in LyCORIS repo.

I've included some tests that cover this functionality + fixed several errors in SD adapters conversion script (mentioned in [#978](https://github.com/huggingface/peft/pull/978)).

It would be great if this PR would get merged before the next release, so we won't need to provide some sort of backward compatibility for this.

[@BenjaminBossan](https://github.com/BenjaminBossan) your review is kindly appreciated.