### PR TITLE
Fix issue where you cannot call PeftModel.from_pretrained with a private adapter

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -308,6 +308,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     revision=kwargs.get("revision", None),
                     cache_dir=kwargs.get("cache_dir", None),
                     use_auth_token=kwargs.get("use_auth_token", None),
+                    token=kwargs.get("token", None),
                 )
             ].from_pretrained(model_id, **kwargs)
         elif isinstance(config, PeftConfig):

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -202,7 +202,7 @@ def load_peft_weights(model_id: str, device: Optional[str] = None, **hf_hub_down
             filename=SAFETENSORS_WEIGHTS_NAME,
             revision=hf_hub_download_kwargs.get("revision", None),
             repo_type=hf_hub_download_kwargs.get("repo_type", None),
-            token=hf_hub_download_kwargs.get("token", None),
+            token=token,
         )
         use_safetensors = has_remote_safetensors_file
 

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -198,6 +198,8 @@ def load_peft_weights(model_id: str, device: Optional[str] = None, **hf_hub_down
             filename=SAFETENSORS_WEIGHTS_NAME,
             revision=hf_hub_download_kwargs.get("revision", None),
             repo_type=hf_hub_download_kwargs.get("repo_type", None),
+            token=hf_hub_download_kwargs.get("token", None),
+            use_auth_token=hf_hub_download_kwargs.get("use_auth_token", None),
         )
         use_safetensors = has_remote_safetensors_file
 

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -193,13 +193,17 @@ def load_peft_weights(model_id: str, device: Optional[str] = None, **hf_hub_down
         filename = os.path.join(path, WEIGHTS_NAME)
         use_safetensors = False
     else:
+        
+        token = hf_hub_download_kwargs.get("token", None)
+        if token is None:
+            token = hf_hub_download_kwargs.get("use_auth_token", None) 
+        
         has_remote_safetensors_file = file_exists(
             repo_id=model_id,
             filename=SAFETENSORS_WEIGHTS_NAME,
             revision=hf_hub_download_kwargs.get("revision", None),
             repo_type=hf_hub_download_kwargs.get("repo_type", None),
             token=hf_hub_download_kwargs.get("token", None),
-            use_auth_token=hf_hub_download_kwargs.get("use_auth_token", None),
         )
         use_safetensors = has_remote_safetensors_file
 

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -193,11 +193,10 @@ def load_peft_weights(model_id: str, device: Optional[str] = None, **hf_hub_down
         filename = os.path.join(path, WEIGHTS_NAME)
         use_safetensors = False
     else:
-        
         token = hf_hub_download_kwargs.get("token", None)
         if token is None:
-            token = hf_hub_download_kwargs.get("use_auth_token", None) 
-        
+            token = hf_hub_download_kwargs.get("use_auth_token", None)
+
         has_remote_safetensors_file = file_exists(
             repo_id=model_id,
             filename=SAFETENSORS_WEIGHTS_NAME,


### PR DESCRIPTION
Peft checks if a file exists with ```hub_file_exists```, but doesn't pass the kwargs containing the auth token to it, therefore it fails to load if the repo is private even if it exists. This PR fixes that.