### PR TITLE
FIX: fix adaptation prompt CI and compatibility with latest transformers (4.35.0)

### DIFF
--- a/src/peft/tuners/adaption_prompt/config.py
+++ b/src/peft/tuners/adaption_prompt/config.py
@@ -13,23 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
 from collections import namedtuple
 from dataclasses import dataclass, field
-
-from packaging.version import parse
 
 from peft.config import PeftConfig
 from peft.utils import PeftType
 
 from .utils import llama_compute_query_states
-
-
-MAX_TRANSFORMERS_VERSION = "4.35.0"
-
-
-def is_transformers_version_ge(version: str) -> bool:
-    return parse(importlib.metadata.version("transformers")) >= parse(version)
 
 
 @dataclass
@@ -43,13 +33,6 @@ class AdaptionPromptConfig(PeftConfig):
     adapter_layers: int = field(default=None, metadata={"help": "Number of adapter layers (from the top)"})
 
     def __post_init__(self):
-        # TODO: Remove this check and function once PEFT works again with newest transformers version.
-        # Also remove the skip in test_adaption_prompt.py and uncomment the adaption prompt config in test_config.py.
-        if is_transformers_version_ge(MAX_TRANSFORMERS_VERSION):
-            raise ValueError(
-                f"Adaption prompt is not compatible with transformers >= {MAX_TRANSFORMERS_VERSION}, "
-                "please use an older version of transformers until this is fixed."
-            )
         self.peft_type = PeftType.ADAPTION_PROMPT
 
     @property

--- a/tests/test_adaption_prompt.py
+++ b/tests/test_adaption_prompt.py
@@ -53,12 +53,6 @@ class AdaptionPromptTester(TestCase, PeftCommonTester):
     """
 
     def setUp(self):
-        # TODO: remove the imports and version check once PEFT works again with transformers
-        from peft.tuners.adaption_prompt.config import MAX_TRANSFORMERS_VERSION, is_transformers_version_ge
-
-        if is_transformers_version_ge(MAX_TRANSFORMERS_VERSION):
-            self.skipTest("Adaption prompt is currently failing on transformers 4.35.0, skipping test.")
-
         # Check that llama is available in transformers package before running each test.
         if not is_llama_available():
             self.skipTest("Llama not available in transformers. Skipping test.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,7 +25,7 @@ from parameterized import parameterized
 from peft import (
     AdaLoraConfig,
     # TODO: uncomment once PEFT works again with transformers
-    # AdaptionPromptConfig,
+    AdaptionPromptConfig,
     IA3Config,
     LoHaConfig,
     LoraConfig,
@@ -42,7 +42,7 @@ PEFT_MODELS_TO_TEST = [("lewtun/tiny-random-OPTForCausalLM-delta", "v1")]
 
 ALL_CONFIG_CLASSES = (
     # TODO: uncomment once PEFT works again with transformers
-    # AdaptionPromptConfig,
+    AdaptionPromptConfig,
     AdaLoraConfig,
     IA3Config,
     LoHaConfig,


### PR DESCRIPTION
# What does this PR do?

As per title, fixes the current CI for adaption prompt and makes it compatible.
Transformers refactored the way positional embeddings are computed for llama, in the previous versions `cos` and `sin` cache values had a shape of length 4, now it was only a shape of length 2, breaking the assumptions we made in `llama_apply_rotary_pos_emb`.

I propose to keep the previous behaviour in case len(cos.shape) == 4, and fall back to the newest way of computing `q_embed` as depicted here: https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L222-L226

cc @BenjaminBossan @pacman100 