### PR TITLE
Refactor and a couple of fixes for adapter layer updates

### DIFF
--- a/src/peft/tuners/adalora/layer.py
+++ b/src/peft/tuners/adalora/layer.py
@@ -37,6 +37,9 @@ class AdaLoraLayer(LoraLayer):
         self.ranknum = nn.ParameterDict({})
 
     def update_layer(self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights):
+        if r <= 0:
+            raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
+
         self.r[adapter_name] = r
         self.lora_alpha[adapter_name] = lora_alpha
         if lora_dropout > 0.0:

--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -53,6 +53,7 @@ class IA3Layer(BaseTunerLayer):
         self.out_features = out_features
 
     def update_layer(self, adapter_name, init_ia3_weights):
+        # This code works for linear layers, override for other layer types
         # Actual trainable parameters
         if self.is_feedforward:
             weight = torch.randn((1, self.in_features))
@@ -88,18 +89,6 @@ class Linear(nn.Module, IA3Layer):
         self.is_target_conv_1d_layer = is_target_conv_1d_layer
         self._active_adapter = adapter_name
         self.update_layer(adapter_name, init_ia3_weights)
-
-    def update_layer(self, adapter_name, init_ia3_weights):
-        # Actual trainable parameters
-        if self.is_feedforward:
-            weight = torch.randn((1, self.in_features))
-        else:
-            weight = torch.randn((self.out_features, 1))
-        self.ia3_l[adapter_name] = nn.Parameter(weight)
-        if init_ia3_weights:
-            self.reset_ia3_parameters(adapter_name)
-        self.to(self.get_base_layer().weight.device)
-        self.set_adapter(self.active_adapters)
 
     def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
         """

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -177,12 +177,7 @@ class IA3Model(BaseTuner):
             "is_feedforward": is_feedforward,
         }
 
-        if isinstance(target, Conv2d):
-            target.update_layer(
-                adapter_name,
-                ia3_config.init_ia3_weights,
-            )
-        elif isinstance(target, Linear):
+        if isinstance(target, IA3Layer):
             target.update_layer(
                 adapter_name,
                 ia3_config.init_ia3_weights,

--- a/src/peft/tuners/loha/layer.py
+++ b/src/peft/tuners/loha/layer.py
@@ -114,6 +114,8 @@ class LoHaLayer(nn.Module, LycorisLayer):
             use_effective_conv2d (`bool`, *optional*, defaults to `False`):
                 Use parameter effective decomposition for Conv2d with ksize > 1.
         """
+        if r <= 0:
+            raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
 
         self.r[adapter_name] = r
         self.alpha[adapter_name] = alpha

