### PR TITLE
Refactor dispatching logic of LoRA layers

### DIFF
--- a/src/peft/tuners/adalora/model.py
+++ b/src/peft/tuners/adalora/model.py
@@ -110,24 +110,22 @@ class AdaLoraModel(LoraModel):
         target,
         target_name,
         parent,
-        **optional_kwargs,
+        current_key,
     ):
-        loaded_in_8bit = optional_kwargs.get("loaded_in_8bit", False)
-        loaded_in_4bit = optional_kwargs.get("loaded_in_4bit", False)
-        if (loaded_in_8bit or loaded_in_4bit) and not is_bnb_available():
-            raise ImportError(
-                "To use AdaLora with 8-bit quantization, please install the `bitsandbytes` package. "
-                "You can install it with `pip install bitsandbytes`."
-            )
         kwargs = {
             "r": lora_config.init_r,
             "lora_alpha": lora_config.lora_alpha,
             "lora_dropout": lora_config.lora_dropout,
             "fan_in_fan_out": lora_config.fan_in_fan_out,
             "init_lora_weights": lora_config.init_lora_weights,
-            "loaded_in_8bit": loaded_in_8bit,
-            "loaded_in_4bit": loaded_in_4bit,
+            "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
+            "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
         }
+        if (kwargs["loaded_in_8bit"] or kwargs["loaded_in_4bit"]) and not is_bnb_available():
+            raise ImportError(
+                "To use AdaLora with 8-bit quantization, please install the `bitsandbytes` package. "
+                "You can install it with `pip install bitsandbytes`."
+            )
 
         quantization_config = get_quantization_config(self.model, method="gptq")
         if quantization_config is not None:

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -160,21 +160,17 @@ class IA3Model(BaseTuner):
         target,
         target_name,
         parent,
-        **optional_kwargs,
+        current_key,
     ):
-        loaded_in_8bit = optional_kwargs["loaded_in_8bit"]
-        loaded_in_4bit = optional_kwargs["loaded_in_4bit"]
-        current_key = optional_kwargs["current_key"]
-
         # check if target module is in feedforward_modules
         is_feedforward = self._check_target_module_feedforward(ia3_config, current_key)
 
         kwargs = {
             "fan_in_fan_out": ia3_config.fan_in_fan_out,
             "init_ia3_weights": ia3_config.init_ia3_weights,
-            "loaded_in_8bit": loaded_in_8bit,
-            "loaded_in_4bit": loaded_in_4bit,
             "is_feedforward": is_feedforward,
+            "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
+            "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
         }
 
         if isinstance(target, IA3Layer):

--- a/src/peft/tuners/loha/model.py
+++ b/src/peft/tuners/loha/model.py
@@ -95,7 +95,6 @@ class LoHaModel(LycorisTuner):
         target_name: str,
         parent: nn.Module,
         current_key: str,
-        **optional_kwargs,
     ) -> None:
         """
         A private method to create and replace the target module with the adapter module.

--- a/src/peft/tuners/lokr/model.py
+++ b/src/peft/tuners/lokr/model.py
@@ -96,7 +96,6 @@ class LoKrModel(LycorisTuner):
         target_name: str,
         parent: nn.Module,
         current_key: str,
-        **optional_kwargs,
     ) -> None:
         """
         A private method to create and replace the target module with the adapter module.

--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -20,6 +20,7 @@ import bitsandbytes as bnb
 import torch
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
+from peft.tuners.tuners_utils import BaseTunerLayer
 from peft.utils.other import transpose
 
 from .layer import LoraLayer
@@ -183,6 +184,29 @@ if is_bnb_available():
             rep = super().__repr__()
             return "lora." + rep
 
