### PR TITLE
[`Docker`] Update Dockerfile to force-use transformers main

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -29,15 +29,6 @@ ENV PATH /opt/conda/envs/peft/bin:$PATH
 # Activate our bash shell
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
-# Activate the conda env and install transformers + accelerate from source
-RUN source activate peft && \
-    python3 -m pip install --no-cache-dir \
-    librosa \
-    "soundfile>=0.12.1" \
-    scipy \
-    git+https://github.com/huggingface/transformers \
-    git+https://github.com/huggingface/accelerate \
-    peft[test]@git+https://github.com/huggingface/peft
 
 # Stage 2
 FROM nvidia/cuda:12.2.2-devel-ubuntu22.04 AS build-image
@@ -47,8 +38,17 @@ ENV PATH /opt/conda/bin:$PATH
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
 RUN source activate peft && \ 
-    python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq && \
-    python3 -m pip install -U git+https://github.com/huggingface/transformers
+    python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq
+
+# Activate the conda env and install transformers + accelerate from source
+RUN source activate peft && \
+    python3 -m pip install -U --no-cache-dir \
+    librosa \
+    "soundfile>=0.12.1" \
+    scipy \
+    git+https://github.com/huggingface/transformers \
+    git+https://github.com/huggingface/accelerate \
+    peft[test]@git+https://github.com/huggingface/peft
 
 RUN pip freeze | grep transformers
 

--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -50,6 +50,8 @@ RUN source activate peft && \
     python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq && \
     python3 -m pip install -U git+https://github.com/huggingface/transformers
 
+RUN pip freeze | grep transformers
+
 # Install apt libs
 RUN apt-get update && \
     apt-get install -y curl git wget && \

--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -47,7 +47,8 @@ ENV PATH /opt/conda/bin:$PATH
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
 RUN source activate peft && \ 
-    python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq
+    python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq && \
+    python3 -m pip install -U git+https://github.com/huggingface/transformers
 
 # Install apt libs
 RUN apt-get update && \


### PR DESCRIPTION
# What does this PR do?

Optimum pins transformers to <4.35.0, leading our docker images to have transformers==4.34.1, which is not intended since we want to test PEFT against transformers and accelerate main

This PR fixes it, there is no need to update the cpu docker file as optimum is not installed there

cc @pacman100 @BenjaminBossan 