### PR TITLE
Fix P-tuning for sequence classification docs

### DIFF
--- a/docs/source/task_guides/ptuning-seq-classification.mdx
+++ b/docs/source/task_guides/ptuning-seq-classification.mdx
@@ -197,7 +197,7 @@ Once the model has been uploaded to the Hub, anyone can easily use it for infere
 ```py
 import torch
 from peft import PeftModel, PeftConfig
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 peft_model_id = "smangrul/roberta-large-peft-p-tuning"
 config = PeftConfig.from_pretrained(peft_model_id)


### PR DESCRIPTION
## What does this PR do?
This PR includes a very minor change in the P-tuning for sequence classification task guide documentation. Previously, in the inference part, the docs showed that the user should import the `AutoModelForCasualLM` module while the right one should be `AutoModelForSequenceClassification`.