+    def dispatch_bnb_8bit(target: torch.nn.Module, adapter_name: str, **kwargs):
+        new_module = None
+
+        if isinstance(target, BaseTunerLayer):
+            target_base_layer = target.get_base_layer()
+        else:
+            target_base_layer = target
+
+        loaded_in_8bit = kwargs.get("loaded_in_8bit", False)
+        if loaded_in_8bit and isinstance(target_base_layer, bnb.nn.Linear8bitLt):
+            eightbit_kwargs = kwargs.copy()
+            eightbit_kwargs.update(
+                {
+                    "has_fp16_weights": target.state.has_fp16_weights,
+                    "memory_efficient_backward": target.state.memory_efficient_backward,
+                    "threshold": target.state.threshold,
+                    "index": target.index,
+                }
+            )
+            new_module = Linear8bitLt(target, adapter_name, **eightbit_kwargs)
+
+        return new_module
+
 
 if is_bnb_4bit_available():
 
@@ -321,3 +345,25 @@ if is_bnb_4bit_available():
         def __repr__(self) -> str:
             rep = super().__repr__()
             return "lora." + rep
+
+    def dispatch_bnb_4bit(target: torch.nn.Module, adapter_name: str, **kwargs):
+        new_module = None
+
+        if isinstance(target, BaseTunerLayer):
+            target_base_layer = target.get_base_layer()
+        else:
+            target_base_layer = target
+
+        loaded_in_4bit = kwargs.get("loaded_in_4bit", False)
+        if loaded_in_4bit and is_bnb_4bit_available() and isinstance(target_base_layer, bnb.nn.Linear4bit):
+            fourbit_kwargs = kwargs.copy()
+            fourbit_kwargs.update(
+                {
+                    "compute_dtype": target_base_layer.compute_dtype,
+                    "compress_statistics": target_base_layer.weight.compress_statistics,
+                    "quant_type": target_base_layer.weight.quant_type,
+                }
+            )
+            new_module = Linear4bit(target, adapter_name, **fourbit_kwargs)
+
+        return new_module

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -13,9 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Optional
+
 import torch
 
 from peft.tuners.lora.layer import LoraLayer
+from peft.tuners.tuners_utils import BaseTunerLayer
+from peft.utils import get_auto_gptq_quant_linear
 
 
 class QuantLinear(torch.nn.Module, LoraLayer):
@@ -74,3 +78,25 @@ class QuantLinear(torch.nn.Module, LoraLayer):
     #     if adapter_name in self.lora_A.keys():
     #         torch.nn.init.xavier_uniform_(self.lora_A[adapter_name].weight)
     #         torch.nn.init.zeros_(self.lora_B[adapter_name].weight)
+
+
+def dispatch_gptq(
+    target: torch.nn.Module,
+    adapter_name: str,
+    **kwargs: Any,
+) -> Optional[torch.nn.Module]:
+    new_module = None
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    gptq_quantization_config = kwargs.get("gptq_quantization_config", None)
+    AutoGPTQQuantLinear = get_auto_gptq_quant_linear(gptq_quantization_config)
+
+    if AutoGPTQQuantLinear is not None and isinstance(target_base_layer, AutoGPTQQuantLinear):
+        new_module = QuantLinear(target, adapter_name, **kwargs)
+        target.qweight = target_base_layer.qweight
+
+    return new_module

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -25,6 +25,8 @@ from transformers.pytorch_utils import Conv1D
 from peft.tuners.tuners_utils import BaseTunerLayer
 from peft.utils.other import transpose
 
+from .config import LoraConfig
+
 
 class LoraLayer(BaseTunerLayer):
     # All names of layers that may contain (trainable) adapter weights
@@ -684,3 +686,45 @@ class Conv2d(nn.Module, LoraLayer):
     def __repr__(self) -> str:
         rep = super().__repr__()
         return "lora." + rep
