### PR TITLE
Added lora support for phi

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -507,6 +507,7 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "codegen": ["qkv_proj"],
     "mistral": ["q_proj", "v_proj"],
     "stablelm": ["q_proj", "v_proj"],
+    "phi": ["Wqkv", "out_proj", "fc1", "fc2"],
 }
 
 TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING = {


### PR DESCRIPTION
This pull request adds support for lora training [`microsoft/phi-1_5`](https://huggingface.co/microsoft/phi-1_5) by creating a new target modules mapping for models of the `model_type` `phi`.