### PR TITLE
Handle resizing of embedding layers for AutoPeftModel

### DIFF
--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -41,7 +41,7 @@ from .peft_model import (
     PeftModelForSequenceClassification,
     PeftModelForTokenClassification,
 )
-from .utils.other import TOKENIZER_CONFIG_NAME
+from .utils.constants import TOKENIZER_CONFIG_NAME
 
 
 class _BaseAutoPeftModel:

--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -16,8 +16,10 @@
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Optional
 
+from huggingface_hub import file_exists
 from transformers import (
     AutoModel,
     AutoModelForCausalLM,
@@ -25,6 +27,7 @@ from transformers import (
     AutoModelForSeq2SeqLM,
     AutoModelForSequenceClassification,
     AutoModelForTokenClassification,
+    AutoTokenizer,
 )
 
 from .config import PeftConfig
@@ -38,6 +41,7 @@ from .peft_model import (
     PeftModelForSequenceClassification,
     PeftModelForTokenClassification,
 )
+from .utils.other import TOKENIZER_CONFIG_NAME
 
 
 class _BaseAutoPeftModel:
@@ -99,6 +103,26 @@ class _BaseAutoPeftModel:
             )
 
         base_model = target_class.from_pretrained(base_model_path, **kwargs)
+
+        tokenizer_exists = False
+        if os.path.exists(os.path.join(pretrained_model_name_or_path, TOKENIZER_CONFIG_NAME)):
+            tokenizer_exists = True
+        else:
+            token = kwargs.get("token", None)
+            if token is None:
+                token = kwargs.get("use_auth_token", None)
+
+            tokenizer_exists = file_exists(
+                repo_id=pretrained_model_name_or_path,
+                filename=TOKENIZER_CONFIG_NAME,
+                revision=kwargs.get("revision", None),
+                repo_type=kwargs.get("repo_type", None),
+                token=token,
+            )
+
+        if tokenizer_exists:
+            tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path)
+            base_model.resize_token_embeddings(len(tokenizer))
 
         return cls._target_peft_class.from_pretrained(
             base_model,

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -148,3 +148,4 @@ SAFETENSORS_WEIGHTS_NAME = "adapter_model.safetensors"
 CONFIG_NAME = "adapter_config.json"
 EMBEDDING_LAYER_NAMES = ["embed_tokens", "lm_head"]
 INCLUDE_LINEAR_LAYERS_SHORTHAND = "all-linear"
+TOKENIZER_CONFIG_NAME = "tokenizer_config.json"

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -57,6 +57,21 @@ class PeftAutoModelTester(unittest.TestCase):
         # This should work
         _ = AutoPeftModelForCausalLM.from_pretrained(model_id, adapter_name, is_trainable, torch_dtype=torch.bfloat16)
 
+    def test_peft_causal_lm_extended_vocab(self):
+        model_id = "peft-internal-testing/tiny-random-OPTForCausalLM-extended-vocab"
+        model = AutoPeftModelForCausalLM.from_pretrained(model_id)
+        self.assertTrue(isinstance(model, PeftModelForCausalLM))
+
+        # check if kwargs are passed correctly
+        model = AutoPeftModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16)
+        self.assertTrue(isinstance(model, PeftModelForCausalLM))
+        self.assertTrue(model.base_model.lm_head.weight.dtype == torch.bfloat16)
+
+        adapter_name = "default"
+        is_trainable = False
+        # This should work
+        _ = AutoPeftModelForCausalLM.from_pretrained(model_id, adapter_name, is_trainable, torch_dtype=torch.bfloat16)
+
     def test_peft_seq2seq_lm(self):
         model_id = "peft-internal-testing/tiny_T5ForSeq2SeqLM-lora"
         model = AutoPeftModelForSeq2SeqLM.from_pretrained(model_id)


### PR DESCRIPTION
### What does this PR do?
1. In few scenarios the vocab of the model is extended to add special tokens like `<|im_start|>` ... In such scenarios during inference, the user needs to load the base model first and resize it the same way they did before training the model as shown below:
```python
from transformers import AutoModelForCausalLM, AutoTokenizer
peft_model_id = "smangrul/tinyllama_lora_norobots"
config = PeftConfig.from_pretrained(peft_model_id)
model = AutoModelForCausalLM.from_pretrained(config.base_model_name_or_path, load_in_4bit=True, device_map="auto")
tokenizer = AutoTokenizer.from_pretrained(peft_model_id)
model.resize_token_embeddings(len(tokenizer))
model = PeftModel.from_pretrained(model, peft_model_id, adapter_name="norobots")
```

2. This wasn't handled by `AutoPeftModel` classes. This PR automates the resizing of the base model if the tokenizer is saved with the adapter weights. The above code gets simplified to the one shown below:
```diff
from peft import AutoPeftModelForCausalLM, PeftConfig
from transformers import AutoTokenizer

peft_model_id = "smangrul/tinyllama_lora_norobots"
config = PeftConfig.from_pretrained(peft_model_id)
+ model = AutoPeftModelForCausalLM.from_pretrained(peft_model_id, adapter_name="norobots", load_in_4bit=True, device_map="auto")
tokenizer = AutoTokenizer.from_pretrained(peft_model_id)
- model.resize_token_embeddings(len(tokenizer))
- model = PeftModel.from_pretrained(model, peft_model_id, adapter_name="norobots")
```

- [x] Add tests