### PR TITLE
Bump version to 0.7.1.dev0 post release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.7.0"
+VERSION = "0.7.1.dev0"
 
 extras = {}
 extras["quality"] = ["black ~= 22.0", "ruff>=0.0.241", "urllib3<=2.0.0"]
@@ -84,7 +84,7 @@ setup(
 # 6. Upload the package to the pypi test server first:
 #      twine upload dist/* -r pypitest
 # 7. Check that you can install it in a virtualenv by running:
-#      pip install -i https://testpypi.python.org/pypi peft
+#      pip install -i https://testpypi.python.org/pypi --extra-index-url https://pypi.org/simple peft
 # 8. Upload the final version to actual pypi:
 #      twine upload dist/* -r pypi
 # 9. Add release notes to the tag on https://github.com/huggingface/peft/releases once everything is looking hunky-dory.

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0"
+__version__ = "0.7.1.dev0"
 
 from .auto import (
     AutoPeftModel,


### PR DESCRIPTION
Also updated the release instruction for installing from pypi, as the previous command seems to be causing trouble recently (see internal discussion).