### PR TITLE
Experiment fast lora train

### DIFF
--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -20,6 +20,7 @@ import bitsandbytes as bnb
 import torch
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
+from peft.tuners.tuners_utils import BaseTunerLayer
 from peft.utils.other import transpose
 
 from .layer import LoraLayer
@@ -319,3 +320,50 @@ if is_bnb_4bit_available():
         def __repr__(self) -> str:
             rep = super().__repr__()
             return "lora." + rep
+
+
+def dispatch_bnb_8bit(target: torch.nn.Module, adapter_name: str, **kwargs):
+    new_module = None
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    loaded_in_8bit = kwargs.get("loaded_in_8bit", False)
+    if loaded_in_8bit and isinstance(target_base_layer, bnb.nn.Linear8bitLt):
+        eightbit_kwargs = kwargs.copy()
+        eightbit_kwargs.update(
+            {
+                "has_fp16_weights": target.state.has_fp16_weights,
+                "memory_efficient_backward": target.state.memory_efficient_backward,
+                "threshold": target.state.threshold,
+                "index": target.index,
+            }
+        )
+        new_module = Linear8bitLt(target, adapter_name, **eightbit_kwargs)
+
+    return new_module
+
+
+def dispatch_bnb_4bit(target: torch.nn.Module, adapter_name: str, **kwargs):
+    new_module = None
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    loaded_in_4bit = kwargs.get("loaded_in_4bit", False)
+    if loaded_in_4bit and is_bnb_4bit_available() and isinstance(target_base_layer, bnb.nn.Linear4bit):
+        fourbit_kwargs = kwargs.copy()
+        fourbit_kwargs.update(
+            {
+                "compute_dtype": target_base_layer.compute_dtype,
+                "compress_statistics": target_base_layer.weight.compress_statistics,
+                "quant_type": target_base_layer.weight.quant_type,
+            }
+        )
+        new_module = Linear4bit(target, adapter_name, **fourbit_kwargs)
+
+    return new_module

