### PR TITLE
Added num_dataloader_workers arg to fix Windows issue

### DIFF
--- a/docs/source/task_guides/dreambooth_lora.mdx
+++ b/docs/source/task_guides/dreambooth_lora.mdx
@@ -83,6 +83,7 @@ accelerate launch train_dreambooth.py \
   --output_dir=$OUTPUT_DIR \
   --train_text_encoder \
   --with_prior_preservation --prior_loss_weight=1.0 \
+  --num_dataloader_workers=1 \
   --instance_prompt="a photo of sks dog" \
   --class_prompt="a photo of dog" \
   --resolution=512 \
@@ -100,6 +101,8 @@ accelerate launch train_dreambooth.py \
   --gradient_checkpointing \
   --max_train_steps=800
 ```
+
+If you are running this script on Windows, you may need to set the `--num_dataloader_workers` to 0.
 
 ## Inference with a single adapter
 

--- a/examples/lora_dreambooth/train_dreambooth.py
+++ b/examples/lora_dreambooth/train_dreambooth.py
@@ -214,6 +214,10 @@ def parse_args(input_args=None):
     )
 
     parser.add_argument(
+        "--num_dataloader_workers", type=int, default=1, help="Num of workers for the training dataloader."
+    )
+
+    parser.add_argument(
         "--train_batch_size", type=int, default=4, help="Batch size (per device) for the training dataloader."
     )
     parser.add_argument(
@@ -799,7 +803,7 @@ def main(args):
         batch_size=args.train_batch_size,
         shuffle=True,
         collate_fn=lambda examples: collate_fn(examples, args.with_prior_preservation),
-        num_workers=1,
+        num_workers=args.num_dataloader_workers,
     )
 
     # Scheduler and math around the number of training steps.


### PR DESCRIPTION
Running the train_dreambooth.py script on Windows leads to the common issue that the pytorch dataloader crashes or is extremly slow because num_workers > 0 is not well supported ([Pytorch Issue#12831](https://github.com/pytorch/pytorch/issues/12831)).

I have therefore added the parser arg `--num_dataloader_workers` which by default is set to 1 (same default as before but now possible to configure from the outside). I also added a small sentence to the documentation, warning others about this common pitfall.