### PR TITLE
fix diffusers tests

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -135,7 +135,7 @@ def get_peft_model_state_dict(
         vocab_size = getattr(getattr(model, "config", None), "vocab_size", None)
         model_id = getattr(config, "base_model_name_or_path", None)
         # check if the vocab size of the base model is different from the vocab size of the finetuned model
-        if vocab_size and model_id and (vocab_size != AutoConfig.from_pretrained(model_id).vocab_size):
+        if vocab_size and model_id and (vocab_size != model.config.__class__.from_pretrained(model_id).vocab_size):
             warnings.warn(
                 "Setting `save_embedding_layers` to `True` as the embedding layer has been resized during finetuning."
             )

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -20,7 +20,6 @@ import torch
 from huggingface_hub import file_exists, hf_hub_download
 from huggingface_hub.utils import EntryNotFoundError
 from safetensors.torch import load_file as safe_load_file
-from transformers import AutoConfig
 
 from .other import EMBEDDING_LAYER_NAMES, SAFETENSORS_WEIGHTS_NAME, WEIGHTS_NAME, infer_device
 from .peft_types import PeftType


### PR DESCRIPTION
### What does this PR do?
1. fix diffusers tests 

```
FAILED tests/lora/test_lora_layers_peft.py::StableDiffusionXLLoRATests::test_simple_inference_with_text_unet_lora_save_load - ValueError: The checkpoint you are trying to load has model type `clip_text_model` but Transformers does not recognize this architecture. This could be because of an issue with the checkpoint, or because your version of Transformers is out of date.
```