### PR TITLE
DON'T MERGE This is for debugging only

### DIFF
--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -283,6 +283,7 @@ class IA3Model(BaseTuner):
                     warnings.warn("Adapter cannot be set when the model is merged. Unmerging the model first.")
                     module.unmerge()
                 module.set_adapter(adapter_name)
+        self.active_adapter = adapter_name
 
     def _prepare_adapter_config(self, peft_config, model_config):
         if peft_config.target_modules is None:

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -167,6 +167,32 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
             },
         )
     )
+    def test_merge_layers_multi_1(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_merge_layers_multi_1(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(
+        PeftTestConfigManager.get_grid_parameters(
+            {
+                "model_ids": PEFT_DECODER_MODELS_TO_TEST,
+                "lora_kwargs": {"init_lora_weights": [False]},
+                "ia3_kwargs": {"init_ia3_weights": [False]},
+                "task_type": "CAUSAL_LM",
+            },
+        )
+    )
+    def test_merge_layers_multi_2(self, test_name, model_id, config_cls, config_kwargs):
+        self._test_merge_layers_multi_2(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(
+        PeftTestConfigManager.get_grid_parameters(
+            {
+                "model_ids": PEFT_DECODER_MODELS_TO_TEST,
+                "lora_kwargs": {"init_lora_weights": [False]},
+                "ia3_kwargs": {"init_ia3_weights": [False]},
+                "task_type": "CAUSAL_LM",
+            },
+        )
+    )
     def test_merge_layers_nan(self, test_name, model_id, config_cls, config_kwargs):
         self._test_merge_layers_nan(model_id, config_cls, config_kwargs)
 


### PR DESCRIPTION
It appears that for LoRA, merging the first adapter works but merging the second adapter does not work.

@younesbelkada While debugging #1132, I wanted to isolate the error and found that it can already be reproduced on the main branch, without the changes from your PR.

I added two tests, one where the first adapter is merged, one where the second adapter is merged. The first test passes as expected, the second one fails for LoRA (it works for IA³):

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  File                          ┃  Function                                                                                                             ┃  Function Line  ┃  Error Line  ┃  Error                          ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│  tests/test_decoder_models.py  │  PeftDecoderModelTester.test_merge_layers_multi_2_01_test_hf_internal_testing_tiny_random_OPTForCausalLM_lora         │  173            │  620         │  in _test_merge_layers_multi_2  │
│  tests/test_decoder_models.py  │  PeftDecoderModelTester.test_merge_layers_multi_2_07_test_hf_internal_testing_tiny_random_GPTNeoXForCausalLM_lora     │  173            │  620         │  in _test_merge_layers_multi_2  │
│  tests/test_decoder_models.py  │  PeftDecoderModelTester.test_merge_layers_multi_2_13_test_hf_internal_testing_tiny_random_GPT2LMHeadModel_lora        │  173            │  620         │  in _test_merge_layers_multi_2  │
│  tests/test_decoder_models.py  │  PeftDecoderModelTester.test_merge_layers_multi_2_19_test_hf_internal_testing_tiny_random_BloomForCausalLM_lora       │  173            │  620         │  in _test_merge_layers_multi_2  │
│  tests/test_decoder_models.py  │  PeftDecoderModelTester.test_merge_layers_multi_2_25_test_hf_internal_testing_tiny_random_gpt_neo_lora                │  173            │  620         │  in _test_merge_layers_multi_2  │
│  tests/test_decoder_models.py  │  PeftDecoderModelTester.test_merge_layers_multi_2_31_test_hf_internal_testing_tiny_random_GPTJForCausalLM_lora        │  173            │  620         │  in _test_merge_layers_multi_2  │
│  tests/test_decoder_models.py  │  PeftDecoderModelTester.test_merge_layers_multi_2_37_test_hf_internal_testing_tiny_random_GPTBigCodeForCausalLM_lora  │  173            │  620         │  in _test_merge_layers_multi_2  │
│  tests/test_decoder_models.py  │  PeftDecoderModelTester.test_merge_layers_multi_2_43_test_HuggingFaceM4_tiny_random_LlamaForCausalLM_lora             │  173            │  620         │  in _test_merge_layers_multi_2  │
└────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴─────────────────┴──────────────┴─────────────────────────────────┘
```

PS: There is a small bug in IA³ where the active adapter attribute is not set after calling `set_adapter`, but that's not really related to the discussed issue.

**EDIT**: Also tested this with `merge_adapter()` instead of `merge_and_unload`, but that doesn't change the outcome.