### PR TITLE
FIX: Skip adaption prompt tests with new transformers versions

### DIFF
--- a/src/peft/tuners/adaption_prompt/config.py
+++ b/src/peft/tuners/adaption_prompt/config.py
@@ -44,6 +44,7 @@ class AdaptionPromptConfig(PeftConfig):
 
     def __post_init__(self):
         # TODO: Remove this check and function once PEFT works again with newest transformers version.
+        # Also remove the skip in test_adaption_prompt.py and uncomment the adaption prompt config in test_config.py.
         if is_transformers_version_ge(MAX_TRANSFORMERS_VERSION):
             raise ValueError(
                 f"Adaption prompt is not compatible with transformers >= {MAX_TRANSFORMERS_VERSION}, "

--- a/src/peft/tuners/adaption_prompt/config.py
+++ b/src/peft/tuners/adaption_prompt/config.py
@@ -13,13 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 from collections import namedtuple
 from dataclasses import dataclass, field
+
+from packaging.version import parse
 
 from peft.config import PeftConfig
 from peft.utils import PeftType
 
 from .utils import llama_compute_query_states
+
+
+MAX_TRANSFORMERS_VERSION = "4.35.0"
+
+
+def is_transformers_version_ge(version: str) -> bool:
+    return parse(importlib.metadata.version("transformers")) >= parse(version)
 
 
 @dataclass
@@ -33,6 +43,12 @@ class AdaptionPromptConfig(PeftConfig):
     adapter_layers: int = field(default=None, metadata={"help": "Number of adapter layers (from the top)"})
 
     def __post_init__(self):
+        # TODO: Remove this check and function once PEFT works again with newest transformers version.
+        if is_transformers_version_ge(MAX_TRANSFORMERS_VERSION):
+            raise ValueError(
+                f"Adaption prompt is not compatible with transformers >= {MAX_TRANSFORMERS_VERSION}, "
+                "please use an older version of transformers until this is fixed."
+            )
         self.peft_type = PeftType.ADAPTION_PROMPT
 
     @property

--- a/tests/test_adaption_prompt.py
+++ b/tests/test_adaption_prompt.py
@@ -53,7 +53,13 @@ class AdaptionPromptTester(TestCase, PeftCommonTester):
     """
 
     def setUp(self):
-        """Check that llama is available in transformers package before running each test."""
+        # TODO: remove the imports and version check once PEFT works again with transformers
+        from peft.tuners.adaption_prompt.config import MAX_TRANSFORMERS_VERSION, is_transformers_version_ge
+
+        if is_transformers_version_ge(MAX_TRANSFORMERS_VERSION):
+            self.skipTest("Adaption prompt is currently failing on transformers 4.35.0, skipping test.")
+
+        # Check that llama is available in transformers package before running each test.
         if not is_llama_available():
             self.skipTest("Llama not available in transformers. Skipping test.")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,8 @@ from parameterized import parameterized
 
 from peft import (
     AdaLoraConfig,
-    AdaptionPromptConfig,
+    # TODO: uncomment once PEFT works again with transformers
+    # AdaptionPromptConfig,
     IA3Config,
     LoHaConfig,
     LoraConfig,
@@ -40,7 +41,8 @@ from peft import (
 PEFT_MODELS_TO_TEST = [("lewtun/tiny-random-OPTForCausalLM-delta", "v1")]
 
 ALL_CONFIG_CLASSES = (
-    AdaptionPromptConfig,
+    # TODO: uncomment once PEFT works again with transformers
+    # AdaptionPromptConfig,
     AdaLoraConfig,
     IA3Config,
     LoHaConfig,


### PR DESCRIPTION
Adaption prompt is failing with transformers v4.35.0. This PR skips the adaption prompt tests so that CI is green again. The PR also adds an error when users try to use adaption prompt with that version, instructing them to use an older transformers version instead.

This should be removed as soon as the issue is fixed in PEFT/transformers.