### PR TITLE
Issue with transformers 4.36

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1141,13 +1141,13 @@ class PeftModelForCausalLM(PeftModel):
 
         # https://github.com/huggingface/transformers/pull/26681/ introduced new cache format
         # for some architectures which requires a special fix for prompt tuning etc.
-        uses_transformers_4_26 = packaging.version.parse(transformers.__version__) >= packaging.version.parse("4.36.0")
+        uses_transformers_4_36 = packaging.version.parse(transformers.__version__) >= packaging.version.parse("4.36.0")
         transformers_new_cache_archs = ["llama", "mistral", "persimmon", "phi"]
         uses_cache = self.base_model.config.model_type in transformers_new_cache_archs
 
         if peft_config.is_prompt_learning:
             if model_kwargs.get("attention_mask", None) is not None:
-                if uses_transformers_4_26 and uses_cache and (model_kwargs["past_key_values"] is not None):
+                if uses_transformers_4_36 and uses_cache and (model_kwargs["past_key_values"] is not None):
                     # TODO figure out why this workaround is necessary, see #1252 for context
                     size = model_kwargs["input_ids"].shape[0], model_kwargs["past_key_values"][0][0].shape[-2]
                 else:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -23,7 +23,9 @@ from contextlib import contextmanager
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Union
 
+import packaging.version
 import torch
+import transformers
 from accelerate import dispatch_model, infer_auto_device_map
 from accelerate.hooks import AlignDevicesHook, add_hook_to_module, remove_hook_from_submodules
 from accelerate.utils import get_balanced_memory
@@ -1138,9 +1140,15 @@ class PeftModelForCausalLM(PeftModel):
         model_kwargs = self.base_model_prepare_inputs_for_generation(*args, **kwargs)
         if peft_config.is_prompt_learning:
             if model_kwargs.get("attention_mask", None) is not None:
-                prefix_attention_mask = torch.ones(
-                    model_kwargs["input_ids"].shape[0], peft_config.num_virtual_tokens
-                ).to(model_kwargs["input_ids"].device)
+                if packaging.version.parse(transformers.__version__) < packaging.version.parse("4.36.0"):
+                    # TODO figure out why this workaround is necessary, see #1252 for context
+                    size = model_kwargs["input_ids"].shape[0], peft_config.num_virtual_tokens
+                elif model_kwargs["past_key_values"] is None:
+                    size = model_kwargs["input_ids"].shape[0], peft_config.num_virtual_tokens
+                else:
+                    size = model_kwargs["input_ids"].shape[0], model_kwargs["past_key_values"][0][0].shape[-2]
+
+                prefix_attention_mask = torch.ones(size).to(model_kwargs["input_ids"].device)
                 model_kwargs["attention_mask"] = torch.cat(
                     (prefix_attention_mask, model_kwargs["attention_mask"]), dim=1
                 )

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1141,6 +1141,7 @@ class PeftModelForCausalLM(PeftModel):
 
         # https://github.com/huggingface/transformers/pull/26681/ introduced new cache format
         # for some architectures which requires a special fix for prompt tuning etc.
+        # TODO: starting with transformers 4.37, all architectures should support caching.
         uses_transformers_4_36 = packaging.version.parse(transformers.__version__) >= packaging.version.parse("4.36.0")
         transformers_new_cache_archs = ["llama", "mistral", "persimmon", "phi"]
         uses_cache = self.base_model.config.model_type in transformers_new_cache_archs

--- a/src/peft/tuners/adaption_prompt/utils.py
+++ b/src/peft/tuners/adaption_prompt/utils.py
@@ -73,7 +73,12 @@ def llama_compute_query_states(model: nn.Module, **kwargs) -> torch.Tensor:
 
     seq_len = q_len
     if past_key_value is not None:
-        seq_len += past_key_value[0].shape[-2]
+        if isinstance(past_key_value, tuple):
+            # for transformers <= 4.35
+            seq_len += past_key_value[0].shape[-2]
+        else:
+            # since transformers 4.36, this is a DynamicCache instance
+            seq_len += past_key_value.get_seq_length(model.layer_idx)
     cos, sin = model.rotary_emb(value_states, seq_len=seq_len)
 
     return llama_apply_rotary_pos_emb(query_states, cos, sin, position_ids)

--- a/tests/test_adaption_prompt.py
+++ b/tests/test_adaption_prompt.py
@@ -15,7 +15,6 @@
 
 import importlib
 import os
-import platform
 import tempfile
 import unittest
 from unittest import TestCase
@@ -388,10 +387,7 @@ class AdaptionPromptTester(TestCase, PeftCommonTester):
 
     def test_use_cache(self) -> None:
         """Test that AdaptionPrompt works when Llama config use_cache=True."""
