### PR TITLE
Revert "FIX Pin bitsandbytes to <0.41.3 temporarily (#1234)"

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -37,9 +37,8 @@ ENV PATH /opt/conda/bin:$PATH
 
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
-# TODO: unpin bitsandbytes when error is solved
 RUN source activate peft && \ 
-    python3 -m pip install --no-cache-dir "bitsandbytes<0.41.3" optimum auto-gptq
+    python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq
 
 # Install apt libs
 RUN apt-get update && \


### PR DESCRIPTION
This reverts commit 86562eec49bede2f4525be343f642af8fb46ddbc.

[`bitsandbytes==0.41.3.post1`](https://pypi.org/project/bitsandbytes/0.41.3.post1/) is now released with the reversal of the contribution that caused the issue with the integration tests. The tests are passing again with this release.