### PR TITLE
Updating multi LoRA inference examples notebook to be usable

### DIFF
--- a/examples/multi_adapter_examples/PEFT_Multi_LoRA_Inference.ipynb
+++ b/examples/multi_adapter_examples/PEFT_Multi_LoRA_Inference.ipynb
@@ -1,4 +1,4 @@
-e{
+{
  "cells": [
   {
    "cell_type": "code",

--- a/examples/multi_adapter_examples/PEFT_Multi_LoRA_Inference.ipynb
+++ b/examples/multi_adapter_examples/PEFT_Multi_LoRA_Inference.ipynb
@@ -1,4 +1,4 @@
-{
+e{
  "cells": [
   {
    "cell_type": "code",
@@ -58,7 +58,7 @@
     "from peft import PeftModel\n",
     "from transformers import LlamaTokenizer, LlamaForCausalLM, GenerationConfig\n",
     "\n",
-    "model_name = \"decapoda-research/llama-7b-hf\"\n",
+    "model_name = \"baffo32/decapoda-research-llama-7B-hf\"\n",
     "tokenizer = LlamaTokenizer.from_pretrained(model_name)\n",
     "model = LlamaForCausalLM.from_pretrained(model_name, load_in_8bit=True, device_map=\"auto\", use_auth_token=True)"
    ]


### PR DESCRIPTION
Right now, the base model isn't available.

[Related issue](https://github.com/tloen/alpaca-lora/issues/598) recognizing same thing, using the base model suggested there.