-        if platform.system() == "Darwin":
-            # TODO: check why this is, may have started with transformers 4.36.0
-            self.skipTest("This test is flaky on macOS.")
-
+        torch.manual_seed(0)
         input_ids = torch.LongTensor([[1, 1, 1], [2, 1, 2]]).to(self.torch_device)
         original = LlamaForCausalLM(
             LlamaConfig(
@@ -402,7 +398,7 @@ class AdaptionPromptTester(TestCase, PeftCommonTester):
                 num_attention_heads=4,
                 use_cache=False,
             )
-        )
+        ).eval()
         adapted = get_peft_model(
             original, AdaptionPromptConfig(adapter_layers=2, adapter_len=4, task_type="CAUSAL_LM")
         )

--- a/tests/test_adaption_prompt.py
+++ b/tests/test_adaption_prompt.py
@@ -15,6 +15,7 @@
 
 import importlib
 import os
+import platform
 import tempfile
 import unittest
 from unittest import TestCase
@@ -387,6 +388,10 @@ class AdaptionPromptTester(TestCase, PeftCommonTester):
 
     def test_use_cache(self) -> None:
         """Test that AdaptionPrompt works when Llama config use_cache=True."""
+        if platform.system() == "Darwin":
+            # TODO: check why this is, may have started with transformers 4.36.0
+            self.skipTest("This test is flaky on macOS.")
+
         input_ids = torch.LongTensor([[1, 1, 1], [2, 1, 2]]).to(self.torch_device)
         original = LlamaForCausalLM(
             LlamaConfig(

--- a/tests/test_multitask_prompt_tuning.py
+++ b/tests/test_multitask_prompt_tuning.py
@@ -15,6 +15,7 @@
 
 import importlib
 import os
+import platform
 import tempfile
 from unittest import TestCase
 
@@ -220,6 +221,10 @@ class MultiTaskPromptTuningTester(TestCase, PeftCommonTester):
 
     def test_use_cache(self) -> None:
         """Test that MultiTaskPromptTuning works when Llama config use_cache=True."""
+        if platform.system() == "Darwin":
+            # TODO: check why this is, may have started with transformers 4.36.0
+            self.skipTest("This test is flaky on macOS.")
+
         input_ids = torch.LongTensor([[1, 1, 1], [2, 1, 2]]).to(self.torch_device)
         task_ids = torch.LongTensor([1, 2]).to(self.torch_device)
 

--- a/tests/test_multitask_prompt_tuning.py
+++ b/tests/test_multitask_prompt_tuning.py
@@ -15,7 +15,6 @@
 
 import importlib
 import os
-import platform
 import tempfile
 from unittest import TestCase
 
@@ -221,14 +220,11 @@ class MultiTaskPromptTuningTester(TestCase, PeftCommonTester):
 
     def test_use_cache(self) -> None:
         """Test that MultiTaskPromptTuning works when Llama config use_cache=True."""
-        if platform.system() == "Darwin":
-            # TODO: check why this is, may have started with transformers 4.36.0
-            self.skipTest("This test is flaky on macOS.")
-
+        torch.manual_seed(0)
         input_ids = torch.LongTensor([[1, 1, 1], [2, 1, 2]]).to(self.torch_device)
         task_ids = torch.LongTensor([1, 2]).to(self.torch_device)
 
-        original = LlamaForCausalLM(self._create_test_llama_config())
+        original = LlamaForCausalLM(self._create_test_llama_config()).eval()
         mpt = get_peft_model(original, self._create_multitask_prompt_tuning_config())
         mpt = mpt.to(self.torch_device)
 


### PR DESCRIPTION
It seems that transformers==4.36 breaks some of our tests. Locally, they pass with 4.35 but fail with 4.36.

One offending line is this:

https://github.com/huggingface/peft/blob/b08e6faf2b23a52e6853b59e9cf9e5663474da7f/src/peft/tuners/adaption_prompt/utils.py#L76

It seems that `past_key_values` used to be a tuple of tensors, now it is a [`DynamicCache`](https://github.com/huggingface/transformers/pull/26681), whose `__getitem__` returns a tuple of tensors. How can we rewrite the PEFT code in a backwards compatible fashion (i.e. it should also work with older transformers versions)?

Another error is [this](https://github.com/huggingface/peft/actions/runs/7168973578/job/19518392410#step:5:387):

```
        if causal_4d_mask is not None:
>           expanded_attn_mask = causal_4d_mask.masked_fill(expanded_attn_mask.bool(), torch.finfo(dtype).min)
E           RuntimeError: The size of tensor a (14) must match the size of tensor b (17) at non-singleton dimension 3
```

If there is no easy fix, LMK and we'll have to pin the transformers version for now.

ping @tomaarsen @younesbelkada 