### PR TITLE
Add PeftModel.generate

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -535,6 +535,12 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         """
         return self.get_base_model()(*args, **kwargs)
 
+    def generate(self, *args: Any, **kwargs: Any):
+        """
+        Generate output.
+        """
+        return self.get_base_model().generate(*args, **kwargs)
+
     def _get_base_model_class(self, is_prompt_tuning=False):
         """
         Returns the base model class.


### PR DESCRIPTION
Hello all,

While working with `PeftModel`, I realized that unlike `PeftMixedModel`, it lacks the `generate` function. This PR solves the issue by adding the function.