### PR TITLE
FIX Use torch.long instead of torch.int in LoftQ for PyTorch versions <2.x

### DIFF
--- a/src/peft/utils/loftq_utils.py
+++ b/src/peft/utils/loftq_utils.py
@@ -155,7 +155,7 @@ class NFQuantizer:
         weight = torch.zeros((qweight.shape[0], 8 // self.num_bits), dtype=torch.float32, device=device)
         for i in range(8 // self.num_bits):
             lookup_table_idx = qweight.to(torch.long) % 2**self.num_bits  # get the most right 2 bits
-            lookup_table_idx = lookup_table_idx.to(torch.int)
+            lookup_table_idx = lookup_table_idx.to(torch.long)
             weight[:, i] = self.norm_lookup_table[lookup_table_idx].squeeze()
             qweight = qweight >> self.num_bits  # right shift 2 bits of the original data
 


### PR DESCRIPTION
Resolves #1307 

For PyTorch versions below 2, the usage of torch.int instead of torch.long when indexing inside of `dequantize_block` for LoftQ leads to an error. The fix consists of using torch.long.

I tested the change with my local GPU for both PyTorch 1.13 and 2.1 and the tests passed for both.

Note that initially, it seemed to be an issue with seq2seq models, until it was discovered to be PyTorch-related. This is why I added the seq2seq tests. Even though the tests not really necessary, I kept them in.