### PR TITLE
fix fsdp auto wrap policy

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -97,7 +97,7 @@ class BaseTuner(nn.Module, ABC):
         return self.active_adapter
 
     def forward(self, *args: Any, **kwargs: Any):
-        return self.model.forward(*args, **kwargs)
+        return self.model(*args, **kwargs)
 
     @abstractmethod
     def _prepare_adapter_config(self, peft_config: PeftConfig, model_config: dict) -> PeftConfig:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -97,7 +97,7 @@ class BaseTuner(nn.Module, ABC):
         return self.active_adapter
 
     def forward(self, *args: Any, **kwargs: Any):
-        return self.model(*args, **kwargs)
+        return self.model.forward(*args, **kwargs)
 
     @abstractmethod
     def _prepare_adapter_config(self, peft_config: PeftConfig, model_config: dict) -> PeftConfig:

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -360,6 +360,10 @@ def fsdp_auto_wrap_policy(model):
 
     from ..tuners import PrefixEncoder, PromptEmbedding, PromptEncoder
 
+    default_transformer_cls_names_to_wrap = (
+        model._no_split_modules[0] if getattr(model, "_no_split_modules", None) is not None else ""
+    )
+
     def lambda_policy_fn(module):
         if (
             len(list(module.named_children())) == 0
@@ -377,7 +381,7 @@ def fsdp_auto_wrap_policy(model):
             PromptEncoder,
             PromptEmbedding,
             FullyShardedDataParallelPlugin.get_module_class_from_name(
-                model, os.environ.get("FSDP_TRANSFORMER_CLS_TO_WRAP", "")
+                model, os.environ.get("FSDP_TRANSFORMER_CLS_TO_WRAP", default_transformer_cls_names_to_wrap)
             ),
         ),
     )


### PR DESCRIPTION
### What does this PR do?
1. Fixes the FSDP Auto Wrap policy for PEFT models to use the default `_no_split_modules` when available.