### PR TITLE
TST: Revert device_map for AdaLora 4bit GPU test

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -322,11 +322,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         """
         model_id = "facebook/opt-350m"
 
-        model = AutoModelForCausalLM.from_pretrained(
-            model_id,
-            load_in_4bit=True,
-            device_map={"": "cuda:0"},  # fix for >3 GPUs
-        )
+        # for >3 GPUs, might need: device_map={"": "cuda:0"}
+        model = AutoModelForCausalLM.from_pretrained(model_id, load_in_4bit=True)
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         model.gradient_checkpointing_enable()


### PR DESCRIPTION
This was recently added in #1242 but fails on CI with single GPU.

Refer to internal discussion.