### PR TITLE
Prompt tuning: Allow to pass additional args to AutoTokenizer.from_pretrained

### DIFF
--- a/src/peft/tuners/prompt_tuning/config.py
+++ b/src/peft/tuners/prompt_tuning/config.py
@@ -37,6 +37,9 @@ class PromptTuningConfig(PromptLearningConfig):
             The text to initialize the prompt embedding. Only used if `prompt_tuning_init` is `TEXT`.
         tokenizer_name_or_path (`str`, *optional*):
             The name or path of the tokenizer. Only used if `prompt_tuning_init` is `TEXT`.
+        tokenizer_kwargs (`dict`, *optional*):
+            The keyword arguments to pass to `AutoTokenizer.from_pretrained`. Only used if `prompt_tuning_init` is
+            `TEXT`.
     """
 
     prompt_tuning_init: Union[PromptTuningInit, str] = field(
@@ -56,5 +59,18 @@ class PromptTuningConfig(PromptLearningConfig):
         },
     )
 
+    tokenizer_kwargs: Optional[dict] = field(
+        default=None,
+        metadata={
+            "help": (
+                "The keyword arguments to pass to `AutoTokenizer.from_pretrained`. Only used if prompt_tuning_init is "
+                "`TEXT`"
+            ),
+        },
+    )
+
     def __post_init__(self):
         self.peft_type = PeftType.PROMPT_TUNING
+
+        if self.tokenizer_kwargs and (self.prompt_tuning_init != PromptTuningInit.TEXT):
+            raise ValueError(f"tokenizer_kwargs only valid when using prompt_tuning_init='{PromptTuningInit.TEXT}'.")

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -43,13 +43,6 @@ from peft.utils import _get_submodules, infer_device
 from .testing_utils import get_state_dict
 
 
-CONFIG_CLASSES = (
-    IA3Config,
-    LoraConfig,
-    PrefixTuningConfig,
-    PromptEncoderConfig,
-    PromptTuningConfig,
-)
 CONFIG_TESTING_KWARGS = (
     # IA³
     {


### PR DESCRIPTION
Fixes #1032

## Description

Currently, when using prompt tuning with `TEXT`, we call `AutoTokenizer.from_pretrained` with only the model id. However, it may be necessary to pass additional arguments, e.g. `trust_remote_code=True`. This fix allows to pass more arguments by setting the argument `tokenizer_kwargs` in the `PromptTuningConfig`.

I also added a check that when `tokenizer_kwargs` is set, the `TEXT` option is actually being used.

Moreover, I noticed that we have no tests for prompt tuning with `TEXT`, so I added those tests for decoder models.

## Additional changes

There was a bug in `PromptEmbedding` where the device of the init_token_ids was not set, which resulted in errors when using CUDA.

Finally, I removed an unused constant `CONFIG_CLASSES` from a test.