### PR TITLE
Align offloaded parameters before merging

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -384,8 +384,7 @@ class LoraModel(BaseTuner):
 
         km_list = [[key, module] for key, module in self.model.named_modules() if "lora" not in key]
         desc = "Unloading " + ("and merging " if merge else "") + "model"
-        for pair in tqdm(km_list, disable=not progressbar, desc=desc):
-            key, module = pair[0], pair[1]
+        for key, module in tqdm(km_list, disable=not progressbar, desc=desc):
             # re-load module params if offloaded to the meta device
             if hasattr(module, "_hf_hook") and isinstance(module._hf_hook, AlignDevicesHook):
                 module._hf_hook.pre_forward(module)


### PR DESCRIPTION
Fixes issue #868  to allow for merging and unloading using `auto` device alignment.   

For models of sufficient size relative to memory constraints, choosing `auto` device alignment causes `accelerate` to perform lazy offloaded parameter loading just before a forward call. Calling `merge_and_unload` on a model with offloaded parameters results in errors due to these offloaded parameters.

This PR addresses that issue by activating the appropriate `accelerate` device alignment hook methods for each module that is to be merged.  This loads offloaded parameters which are otherwise on the "meta' device (if the model does not fit on the execution device) to allow merging and then offloads the merged parameters to avoid out-of-memory errors.

The implementation is fairly straightforward with one exception: it seems that we must avoid calling`self._replace_module(parent, target_name, new_module, target)` as doing so leads to a memory leak as the `new_module` does not have the appropriate `AlignDevicesHook` hook.  Another approach would be to add this hook and proceed with replacement, but this may not be necessary for successful merging right now.

The main benefit compared to the existing approach of loading models using `cpu` is that this method should succeed even when cpu cannot load the model in its entirety, as each module is loaded and merged and unloaded sequentially.

