### PR TITLE
Fix code example in quicktour.md

### DIFF
--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -92,7 +92,7 @@ Easily load your model for inference using the [`~transformers.PreTrainedModel.f
   from transformers import AutoModelForCausalLM, AutoTokenizer
 + from peft import PeftModel, PeftConfig
 
-+ peft_model_id = "dfurman/Mistral-7B-Instruct-v0.2"
++ peft_model_id = "merve/Mistral-7B-Instruct-v0.2"
 + config = PeftConfig.from_pretrained(peft_model_id)
   model = AutoModelForCausalLM.from_pretrained(config.base_model_name_or_path)
 + model = PeftModel.from_pretrained(model, peft_model_id)

--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -89,23 +89,24 @@ This only saves the incremental 🤗 PEFT weights that were trained, meaning it 
 Easily load your model for inference using the [`~transformers.PreTrainedModel.from_pretrained`] function:
 
 ```diff
-  from transformers import AutoModelForSeq2SeqLM
+  from transformers import AutoModelForCausalLM, AutoTokenizer
 + from peft import PeftModel, PeftConfig
 
-+ peft_model_id = "smangrul/twitter_complaints_bigscience_T0_3B_LORA_SEQ_2_SEQ_LM"
++ peft_model_id = "dfurman/Mistral-7B-Instruct-v0.2"
 + config = PeftConfig.from_pretrained(peft_model_id)
-  model = AutoModelForSeq2SeqLM.from_pretrained(config.base_model_name_or_path)
+  model = AutoModelForCausalLM.from_pretrained(config.base_model_name_or_path)
 + model = PeftModel.from_pretrained(model, peft_model_id)
   tokenizer = AutoTokenizer.from_pretrained(config.base_model_name_or_path)
 
   model = model.to(device)
   model.eval()
-  inputs = tokenizer("Tweet text : @HondaCustSvc Your customer service has been horrible during the recall process. I will never purchase a Honda again. Label :", return_tensors="pt")
+  inputs = tokenizer("Tell me the recipe for chocolate chip cookie", return_tensors="pt")
 
   with torch.no_grad():
       outputs = model.generate(input_ids=inputs["input_ids"].to("cuda"), max_new_tokens=10)
       print(tokenizer.batch_decode(outputs.detach().cpu().numpy(), skip_special_tokens=True)[0])
-  'complaint'
+  'Tell me the recipe for chocolate chip cookie dough.
+  1. Preheat oven'
 ```
 
 ## Easy loading with Auto classes 


### PR DESCRIPTION
Hello 👋 
The model in the code snippet in `quicktour.md` has a key in it's `config` file that's likely either deprecated (breaks backwards compatibility?). 
The code is as follows 👇 
```py
from transformers import AutoModelForSeq2SeqLM
from peft import PeftModel, PeftConfig

peft_model_id = "smangrul/twitter_complaints_bigscience_T0_3B_LORA_SEQ_2_SEQ_LM"
config = PeftConfig.from_pretrained(peft_model_id)
model = AutoModelForSeq2SeqLM.from_pretrained(config.base_model_name_or_path)
model = PeftModel.from_pretrained(model, peft_model_id)
tokenizer = AutoTokenizer.from_pretrained(config.base_model_name_or_path)

model = model.to(device)
model.eval()
inputs = tokenizer("Tweet text : @HondaCustSvc Your customer service has been horrible during the recall process. I will never purchase a Honda again. Label :", return_tensors="pt")

with torch.no_grad():
    outputs = model.generate(input_ids=inputs["input_ids"].to("cuda"), max_new_tokens=10)
    print(tokenizer.batch_decode(outputs.detach().cpu().numpy(), skip_special_tokens=True)[0])
'complaint'
```

The model's config has `enable_lora` key which raises this error and it fails when initializing the `LoraConfig` object. So I changed the code snippet to add a more recent model that doesn't error out (and it's currently trending with good amount of likes too so might be useful).