### PR TITLE
Fix bnb lora layers not setting active adapter

### DIFF
--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -43,6 +43,7 @@ if is_bnb_available():
             super().__init__()
             LoraLayer.__init__(self, base_layer)
 
+            self._active_adapter = adapter_name
             self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
 
         def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
@@ -201,6 +202,7 @@ if is_bnb_4bit_available():
             super().__init__()
             LoraLayer.__init__(self, base_layer)
 
+            self._active_adapter = adapter_name
             self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
 
         def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:


### PR DESCRIPTION
This appears to be a small oversight introduced with #1106. I was trying to load some loras onto LLMs using text-generation-webui, and noticed that the lora had no effect if the model was loaded with load_in_4bit. But non-quantized models still worked with the lora.

By adding this single line, it matches what is in the standard Linear lora layer. Now the quantized linear lora layers have the lora active by default.