### PR TITLE
[`core`] Fix `use_reentrant` issues

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -65,6 +65,8 @@ def starcoder_model_postprocess_past_key_value(past_key_values):
 
 def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, gradient_checkpointing_kwargs=None):
     r"""
+    Note this method only works for `transformers` models.
+
     This method wraps the entire protocol for preparing a model before running a training. This includes:
         1- Cast the layernorm in fp32 2- making output embedding layer require grads 3- Add the upcasting of the lm
         head to fp32
@@ -75,8 +77,9 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
         use_gradient_checkpointing (`bool`, *optional*, defaults to `True`):
             If True, use gradient checkpointing to save memory at the expense of slower backward pass.
         gradient_checkpointing_kwargs (`dict`, *optional*, defaults to `None`):
-            Keyword arguments to pass to the gradient checkpointing function, e.g. `use_reentrant=True`. Note this is
-            only available in the latest transformers versions.
+            Keyword arguments to pass to the gradient checkpointing function, please refer to the documentation of
+            `torch.utils.checkpoint.checkpoint` for more details about the arguments that you can pass to that method.
+            Note this is only available in the latest transformers versions (> 4.34.1).
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
     is_gptq_quantized = getattr(model, "quantization_method", None) == "gptq"

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -97,8 +97,8 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
                 param.data = param.data.to(torch.float32)
 
     if (loaded_in_kbit or is_gptq_quantized) and use_gradient_checkpointing:
-        # When having `use_reentrant` + gradient_checkpointing, there is no need for this hack
-        if "use_reentrant" not in gradient_checkpointing_kwargs or not gradient_checkpointing_kwargs["use_reentrant"]:
+        # When having `use_reentrant=False` + gradient_checkpointing, there is no need for this hack
+        if not ("use_reentrant" in gradient_checkpointing_kwargs) or gradient_checkpointing_kwargs["use_reentrant"]:
             # For backward compatibility
             if hasattr(model, "enable_input_require_grads"):
                 model.enable_input_require_grads()

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -98,7 +98,7 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
 
     if (loaded_in_kbit or is_gptq_quantized) and use_gradient_checkpointing:
         # When having `use_reentrant=False` + gradient_checkpointing, there is no need for this hack
-        if not ("use_reentrant" in gradient_checkpointing_kwargs) or gradient_checkpointing_kwargs["use_reentrant"]:
+        if "use_reentrant" not in gradient_checkpointing_kwargs or gradient_checkpointing_kwargs["use_reentrant"]:
             # For backward compatibility
             if hasattr(model, "enable_input_require_grads"):
                 model.enable_input_require_grads()

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -70,8 +70,13 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
         head to fp32
 
     Args:
-        model, (`transformers.PreTrainedModel`):
+        model (`transformers.PreTrainedModel`):
             The loaded model from `transformers`
+        use_gradient_checkpointing (`bool`, *optional*, defaults to `True`):
+            If True, use gradient checkpointing to save memory at the expense of slower backward pass.
+        gradient_checkpointing_kwargs (`dict`, *optional*, defaults to `None`):
+            Keyword arguments to pass to the gradient checkpointing function, e.g. `use_reentrant=True`. Note this is
+            only available in the latest transformers versions.
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
     is_gptq_quantized = getattr(model, "quantization_method", None) == "gptq"

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -114,6 +114,13 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
             inspect.signature(model.gradient_checkpointing_enable).parameters
         )
 
+        if not _supports_gc_kwargs and len(gradient_checkpointing_kwargs) >= 1:
+            warnings.warn(
+                "gradient_checkpointing_kwargs is not supported in this version of transformers. The passed kwargs will be ignored.",
+                " if you want to use that feature, please upgrade to the latest version of transformers.",
+                FutureWarning,
+            )
+
         gc_enable_kwargs = (
             {} if not _supports_gc_kwargs else {"gradient_checkpointing_kwargs": gradient_checkpointing_kwargs}
         )

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -114,9 +114,9 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
             inspect.signature(model.gradient_checkpointing_enable).parameters
         )
 
-        if not _supports_gc_kwargs and len(gradient_checkpointing_kwargs) >= 1:
+        if not _supports_gc_kwargs and len(gradient_checkpointing_kwargs) > 0:
             warnings.warn(
-                "gradient_checkpointing_kwargs is not supported in this version of transformers. The passed kwargs will be ignored.",
+                "gradient_checkpointing_kwargs is not supported in this version of transformers. The passed kwargs will be ignored."
                 " if you want to use that feature, please upgrade to the latest version of transformers.",
                 FutureWarning,
             )


### PR DESCRIPTION
Partially fixes: https://github.com/huggingface/trl/issues/835

This PR depends on https://github.com/huggingface/transformers/pull/27020 - with that PR, we introduce a new argument in the `gradient_checkpointing_enable()` API in order for users to pass `gradient_checkpointing_kwargs`. To fix some issues with DDP and gradient_checkpointing, it is recommended to use `use_reentrant=True` which is the fix for  https://github.com/huggingface/trl/issues/835 

Therefore I propose to expose an optional argument `gradient_checkpointing_kwargs` in `prepare_model_for_kbit_training`

cc @BenjaminBossan @pacman100 