### PR TITLE
fix-gptq-training

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
+import sys
+
 import packaging
-import sys 
+
 
 # The package importlib_metadata is in a different place, depending on the python version.
 if sys.version_info < (3, 8):
@@ -46,6 +48,7 @@ def is_auto_gptq_available():
             raise ImportError(
                 f"Found an incompatible version of auto-gptq. Found version {version_autogptq}, but only version above {AUTOGPTQ_MINIMUM_VERSION} are supported"
             )
+
 
 def is_optimum_available() -> bool:
     return importlib.util.find_spec("optimum") is not None

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -13,16 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
-import sys
+import importlib.metadata as importlib_metadata
 
-import packaging
-
-
-# The package importlib_metadata is in a different place, depending on the python version.
-if sys.version_info < (3, 8):
-    import importlib_metadata
-else:
-    import importlib.metadata as importlib_metadata
+import packaging.version
 
 
 def is_bnb_available() -> bool:
@@ -46,7 +39,8 @@ def is_auto_gptq_available():
             return True
         else:
             raise ImportError(
-                f"Found an incompatible version of auto-gptq. Found version {version_autogptq}, but only version above {AUTOGPTQ_MINIMUM_VERSION} are supported"
+                f"Found an incompatible version of auto-gptq. Found version {version_autogptq}, "
+                "but only versions above {AUTOGPTQ_MINIMUM_VERSION} are supported"
             )
 
 

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -13,6 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
+import packaging
+import sys 
+
+# The package importlib_metadata is in a different place, depending on the python version.
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
 
 
 def is_bnb_available() -> bool:
@@ -28,9 +36,16 @@ def is_bnb_4bit_available() -> bool:
     return hasattr(bnb.nn, "Linear4bit")
 
 
-def is_auto_gptq_available() -> bool:
-    return importlib.util.find_spec("auto_gptq") is not None
-
+def is_auto_gptq_available():
+    if importlib.util.find_spec("auto_gptq") is not None:
+        AUTOGPTQ_MINIMUM_VERSION = packaging.version.parse("0.5.0")
+        version_autogptq = packaging.version.parse(importlib_metadata.version("auto_gptq"))
+        if AUTOGPTQ_MINIMUM_VERSION <= version_autogptq:
+            return True
+        else:
+            raise ImportError(
+                f"Found an incompatible version of auto-gptq. Found version {version_autogptq}, but only version above {AUTOGPTQ_MINIMUM_VERSION} are supported"
+            )
 
 def is_optimum_available() -> bool:
     return importlib.util.find_spec("optimum") is not None

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -419,13 +419,21 @@ def get_auto_gptq_quant_linear(gptq_quantization_config):
             desc_act = gptq_quantization_config.desc_act
             group_size = gptq_quantization_config.group_size
             bits = gptq_quantization_config.bits
-            disable_exllama = gptq_quantization_config.disable_exllama
+            if hasattr(gptq_quantization_config,"use_exllama"):
+                use_exllama = gptq_quantization_config.use_exllama
+            else:
+                use_exllama = not gptq_quantization_config.disable_exllama
+            if hasattr(gptq_quantization_config,"exllama_config"):
+                exllama_version = gptq_quantization_config.exllama_config["version"]
+            else:
+                exllama_version = 1
             AutoGPTQQuantLinear = dynamically_import_QuantLinear(
                 use_triton=False,
                 desc_act=desc_act,
                 group_size=group_size,
                 bits=bits,
-                disable_exllama=disable_exllama,
+                disable_exllama = not (use_exllama and exllama_version == 1),
+                disable_exllamav2 = not (use_exllama and exllama_version == 2),
             )
             return AutoGPTQQuantLinear
     return None

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -419,11 +419,11 @@ def get_auto_gptq_quant_linear(gptq_quantization_config):
             desc_act = gptq_quantization_config.desc_act
             group_size = gptq_quantization_config.group_size
             bits = gptq_quantization_config.bits
-            if hasattr(gptq_quantization_config,"use_exllama"):
+            if hasattr(gptq_quantization_config, "use_exllama"):
                 use_exllama = gptq_quantization_config.use_exllama
             else:
                 use_exllama = not gptq_quantization_config.disable_exllama
-            if hasattr(gptq_quantization_config,"exllama_config"):
+            if hasattr(gptq_quantization_config, "exllama_config"):
                 exllama_version = gptq_quantization_config.exllama_config["version"]
             else:
                 exllama_version = 1
@@ -432,8 +432,8 @@ def get_auto_gptq_quant_linear(gptq_quantization_config):
                 desc_act=desc_act,
                 group_size=group_size,
                 bits=bits,
-                disable_exllama = not (use_exllama and exllama_version == 1),
-                disable_exllamav2 = not (use_exllama and exllama_version == 2),
+                disable_exllama=not (use_exllama and exllama_version == 1),
+                disable_exllamav2=not (use_exllama and exllama_version == 2),
             )
             return AutoGPTQQuantLinear
     return None

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -658,7 +658,7 @@ class PeftGPTQGPUTests(unittest.TestCase):
         from transformers import GPTQConfig
 
         self.causal_lm_model_id = "marcsun13/opt-350m-gptq-4bit"
-        self.quantization_config = GPTQConfig(bits=4, disable_exllama=True)
+        self.quantization_config = GPTQConfig(bits=4, use_exllama=False)
         self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
 
     def tearDown(self):

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -658,6 +658,7 @@ class PeftGPTQGPUTests(unittest.TestCase):
         from transformers import GPTQConfig
 
         self.causal_lm_model_id = "marcsun13/opt-350m-gptq-4bit"
+        # TODO : check if it works for Exllamav2 kernels
         self.quantization_config = GPTQConfig(bits=4, use_exllama=False)
         self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
 


### PR DESCRIPTION
# What does this PR do ?
This PR updates the GPTQ training since the latest version of gptq includes breaking changes. We also switch `disable_exllama` to `use_exllama` since it is deprecated in the latest version of transformers. Tests are passing with transformers main. 