### PR TITLE
DOC Add PeftMixedModel to API docs

### DIFF
--- a/docs/source/package_reference/peft_model.md
+++ b/docs/source/package_reference/peft_model.md
@@ -53,6 +53,13 @@ A `PeftModel` for getting extracting features/embeddings from transformer models
 [[autodoc]] PeftModelForFeatureExtraction
     - all
 
+## PeftMixedModel
+
+A `PeftModel` for mixing different adapter types (e.g. LoRA and LoHa).
+
+[[autodoc]] PeftMixedModel
+    - all
+
 ## Utilities
 
 [[autodoc]] get_peft_model


### PR DESCRIPTION
Adds missing API doc entry for `PeftMixedModel`.

HT @sayakpaul 