--- a/src/peft/tuners/lokr/layer.py
+++ b/src/peft/tuners/lokr/layer.py
@@ -153,6 +153,8 @@ class LoKrLayer(nn.Module, LycorisLayer):
             decompose_both (`bool`): Perform rank decomposition of left kronecker product matrix.
             decompose_factor (`int`): Kronecker product decomposition factor.
         """
+        if r <= 0:
+            raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
 
         self.r[adapter_name] = r
         self.alpha[adapter_name] = alpha

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -64,9 +64,9 @@ class QuantLinear(torch.nn.Module, LoraLayer):
             result += output
         return result
 
-        def __repr__(self) -> str:
-            rep = super().__repr__()
-            return "lora." + rep
+    def __repr__(self) -> str:
+        rep = super().__repr__()
+        return "lora." + rep
 
     # TODO: Check if it is better as suggested by users https://github.com/PanQiWei/AutoGPTQ/pull/102
     # def reset_lora_parameters(self, adapter_name):

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -75,6 +75,7 @@ class LoraLayer(BaseTunerLayer):
         # This code works for linear layers, override for other layer types
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
+
         self.r[adapter_name] = r
         self.lora_alpha[adapter_name] = lora_alpha
         if lora_dropout > 0.0:
@@ -84,10 +85,9 @@ class LoraLayer(BaseTunerLayer):
 
         self.lora_dropout.update(nn.ModuleDict({adapter_name: lora_dropout_layer}))
         # Actual trainable parameters
-        if r > 0:
-            self.lora_A[adapter_name] = nn.Linear(self.in_features, r, bias=False)
-            self.lora_B[adapter_name] = nn.Linear(r, self.out_features, bias=False)
-            self.scaling[adapter_name] = lora_alpha / r
+        self.lora_A[adapter_name] = nn.Linear(self.in_features, r, bias=False)
+        self.lora_B[adapter_name] = nn.Linear(r, self.out_features, bias=False)
+        self.scaling[adapter_name] = lora_alpha / r
 
         if init_lora_weights == "loftq":
             self.loftq_init(adapter_name)
@@ -339,6 +339,7 @@ class Embedding(nn.Module, LoraLayer):
     def update_layer(self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights):
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
+
         self.r[adapter_name] = r
         self.lora_alpha[adapter_name] = lora_alpha
         if lora_dropout > 0.0:
@@ -348,12 +349,11 @@ class Embedding(nn.Module, LoraLayer):
 
         self.lora_dropout[adapter_name] = lora_dropout_layer
         # Actual trainable parameters
-        if r > 0:
-            weight_A = torch.randn((r, self.in_features))
-            weight_B = torch.randn((self.out_features, r))
-            self.lora_embedding_A[adapter_name] = nn.Parameter(weight_A)
-            self.lora_embedding_B[adapter_name] = nn.Parameter(weight_B)
-            self.scaling[adapter_name] = lora_alpha / r
+        weight_A = torch.randn((r, self.in_features))
+        weight_B = torch.randn((self.out_features, r))
+        self.lora_embedding_A[adapter_name] = nn.Parameter(weight_A)
+        self.lora_embedding_B[adapter_name] = nn.Parameter(weight_B)
+        self.scaling[adapter_name] = lora_alpha / r
 
         if init_lora_weights == "loftq":
             self.loftq_init(adapter_name)
@@ -513,6 +513,7 @@ class Conv2d(nn.Module, LoraLayer):
     def update_layer(self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights):
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
+
         self.r[adapter_name] = r
         self.lora_alpha[adapter_name] = lora_alpha
         if lora_dropout > 0.0:
@@ -523,13 +524,12 @@ class Conv2d(nn.Module, LoraLayer):
         self.lora_dropout[adapter_name] = lora_dropout_layer
         # Actual trainable parameters
         base_layer = self.get_base_layer()
-        if r > 0:
-            kernel_size = base_layer.kernel_size
-            stride = base_layer.stride
-            padding = base_layer.padding
-            self.lora_A[adapter_name] = nn.Conv2d(self.in_features, r, kernel_size, stride, padding, bias=False)
-            self.lora_B[adapter_name] = nn.Conv2d(r, self.out_features, (1, 1), (1, 1), bias=False)
-            self.scaling[adapter_name] = lora_alpha / r
+        kernel_size = base_layer.kernel_size
+        stride = base_layer.stride
+        padding = base_layer.padding
+        self.lora_A[adapter_name] = nn.Conv2d(self.in_features, r, kernel_size, stride, padding, bias=False)
+        self.lora_B[adapter_name] = nn.Conv2d(r, self.out_features, (1, 1), (1, 1), bias=False)
+        self.scaling[adapter_name] = lora_alpha / r
 
         if init_lora_weights == "loftq":
             self.loftq_init(adapter_name)

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -94,13 +94,17 @@ class LoraLayer(BaseTunerLayer):
         elif init_lora_weights:
             self.reset_lora_parameters(adapter_name, init_lora_weights)
 
-        weight = getattr(self.get_base_layer(), "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                self.to(weight.device, dtype=weight.dtype)
-            else:
-                self.to(weight.device)
+        # check weight and qweight (for GPTQ)
+        for weight_name in ("weight", "qweight"):
+            weight = getattr(self.get_base_layer(), weight_name, None)
+            if weight is not None:
+                # the layer is already completely initialized, this is an update
+                if weight.dtype.is_floating_point or weight.dtype.is_complex:
+                    self.to(weight.device, dtype=weight.dtype)
+                else:
+                    self.to(weight.device)
+                break
+
         self.set_adapter(self.active_adapters)
 
     def reset_lora_parameters(self, adapter_name, init_lora_weights):

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -163,34 +163,7 @@ class LoraModel(BaseTuner):
         if quantization_config is not None:
             kwargs["gptq_quantization_config"] = quantization_config
 
-        linear_types = (Linear,)
-        if is_bnb_available():
-            from .bnb import Linear8bitLt
-
-            linear_types += (Linear8bitLt,)
-        if is_bnb_4bit_available():
-            from .bnb import Linear4bit
-
-            linear_types += (Linear4bit,)
-
-        # TODO: better deal with that
-        if isinstance(target, Conv2d):
-            target.update_layer_conv2d(
-                adapter_name,
-                r,
-                alpha,
-                lora_config.lora_dropout,
-                lora_config.init_lora_weights,
-            )
-        elif isinstance(target, Embedding):
-            target.update_layer_embedding(
-                adapter_name,
-                r,
-                alpha,
-                lora_config.lora_dropout,
-                lora_config.init_lora_weights,
-            )
-        elif isinstance(target, linear_types):
+        if isinstance(target, LoraLayer):
             target.update_layer(
                 adapter_name,
                 r,

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -141,6 +141,7 @@ class LoraModel(BaseTuner):
     ):
         if current_key is None:
             raise ValueError("Current Key shouldn't be `None`")
+
         # Regexp matching - Find key which matches current target_name in patterns provided
         pattern_keys = list(chain(lora_config.rank_pattern.keys(), lora_config.alpha_pattern.keys()))
         target_name_key = next(filter(lambda key: re.match(f".*\.{key}$", current_key), pattern_keys), current_key)
@@ -163,7 +164,10 @@ class LoraModel(BaseTuner):
         if quantization_config is not None:
             kwargs["gptq_quantization_config"] = quantization_config
 
-        if isinstance(target, LoraLayer):
+        # note: AdaLoraLayer is a subclass of LoraLayer, we need to exclude it
+        from peft.tuners.adalora import AdaLoraLayer
+
+        if isinstance(target, LoraLayer) and not isinstance(target, AdaLoraLayer):
             target.update_layer(
                 adapter_name,
                 r,

--- a/src/peft/tuners/oft/layer.py
+++ b/src/peft/tuners/oft/layer.py
@@ -77,6 +77,8 @@ class OFTLayer(nn.Module, LycorisLayer):
                 The control strength of COFT. The freedom of rotation. Only has an effect if `coft` is set to True.
             block_share (`bool`): Whether to share the OFT parameters between blocks or not.
         """
