### PR TITLE
DOC: Update docstring for the config classes

### DIFF
--- a/src/peft/tuners/ia3/config.py
+++ b/src/peft/tuners/ia3/config.py
@@ -26,23 +26,26 @@ class IA3Config(PeftConfig):
     This is the configuration class to store the configuration of a [`IA3Model`].
 
     Args:
-        target_modules (`Union[List[str],str]`):
-            The names of the modules to apply (IA)³ to. If this is specified, only the modules with the specified names
-            will be replaced. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
+        target_modules (`Optional[Union[List[str], str]]`):
+            The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
+            names will be replaced. When passing a string, a regex match will be performed. When passing a list of
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
+            the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
             excluding the output layer. If this is not specified, modules will be chosen according to the model
             architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
             the target modules manually.
-        feedforward_modules (`Union[List[str],str]`):
+        feedforward_modules (`Optional[Union[List[str], str]]`):
             The names of the modules to be treated as feedforward modules, as in the original paper. These modules will
-            have (IA)^3 vectors multiplied to the input, instead of the output. feedforward_modules must be a name or a
-            subset of names present in target_modules.
+            have (IA)³ vectors multiplied to the input, instead of the output. `feedforward_modules` must be a name or a
+            subset of names present in `target_modules`.
         fan_in_fan_out (`bool`):
             Set this to True if the layer to replace stores weight like (fan_in, fan_out). For example, gpt-2 uses
             `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`.
-        modules_to_save (`List[str]`):
-            List of modules apart from (IA)^3 layers to be set as trainable and saved in the final checkpoint.
+        modules_to_save (`Optional[List[str]]`):
+            List of modules apart from (IA)³ layers to be set as trainable and saved in the final checkpoint.
         init_ia3_weights (`bool`):
