### PR TITLE
Correctly deal with  `ModulesToSaveWrapper` when using Low-level API

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -25,7 +25,7 @@ from torch import nn
 from peft.utils import COMMON_LAYERS_PATTERN
 
 from ..config import PeftConfig
-from ..utils import _get_submodules, ModulesToSaveWrapper
+from ..utils import ModulesToSaveWrapper, _get_submodules
 
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,6 @@ class BaseTuner(nn.Module, ABC):
 
         # Copy the peft_config in the injected model.
         self.model.peft_config = self.peft_config
-
 
     @property
     def active_adapters(self) -> list[str]:

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -19,6 +19,7 @@ import unittest
 import torch
 
 from peft import LoraConfig, get_peft_model_state_dict, inject_adapter_in_model
+from peft.utils import ModulesToSaveWrapper
 
 
 class DummyModel(torch.nn.Module):
@@ -63,3 +64,28 @@ class TestPeft(unittest.TestCase):
 
         for key in peft_state_dict.keys():
             self.assertTrue("lora" in key)
+
+    def test_modules_to_save(self):
+        self.model = DummyModel()
+
+        lora_config = LoraConfig(
+            lora_alpha=16,
+            lora_dropout=0.1,
+            r=64,
+            bias="none",
+            target_modules=["linear"],
+            modules_to_save=["embedding"]
+        )
+
+        self.model = inject_adapter_in_model(lora_config, self.model)
+
+        for name, module in self.model.named_modules():
+            if name == "linear":
+                self.assertTrue(hasattr(module, "lora_A"))
+                self.assertTrue(hasattr(module, "lora_B"))
+            elif name == "embedding":
+                self.assertTrue(isinstance(module, ModulesToSaveWrapper))
+
+        state_dict = get_peft_model_state_dict(self.model)
+
+        self.assertTrue("embedding.weight" in state_dict.keys())

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -74,7 +74,7 @@ class TestPeft(unittest.TestCase):
             r=64,
             bias="none",
             target_modules=["linear"],
-            modules_to_save=["embedding"]
+            modules_to_save=["embedding"],
         )
 
         self.model = inject_adapter_in_model(lora_config, self.model)


### PR DESCRIPTION
# What does this PR do?

Currently when using the low-level API of PEFT, the `modules_to_save` gets silently ignored. The PR addressed that.

cc @BenjaminBossan @pacman100 

Will also test the integration tests and add corresponding tests on transformers once we release a PEFT version with it