+
+
+def dispatch_default(
+    target: torch.nn.Module,
+    adapter_name: str,
+    lora_config: LoraConfig,
+    **kwargs,
+) -> Optional[torch.nn.Module]:
+    new_module = None
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    if isinstance(target_base_layer, torch.nn.Embedding):
+        embedding_kwargs = kwargs.copy()
+        embedding_kwargs.pop("fan_in_fan_out", None)
+        embedding_kwargs.update(lora_config.loftq_config)
+        new_module = Embedding(target, adapter_name, **embedding_kwargs)
+    elif isinstance(target_base_layer, torch.nn.Conv2d):
+        kwargs.update(lora_config.loftq_config)
+        new_module = Conv2d(target, adapter_name, **kwargs)
+    elif isinstance(target_base_layer, torch.nn.Linear):
+        if kwargs["fan_in_fan_out"]:
+            warnings.warn(
+                "fan_in_fan_out is set to True but the target module is `torch.nn.Linear`. "
+                "Setting fan_in_fan_out to False."
+            )
+            kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = False
+        kwargs.update(lora_config.loftq_config)
+        new_module = Linear(target, adapter_name, **kwargs)
+    elif isinstance(target_base_layer, Conv1D):
+        if not kwargs["fan_in_fan_out"]:
+            warnings.warn(
+                "fan_in_fan_out is set to False but the target module is `Conv1D`. " "Setting fan_in_fan_out to True."
+            )
+            kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = True
+        kwargs.update(lora_config.loftq_config)
+        new_module = Linear(target, adapter_name, is_target_conv_1d_layer=True, **kwargs)
+
+    return new_module

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import importlib
 import math
 import operator
 import re
@@ -28,7 +27,6 @@ from typing import List, Optional
 import torch
 from torch import nn
 from tqdm import tqdm
-from transformers.pytorch_utils import Conv1D
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
 from peft.tuners.tuners_utils import BaseTuner, BaseTunerLayer, check_target_module_exists
@@ -37,13 +35,13 @@ from peft.utils import (
     ModulesToSaveWrapper,
     _freeze_adapter,
     _get_submodules,
-    get_auto_gptq_quant_linear,
     get_quantization_config,
 )
 
 from .config import LoraConfig
-from .gptq import QuantLinear
-from .layer import Conv2d, Embedding, Linear, LoraLayer
+from .gptq import dispatch_gptq
+from .layer import Conv2d, LoraLayer, dispatch_default
+from .tp_layer import dispatch_megatron
 
 
 class LoraModel(BaseTuner):
@@ -137,7 +135,6 @@ class LoraModel(BaseTuner):
         target_name,
         parent,
         current_key,
-        **optional_kwargs,
     ):
         if current_key is None:
             raise ValueError("Current Key shouldn't be `None`")
@@ -145,10 +142,9 @@ class LoraModel(BaseTuner):
         # Regexp matching - Find key which matches current target_name in patterns provided
         pattern_keys = list(chain(lora_config.rank_pattern.keys(), lora_config.alpha_pattern.keys()))
         target_name_key = next(filter(lambda key: re.match(f".*\.{key}$", current_key), pattern_keys), current_key)
-
         r = lora_config.rank_pattern.get(target_name_key, lora_config.r)
         alpha = lora_config.alpha_pattern.get(target_name_key, lora_config.lora_alpha)
-        bias = hasattr(target, "bias") and target.bias is not None
+
         kwargs = {
             "r": r,
             "lora_alpha": alpha,
@@ -156,10 +152,9 @@ class LoraModel(BaseTuner):
             "fan_in_fan_out": lora_config.fan_in_fan_out,
             "init_lora_weights": lora_config.init_lora_weights,
             "use_rslora": lora_config.use_rslora,
+            "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
+            "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
         }
-        kwargs["loaded_in_8bit"] = optional_kwargs.pop("loaded_in_8bit", False)
-        kwargs["loaded_in_4bit"] = optional_kwargs.pop("loaded_in_4bit", False)
-        kwargs["bias"] = bias
 
         quantization_config = get_quantization_config(self.model, method="gptq")
         if quantization_config is not None:
@@ -234,103 +229,31 @@ class LoraModel(BaseTuner):
 
     @staticmethod
     def _create_new_module(lora_config, adapter_name, target, **kwargs):
