### PR TITLE
Added missing getattr dunder methods for mixed model

### DIFF
--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -191,6 +191,13 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
             f"trainable%: {100 * trainable_params / all_param:.4f}"
         )
 
+    def __getattr__(self, name: str):
+        """Forward missing attributes to the wrapped module."""
+        try:
+            return super().__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            return getattr(self.base_model, name)
+
     def forward(self, *args: Any, **kwargs: Any):
         """
         Forward pass of the model.

--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -179,6 +179,13 @@ class MixedModel(BaseTuner):
             raise ValueError(f"Unknown config type {type(config)}, should be one of {COMPATIBLE_TUNER_TYPES}.")
         return new_module
 
+    def __getattr__(self, name: str):
+        """Forward missing attributes to the wrapped module."""
+        try:
+            return super().__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            return getattr(self.model, name)
+
     def _set_adapter_layers(self, enabled=True):
         for module in self.model.modules():
             if isinstance(module, (BaseTunerLayer, ModulesToSaveWrapper)):


### PR DESCRIPTION
Hello, PEFT team!

I tried to use the new interface for MixedModel and discovered that the current implementation of PeftMixedModel and MixedModel lacks getattr dunder methods (so we cannot use corresponding underlying implementations for e.g. device).

This PR just adds these missing methods.