### PR TITLE
DOC Update a few places in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ An example is provided in [this notebook](https://github.com/huggingface/peft/bl
 
 ## Models support matrix
 
-Find models that are supported out of the box below. Note that PEFT works with almost all models -- it it is not listed, you just need to [do some manual configuration](https://huggingface.co/docs/peft/developer_guides/custom_models).
+Find models that are supported out of the box below. Note that PEFT works with almost all models -- if it is not listed, you just need to [do some manual configuration](https://huggingface.co/docs/peft/developer_guides/custom_models).
 
 ### Causal Language Modeling
 | Model        | LoRA | Prefix Tuning  | P-Tuning | Prompt Tuning  | IA3 |

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Try out the 🤗 Gradio Space which should run seamlessly on a T4 instance:
 - Here is an example in [trl](https://github.com/lvwerra/trl) library using PEFT+INT8 for tuning policy model: [gpt2-sentiment_peft.py](https://github.com/lvwerra/trl/blob/main/examples/sentiment/scripts/gpt2-sentiment_peft.py) and corresponding [Blog](https://huggingface.co/blog/trl-peft)
 - Example using PEFT for Instruction finetuning, reward model and policy : [stack_llama](https://github.com/lvwerra/trl/tree/main/examples/research_projects/stack_llama/scripts) and corresponding [Blog](https://huggingface.co/blog/stackllama) 
 
-### INT8 training of large models in Colab using PEFT LoRA and bits_and_bytes
+### INT8 training of large models in Colab using PEFT LoRA and bitsandbytes
 
 - Here is now a demo on how to fine tune [OPT-6.7b](https://huggingface.co/facebook/opt-6.7b) (14GB in fp16) in a Google Colab: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1jCkpikz0J2o20FBQmYmAGdiKmJGOMo-o?usp=sharing)
 
@@ -223,10 +223,12 @@ DeepSpeed version required `v0.8.0`. An example is provided in `~examples/condit
   ```
 
 ### Example of PEFT model inference using 🤗 Accelerate's Big Model Inferencing capabilities
-An example is provided in `~examples/causal_language_modeling/peft_lora_clm_accelerate_big_model_inference.ipynb`. 
+An example is provided in [this notebook](https://github.com/huggingface/peft/blob/main/examples/causal_language_modeling/peft_lora_clm_accelerate_big_model_inference.ipynb).
 
 
 ## Models support matrix
+
+Find models that are supported out of the box below. Note that PEFT works with almost all models -- it it is not listed, you just need to [do some manual configuration](https://huggingface.co/docs/peft/developer_guides/custom_models).
 
 ### Causal Language Modeling
 | Model        | LoRA | Prefix Tuning  | P-Tuning | Prompt Tuning  | IA3 |
@@ -239,6 +241,7 @@ An example is provided in `~examples/causal_language_modeling/peft_lora_clm_acce
 | GPT-NeoX-20B | ✅  | ✅  | ✅  | ✅  | ✅  |
 | LLaMA        | ✅  | ✅  | ✅  | ✅  | ✅  |
 | ChatGLM      | ✅  | ✅  | ✅  | ✅  | ✅  |
+| Mistral      | ✅  |    |    |    |    |
 
 ### Conditional Generation
 |   Model         | LoRA | Prefix Tuning  | P-Tuning | Prompt Tuning  | IA3 |
@@ -395,6 +398,8 @@ model = inject_adapter_in_model(lora_config, model)
 dummy_inputs = torch.LongTensor([[0, 1, 2, 3, 4, 5, 6, 7]])
 dummy_outputs = model(dummy_inputs)
 ```
+
+Learn more about the [low level API in the docs](https://huggingface.co/docs/peft/developer_guides/low_level_api).
 
 ## Contributing
 


### PR DESCRIPTION
Resolves #1151

- fix bits_and_bytes => bitsandbytes
- add a few links
- add mistral to list of supported models

A question: What is the criterion for a model to be considered to be "supported" for a given adapter? E.g. "ChatGLM" is listed as having support for all methods, but we only have an entry for it in `TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING`, not in `TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING` etc. So should we really put a ✅ in all those columns? For mistral, I only added a ✅ for LoRA, as that's the only entry for mistral that we have, even though I'm pretty sure we can just use the same settings for other adapters.