+        if r <= 0:
+            raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
 
         self.r[adapter_name] = r
         self.module_dropout[adapter_name] = module_dropout

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -211,6 +211,10 @@ class PeftGPUCommonTests(unittest.TestCase):
         model.set_adapter("adapter2")
         model.generate(input_ids=torch.LongTensor([[0, 2, 3, 1]]).to(0))
 
+        # check that both adapters are in the same layer
+        self.assertIn("default", model.base_model.model.model.decoder.layers[0].self_attn.q_proj.lora_A)
+        self.assertIn("adapter2", model.base_model.model.model.decoder.layers[0].self_attn.q_proj.lora_A)
+
     @require_bitsandbytes
     @pytest.mark.multi_gpu_tests
     @pytest.mark.single_gpu_tests
@@ -243,6 +247,10 @@ class PeftGPUCommonTests(unittest.TestCase):
             model.load_adapter(tmp_dir, "adapter2")
             model.set_adapter("adapter2")
             model.generate(input_ids=torch.LongTensor([[0, 2, 3, 1]]).to(0))
+
+            # check that both adapters are in the same layer
+            self.assertIn("default", model.base_model.model.model.decoder.layers[0].self_attn.q_proj.lora_A)
+            self.assertIn("adapter2", model.base_model.model.model.decoder.layers[0].self_attn.q_proj.lora_A)
 
     @require_bitsandbytes
     @pytest.mark.multi_gpu_tests
