### PR TITLE
FIX: Adding 2 adapters when target_modules is a str fails

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -547,7 +547,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 self.base_model.add_adapter(adapter_name, peft_config)
             else:
                 self.peft_config[adapter_name] = peft_config
-                self.base_model.inject_adapter(self, adapter_name)
+                self.base_model.inject_adapter(self.base_model.model, adapter_name)
         except Exception:  # somthing went wrong, roll back
             if adapter_name in self.peft_config:
                 del self.peft_config[adapter_name]

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -827,10 +827,6 @@ class PeftCommonTester:
             return
 
         model = self.transformers_class.from_pretrained(model_id)
-        if isinstance(config.target_modules, str):
-            # TODO this should be doable
-            self.skipTest("Multiple adapters cannot currently be added when target_modules is a string.")
-
         adapter_to_delete = "delete_me"
         model = get_peft_model(model, config)
         model.add_adapter(adapter_to_delete, config)
@@ -869,10 +865,6 @@ class PeftCommonTester:
             return
 
         model = self.transformers_class.from_pretrained(model_id)
-        if isinstance(config.target_modules, str):
-            # TODO this should be doable
-            self.skipTest("Multiple adapters cannot currently be added when target_modules is a string.")
-
         adapter_to_delete = "delete_me"
         model = get_peft_model(model, config)
         model.add_adapter(adapter_to_delete, config)


### PR DESCRIPTION
## Problem description

Adding two adapters (e.g. LoRA) when using a list for `target_mdules` works but passing a str fails. The issue is that for str, we do a `re.fullmatch`, whereas for list, we just check `endswith`. After adding the first adapter, though, the naming pattern of the modules changes. In the example above, the name for the linear layer changes from `"lin0"` to `"base_model.model.lin0"`, which is why the `fullmatch` fails but the `endswith` still works.

## Reproduction

```python
from peft import LoraConfig, get_peft_model
from torch import nn

class MLP(nn.Module):
    def __init__(self, bias=True):
        super().__init__()
        self.lin0 = nn.Linear(10, 20, bias=bias)

def test_target_modules_list():
    config = LoraConfig(target_modules=["lin0"])
    test_it(config)
    print("Adding two adapters with target_module being a list works")

def test_target_modules_str():
    config = LoraConfig(target_modules="lin0")
    test_it(config)

def test_it(config):
    model = MLP()
    model = get_peft_model(model, config, "adapter0")
    model.add_adapter("adapter1", config)
    print("Adding two adapters with target_module being a str works")

if __name__ == "__main__":
    # works
    test_target_modules_list()
    # ValueError: Target modules lin0 not found in the base model
    test_target_modules_str()
```

I think that most users would be surprised that:

1. Adding the first adapter works but adding the second fails, even though they use the same config.
2. Using `target_modules=["lin0"]` works but `target_modules="lin0"` fails for the 2nd adapter.

## Solution

We could change the logic of not using `re.fullmatch` for str, but I think that could be tricky to achieve without breaking BC. Instead, I chose to change the inject_adapter call in add_adapter to pass the base model, not the whole peft model. This way, the naming pattern is preserved.

## Tests

Tests were added by removing the guard from #1105. This guard was added because of this bug and was how it was discovered first.