### PR TITLE
FIX: Make merging of adapter weights idempotent

### DIFF
--- a/src/peft/tuners/adalora/layer.py
+++ b/src/peft/tuners/adalora/layer.py
@@ -20,6 +20,7 @@ import torch
 from torch import nn
 
 from peft.tuners.lora import LoraLayer
+from peft.tuners.tuners_utils import check_adapters_to_merge
 from peft.utils import transpose
 
 
@@ -112,14 +113,10 @@ class SVDLinear(nn.Module, AdaLoraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        if self.merged:
-            warnings.warn(
-                f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                f"You are now additionally merging {','.join(self.active_adapters)}."
-            )
-
-        if adapter_names is None:
-            adapter_names = self.active_adapters
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        if not adapter_names:
+            # no adapter to merge
+            return
 
         for active_adapter in adapter_names:
             base_layer = self.get_base_layer()

--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -20,7 +20,7 @@ import torch
 import torch.nn as nn
 from transformers.pytorch_utils import Conv1D
 
-from peft.tuners.tuners_utils import BaseTunerLayer
+from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
 from peft.utils import transpose
 
 
@@ -103,14 +103,10 @@ class Linear(nn.Module, IA3Layer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        if self.merged:
-            warnings.warn(
-                f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                f"You are now additionally merging {','.join(self.active_adapters)}."
-            )
-
-        if adapter_names is None:
-            adapter_names = self.active_adapters
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        if not adapter_names:
+            # no adapter to merge
+            return
 
         for active_adapter in adapter_names:
             if active_adapter in self.ia3_l.keys():
@@ -228,14 +224,10 @@ class Conv2d(nn.Module, IA3Layer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        if self.merged:
-            warnings.warn(
-                f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                f"You are now additionally merging {','.join(self.active_adapters)}."
-            )
-
-        if adapter_names is None:
-            adapter_names = self.active_adapters
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        if not adapter_names:
+            # no adapter to merge
+            return
 
         for active_adapter in adapter_names:
             if active_adapter in self.ia3_l.keys():

--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -20,7 +20,7 @@ import bitsandbytes as bnb
 import torch
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
-from peft.tuners.tuners_utils import BaseTunerLayer
+from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
 from peft.utils.other import transpose
 
 from .layer import LoraLayer
@@ -60,14 +60,10 @@ if is_bnb_available():
                     The list of adapter names that should be merged. If None, all active adapters will be merged.
                     Defaults to `None`.
             """
-            if self.merged:
-                warnings.warn(
-                    f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                    f"You are now additionally merging {','.join(self.active_adapters)}."
-                )
-
-            if adapter_names is None:
-                adapter_names = self.active_adapters
+            adapter_names = check_adapters_to_merge(self, adapter_names)
+            if not adapter_names:
+                # no adapter to merge
+                return
 
             for active_adapter in adapter_names:
                 if active_adapter not in self.lora_A.keys():
@@ -242,14 +238,10 @@ if is_bnb_4bit_available():
                     The list of adapter names that should be merged. If None, all active adapters will be merged.
                     Defaults to `None`.
             """
-            if self.merged:
-                warnings.warn(
-                    f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                    f"You are now additionally merging {','.join(self.active_adapters)}."
-                )
-
-            if adapter_names is None:
-                adapter_names = self.active_adapters
+            adapter_names = check_adapters_to_merge(self, adapter_names)
+            if not adapter_names:
+                # no adapter to merge
+                return
 
             for active_adapter in adapter_names:
                 if active_adapter not in self.lora_A.keys():

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -22,7 +22,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers.pytorch_utils import Conv1D
 
-from peft.tuners.tuners_utils import BaseTunerLayer
+from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
 from peft.utils.other import transpose
 
 from .config import LoraConfig
@@ -224,14 +224,10 @@ class Linear(nn.Module, LoraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        if self.merged:
-            warnings.warn(
-                f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                f"You are now additionally merging {','.join(self.active_adapters)}."
-            )
-
-        if adapter_names is None:
-            adapter_names = self.active_adapters
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        if not adapter_names:
+            # no adapter to merge
+            return
 
         for active_adapter in adapter_names:
             if active_adapter in self.lora_A.keys():
@@ -393,14 +389,10 @@ class Embedding(nn.Module, LoraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        if self.merged:
-            warnings.warn(
-                f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                f"You are now additionally merging {','.join(self.active_adapters)}."
-            )
-
-        if adapter_names is None:
-            adapter_names = self.active_adapters
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        if not adapter_names:
+            # no adapter to merge
+            return
 
         for active_adapter in adapter_names:
             if active_adapter in self.lora_embedding_A.keys():
@@ -572,14 +564,10 @@ class Conv2d(nn.Module, LoraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        if self.merged:
-            warnings.warn(
-                f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                f"You are now additionally merging {','.join(self.active_adapters)}."
-            )
-
-        if adapter_names is None:
-            adapter_names = self.active_adapters
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        if not adapter_names:
+            # no adapter to merge
+            return
 
         for active_adapter in adapter_names:
             if active_adapter in self.lora_A.keys():

--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -29,7 +29,7 @@ from peft.utils import (
     _get_submodules,
 )
 
-from .tuners_utils import BaseTuner, BaseTunerLayer, check_target_module_exists
+from .tuners_utils import BaseTuner, BaseTunerLayer, check_target_module_exists, check_adapters_to_merge
 
 
 @dataclass
@@ -121,13 +121,10 @@ class LycorisLayer(BaseTunerLayer):
                 The list of adapter names that should be merged. If `None`, all active adapters will be merged.
                 Defaults to `None`.
         """
-        if self.merged:
-            warnings.warn(
-                f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                f"You are now additionally merging {','.join(self.active_adapters)}."
-            )
-        if adapter_names is None:
-            adapter_names = self.active_adapters
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        if not adapter_names:
+            # no adapter to merge
+            return
 
         for active_adapter in adapter_names:
             if active_adapter in self._available_adapters:

--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -29,7 +29,7 @@ from peft.utils import (
     _get_submodules,
 )
 
-from .tuners_utils import BaseTuner, BaseTunerLayer, check_target_module_exists, check_adapters_to_merge
+from .tuners_utils import BaseTuner, BaseTunerLayer, check_adapters_to_merge, check_target_module_exists
 
 
 @dataclass

--- a/src/peft/tuners/oft/layer.py
+++ b/src/peft/tuners/oft/layer.py
@@ -20,7 +20,7 @@ from typing import Any, List, Optional, Set, Tuple
 import torch
 import torch.nn as nn
 
-from peft.tuners.lycoris_utils import LycorisLayer
+from peft.tuners.lycoris_utils import LycorisLayer, check_adapters_to_merge
 
 
 class OFTLayer(nn.Module, LycorisLayer):
@@ -135,13 +135,10 @@ class OFTLayer(nn.Module, LycorisLayer):
                 The list of adapter names that should be merged. If `None`, all active adapters will be merged.
                 Defaults to `None`.
         """
-        if self.merged:
-            warnings.warn(
-                f"Already following adapters were merged {','.join(self.merged_adapters)}. "
-                f"You are now additionally merging {','.join(self.active_adapters)}."
-            )
-        if adapter_names is None:
-            adapter_names = self.active_adapters
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        if not adapter_names:
+            # no adapter to merge
+            return
 
         for active_adapter in adapter_names:
             if active_adapter in self._available_adapters:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -631,3 +631,29 @@ def _maybe_include_all_linear_layers(peft_config: PeftConfig, model: nn.Module) 
         linear_module_names -= {last_module_name}
     peft_config.target_modules = linear_module_names
     return peft_config
+
+
+def check_adapters_to_merge(module: BaseTunerLayer, adapter_names: Optional[List[str]] = None) -> list[str]:
+    """
+    Helper function to check which adapters should be merged.
+
+    Only return those adapters that are not already merged. Give a warning if some or all of the adapters are already
+    merged.
+
+    """
+    if adapter_names is None:
+        adapter_names = module.active_adapters
+
+    if module.merged:
+        merged_adapters = set(module.merged_adapters)
+        adapter_names = [name for name in adapter_names if name not in merged_adapters]
+
+        if adapter_names:
+            warnings.warn(
+                f"Already following adapters were merged {','.join(module.merged_adapters)}. "
+                f"You are now additionally merging {','.join(adapter_names)}."
+            )
+        else:
+            warnings.warn("All adapters are already merged, nothing to do.")
+
+    return adapter_names

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -485,6 +485,16 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         self._test_merge_layers_fp16(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(TEST_CASES)
+    def test_merge_layers_is_idempotent(self, test_name, model_id, config_cls, config_kwargs):
+        # calling merge twice with the same arguments should not change the output
+        config_kwargs = config_kwargs.copy()
+        if issubclass(config_cls, LoraConfig):
+            config_kwargs["init_lora_weights"] = False
+        elif issubclass(config_cls, IA3Config):
+            config_kwargs["init_ia3_weights"] = False
+        self._test_merge_layers_is_idempotent(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(TEST_CASES)
     def test_generate(self, test_name, model_id, config_cls, config_kwargs):
         # Custom models do not (necessarily) have a generate method, so this test is not performed
         pass

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -435,9 +435,10 @@ class PeftCommonTester:
             self.assertIs(model_from_pretrained.peft_config["default"], config)
 
     def _test_merge_layers_fp16(self, model_id, config_cls, config_kwargs):
-        if config_cls not in (LoraConfig,):
+        if config_cls not in (LoraConfig, IA3Config):
             # Merge layers only supported for LoRA and IA³
             return
+
         if ("gpt2" in model_id.lower()) and (config_cls != LoraConfig):
             self.skipTest("Merging GPT2 adapters not supported for IA³ (yet)")
 
@@ -635,6 +636,31 @@ class PeftCommonTester:
             logits_merged_adapter_default = model_merged_adapter_default(**dummy_input)[0]
 
         self.assertTrue(torch.allclose(logits_merged_adapter_default, logits_adapter_1, atol=1e-3, rtol=1e-3))
+
+    def _test_merge_layers_is_idempotent(self, model_id, config_cls, config_kwargs):
+        if ("gpt2" in model_id.lower()) and (config_cls != LoraConfig):
+            self.skipTest("Merging GPT2 adapters not supported for IA³ (yet)")
+
+        model = self.transformers_class.from_pretrained(model_id)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config)
+        model = model.to(self.torch_device)
+
+        model.eval()
+        torch.manual_seed(0)
+        model.merge_adapter()
+        logits_0 = model(**self.prepare_inputs_for_testing())[0]
+
+        # merging again should not change anything
+        # also check warning:
+        with self.assertWarnsRegex(UserWarning, "All adapters are already merged, nothing to do"):
+            model.merge_adapter()
+        logits_1 = model(**self.prepare_inputs_for_testing())[0]
+
+        self.assertTrue(torch.allclose(logits_0, logits_1, atol=1e-6, rtol=1e-6))
 
     def _test_generate(self, model_id, config_cls, config_kwargs):
         model = self.transformers_class.from_pretrained(model_id)


### PR DESCRIPTION
Right now, merging of adapters weights such as LoRA and IA³ is not idempotent. This means that if a user calls `merge` multiple times, the resulting weights will be different each time because the delta weights are added again and again.

This fix checks that only those adapters are merged that are not yet merged. Also, gives a more precise warning:

- Say when there is nothing to merge.
- If there are some adapters to merge, only mention those

This bug is more subtle than it may seem at first, since we sometimes merge implicitly without the user necessarily being aware of it (e.g. when calling `merge_and_unload`). Therefore, this bug can occur quite easily, even if the user does not explicitly call `merge` twice in a row.