@@ -277,6 +285,10 @@ class PeftGPUCommonTests(unittest.TestCase):
             model.set_adapter("adapter2")
             model.generate(input_ids=torch.LongTensor([[0, 2, 3, 1]]).to(0))
 
+            # check that both adapters are in the same layer
+            self.assertIn("default", model.base_model.model.model.decoder.layers[0].self_attn.q_proj.ia3_l)
+            self.assertIn("adapter2", model.base_model.model.model.decoder.layers[0].self_attn.q_proj.ia3_l)
+
     @pytest.mark.single_gpu_tests
     def test_lora_gptq_quantization_from_pretrained_safetensors(self):
         r"""
@@ -310,6 +322,10 @@ class PeftGPUCommonTests(unittest.TestCase):
             model.load_adapter(tmp_dir, "adapter2")
             model.set_adapter("adapter2")
             model.generate(input_ids=torch.LongTensor([[0, 2, 3, 1]]).to(0))
+
+            # check that both adapters are in the same layer
+            self.assertIn("default", model.base_model.model.model.decoder.layers[0].self_attn.q_proj.lora_A)
+            self.assertIn("adapter2", model.base_model.model.model.decoder.layers[0].self_attn.q_proj.lora_A)
 
     @require_bitsandbytes
     @pytest.mark.multi_gpu_tests


### PR DESCRIPTION
This started as a simple refactor, but during this, I discovered a few issues too, which should now be fixed. This is probably best reviewed by checking each commit separately.

Here are the descriptions for the individual changes:

## 1. Refactor: Move LoRA `update_layer` to child classes 

For LoRA, so far, we have `update_layer` for `Linear`, `update_layer_embedding` for `Embedding`, and `update_layer_conv2d` for Conv2d, all defined on `LoraLayer`.

We can simplify the code by always using the name `update_layer`, and by moving the layer-specific methods to the subclasses. So e.g. `update_layer_embedding` is moved to the `Embedding` class and renamed to `update_layer`. This way, the caller does not need to differentiate which type of layer it's calling, making it much easier (see the simplification in `LoraModel._create_and_replace`). It also makes the code less error prone (see change 4 described below).

Interestingly, this was already practiced for IA³, so the same change was not necessary there. But I did find the same method implemented twice, once on `IA3Layer` and once on `Linear`, so I removed one of the duplicates. For all other adapter methods, no change was required, as they only implement `Linear`.

*Note: This could technically be backwards incompatible if users do some custom stuff with `LoraLayer`s. I could add a note for next release that all `update_layer_*` methods have been consolidated to use the same `update_layer` name.*

## 2. Systematic handling of `r` (rank) <= 0 

Always raise an error when `r <= 0`, not only for LoRA. Also, removed later check for `r > 0` in LoRA layers, since we already check for `r <= 0`.

*Note: This could technically also be considered backwards incompatible, but `r<=0` should not work correctly anyway, so better to raise an error right away.*

## 3. Fix broken `__repr__` method on `QuantLinear` 

Was indented too deep, thus not being applied.

## 4. Fix bug for updating Lora GPTQ and IA3 bnb layers 

Before this fix, when adding a 2nd adapter to a model, we did not correctly check if there was already an adapter layer in the model when dealing with LoRA GPTQ or IA3 bnb layers. As a consequence, instead of updating the existing layers, we would create a new layer and the existing layer would be set as the `base_layer` of that new layer. Now, we correctly update the existing layer to add the new adapter.

For this fix to work correctly with LoRA and GPTQ, I had to add a check for `qweight` in `update_layer`, since we only checked for `weight` before. This was a mistake that didn't surface so far because of the error described in the previous paragraph.

Tests were extended to check this. They fail with the current main but pass on my machine with this PR.