-            Whether to initialize the vectors in the (IA)^3 layers, defaults to `True`.
+            Whether to initialize the vectors in the (IA)³ layers, defaults to `True`. Setting this to `False` is
+            discouraged.
     """
 
     target_modules: Optional[Union[List[str], str]] = field(

--- a/src/peft/tuners/ia3/config.py
+++ b/src/peft/tuners/ia3/config.py
@@ -29,15 +29,15 @@ class IA3Config(PeftConfig):
         target_modules (`Optional[Union[List[str], str]]`):
             The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
             names will be replaced. When passing a string, a regex match will be performed. When passing a list of
-            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
-            the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any
+            of the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
             excluding the output layer. If this is not specified, modules will be chosen according to the model
             architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
             the target modules manually.
         feedforward_modules (`Optional[Union[List[str], str]]`):
             The names of the modules to be treated as feedforward modules, as in the original paper. These modules will
-            have (IA)³ vectors multiplied to the input, instead of the output. `feedforward_modules` must be a name or a
-            subset of names present in `target_modules`.
+            have (IA)³ vectors multiplied to the input, instead of the output. `feedforward_modules` must be a name or
+            a subset of names present in `target_modules`.
         fan_in_fan_out (`bool`):
             Set this to True if the layer to replace stores weight like (fan_in, fan_out). For example, gpt-2 uses
             `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`.

--- a/src/peft/tuners/loha/config.py
+++ b/src/peft/tuners/loha/config.py
@@ -39,8 +39,8 @@ class LoHaConfig(LycorisConfig):
         target_modules (`Optional[Union[List[str], str]]`):
             The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
             names will be replaced. When passing a string, a regex match will be performed. When passing a list of
-            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
-            the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any
+            of the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
             excluding the output layer. If this is not specified, modules will be chosen according to the model
             architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
             the target modules manually.

--- a/src/peft/tuners/loha/config.py
+++ b/src/peft/tuners/loha/config.py
@@ -26,29 +26,41 @@ class LoHaConfig(LycorisConfig):
     This is the configuration class to store the configuration of a [`LoHaModel`].
 
     Args:
-        r (`int`): LoHa rank.
-        alpha (`int`): The alpha parameter for LoHa scaling.
-        rank_dropout (`int`): The dropout probability for rank dimension during training.
-        module_dropout (`int`): The dropout probability for disabling LoHa modules during training.
+        r (`int`):
+            LoHa rank.
+        alpha (`int`):
+            The alpha parameter for LoHa scaling.
+        rank_dropout (`float`):
+            The dropout probability for rank dimension during training.
+        module_dropout (`float`):
+            The dropout probability for disabling LoHa modules during training.
         use_effective_conv2d (`bool`):
             Use parameter effective decomposition for Conv2d with ksize > 1 ("Proposition 3" from FedPara paper).
-        target_modules (`Union[List[str],str]`): The names of the modules to apply LoHa to. If this is specified as
-            'all-linear', then all linear/Conv1D modules are chosen, excluding the output layer.
-        init_weights (`bool`): Whether to perform initialization of LoHa weights.
-        layers_to_transform (`Union[List[int],int]`):
-            The layer indexes to transform, if this argument is specified, it will apply the LoHa transformations on
-            the layer indexes that are specified in this list. If a single integer is passed, it will apply the LoHa
-            transformations on the layer at this index.
+        target_modules (`Optional[Union[List[str], str]]`):
+            The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
+            names will be replaced. When passing a string, a regex match will be performed. When passing a list of
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
+            the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
+            excluding the output layer. If this is not specified, modules will be chosen according to the model
+            architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
+            the target modules manually.
+        init_weights (`bool`):
+            Whether to perform initialization of adapter weights. This defaults to `True`, passing `False` is
+            discouraged.
+        layers_to_transform (`Union[List[int], int]`):
+            The layer indices to transform. If a list of ints is passed, it will apply the adapter to the layer indices
+            that are specified in this list. If a single integer is passed, it will apply the transformations on the
+            layer at this index.
         layers_pattern (`str`):
-            The layer pattern name, used only if `layers_to_transform` is different from `None` and if the layer
-            pattern is not in the common layers pattern.
+            The layer pattern name, used only if `layers_to_transform` is different from `None`.
         rank_pattern (`dict`):
             The mapping from layer names or regexp expression to ranks which are different from the default rank
             specified by `r`.
         alpha_pattern (`dict`):
             The mapping from layer names or regexp expression to alphas which are different from the default alpha
             specified by `alpha`.
-        modules_to_save (`List[str]`): The names of modules to be set as trainable except LoHa parameters.
+        modules_to_save (`Optional[List[str]]`):
+            List of modules apart from adapter layers to be set as trainable and saved in the final checkpoint.
     """
 
     r: int = field(default=8, metadata={"help": "LoHa rank"})

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -43,8 +43,8 @@ class LoKrConfig(LycorisConfig):
         target_modules (`Optional[Union[List[str], str]]`):
             The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
             names will be replaced. When passing a string, a regex match will be performed. When passing a list of
-            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
-            the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any
+            of the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
             excluding the output layer. If this is not specified, modules will be chosen according to the model
             architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
             the target modules manually.

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -26,31 +26,45 @@ class LoKrConfig(LycorisConfig):
     Configuration class of [`LoKrModel`].
 
     Args:
-        r (`int`): LoKr rank.
-        alpha (`int`): The alpha parameter for LoKr scaling.
-        rank_dropout (`int`): The dropout probability for rank dimension during training.
-        module_dropout (`int`): The dropout probability for disabling LoKr modules during training.
+        r (`int`):
+            LoKr rank.
+        alpha (`int`):
+            The alpha parameter for LoKr scaling.
+        rank_dropout (`float`):
+            The dropout probability for rank dimension during training.
+        module_dropout (`float`):
+            The dropout probability for disabling LoKr modules during training.
         use_effective_conv2d (`bool`):
             Use parameter effective decomposition for Conv2d with ksize > 1 ("Proposition 3" from FedPara paper).