+        # Collect dispatcher functions to decide what backend to use for the replaced LoRA layer. The order matters,
+        # because the first match is always used. Therefore, the default layers should be checked last.
+        dispatchers = []
+
         # avoid eager bnb import
         if is_bnb_available():
-            import bitsandbytes as bnb
+            from .bnb import dispatch_bnb_8bit
 
-            from .bnb import Linear8bitLt
+            dispatchers.append(dispatch_bnb_8bit)
 
         if is_bnb_4bit_available():
-            from .bnb import Linear4bit
+            from .bnb import dispatch_bnb_4bit
 
-        gptq_quantization_config = kwargs.get("gptq_quantization_config", None)
-        AutoGPTQQuantLinear = get_auto_gptq_quant_linear(gptq_quantization_config)
+            dispatchers.append(dispatch_bnb_4bit)
 
-        loaded_in_8bit = kwargs.pop("loaded_in_8bit", False)
-        loaded_in_4bit = kwargs.pop("loaded_in_4bit", False)
+        dispatchers.extend([dispatch_gptq, dispatch_megatron, dispatch_default])
 
-        if isinstance(target, BaseTunerLayer):
-            target_base_layer = target.get_base_layer()
-        else:
-            target_base_layer = target
+        new_module = None
+        for dispatcher in dispatchers:
+            new_module = dispatcher(target, adapter_name, lora_config=lora_config, **kwargs)
+            if new_module is not None:  # first match wins
+                break
 
