### PR TITLE
Improve documentation for the `all-linear` flag

### DIFF
--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -183,7 +183,7 @@ model.delete_adapter("dpo")
 
 ## QLoRA-style training
 
-The default LoRA settings in PEFT follow the [original paper](https://hf.co/papers/2106.09685) and add trainable weights to the query and value layers. However, in [QLoRa](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let PEFT handle the rest: 
+The default LoRA settings in PEFT follow the [original paper](https://hf.co/papers/2106.09685) and add trainable weights to the query and value layers of each attention block. However, in [QLoRA](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let PEFT handle the rest: 
 
 ```py
 config = LoraConfig(target_modules="all-linear", ...) # adds LoRA to all linear layers like in QLoRA

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -183,8 +183,8 @@ model.delete_adapter("dpo")
 
 ## QLoRA-style training
 
-The default LoRA settings in PEFT follow the original paper and add trainable weights to the query and value layers. However, in [QLoRa](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let PEFT handle the rest: 
+The default LoRA settings in PEFT follow the [original paper](https://hf.co/papers/2106.09685) and add trainable weights to the query and value layers. However, in [QLoRa](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let PEFT handle the rest: 
 
 ```py
-config = LoraConfig(target_modules="all-linear", ...)
+config = LoraConfig(target_modules="all-linear", ...) # adds LoRA to all linear layers like in QLoRA
 ```

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -183,7 +183,7 @@ model.delete_adapter("dpo")
 
 ## QLoRA-style training
 
-The default LoRA settings in 🤗PEFT follow the [original paper](https://hf.co/papers/2106.09685) and add trainable weights to the query and value layers of each attention block. However, in [QLoRA](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let PEFT handle the rest: 
+The default LoRA settings in 🤗PEFT follow the [original paper](https://hf.co/papers/2106.09685) and add trainable weights to the query and value layers of each attention block. However, in [QLoRA](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let 🤗PEFT handle the rest: 
 
 ```py
 config = LoraConfig(target_modules="all-linear", ...) # adds LoRA to all linear layers like in QLoRA

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -183,7 +183,7 @@ model.delete_adapter("dpo")
 
 ## QLoRA-style training
 
-The default LoRA settings in PEFT follow the [original paper](https://hf.co/papers/2106.09685) and add trainable weights to the query and value layers of each attention block. However, in [QLoRA](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let PEFT handle the rest: 
+The default LoRA settings in 🤗PEFT follow the [original paper](https://hf.co/papers/2106.09685) and add trainable weights to the query and value layers of each attention block. However, in [QLoRA](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let PEFT handle the rest: 
 
 ```py
 config = LoraConfig(target_modules="all-linear", ...) # adds LoRA to all linear layers like in QLoRA

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -180,3 +180,11 @@ model.unload()
 # delete adapter
 model.delete_adapter("dpo")
 ```
+
+## QLoRA-style training
+
+The default LoRA settings in PEFT follow the original paper and add trainable weights to the query and value layers. However, in [QLoRa](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let PEFT handle the rest: 
+
+```py
+config = LoraConfig(target_modules="all-linear", ...)
+```

--- a/docs/source/developer_guides/quantization.md
+++ b/docs/source/developer_guides/quantization.md
@@ -125,6 +125,12 @@ lora_config = LoraConfig(
 
 model = get_peft_model(model, lora_config)
 ```
+### QLoRA-style training
+QLoRA adds trainable weights to all the linear layers in the transformer architecture. Since the attribute names for these linear layers can vary across architectures, we provide a convenient flag `'all-linear'` for this setting:
+
+```py
+config = LoraConfig(target_modules="all-linear", ...) # adds LoRA to all linear layers like in QLoRA
+```
 
 ## Next steps
 


### PR DESCRIPTION
A small PR to add the new `all-linear` flag  (#1295) to PEFT docs. 