### PR TITLE
FIX: Setting active adapter correctly

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -133,6 +133,16 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             return self._peft_config
         return self.base_model.peft_config
 
+    @property
+    def active_adapters(self):
+        try:
+            adapters = self.base_model.active_adapters
+        except AttributeError:
+            adapters = self.active_adapter
+            if isinstance(adapters, str):
+                adapters = [adapters]
+        return adapters
+
     @peft_config.setter
     def peft_config(self, value: Dict[str, PeftConfig]):
         if self._is_prompt_learning:

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -364,6 +364,7 @@ class LoraModel(BaseTuner):
                     warnings.warn("Adapter cannot be set when the model is merged. Unmerging the model first.")
                     module.unmerge()
                 module.set_adapter(adapter_name)
+        self.active_adapter = adapter_name
 
     @staticmethod
     def _prepare_adapter_config(peft_config, model_config):

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -948,12 +948,14 @@ class PeftCommonTester:
                     elif "cat" in adapter_name:
                         self.assertTrue(target.r[adapter_name] == 28)
 
+        dummy_input = self.prepare_inputs_for_testing()
+        model.eval()
         for adapter_name in new_adapters:
             # ensuring new adapters pass the forward loop
             model.set_adapter(adapter_name)
-            dummy_input = self.prepare_inputs_for_testing()
-            model.eval()
-            _ = model(**dummy_input)[0]
+            self.assertTrue(model.active_adapter == adapter_name)
+            self.assertTrue(model.active_adapters == [adapter_name])
+            model(**dummy_input)[0]
 
     def _test_disable_adapter(self, model_id, config_cls, config_kwargs):
         task_type = config_kwargs.get("task_type")


### PR DESCRIPTION
Bug was reported [here](https://github.com/huggingface/peft/issues/1045#issuecomment-1777761363).

Currently, when calling `set_adapter`, the active adapter is not updated. Tests have been added to trigger the bug, and the method updated to fix it.

Moreover, I created an `active_adapters` property on the `PeftModel` class so that it behaves consistently with the underlying base model classes like `LoraModel`.