### PR TITLE
TST: Add tolerance for regression tests

### DIFF
--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -192,7 +192,7 @@ class RegressionTester(unittest.TestCase):
     torch_device = infer_device()
 
     def setUp(self):
-        self.tol = 1e-5
+        self.tol = 1e-4
         self.creation_mode = strtobool(os.environ.get("REGRESSION_CREATION_MODE", "False"))
         self.force_mode = strtobool(os.environ.get("REGRESSION_FORCE_MODE", "False"))
         if self.force_mode and not self.creation_mode:

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -192,6 +192,7 @@ class RegressionTester(unittest.TestCase):
     torch_device = infer_device()
 
     def setUp(self):
+        self.tol = 1e-5
         self.creation_mode = strtobool(os.environ.get("REGRESSION_CREATION_MODE", "False"))
         self.force_mode = strtobool(os.environ.get("REGRESSION_FORCE_MODE", "False"))
         if self.force_mode and not self.creation_mode:
@@ -248,7 +249,7 @@ class RegressionTester(unittest.TestCase):
             base_model = self.load_base_model()
             model = PeftModel.from_pretrained(base_model, os.path.join(path, version))
             output = self.get_output(model)
-            self.assertTrue(torch.allclose(output_loaded, output))
+            self.assertTrue(torch.allclose(output_loaded, output, atol=self.tol, rtol=self.tol))
 
     def get_output(self, model):
         raise NotImplementedError


### PR DESCRIPTION
Tests currently call `torch.allclose` without any tolerance, which is probably the cause of the CI failure. Now, tolerance is set to 1e-4. When testing on another machine, the tests now pass for me.

[Failing tests](https://github.com/huggingface/peft/actions/runs/7136508584/job/19435046711).