### PR TITLE
FIX Setting active adapter for quantized layers

### DIFF
--- a/src/peft/tuners/adalora/bnb.py
+++ b/src/peft/tuners/adalora/bnb.py
@@ -41,6 +41,7 @@ if is_bnb_available():
             # Freezing the pre-trained weight matrix
             self.get_base_layer().weight.requires_grad = False
 
+            self._active_adapter = adapter_name
             self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
 
         def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -98,6 +99,7 @@ if is_bnb_4bit_available():
             # Freezing the pre-trained weight matrix
             self.get_base_layer().weight.requires_grad = False
 
+            self._active_adapter = adapter_name
             self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
 
         def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:

--- a/src/peft/tuners/adalora/gptq.py
+++ b/src/peft/tuners/adalora/gptq.py
@@ -34,6 +34,7 @@ class SVDQuantLinear(torch.nn.Module, AdaLoraLayer):
         # self.base_layer and self.quant_linear_module are the same; we need the former for consistency and the latter
         # for backwards compatibility
         self.quant_linear_module = base_layer
+        self._active_adapter = adapter_name
         self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/src/peft/tuners/ia3/bnb.py
+++ b/src/peft/tuners/ia3/bnb.py
@@ -39,6 +39,7 @@ if is_bnb_available():
 
             # Freezing the pre-trained weight matrix
             self.get_base_layer().weight.requires_grad = False
+            self._active_adapter = adapter_name
             self.update_layer(adapter_name, init_ia3_weights)
 
         def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
@@ -90,6 +91,7 @@ if is_bnb_4bit_available():
 
             # Freezing the pre-trained weight matrix
             self.get_base_layer().weight.requires_grad = False
+            self._active_adapter = adapter_name
             self.update_layer(adapter_name, init_ia3_weights)
 
         def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -40,6 +40,7 @@ class QuantLinear(torch.nn.Module, LoraLayer):
         # self.base_layer and self.quant_linear_module are the same; we need the former for consistency and the latter
         # for backwards compatibility
         self.quant_linear_module = base_layer
+        self._active_adapter = adapter_name
         self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
 
     def forward(self, x: torch.Tensor):

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -754,7 +754,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
             load_in_4bit=True,
         )
         model = prepare_model_for_kbit_training(model)
-        model = get_peft_model(model, config)
+        model = get_peft_model(model, config, adapter_name="other")
         n_trainable_other, n_total_other = model.get_nb_trainable_parameters()
 
         self.assertGreater(n_trainable_other, 0)  # sanity check
@@ -788,7 +788,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
             load_in_8bit=True,
         )
         model = prepare_model_for_kbit_training(model)
-        model = get_peft_model(model, config)
+        model = get_peft_model(model, config, adapter_name="other")
         n_trainable_other, n_total_other = model.get_nb_trainable_parameters()
 
         self.assertGreater(n_trainable_other, 0)  # sanity check


### PR DESCRIPTION
Resolves #1346

See also #1294 for a similar (but incomplete) fix.

This commit fixes the setting of the adapter name on a couple of quantized layers that was accidentally removed in #1106. This affects users who use a non-default adapter name when they want to train these layers.

Running the tests locally with GPU passes.