### PR TITLE
remove unnecessary code `len(unique_adapters)`

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -217,7 +217,6 @@ class Linear(nn.Linear, LoraLayer):
 
     def multi_batched_forward(self, x: torch.Tensor, adapter_names) -> torch.Tensor:
         unique_adapters = set(adapter_names)
-        len(unique_adapters)
         sub_batch_indices_list = []
         for adapter in unique_adapters:
             sub_batch_indices_list.append([index for index, item in enumerate(adapter_names) if item == adapter])


### PR DESCRIPTION
A small PR that removes seemingly unnecessary code([peft/src/peft/tuners/lora/layer.py#L220](https://github.com/huggingface/peft/blob/918d4c6997de35c1cdcfe068e69eedda6cc10b80/src/peft/tuners/lora/layer.py#L220)).

https://github.com/huggingface/peft/blob/918d4c6997de35c1cdcfe068e69eedda6cc10b80/src/peft/tuners/lora/layer.py#L220