### PR TITLE
Fix: TorchTracemalloc ruins Windows performance

### DIFF
--- a/examples/lora_dreambooth/train_dreambooth.py
+++ b/examples/lora_dreambooth/train_dreambooth.py
@@ -219,10 +219,10 @@ def parse_args(input_args=None):
     )
 
     parser.add_argument(
-        "--trace_memory_allocation",
-        default=True,
+        "--no_tracemalloc",
+        default=False,
         action="store_true",
-        help="Flag to track memory allocation during training. This could slow down training on Windows.",
+        help="Flag to stop memory allocation tracing during training. This could speed up training on Windows.",
     )
 
     parser.add_argument(
@@ -905,7 +905,7 @@ def main(args):
         unet.train()
         if args.train_text_encoder:
             text_encoder.train()
-        with TorchTracemalloc() if args.trace_memory_allocation else nullcontext() as tracemalloc:
+        with TorchTracemalloc() if not args.no_tracemalloc else nullcontext() as tracemalloc:
             for step, batch in enumerate(train_dataloader):
                 # Skip steps until we reach the resumed step
                 if args.resume_from_checkpoint and epoch == first_epoch and step < resume_step:
@@ -1047,7 +1047,7 @@ def main(args):
                     break
         # Printing the GPU memory usage details such as allocated memory, peak memory, and total memory usage
 
-        if args.trace_memory_allocation:
+        if not args.no_tracemalloc:
             accelerator.print("GPU Memory before entering the train : {}".format(b2mb(tracemalloc.begin)))
             accelerator.print("GPU Memory consumed at the end of the train (end-begin): {}".format(tracemalloc.used))
             accelerator.print("GPU Peak Memory consumed during the train (max-begin): {}".format(tracemalloc.peaked))

--- a/examples/lora_dreambooth/train_dreambooth.py
+++ b/examples/lora_dreambooth/train_dreambooth.py
@@ -222,7 +222,7 @@ def parse_args(input_args=None):
         "--trace_memory_allocation",
         default=True,
         action="store_true",
-        help="Flag to track memory allocation during training.",
+        help="Flag to track memory allocation during training. This could slow down training on Windows.",
     )
 
     parser.add_argument(

--- a/examples/lora_dreambooth/train_dreambooth.py
+++ b/examples/lora_dreambooth/train_dreambooth.py
@@ -1058,8 +1058,12 @@ def main(args):
             )
 
             accelerator.print("CPU Memory before entering the train : {}".format(b2mb(tracemalloc.cpu_begin)))
-            accelerator.print("CPU Memory consumed at the end of the train (end-begin): {}".format(tracemalloc.cpu_used))
-            accelerator.print("CPU Peak Memory consumed during the train (max-begin): {}".format(tracemalloc.cpu_peaked))
+            accelerator.print(
+                "CPU Memory consumed at the end of the train (end-begin): {}".format(tracemalloc.cpu_used)
+            )
+            accelerator.print(
+                "CPU Peak Memory consumed during the train (max-begin): {}".format(tracemalloc.cpu_peaked)
+            )
             accelerator.print(
                 "CPU Total Peak Memory consumed during the train (max): {}".format(
                     tracemalloc.cpu_peaked + b2mb(tracemalloc.cpu_begin)

--- a/examples/lora_dreambooth/train_dreambooth.py
+++ b/examples/lora_dreambooth/train_dreambooth.py
@@ -7,9 +7,9 @@ import math
 import os
 import threading
 import warnings
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Optional
-from contextlib import nullcontext
 
 import datasets
 import diffusers


### PR DESCRIPTION
`TorchTracemalloc` ruins the Dreambooth training performance on Windows, so that the training barely even runs. I fixed this issue by providing a parser argument `--trace_memory_allocation` that is set to `True` by default but can be turned off for Windows users. This significantly speeds up the training process.