### PR TITLE
Don't set config attribute on custom models

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -87,11 +87,6 @@ class BaseTuner(nn.Module, ABC):
                 self.peft_config.update(peft_config)
 
         self.active_adapter = adapter_name
-
-        # transformers models have a .config attribute, whose presence is assumed later on
-        if not hasattr(self, "config"):
-            self.config = {"model_type": "custom"}
-
         self.inject_adapter(self.model, adapter_name)
 
         # Copy the peft_config in the injected model.

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -180,10 +180,9 @@ class PeftCommonTester:
         dct = yaml.safe_load(metainfo)
         self.assertEqual(dct["library_name"], "peft")
 
-        model_config = model.config if isinstance(model.config, dict) else model.config.to_dict()
-        if model_config["model_type"] != "custom":
-            self.assertEqual(dct["base_model"], model_config["_name_or_path"])
-        else:
+        if hasattr(model, "config"):
+            self.assertEqual(dct["base_model"], model.config.to_dict()["_name_or_path"])
+        else:  # a custom model
             self.assertTrue("base_model" not in dct)
 
     def check_config_json(self, tmp_dirname, model):
@@ -193,9 +192,8 @@ class PeftCommonTester:
         with open(filename, "r", encoding="utf-8") as f:
             config = json.load(f)
 
-        model_config = model.config if isinstance(model.config, dict) else model.config.to_dict()
-        if model_config["model_type"] != "custom":
-            self.assertEqual(config["base_model_name_or_path"], model_config["_name_or_path"])
+        if hasattr(model, "config"):  # custom models don't have a config attribute
+            self.assertEqual(config["base_model_name_or_path"], model.config.to_dict()["_name_or_path"])
 
     def _test_model_attr(self, model_id, config_cls, config_kwargs):
         model = self.transformers_class.from_pretrained(model_id)


### PR DESCRIPTION
## Description

Initially, we had the issue that it was sometimes assumed that models had a `config` attribute, as is given for transformers models. This made PEFT fail with custom models, so we made a change to set a dummy config on those.

However, this can lead to issues down the line. For example, when users use the `Trainer` class from transformers, they can stumble upon lines like this:

https://github.com/huggingface/transformers/blob/62ab32b2997846526cdffd629c72c47bc7b4f215/src/transformers/integrations/integration_utils.py#L636-L637

https://github.com/huggingface/transformers/blob/62ab32b2997846526cdffd629c72c47bc7b4f215/src/transformers/integrations/integration_utils.py#L729-L730

Here transformers assumes that if `config` attribute exists on the model, it must have a `to_json_string` method or a `to_dict` method (as it assumes the config to be a `PretrainedConfig` instance). Therefore, in order not to trip up transformers, it is best not to set any config at all.

## Note

I _think_ this should be fully backwards compatible, as the `config` attribute should not affect checkpoints. LMK if I'm missing something.

## Other solutions

1. Alternatively, transformers could be changed to check each time when the config attributes exists, if it is a `PretrainedConfig` instance, but that would be a much larger change (albeit a cleaner one).
2. Instead of creating a `dict` type `config` on custom models, we could create a `PretrainedConfig`. This would probably require setting a couple of fields correctly, as the config should not be empty.