### PR TITLE
Fix ModulesToSaveWrapper __getattr__

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -186,6 +186,14 @@ class ModulesToSaveWrapper(torch.nn.Module):
         # use a property to ensure that active_adapter is not set directly, instead use the set_adapter method
         return self._active_adapter
 
+    def __getattr__(self, name: str):
+        try:
+            return super(ModulesToSaveWrapper, self).__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            if self.active_adapter not in self.modules_to_save:
+                return getattr(self.original_module, name)
+            return getattr(self.modules_to_save[self.active_adapter], name)
+
     def update(self, adapter_name):
         self.modules_to_save.update(torch.nn.ModuleDict({adapter_name: copy.deepcopy(self.original_module)}))
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -186,13 +186,11 @@ class ModulesToSaveWrapper(torch.nn.Module):
         # use a property to ensure that active_adapter is not set directly, instead use the set_adapter method
         return self._active_adapter
 
-    def __getattr__(self, name: str):
-        try:
-            return super(ModulesToSaveWrapper, self).__getattr__(name)  # defer to nn.Module's logic
-        except AttributeError:
-            if self.active_adapter not in self.modules_to_save:
-                return getattr(self.original_module, name)
-            return getattr(self.modules_to_save[self.active_adapter], name)
+    @property
+    def weight(self):
+        if self.active_adapter not in self.modules_to_save:
+            return self.original_module.weight
+        return self.modules_to_save[self.active_adapter].weight
 
     def update(self, adapter_name):
         self.modules_to_save.update(torch.nn.ModuleDict({adapter_name: copy.deepcopy(self.original_module)}))

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -89,3 +89,5 @@ class TestPeft(unittest.TestCase):
         state_dict = get_peft_model_state_dict(self.model)
 
         self.assertTrue("embedding.weight" in state_dict.keys())
+
+        self.assertTrue(hasattr(self.model.embedding, "weight"))


### PR DESCRIPTION
https://github.com/huggingface/peft/issues/1225

We are recently using peft=0.4.0+Megatron to run GPTModel. There is a code of the model [`self.language_model.output_layer.weight`](https://github.com/NVIDIA/Megatron-LM/blob/bcce6f54e075e3c3374ea67adefe54f3f2da2b07/megatron/model/gpt_model.py#L94), which directly takes the `weight` of the `output_layer`, but the `output_layer` has already been `modules_to_save`, so it reported "ModulesToSaveWrapper has no 'weight' attribute" error.

So, I returns the weight of the currently active adapter or of the original module of the adapter is deactivated. 

And `__getattr__` will be called only when its own class does not have this attribute, so this should not destroy the original scene.