--- a/src/peft/tuners/lora/fast.py
+++ b/src/peft/tuners/lora/fast.py
@@ -1,0 +1,410 @@
+# coding=utf-8
+# Copyright 2023-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import warnings
+from typing import Any, Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.pytorch_utils import Conv1D
+
+from peft.tuners.tuners_utils import BaseTunerLayer
+
+from .config import LoraConfig
+
+
+class FastLoraLayer(BaseTunerLayer):
+    # All names of layers that may contain (trainable) adapter weights
+    adapter_layer_names = ("lora_A", "lora_B", "lora_embedding_A", "lora_embedding_B")
+    # All names of other parameters that may contain adapter-related parameters
+    other_param_names = ("r", "lora_alpha", "scaling", "lora_dropout")
+
+    def __init__(self, base_layer: nn.Module, **kwargs) -> None:
+        self.base_layer = base_layer
+        self.kwargs = kwargs
+
+        base_layer = self.get_base_layer()
+        if isinstance(base_layer, nn.Linear):
+            in_features, out_features = base_layer.in_features, base_layer.out_features
+        elif isinstance(base_layer, nn.Conv2d):
+            in_features, out_features = base_layer.in_channels, base_layer.out_channels
+        elif isinstance(base_layer, nn.Embedding):
+            in_features, out_features = base_layer.num_embeddings, base_layer.embedding_dim
+        elif isinstance(base_layer, Conv1D):
+            in_features, out_features = (
+                base_layer.weight.ds_shape if hasattr(base_layer.weight, "ds_shape") else base_layer.weight.shape
+            )
+        elif hasattr(base_layer, "infeatures") and hasattr(base_layer, "outfeatures"):
+            # QuantLinear
+            in_features, out_features = base_layer.infeatures, base_layer.outfeatures
+        elif hasattr(base_layer, "input_size") and hasattr(base_layer, "output_size"):
+            # Megatron ColumnParallelLinear,RowParallelLinear
+            in_features, out_features = base_layer.input_size, base_layer.output_size
+        else:
+            raise ValueError(f"Unsupported layer type {type(base_layer)}")
+
+        self.in_features = in_features
+        self.out_features = out_features
+
+    def get_base_layer(self) -> nn.Module:
+        # For fast layers, nested base layers are not possible, so we can simplify this
+        return self.base_layer
+
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
+        raise TypeError(f"{self.__class__.__name__} does not support merging.")
+
+    def unmerge(self) -> None:
+        raise TypeError(f"{self.__class__.__name__} does not support unmerging.")
+
+    @property
+    def merged(self) -> bool:
+        return False
+
+    @property
+    def disable_adapters(self) -> bool:
+        raise TypeError(f"{self.__class__.__name__} does not support disabling adapters.")
+
+    def update_layer(self, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora):
+        # This method is only for the basics, implement the actual learnable parameters in the subclasses
+        if r <= 0:
+            raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
+
+        self.r = r
+        self.lora_alpha = lora_alpha
+        self.dropout = nn.Dropout(p=lora_dropout) if lora_dropout > 0.0 else nn.Identity()
+        self.scaling = lora_alpha / math.sqrt(r) if use_rslora else lora_alpha / r
+
+    def reset_lora_parameters(self, init_lora_weights):
+        # possibly override this for non-Linear layers
+        if init_lora_weights is False:
+            return
+
+        if init_lora_weights is True:
+            # initialize A the same way as the default for nn.Linear and B to zero
+            # https://github.com/microsoft/LoRA/blob/a0a92e0f26c067cf94747bdbf1ce73793fa44d19/loralib/layers.py#L124
+            nn.init.kaiming_uniform_(self.lora_A.weight, a=math.sqrt(5))
+        elif init_lora_weights.lower() == "gaussian":
+            nn.init.normal_(self.lora_A.weight, std=1 / self.r)
+        else:
+            raise ValueError(f"Unknown initialization {init_lora_weights=}")
+        nn.init.zeros_(self.lora_B.weight)
+
+    def loftq_init(self):
+        from peft.utils.loftq_utils import loftq_init
+
+        weight = self.get_base_layer().weight
+        kwargs = {
+            "num_bits": self.kwargs.get("loftq_bits", 4),
+            "reduced_rank": self.r,
+            "num_iter": self.kwargs.get("loftq_iter", 1),
+        }
+
+        qweight, lora_A, lora_B = loftq_init(weight, **kwargs)
+        # initialize A the same way as the default for nn.Linear and B to zero
+        self.lora_A.weight.data = lora_A
+        self.lora_B.weight.data = lora_B
+        self.get_base_layer().weight.data = qweight
+
+    def set_scale(self, adapter, scale):
+        if adapter not in self.scaling:
+            # Ignore the case where the adapter is not in the layer
+            return
+        self.scaling = scale * self.lora_alpha / self.r
+
+    def scale_layer(self, scale: float) -> None:
+        if scale == 1:
+            return
+
+        self.scaling *= scale
+
+    def unscale_layer(self, scale=None) -> None:
+        if scale is None:
+            self.scaling = self.lora_alpha / self.r
+        else:
+            self.scaling /= scale
+
+    def enable_adapters(self, enabled: bool) -> None:
+        pass
+
+    def set_adapter(self, adapter_names: str | list[str]) -> None:
+        if not isinstance(adapter_names, str):
+            adapter_name = list(adapter_names)[0]
+        else:
+            adapter_name = adapter_names
+
+        if adapter_name != self._active_adapter:
+            raise TypeError(f"{self.__class__.__name__} does not support changing the active adapter.")
+
+    def delete_adapter(self, adapter_name: str) -> None:
+        raise TypeError(f"{self.__class__.__name__} does not support deleting adapters.")
+
+
+# Below code is based on https://github.com/microsoft/LoRA/blob/main/loralib/layers.py
+# and modified to work with PyTorch FSDP
+
+
+#  ------------------------------------------------------------------------------------------
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+#  ------------------------------------------------------------------------------------------
+
+
+class Linear(nn.Module, FastLoraLayer):
+    # Lora implemented in a dense layer
+    def __init__(
+        self,
+        base_layer,
+        adapter_name: str,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        fan_in_fan_out: bool = False,  # Set this to True if the layer to replace stores weight like (fan_in, fan_out)
+        is_target_conv_1d_layer: bool = False,
+        init_lora_weights: Union[bool, str] = True,
+        use_rslora: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        FastLoraLayer.__init__(self, base_layer, **kwargs)
+        self.fan_in_fan_out = fan_in_fan_out
+
+        self._active_adapter = adapter_name
+        self.update_layer(r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
+        self.is_target_conv_1d_layer = is_target_conv_1d_layer
+
+    def update_layer(self, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora):
+        super().update_layer(r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
+
+        # Actual trainable parameters
+        self.lora_A = nn.Linear(self.in_features, r, bias=False)
+        self.lora_B = nn.Linear(r, self.out_features, bias=False)
+
+        if init_lora_weights == "loftq":
+            self.loftq_init()
+        elif init_lora_weights:
+            self.reset_lora_parameters(init_lora_weights)
+
+        # check weight and qweight (for GPTQ)
+        for weight_name in ("weight", "qweight"):
+            weight = getattr(self.get_base_layer(), weight_name, None)
+            if weight is not None:
+                # the layer is already completely initialized, this is an update
+                if weight.dtype.is_floating_point or weight.dtype.is_complex:
+                    self.to(weight.device, dtype=weight.dtype)
+                else:
+                    self.to(weight.device)
+                break
+
+    def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
+        previous_dtype = x.dtype
+        result = self.base_layer(x, *args, **kwargs)
+        x = x.to(self.lora_A.weight.dtype)
+        result += self.lora_B(self.lora_A(self.dropout(x))) * self.scaling
+        result = result.to(previous_dtype)
+        return result
+
+    def __repr__(self) -> str:
+        rep = super().__repr__()
+        return "lora.fast." + rep
+
+
+class Embedding(nn.Module, FastLoraLayer):
+    # LoRA implemented in a Embedding layer
+    def __init__(
+        self,
+        base_layer: nn.Module,
+        adapter_name: str,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        init_lora_weights: Union[bool, str] = True,
+        use_rslora: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        FastLoraLayer.__init__(self, base_layer)
+
+        self._active_adapter = adapter_name
+        self.update_layer(r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
+
+    def update_layer(self, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora):
+        super().update_layer(r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
+
+        # Actual trainable parameters
+        weight_A = torch.randn((r, self.in_features))
+        weight_B = torch.randn((self.out_features, r))
+        self.lora_embedding_A = nn.Parameter(weight_A)
+        self.lora_embedding_B = nn.Parameter(weight_B)
+
+        if init_lora_weights == "loftq":
+            self.loftq_init()
+        elif init_lora_weights:
+            self.reset_lora_parameters(init_lora_weights)
+
+        base_layer = self.get_base_layer()
+        weight = getattr(base_layer, "weight", None)
+        if weight is not None:
+            # the layer is already completely initialized, this is an update
+            self.to(base_layer.weight.device, dtype=weight.dtype)
+        self.set_adapter(self.active_adapters)
+
+    def reset_lora_parameters(self, init_lora_weights):
+        if init_lora_weights is False:
+            return
+
+        nn.init.zeros_(self.lora_B.weight)
+        # initialize a the same way as the default for nn.linear and b to zero
+        nn.init.zeros_(self.lora_embedding_A)
+        nn.init.normal_(self.lora_embedding_B)
+
+    def loftq_init(self):
+        from peft.utils.loftq_utils import loftq_init
+
+        weight = self.get_base_layer().weight
+        kwargs = {
+            "num_bits": self.kwargs.get("loftq_bits", 4),
+            "reduced_rank": self.r,
+            "num_iter": self.kwargs.get("loftq_iter", 1),
+        }
+
+        qweight, lora_A, lora_B = loftq_init(weight, **kwargs)
+        # initialize a the same way as the default for nn.linear and b to zero
+        self.lora_embedding_A.weight.data = lora_A
+        self.lora_embedding_B.weight.data = lora_B
+        self.get_base_layer().weight.data = qweight
+
+    def _embed(self, input: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        base_layer = self.get_base_layer()
+        return F.embedding(
+            input,
+            weight,
+            padding_idx=base_layer.padding_idx,
+            max_norm=base_layer.max_norm,
+            norm_type=base_layer.norm_type,
+            scale_grad_by_freq=base_layer.scale_grad_by_freq,
+            sparse=base_layer.sparse,
+        )
+
+    def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
+        result = self.base_layer(x, *args, **kwargs)
+        after_A = self._embed(x, self.lora_embedding_A)
+        result += (after_A @ self.lora_embedding_B) * self.scaling
+        return result
+
+    def __repr__(self) -> str:
+        rep = super().__repr__()
+        return "lora.fast." + rep
+
+
+class Conv2d(nn.Module, FastLoraLayer):
+    # Lora implemented in a conv2d layer
+    def __init__(
+        self,
+        base_layer: nn.Module,
+        adapter_name: str,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        init_lora_weights: Union[bool, str] = True,
+        use_rslora: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        FastLoraLayer.__init__(self, base_layer)
+
+        self._active_adapter = adapter_name
+        self.update_layer(r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
+
+    def update_layer(self, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora):
+        super().update_layer(r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
+
+        # Actual trainable parameters
+        self.lora_A = nn.Linear(self.in_features, r, bias=False)
+        self.lora_B = nn.Linear(r, self.out_features, bias=False)
+
+        if init_lora_weights == "loftq":
+            self.loftq_init()
+        elif init_lora_weights:
+            self.reset_lora_parameters(init_lora_weights)
+
+        # check weight and qweight (for GPTQ)
+        for weight_name in ("weight", "qweight"):
+            weight = getattr(self.get_base_layer(), weight_name, None)
+            if weight is not None:
+                # the layer is already completely initialized, this is an update
+                if weight.dtype.is_floating_point or weight.dtype.is_complex:
+                    self.to(weight.device, dtype=weight.dtype)
+                else:
+                    self.to(weight.device)
+                break
+
+    def forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        previous_dtype = x.dtype
+
+        result = self.base_layer(x, *args, **kwargs)
+        x = x.to(self.lora_A.weight.dtype)
+        result += self.lora_B(self.lora_A(self.dropout(x))) * self.scaling
+        result = result.to(previous_dtype)
+        return result
+
+    def __repr__(self) -> str:
+        rep = super().__repr__()
+        return "lora.fast." + rep
+
+
+def dispatch_fast(
+    target: torch.nn.Module,
+    adapter_name: str,
+    lora_config: LoraConfig,
+    **kwargs,
+) -> Optional[torch.nn.Module]:
+    new_module = None
+    if getattr(lora_config, "fast_train_mode", False) is False:
+        return new_module
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    if isinstance(target_base_layer, torch.nn.Embedding):
+        embedding_kwargs = kwargs.copy()
+        embedding_kwargs.pop("fan_in_fan_out", None)
+        embedding_kwargs.update(lora_config.loftq_config)
+        new_module = Embedding(target, adapter_name, **embedding_kwargs)
+    elif isinstance(target_base_layer, torch.nn.Conv2d):
+        kwargs.update(lora_config.loftq_config)
+        new_module = Conv2d(target, adapter_name, **kwargs)
+    elif isinstance(target_base_layer, torch.nn.Linear):
+        if kwargs["fan_in_fan_out"]:
+            warnings.warn(
+                "fan_in_fan_out is set to True but the target module is `torch.nn.Linear`. "
+                "Setting fan_in_fan_out to False."
+            )
+            kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = False
+        kwargs.update(lora_config.loftq_config)
+        new_module = Linear(target, adapter_name, **kwargs)
+    elif isinstance(target_base_layer, Conv1D):
+        if not kwargs["fan_in_fan_out"]:
+            warnings.warn(
+                "fan_in_fan_out is set to False but the target module is `Conv1D`. " "Setting fan_in_fan_out to True."
+            )
+            kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = True
+        kwargs.update(lora_config.loftq_config)
+        new_module = Linear(target, adapter_name, is_target_conv_1d_layer=True, **kwargs)
+
+    return new_module

--- a/src/peft/tuners/lora/fast.py
+++ b/src/peft/tuners/lora/fast.py
@@ -266,7 +266,6 @@ class Embedding(nn.Module, FastLoraLayer):
         if init_lora_weights is False:
             return
 
-        nn.init.zeros_(self.lora_B.weight)
         # initialize a the same way as the default for nn.linear and b to zero
         nn.init.zeros_(self.lora_embedding_A)
         nn.init.normal_(self.lora_embedding_B)
@@ -300,9 +299,11 @@ class Embedding(nn.Module, FastLoraLayer):
         )
 
     def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
+        embedding_A = self.lora_embedding_A.T
+        embedding_B = self.lora_embedding_B.T
         result = self.base_layer(x, *args, **kwargs)
-        after_A = self._embed(x, self.lora_embedding_A)
-        result += (after_A @ self.lora_embedding_B) * self.scaling
+        after_A = self._embed(x, embedding_A)
+        result += (after_A @ embedding_B) * self.scaling
         return result
 
     def __repr__(self) -> str:

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -13,9 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Optional
+
 import torch
 
 from peft.tuners.lora.layer import LoraLayer
+from peft.tuners.tuners_utils import BaseTunerLayer
+from peft.utils import get_auto_gptq_quant_linear
 
 
 class QuantLinear(torch.nn.Module, LoraLayer):
@@ -74,3 +78,25 @@ class QuantLinear(torch.nn.Module, LoraLayer):
     #     if adapter_name in self.lora_A.keys():
     #         torch.nn.init.xavier_uniform_(self.lora_A[adapter_name].weight)
     #         torch.nn.init.zeros_(self.lora_B[adapter_name].weight)
+
+
+def dispatch_gptq(
+    target: torch.nn.Module,
+    adapter_name: str,
+    **kwargs: Any,
+) -> Optional[torch.nn.Module]:
+    new_module = None
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    gptq_quantization_config = kwargs.get("gptq_quantization_config", None)
+    AutoGPTQQuantLinear = get_auto_gptq_quant_linear(gptq_quantization_config)
+
+    if AutoGPTQQuantLinear is not None and isinstance(target_base_layer, AutoGPTQQuantLinear):
+        new_module = QuantLinear(target, adapter_name, **kwargs)
+        target.qweight = target_base_layer.qweight
+
+    return new_module

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -25,6 +25,8 @@ from transformers.pytorch_utils import Conv1D
 from peft.tuners.tuners_utils import BaseTunerLayer
 from peft.utils.other import transpose
 
+from .config import LoraConfig
+
 
 class LoraLayer(BaseTunerLayer):
     # All names of layers that may contain (trainable) adapter weights
@@ -684,3 +686,45 @@ class Conv2d(nn.Module, LoraLayer):
     def __repr__(self) -> str:
         rep = super().__repr__()
         return "lora." + rep
+
+
+def dispatch_default(
+    target: torch.nn.Module,
+    adapter_name: str,
+    lora_config: LoraConfig,
+    **kwargs,
+) -> Optional[torch.nn.Module]:
+    new_module = None
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    if isinstance(target_base_layer, torch.nn.Embedding):
+        embedding_kwargs = kwargs.copy()
+        embedding_kwargs.pop("fan_in_fan_out", None)
+        embedding_kwargs.update(lora_config.loftq_config)
+        new_module = Embedding(target, adapter_name, **embedding_kwargs)
+    elif isinstance(target_base_layer, torch.nn.Conv2d):
+        kwargs.update(lora_config.loftq_config)
+        new_module = Conv2d(target, adapter_name, **kwargs)
+    elif isinstance(target_base_layer, torch.nn.Linear):
+        if kwargs["fan_in_fan_out"]:
+            warnings.warn(
+                "fan_in_fan_out is set to True but the target module is `torch.nn.Linear`. "
+                "Setting fan_in_fan_out to False."
+            )
+            kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = False
+        kwargs.update(lora_config.loftq_config)
+        new_module = Linear(target, adapter_name, **kwargs)
+    elif isinstance(target_base_layer, Conv1D):
+        if not kwargs["fan_in_fan_out"]:
+            warnings.warn(
+                "fan_in_fan_out is set to False but the target module is `Conv1D`. " "Setting fan_in_fan_out to True."
+            )
+            kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = True
+        kwargs.update(lora_config.loftq_config)
+        new_module = Linear(target, adapter_name, is_target_conv_1d_layer=True, **kwargs)
+
+    return new_module

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import importlib
 import math
 import operator
 import re
@@ -28,7 +27,6 @@ from typing import List, Optional
 import torch
 from torch import nn
 from tqdm import tqdm
-from transformers.pytorch_utils import Conv1D
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
 from peft.tuners.tuners_utils import BaseTuner, BaseTunerLayer, check_target_module_exists
@@ -37,13 +35,11 @@ from peft.utils import (
     ModulesToSaveWrapper,
     _freeze_adapter,
     _get_submodules,
-    get_auto_gptq_quant_linear,
     get_quantization_config,
 )
 
 from .config import LoraConfig
-from .gptq import QuantLinear
-from .layer import Conv2d, Embedding, Linear, LoraLayer
+from .layer import Conv2d, LoraLayer
 
 
 class LoraModel(BaseTuner):
@@ -234,103 +230,35 @@ class LoraModel(BaseTuner):
 
     @staticmethod
     def _create_new_module(lora_config, adapter_name, target, **kwargs):
+        from .fast import dispatch_fast
+        from .gptq import dispatch_gptq
+        from .layer import dispatch_default
+        from .tp_layer import dispatch_megatron
+
+        # collect dispatcher functions to decide how to replace the module
+        dispatchers = []
+
         # avoid eager bnb import
         if is_bnb_available():
-            import bitsandbytes as bnb
+            from .bnb import dispatch_bnb_8bit
 
-            from .bnb import Linear8bitLt
+            dispatchers.append(dispatch_bnb_8bit)
 
         if is_bnb_4bit_available():
-            from .bnb import Linear4bit
+            from .bnb import dispatch_bnb_4bit
 
-        gptq_quantization_config = kwargs.get("gptq_quantization_config", None)
-        AutoGPTQQuantLinear = get_auto_gptq_quant_linear(gptq_quantization_config)
+            dispatchers.append(dispatch_bnb_4bit)
 
-        loaded_in_8bit = kwargs.pop("loaded_in_8bit", False)
-        loaded_in_4bit = kwargs.pop("loaded_in_4bit", False)
+        dispatchers.extend([dispatch_gptq, dispatch_megatron, dispatch_fast, dispatch_default])
 
-        if isinstance(target, BaseTunerLayer):
-            target_base_layer = target.get_base_layer()
-        else:
-            target_base_layer = target
+        new_module = None
+        for dispatcher in dispatchers:
+            new_module = dispatcher(target, adapter_name, lora_config=lora_config, **kwargs)
+            if new_module is not None:
+                break
 
-        megatron_core = None
-        if lora_config.megatron_config:
-            megatron_core = importlib.import_module(lora_config.megatron_core)
-
-        if loaded_in_8bit and isinstance(target_base_layer, bnb.nn.Linear8bitLt):
-            eightbit_kwargs = kwargs.copy()
-            eightbit_kwargs.update(
-                {
-                    "has_fp16_weights": target.state.has_fp16_weights,
-                    "memory_efficient_backward": target.state.memory_efficient_backward,
-                    "threshold": target.state.threshold,
-                    "index": target.index,
-                }
-            )
-            new_module = Linear8bitLt(target, adapter_name, **eightbit_kwargs)
-        elif loaded_in_4bit and is_bnb_4bit_available() and isinstance(target_base_layer, bnb.nn.Linear4bit):
-            fourbit_kwargs = kwargs.copy()
-            fourbit_kwargs.update(
-                {
-                    "compute_dtype": target_base_layer.compute_dtype,
-                    "compress_statistics": target_base_layer.weight.compress_statistics,
-                    "quant_type": target_base_layer.weight.quant_type,
-                }
-            )
-            new_module = Linear4bit(target, adapter_name, **fourbit_kwargs)
-        elif AutoGPTQQuantLinear is not None and isinstance(target_base_layer, AutoGPTQQuantLinear):
-            new_module = QuantLinear(target, adapter_name, **kwargs)
-            target.qweight = target_base_layer.qweight
-        elif isinstance(target_base_layer, torch.nn.Embedding):
-            embedding_kwargs = kwargs.copy()
-            embedding_kwargs.pop("fan_in_fan_out", None)
-            embedding_kwargs.update(lora_config.loftq_config)
-            new_module = Embedding(target, adapter_name, **embedding_kwargs)
-        elif isinstance(target_base_layer, torch.nn.Conv2d):
-            kwargs.update(lora_config.loftq_config)
-            new_module = Conv2d(target, adapter_name, **kwargs)
-        elif isinstance(target_base_layer, torch.nn.Linear):
-            if kwargs["fan_in_fan_out"]:
-                warnings.warn(
-                    "fan_in_fan_out is set to True but the target module is `torch.nn.Linear`. "
-                    "Setting fan_in_fan_out to False."
-                )
-                kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = False
-            kwargs.update(lora_config.loftq_config)
-            new_module = Linear(target, adapter_name, **kwargs)
-        elif megatron_core and isinstance(
-            target_base_layer,
-            (megatron_core.tensor_parallel.ColumnParallelLinear, megatron_core.tensor_parallel.RowParallelLinear),
-        ):
-            from .tp_layer import LoraParallelLinear
-
-            megatron_kwargs = kwargs.copy()
-            megatron_config = lora_config.megatron_config
-            if isinstance(megatron_config, dict):
-                transformer_config_class = megatron_core.transformer.transformer_config.TransformerConfig
-                megatron_config = transformer_config_class(**lora_config.megatron_config)
-            megatron_kwargs["megatron_config"] = megatron_config
-            if megatron_kwargs["fan_in_fan_out"]:
-                warnings.warn(
-                    "fan_in_fan_out is set to True but the target module is `ColumnParallelLinear` "
-                    "or `RowParallelLinear`. "
-                    "Setting fan_in_fan_out to False."
-                )
-                megatron_kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = False
-            new_module = LoraParallelLinear(
-                base_layer=target, adapter_name=adapter_name, backend=megatron_core.tensor_parallel, **megatron_kwargs
-            )
-        elif isinstance(target_base_layer, Conv1D):
-            if not kwargs["fan_in_fan_out"]:
-                warnings.warn(
-                    "fan_in_fan_out is set to False but the target module is `Conv1D`. "
-                    "Setting fan_in_fan_out to True."
-                )
-                kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = True
-            kwargs.update(lora_config.loftq_config)
-            new_module = Linear(target, adapter_name, is_target_conv_1d_layer=True, **kwargs)
-        else:
+        if new_module is None:
+            # no dispatcher matched the module
             raise ValueError(
                 f"Target module {target} is not supported. Currently, only the following modules are supported: "
                 "`torch.nn.Linear`, `torch.nn.Embedding`, `torch.nn.Conv2d`, `transformers.pytorch_utils.Conv1D`."

--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -1,8 +1,12 @@
-from typing import Any
+import importlib
+import warnings
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
 import torch.nn.init as init
+
+from peft.tuners.tuners_utils import BaseTunerLayer
 
 from .layer import LoraLayer
 
@@ -162,3 +166,45 @@ class LoraParallelLinear(nn.Module, LoraLayer):
 
         result = result.to(previous_dtype)
         return result, bias
+
+
+def dispatch_megatron(
+    target: torch.nn.Module,
+    adapter_name: str,
+    lora_config,
+    **kwargs: Any,
+) -> Optional[torch.nn.Module]:
+    new_module = None
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    if lora_config.megatron_config:
+        megatron_core = importlib.import_module(lora_config.megatron_core)
+    else:
+        megatron_core = None
+
+    if megatron_core and isinstance(
+        target_base_layer,
+        (megatron_core.tensor_parallel.ColumnParallelLinear, megatron_core.tensor_parallel.RowParallelLinear),
+    ):
+        megatron_kwargs = kwargs.copy()
+        megatron_config = lora_config.megatron_config
+        if isinstance(megatron_config, dict):
+            transformer_config_class = megatron_core.transformer.transformer_config.TransformerConfig
+            megatron_config = transformer_config_class(**lora_config.megatron_config)
+        megatron_kwargs["megatron_config"] = megatron_config
+        if megatron_kwargs["fan_in_fan_out"]:
+            warnings.warn(
+                "fan_in_fan_out is set to True but the target module is `ColumnParallelLinear` "
+                "or `RowParallelLinear`. "
+                "Setting fan_in_fan_out to False."
+            )
+            megatron_kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = False
+        new_module = LoraParallelLinear(
+            base_layer=target, adapter_name=adapter_name, backend=megatron_core.tensor_parallel, **megatron_kwargs
+        )
+
+    return new_module


### PR DESCRIPTION
_WIP, For internal testing_

Experimental branch to check if we can add a faster, feature-incomplete training backend for LoRA. To enable it, pass `fast_train_mode=True` to `LoraConfig`. From the help:

            If this is True, then the model will use specialized layers for faster training, especially in conjunction
            with torch.compile. These layers lack a couple of features, e.g. they cannot be merged or disabled, and
            there can only ever be a single adapter. However, for many training use cases, those features do not matter.
            Later, for example for inference, the adapters can be loaded as normal adapters, enabling all these
            missing features. A good workflow is thus to train the adapter using `fast_train_modle=True`, and then
            load the adapter using `fast_train_modle=False` (the default).