-        decompose_both (`bool`): Perform rank decomposition of left kronecker product matrix.
-        decompose_factor (`int`): Kronecker product decomposition factor.
-        target_modules (`Union[List[str],str]`): The names of the modules to apply LoKr to. If this is specified as
-            'all-linear', then all linear/Conv1D modules are chosen, excluding the output layer.
-        init_weights (`bool`): Whether to perform initialization of LoKr weights.
-        layers_to_transform (`Union[List[int],int]`):
-            The layer indexes to transform, if this argument is specified, it will apply the LoKr transformations on
-            the layer indexes that are specified in this list. If a single integer is passed, it will apply the LoKr
-            transformations on the layer at this index.
+        decompose_both (`bool`):
+            Perform rank decomposition of left kronecker product matrix.
+        decompose_factor (`int`):
+            Kronecker product decomposition factor.
+        target_modules (`Optional[Union[List[str], str]]`):
+            The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
+            names will be replaced. When passing a string, a regex match will be performed. When passing a list of
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
+            the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
+            excluding the output layer. If this is not specified, modules will be chosen according to the model
+            architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
+            the target modules manually.
+        init_weights (`bool`):
+            Whether to perform initialization of adapter weights. This defaults to `True`, passing `False` is
+            discouraged.
+        layers_to_transform (`Union[List[int], int]`):
+            The layer indices to transform. If a list of ints is passed, it will apply the adapter to the layer indices
+            that are specified in this list. If a single integer is passed, it will apply the transformations on the
+            layer at this index.
         layers_pattern (`str`):
-            The layer pattern name, used only if `layers_to_transform` is different from `None` and if the layer
-            pattern is not in the common layers pattern.
+            The layer pattern name, used only if `layers_to_transform` is different from `None`.
         rank_pattern (`dict`):
             The mapping from layer names or regexp expression to ranks which are different from the default rank
             specified by `r`.
         alpha_pattern (`dict`):
             The mapping from layer names or regexp expression to alphas which are different from the default alpha
             specified by `alpha`.
-        modules_to_save (`List[str]`): The names of modules to be set as trainable except LoKr parameters.
+        modules_to_save (`Optional[List[str]]`):
+            List of modules apart from adapter layers to be set as trainable and saved in the final checkpoint.
     """
 
     r: int = field(default=8, metadata={"help": "LoKr rank"})

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -52,8 +52,8 @@ class LoraConfig(PeftConfig):
         target_modules (`Optional[Union[List[str], str]]`):
             The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
             names will be replaced. When passing a string, a regex match will be performed. When passing a list of
-            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
-            the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any
+            of the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
             excluding the output layer. If this is not specified, modules will be chosen according to the model
             architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
             the target modules manually.
@@ -92,16 +92,16 @@ class LoraConfig(PeftConfig):
             The mapping from layer names or regexp expression to alphas which are different from the default alpha
             specified by `lora_alpha`.
         megatron_config (`Optional[dict]`):
-            The TransformerConfig arguments for Megatron. It is used to create LoRA's parallel linear layer. You can get
-            it like this, `core_transformer_config_from_args(get_args())`, these two functions being from Megatron. The
-            arguments will be used to initialize the TransformerConfig of Megatron. You need to specify this parameter
-            when you want to apply LoRA to the ColumnParallelLinear and RowParallelLinear layers of megatron.
+            The TransformerConfig arguments for Megatron. It is used to create LoRA's parallel linear layer. You can
+            get it like this, `core_transformer_config_from_args(get_args())`, these two functions being from Megatron.
+            The arguments will be used to initialize the TransformerConfig of Megatron. You need to specify this
+            parameter when you want to apply LoRA to the ColumnParallelLinear and RowParallelLinear layers of megatron.
         megatron_core (`Optional[str]`):
             The core module from Megatron to use, defaults to `"megatron.core"`.
         loftq_config (`Optional[LoftQConfig]`):
             The configuration of LoftQ. If this is not None, then LoftQ will be used to quantize the backbone weights
-            and initialize Lora layers. Also pass `init_lora_weights='loftq'`. Note that you should not pass a quantized
-            model in this case, as LoftQ will quantize the model itself.
+            and initialize Lora layers. Also pass `init_lora_weights='loftq'`. Note that you should not pass a
+            quantized model in this case, as LoftQ will quantize the model itself.
     """
 
     r: int = field(default=8, metadata={"help": "Lora attention dimension"})

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -47,39 +47,61 @@ class LoraConfig(PeftConfig):
     This is the configuration class to store the configuration of a [`LoraModel`].
 
     Args:
