### PR TITLE
Fix bug when load the prompt tuning in inference.

### DIFF
--- a/src/peft/tuners/prompt_tuning/model.py
+++ b/src/peft/tuners/prompt_tuning/model.py
@@ -63,7 +63,7 @@ class PromptEmbedding(torch.nn.Module):
 
         total_virtual_tokens = config.num_virtual_tokens * config.num_transformer_submodules
         self.embedding = torch.nn.Embedding(total_virtual_tokens, config.token_dim)
-        if config.prompt_tuning_init == PromptTuningInit.TEXT:
+        if config.prompt_tuning_init == PromptTuningInit.TEXT and not config.inference_mode:
             from transformers import AutoTokenizer
 
             tokenizer_kwargs = config.tokenizer_kwargs or {}


### PR DESCRIPTION
Prompt tuning did not need tokenizer when inference.

And it may encounter some bug if load tokenizer in some cases when inference.

(For my example, it will cant find the config.json for tokenizer in cache dir, and my development environment cant connect to the hugginface.)