-        megatron_core = None
-        if lora_config.megatron_config:
-            megatron_core = importlib.import_module(lora_config.megatron_core)
-
-        if loaded_in_8bit and isinstance(target_base_layer, bnb.nn.Linear8bitLt):
-            eightbit_kwargs = kwargs.copy()
-            eightbit_kwargs.update(
-                {
-                    "has_fp16_weights": target.state.has_fp16_weights,
-                    "memory_efficient_backward": target.state.memory_efficient_backward,
-                    "threshold": target.state.threshold,
-                    "index": target.index,
-                }
-            )
-            new_module = Linear8bitLt(target, adapter_name, **eightbit_kwargs)
-        elif loaded_in_4bit and is_bnb_4bit_available() and isinstance(target_base_layer, bnb.nn.Linear4bit):
-            fourbit_kwargs = kwargs.copy()
-            fourbit_kwargs.update(
-                {
-                    "compute_dtype": target_base_layer.compute_dtype,
-                    "compress_statistics": target_base_layer.weight.compress_statistics,
-                    "quant_type": target_base_layer.weight.quant_type,
-                }
-            )
-            new_module = Linear4bit(target, adapter_name, **fourbit_kwargs)
-        elif AutoGPTQQuantLinear is not None and isinstance(target_base_layer, AutoGPTQQuantLinear):
-            new_module = QuantLinear(target, adapter_name, **kwargs)
-            target.qweight = target_base_layer.qweight
-        elif isinstance(target_base_layer, torch.nn.Embedding):
-            embedding_kwargs = kwargs.copy()
-            embedding_kwargs.pop("fan_in_fan_out", None)
-            embedding_kwargs.update(lora_config.loftq_config)
-            new_module = Embedding(target, adapter_name, **embedding_kwargs)
-        elif isinstance(target_base_layer, torch.nn.Conv2d):
-            kwargs.update(lora_config.loftq_config)
-            new_module = Conv2d(target, adapter_name, **kwargs)
-        elif isinstance(target_base_layer, torch.nn.Linear):
-            if kwargs["fan_in_fan_out"]:
-                warnings.warn(
-                    "fan_in_fan_out is set to True but the target module is `torch.nn.Linear`. "
-                    "Setting fan_in_fan_out to False."
-                )
-                kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = False
-            kwargs.update(lora_config.loftq_config)
-            new_module = Linear(target, adapter_name, **kwargs)
-        elif megatron_core and isinstance(
-            target_base_layer,
-            (megatron_core.tensor_parallel.ColumnParallelLinear, megatron_core.tensor_parallel.RowParallelLinear),
-        ):
-            from .tp_layer import LoraParallelLinear
-
-            megatron_kwargs = kwargs.copy()
-            megatron_config = lora_config.megatron_config
-            if isinstance(megatron_config, dict):
-                transformer_config_class = megatron_core.transformer.transformer_config.TransformerConfig
-                megatron_config = transformer_config_class(**lora_config.megatron_config)
-            megatron_kwargs["megatron_config"] = megatron_config
-            if megatron_kwargs["fan_in_fan_out"]:
-                warnings.warn(
-                    "fan_in_fan_out is set to True but the target module is `ColumnParallelLinear` "
-                    "or `RowParallelLinear`. "
-                    "Setting fan_in_fan_out to False."
-                )
-                megatron_kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = False
-            new_module = LoraParallelLinear(
-                base_layer=target, adapter_name=adapter_name, backend=megatron_core.tensor_parallel, **megatron_kwargs
-            )
-        elif isinstance(target_base_layer, Conv1D):
-            if not kwargs["fan_in_fan_out"]:
-                warnings.warn(
-                    "fan_in_fan_out is set to False but the target module is `Conv1D`. "
-                    "Setting fan_in_fan_out to True."
-                )
-                kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = True
-            kwargs.update(lora_config.loftq_config)
-            new_module = Linear(target, adapter_name, is_target_conv_1d_layer=True, **kwargs)
-        else:
+        if new_module is None:
+            # no module could be matched
             raise ValueError(
                 f"Target module {target} is not supported. Currently, only the following modules are supported: "
                 "`torch.nn.Linear`, `torch.nn.Embedding`, `torch.nn.Conv2d`, `transformers.pytorch_utils.Conv1D`."

--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -1,8 +1,27 @@
-from typing import Any
+# coding=utf-8
+# Copyright 2023-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import warnings
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
 import torch.nn.init as init
+
+from peft.tuners.tuners_utils import BaseTunerLayer
 
 from .layer import LoraLayer
 
@@ -162,3 +181,45 @@ class LoraParallelLinear(nn.Module, LoraLayer):
 
         result = result.to(previous_dtype)
         return result, bias
+
+
+def dispatch_megatron(
+    target: torch.nn.Module,
+    adapter_name: str,
+    lora_config,
+    **kwargs: Any,
+) -> Optional[torch.nn.Module]:
+    new_module = None
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    if lora_config.megatron_config:
+        megatron_core = importlib.import_module(lora_config.megatron_core)
+    else:
+        megatron_core = None
+
+    if megatron_core and isinstance(
+        target_base_layer,
+        (megatron_core.tensor_parallel.ColumnParallelLinear, megatron_core.tensor_parallel.RowParallelLinear),
+    ):
+        megatron_kwargs = kwargs.copy()
+        megatron_config = lora_config.megatron_config
+        if isinstance(megatron_config, dict):
+            transformer_config_class = megatron_core.transformer.transformer_config.TransformerConfig
+            megatron_config = transformer_config_class(**lora_config.megatron_config)
+        megatron_kwargs["megatron_config"] = megatron_config
+        if megatron_kwargs["fan_in_fan_out"]:
+            warnings.warn(
+                "fan_in_fan_out is set to True but the target module is `ColumnParallelLinear` "
+                "or `RowParallelLinear`. "
+                "Setting fan_in_fan_out to False."
+            )
+            megatron_kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = False
+        new_module = LoraParallelLinear(
+            base_layer=target, adapter_name=adapter_name, backend=megatron_core.tensor_parallel, **megatron_kwargs
+        )
+
+    return new_module

--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -225,7 +225,6 @@ class LycorisTuner(BaseTuner):
         target_name,
         parent,
         current_key,
-        **optional_kwargs,
     ):
         ...
 

--- a/src/peft/tuners/oft/model.py
+++ b/src/peft/tuners/oft/model.py
@@ -88,7 +88,6 @@ class OFTModel(LycorisTuner):
         target_name: str,
         parent: nn.Module,
         current_key: str,
