### PR TITLE
FIX: Pin bitsandbytes to <0.41.3 temporarily

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -37,8 +37,9 @@ ENV PATH /opt/conda/bin:$PATH
 
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
+# TODO: unpin bitsandbytes when error is solved
 RUN source activate peft && \ 
-    python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq
+    python3 -m pip install --no-cache-dir "bitsandbytes<0.41.3" optimum auto-gptq
 
 # Install apt libs
 RUN apt-get update && \


### PR DESCRIPTION
Some tests are failing with bitsandbytes 0.41.3:

`python -m pytest -m single_gpu_tests tests/test_common_gpu.py -k test_4bit_merge`

(https://github.com/huggingface/peft/actions/runs/7122876428/job/19394584017)

For the time being, use the next smaller version.