### PR TITLE
avoid unnecessary import

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -412,30 +412,29 @@ def get_auto_gptq_quant_linear(gptq_quantization_config):
     """
     Get the right AutoGPTQQuantLinear class based on the quantization config file
     """
-    if is_auto_gptq_available():
+    if gptq_quantization_config is not None and is_auto_gptq_available():
         from auto_gptq.utils.import_utils import dynamically_import_QuantLinear
 
-        if gptq_quantization_config is not None:
-            desc_act = gptq_quantization_config.desc_act
-            group_size = gptq_quantization_config.group_size
-            bits = gptq_quantization_config.bits
-            if hasattr(gptq_quantization_config, "use_exllama"):
-                use_exllama = gptq_quantization_config.use_exllama
-            else:
-                use_exllama = not gptq_quantization_config.disable_exllama
-            if hasattr(gptq_quantization_config, "exllama_config"):
-                exllama_version = gptq_quantization_config.exllama_config["version"]
-            else:
-                exllama_version = 1
-            AutoGPTQQuantLinear = dynamically_import_QuantLinear(
-                use_triton=False,
-                desc_act=desc_act,
-                group_size=group_size,
-                bits=bits,
-                disable_exllama=not (use_exllama and exllama_version == 1),
-                disable_exllamav2=not (use_exllama and exllama_version == 2),
-            )
-            return AutoGPTQQuantLinear
+        desc_act = gptq_quantization_config.desc_act
+        group_size = gptq_quantization_config.group_size
+        bits = gptq_quantization_config.bits
+        if hasattr(gptq_quantization_config, "use_exllama"):
+            use_exllama = gptq_quantization_config.use_exllama
+        else:
+            use_exllama = not gptq_quantization_config.disable_exllama
+        if hasattr(gptq_quantization_config, "exllama_config"):
+            exllama_version = gptq_quantization_config.exllama_config["version"]
+        else:
+            exllama_version = 1
+        AutoGPTQQuantLinear = dynamically_import_QuantLinear(
+            use_triton=False,
+            desc_act=desc_act,
+            group_size=group_size,
+            bits=bits,
+            disable_exllama=not (use_exllama and exllama_version == 1),
+            disable_exllamav2=not (use_exllama and exllama_version == 2),
+        )
+        return AutoGPTQQuantLinear
     return None
 
 


### PR DESCRIPTION
there is no need to import auto_gptq if we're not going to use it. We're seeing issues downstream with the latest auto-gptq if it happens to be installed but not needed.