-        **optional_kwargs,
     ) -> None:
         """
         A private method to create and replace the target module with the adapter module.

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -139,7 +139,7 @@ class BaseTuner(nn.Module, ABC):
         target: nn.Module,
         target_name: str,
         parent: nn.Module,
-        **optional_kwargs: Any,
+        current_key: str,
     ) -> None:
         r"""
         Inplace replacement of the target module with the adapter layer. This method needs to be overriden by all the
@@ -158,8 +158,8 @@ class BaseTuner(nn.Module, ABC):
                 The target module's name.
             parent (`nn.Module`):
                 The parent module.
-            **optional_kwargs (`dict`):
-                The optional keyword arguments to pass to deal with particular cases (e.g. 8bit, 4bit quantization)
+            current_key (`str`):
+                The key of the current target being adapted.
         """
         ...
 
@@ -235,13 +235,7 @@ class BaseTuner(nn.Module, ABC):
 
             is_target_modules_in_base_model = True
             parent, target, target_name = _get_submodules(model, key)
-
-            optional_kwargs = {
-                "loaded_in_8bit": getattr(model, "is_loaded_in_8bit", False),
-                "loaded_in_4bit": getattr(model, "is_loaded_in_4bit", False),
-                "current_key": key,
-            }
-            self._create_and_replace(peft_config, adapter_name, target, target_name, parent, **optional_kwargs)
+            self._create_and_replace(peft_config, adapter_name, target, target_name, parent, current_key=key)
 
         if not is_target_modules_in_base_model:
             raise ValueError(


### PR DESCRIPTION
This PR's goal is to simplify the logic for deciding which LoRA layer backend is being used when LoRA is applied to a target layer.

Originally, this refactor was done in #1286 which was about adding the "fast" backend for LoRA, but since that PR was closed, I moved the refactor to this dedicated PR.

## Motivation

Right, now, the `LoraModel._create_new_module` method has become quite complex and hard to read, spanning >100 lines:

https://github.com/huggingface/peft/blob/8665e2b5719faa4e4b91749ddec09442927b53e0/src/peft/tuners/lora/model.py#L235-L339

The reason for this is that method contains the logic for deciding which LoRA layer backend to use for all the different types of LoRA layers that we have, i.e. normal `Linear` layer, `Conv2d` layer, bnb layer, gptq, etc.

This PR greatly simplifies this method (30 LOC) and should make it easier to prevent bugs. It should also simplify adding further backends in the future.

## Description

I moved the logic for deciding which layer to match to the respective implementation of the layers. For example, in `lora/layer.py`, there is now a function called `dispatch_default`, whose responsibility it is to decide if an `Embedding` layer, `Conv2d` layer or `Linear` layer is the right match. Similarly, in `lora/bnb.py`, there are now the two functions `dispatch_bnb_8bit` and `dispatch_bnb_4bit` to decide what/if any bnb 8bit or 4bit layer should be matched. Same for the gptq and the megatron backend.

This way, the logic to decide what layer to match now resides next to the respective layers. The only thing that `LoraModel` now needs to do is to collect all the dispatching methods and use the first layer that matches.

Note that the logic to decide if a layer matches is 100% the same, just moved to a different place. Therefore, there should be no difference in the LoRA model being created.

Only LoRA was modified because the other tuners don't have different backends and thus this approach was not necessary for them. The only exception is IA³, which has normal and bnb backend. Since those are only two, it's not as complicated as for LoRA, but if this PR is accepted, I can refactor IA³ in a similar fashion.

## Other changes

- Removed the `optional_kwargs` argument from `_create_and_replace`, as it was an unnecessary indirection.
- Removed the `bias` argument from `kwargs`, as it was not used.

## Backwards compatibility

This should be fully backwards compatible, as the constructed LoRA model is 100% the same. If there are users that override `_create_new_module`, their code will probably break, but since this is a private method, we should be fine.

**Edit**: Also ran regression tests and they passed.