### PR TITLE
FIX: Failing nightly CI tests due to IA3 config

### DIFF
--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -163,7 +163,7 @@ class PeftGPUCommonTests(unittest.TestCase):
             task_type="CAUSAL_LM",
         )
 
-        config = IA3Config(target_modules=["q_proj", "v_proj"], feedforward_modules=["down_proj"])
+        config = IA3Config(target_modules=["q_proj", "v_proj", "fc2"], feedforward_modules=["fc2"])
 
         flan_8bit = get_peft_model(flan_8bit, flan_ia3_config)
         self.assertTrue(
@@ -276,12 +276,12 @@ class PeftGPUCommonTests(unittest.TestCase):
         flan_ia3_config = IA3Config(target_modules=["q", "v"], task_type="SEQ_2_SEQ_LM")
 
         opt_ia3_config = IA3Config(
-            target_modules=["q_proj", "v_proj"],
-            feedforward_modules=["down_proj"],
+            target_modules=["q_proj", "v_proj", "fc2"],
+            feedforward_modules=["fc2"],
             task_type="CAUSAL_LM",
         )
 
-        config = IA3Config(target_modules=["q_proj", "v_proj"], feedforward_modules=["down_proj"])
+        config = IA3Config(target_modules=["q_proj", "v_proj", "fc2"], feedforward_modules=["fc2"])
 
         flan_4bit = get_peft_model(flan_4bit, flan_ia3_config)
         self.assertTrue(


### PR DESCRIPTION
Same idea as in PR as #1094, but for yet more ill-configured IA³ configs. The tests are now failing because we do stricter checks on incorrect IA³ configs.

These are the failing tests:

https://github.com/huggingface/peft/actions/runs/6806502406/job/18507828825
https://github.com/huggingface/peft/actions/runs/6806502406/job/18507829021

With this fix, they now pass locally.