-        r (`int`): Lora attention dimension.
-        target_modules (`Optional[Union[List[str], str]]`): The names of the modules to apply LoRA to. If this is
-            specified, only the modules with the specified names will be replaced. If this is specified as
-            'all-linear', then all linear/Conv1D modules are chosen, excluding the output layer. If this is not
-            specified, modules will be chosen according to the model architecture. If the architecture is not known, an
-            error will be raised -- in this case, you should specify the target modules manually.
-        lora_alpha (`int`): The alpha parameter for Lora scaling.
-        lora_dropout (`float`): The dropout probability for Lora layers.
-        fan_in_fan_out (`bool`): Set this to True if the layer to replace stores weight like (fan_in, fan_out).
-            For example, gpt-2 uses `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set
-            to `True`.
-        bias (`str`): Bias type for Lora. Can be 'none', 'all' or 'lora_only'. If 'all' or 'lora_only', the
-            corresponding biases will be updated during training. Be aware that this means that, even when disabling
-            the adapters, the model will not produce the same output as the base model would have without adaptation.
+        r (`int`):
+            Lora attention dimension (the "rank").
+        target_modules (`Optional[Union[List[str], str]]`):
+            The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
+            names will be replaced. When passing a string, a regex match will be performed. When passing a list of
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
+            the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
+            excluding the output layer. If this is not specified, modules will be chosen according to the model
+            architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
+            the target modules manually.
+        lora_alpha (`int`):
+            The alpha parameter for Lora scaling.
+        lora_dropout (`float`):
+            The dropout probability for Lora layers.
+        fan_in_fan_out (`bool`):
+            Set this to True if the layer to replace stores weight like (fan_in, fan_out). For example, gpt-2 uses
+            `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`.
+        bias (`str`):
+            Bias type for LoRA. Can be 'none', 'all' or 'lora_only'. If 'all' or 'lora_only', the corresponding biases
+            will be updated during training. Be aware that this means that, even when disabling the adapters, the model
+            will not produce the same output as the base model would have without adaptation.
         use_rslora (`bool`):
             When set to True, uses <a href='https://doi.org/10.48550/arXiv.2312.03732'>Rank-Stabilized LoRA</a> which
             sets the adapter scaling factor to `lora_alpha/math.sqrt(r)`, since it was proven to work better.
             Otherwise, it will use the original default value of `lora_alpha/r`.
-        modules_to_save (`List[str]`):List of modules apart from LoRA layers to be set as trainable
-            and saved in the final checkpoint.
-        layers_to_transform (`Union[List[int],int]`):
-            The layer indexes to transform, if this argument is specified, it will apply the LoRA transformations on
-            the layer indexes that are specified in this list. If a single integer is passed, it will apply the LoRA
-            transformations on the layer at this index.
+        modules_to_save (`List[str]`):
+            List of modules apart from adapter layers to be set as trainable and saved in the final checkpoint.
+        init_lora_weights (`bool` | `Literal["gaussian", "loftq"]`):
+            How to initialize the weights of the adapter layers. Passing True (default) results in the default
+            initialization from the reference implementation from Microsoft. Passing 'gaussian' results in Gaussian
+            initialization scaled by the LoRA rank for linear and layers. Setting the initialization to False leads to
+            completely random initialization and is discouraged. Pass `'loftq'` to use LoftQ initialization.
+        layers_to_transform (`Union[List[int], int]`):
+            The layer indices to transform. If a list of ints is passed, it will apply the adapter to the layer indices
+            that are specified in this list. If a single integer is passed, it will apply the transformations on the
+            layer at this index.
         layers_pattern (`str`):
-            The layer pattern name, used only if `layers_to_transform` is different from `None` and if the layer
-            pattern is not in the common layers pattern.
+            The layer pattern name, used only if `layers_to_transform` is different from `None`.
         rank_pattern (`dict`):
             The mapping from layer names or regexp expression to ranks which are different from the default rank
             specified by `r`.
         alpha_pattern (`dict`):
             The mapping from layer names or regexp expression to alphas which are different from the default alpha
             specified by `lora_alpha`.
+        megatron_config (`Optional[dict]`):
+            The TransformerConfig arguments for Megatron. It is used to create LoRA's parallel linear layer. You can get
+            it like this, `core_transformer_config_from_args(get_args())`, these two functions being from Megatron. The
+            arguments will be used to initialize the TransformerConfig of Megatron. You need to specify this parameter
+            when you want to apply LoRA to the ColumnParallelLinear and RowParallelLinear layers of megatron.
+        megatron_core (`Optional[str]`):
+            The core module from Megatron to use, defaults to `"megatron.core"`.
+        loftq_config (`Optional[LoftQConfig]`):
+            The configuration of LoftQ. If this is not None, then LoftQ will be used to quantize the backbone weights
+            and initialize Lora layers. Also pass `init_lora_weights='loftq'`. Note that you should not pass a quantized
+            model in this case, as LoftQ will quantize the model itself.
     """
 
     r: int = field(default=8, metadata={"help": "Lora attention dimension"})
@@ -101,7 +123,9 @@ class LoraConfig(PeftConfig):
         default=False,
         metadata={"help": "Set this to True if the layer to replace stores weight like (fan_in, fan_out)"},
     )
-    bias: str = field(default="none", metadata={"help": "Bias type for Lora. Can be 'none', 'all' or 'lora_only'"})
+    bias: Literal["none", "all", "lora_only"] = field(
+        default="none", metadata={"help": "Bias type for Lora. Can be 'none', 'all' or 'lora_only'"}
+    )
     use_rslora: bool = field(
         default=False,
         metadata={
@@ -169,10 +193,10 @@ class LoraConfig(PeftConfig):
         default=None,
         metadata={
             "help": (
-                "The TransformerConfig from Megatron, it is used to create LoRA's parallel linear layer."
+                "The TransformerConfig from Megatron. It is used to create LoRA's parallel linear layer."
                 "You can get it like this, `core_transformer_config_from_args(get_args())`, "
-                "this two functions are from Megatron."
-                "You need to specify this parameter when you want to loraize the ColumnParallelLinear and "
+                "these two functions being from Megatron."
+                "You need to specify this parameter when you want to apply LoRA to the ColumnParallelLinear and "
                 "RowParallelLinear layers of megatron."
                 "It should be noted that we may not be able to use the `save_pretrained` and `from_pretrained` "
                 "functions, because TransformerConfig may not necessarily be serialized."
@@ -185,7 +209,7 @@ class LoraConfig(PeftConfig):
         default="megatron.core",
         metadata={
             "help": (
-                "The core module from Megatron, it is used to judge and create LoRA's parallel linear layer. "
+                "The core module from Megatron, it is used to create LoRA's parallel linear layer. "
                 "It only needs to be passed in when you need to use your own modified megatron core module. "
                 "Otherwise, it will use the default value `megatron.core`. "
             )
@@ -196,8 +220,8 @@ class LoraConfig(PeftConfig):
         default_factory=dict,
         metadata={
             "help": (
-                "The configuration of LoftQ. If this is not None, then LoftQ will be used to quantize the backbone "
-                "weights and initialize Lora layers."
+                "The configuration of LoftQ. If this is passed, then LoftQ will be used to quantize the backbone "
+                "weights and initialize Lora layers. Also set `init_lora_weights='loftq'` in this case."
             )
         },
     )
@@ -225,5 +249,5 @@ class LoraConfig(PeftConfig):
                 raise ValueError("`loftq_config` must be specified when `init_lora_weights` is 'loftq'.")
 
         # convert loftq_config to dict
-        if self.loftq_config is not None and not isinstance(self.loftq_config, dict):
+        if self.loftq_config and not isinstance(self.loftq_config, dict):
             self.loftq_config = vars(self.loftq_config)

--- a/src/peft/tuners/oft/config.py
+++ b/src/peft/tuners/oft/config.py
@@ -28,24 +28,33 @@ class OFTConfig(LycorisConfig):
     Args:
         r (`int`): OFT rank.
         module_dropout (`int`): The dropout probability for disabling OFT modules during training.
-        target_modules (`Union[List[str],str]`): The names of the modules to apply OFT to. If this is specified as
-            'all-linear', then all linear/Conv1D modules are chosen, excluding the output layer.
-        init_weights (`bool`): Whether to perform initialization of OFT weights.
-        layers_to_transform (`Union[List[int],int]`):
-            The layer indexes to transform, if this argument is specified, it will apply the OFT transformations on the
-            layer indexes that are specified in this list. If a single integer is passed, it will apply the OFT
-            transformations on the layer at this index.
+        target_modules (`Optional[Union[List[str], str]]`):
+            The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
+            names will be replaced. When passing a string, a regex match will be performed. When passing a list of
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
+            the passed strings. If this is specified as 'all-linear', then all linear modules are chosen, excluding the
+            output layer. If this is not specified, modules will be chosen according to the model architecture. If the
+            architecture is not known, an error will be raised -- in this case, you should specify the target modules
+            manually.
+        init_weights (`bool`):
+            Whether to perform initialization of OFT weights.
+        layers_to_transform (`Union[List[int], int]`):
+            The layer indices to transform. If a list of ints is passed, it will apply the adapter to the layer indices
+            that are specified in this list. If a single integer is passed, it will apply the transformations on the
+            layer at this index.
         layers_pattern (`str`):
-            The layer pattern name, used only if `layers_to_transform` is different from `None` and if the layer
-            pattern is not in the common layers pattern.
+            The layer pattern name, used only if `layers_to_transform` is different from `None`.
         rank_pattern (`dict`):
             The mapping from layer names or regexp expression to ranks which are different from the default rank
             specified by `r`.
-        modules_to_save (`List[str]`): The names of modules to be set as trainable except OFT parameters.
-        coft (`bool`): Whether to use the constrainted variant of OFT or not.
+        modules_to_save (`List[str]`):
+            List of modules apart from adapter layers to be set as trainable and saved in the final checkpoint.
+        coft (`bool`):
+            Whether to use the constrainted variant of OFT or not, off by default.
         eps (`float`):
             The control strength of COFT. The freedom of rotation. Only has an effect if `coft` is set to True.
-        block_share (`bool`): Whether to share the OFT parameters between blocks or not.
+        block_share (`bool`):
+            Whether to share the OFT parameters between blocks or not. This is `False` by default.
     """
 
     r: int = field(default=8, metadata={"help": "OFT rank"})

--- a/src/peft/tuners/oft/config.py
+++ b/src/peft/tuners/oft/config.py
@@ -31,11 +31,11 @@ class OFTConfig(LycorisConfig):
         target_modules (`Optional[Union[List[str], str]]`):
             The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
             names will be replaced. When passing a string, a regex match will be performed. When passing a list of
-            strings, either an exact match will be performed or it is checked if the name of the module ends with any of
-            the passed strings. If this is specified as 'all-linear', then all linear modules are chosen, excluding the
-            output layer. If this is not specified, modules will be chosen according to the model architecture. If the
-            architecture is not known, an error will be raised -- in this case, you should specify the target modules
-            manually.
+            strings, either an exact match will be performed or it is checked if the name of the module ends with any
+            of the passed strings. If this is specified as 'all-linear', then all linear modules are chosen, excluding
+            the output layer. If this is not specified, modules will be chosen according to the model architecture. If
+            the architecture is not known, an error will be raised -- in this case, you should specify the target
+            modules manually.
         init_weights (`bool`):
             Whether to perform initialization of OFT weights.
         layers_to_transform (`Union[List[int], int]`):


### PR DESCRIPTION
Over time, the docstrings of the numerous config classes have not kept up to date with changes in the code. This PR updates the docstrings to reflect the current state of the code.

On top of that, multiple small updates have been made:

- Correct wrong or imprecise type annotations.
- More neutral wording of the docstring. E.g., say "adapter" instead of "LoRA". This makes it easier to copy&paste the docstrings between classes.
- Use same wording for shared arguments.
- Add missing arguments.
- Uniform formatting: Always a line break after the first line of the docstring (not mixed, as that can be confusing).
- Fix line lengths to be consistently at 120 characters.