### PR TITLE
Add support for layer replication in LoRA

### DIFF
--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -89,15 +89,13 @@ config = LoraConfig(target_modules="all-linear", ...)
 
 ### Memory efficient Layer Replication with LoRA
 
-One of approach used to improve the performance of models is using model merging techniques is to expand a model by duplicating layers in the model to build a larger model from a pretrained model of a given size.
-For example increasing a 7B model to a 10B model as described in the [SOLAR](https://arxiv.org/abs/2312.15166). PEFT LoRA supports this kind of merge in a memory efficient manner that supports further fine-tuning
-using LoRA adapters attached to the layers post replication of the layers. The replicated layers do not take additional memory as they share the underlying weights so the only additional memory required is the
-memory for the adapter weights. To use this feature you would create a config with the `layer_replication` argument.
+An approach used to improve the performance of models is to expand a model by duplicating layers in the model to build a larger model from a pretrained model of a given size. For example increasing a 7B model to a 10B model as described in the [SOLAR](https://arxiv.org/abs/2312.15166) paper. PEFT LoRA supports this kind of expansion in a memory efficient manner that supports further fine-tuning using LoRA adapters attached to the layers post replication of the layers. The replicated layers do not take additional memory as they share the underlying weights so the only additional memory required is the memory for the adapter weights. To use this feature you would create a config with the `layer_replication` argument.
+
 ```py
 config = LoraConfig(layer_replication=[[0,4], [2,5]], ...)
 ```
-Given the original model had 5 layers `[0, 1, 2 ,3, 4]`, this would create a model with 7 layers arranged as `[0, 1, 2, 3, 2, 3, 4]`. This follows the mergekit pass through merge convention where sequences
-of layers specified as start inclusive and end exclusive tuples are stacked to build the final model. It is important to note that each layer in the final model gets its own distinct set of LoRA adpaters.
+
+Assuming the original model had 5 layers `[0, 1, 2 ,3, 4]`, this would create a model with 7 layers arranged as `[0, 1, 2, 3, 2, 3, 4]`. This follows the [mergekit](https://github.com/arcee-ai/mergekit) pass through merge convention where sequences of layers specified as start inclusive and end exclusive tuples are stacked to build the final model. Each layer in the final model gets its own distinct set of LoRA adpaters.
 
 [Fewshot-Metamath-OrcaVicuna-Mistral-10B](https://huggingface.co/abacusai/Fewshot-Metamath-OrcaVicuna-Mistral-10B) is an example of a model trained using this method on Mistral-7B expanded to 10B. The
 (adapter_config.json)[https://huggingface.co/abacusai/Fewshot-Metamath-OrcaVicuna-Mistral-10B/blob/main/adapter_config.json] shows a sample LoRA adapter config applying this method for fine-tuning.

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -87,6 +87,18 @@ The default LoRA settings in PEFT add trainable weights to the query and value l
 config = LoraConfig(target_modules="all-linear", ...)
 ```
 
+### Memory efficient Layer Replication with LoRA
+
+One of approach used to improve the performance of models is using model merging techniques is to expand a model by duplicating layers in the model to build a larger model from a pretrained model of a given size.
+For example increasing a 7B model to a 10B model as described in the [SOLAR](https://arxiv.org/abs/2312.15166). PEFT LoRA supports this kind of merge in a memory efficient manner that supports further fine-tuning
+using LoRA adapters attached to the layers post replication of the layers. The replicated layers do not take additional memory as they share the underlying weights so the only additional memory required is the
+memory for the adapter weights. To use this feature you would create a config with the `layer_replication` argument.
+```py
+config = LoraConfig(layer_replication=[[0,4], [2,5]], ...)
+```
+Given the original model had 5 layers `[0, 1, 2 ,3, 4]`, this would create a model with 7 layers arranged as `[0, 1, 2, 3, 2, 3, 4]`. This follows the mergekit pass through merge convention where sequences
+of layers specified as start inclusive and end exclusive tuples are stacked to build the final model. It is important to note that each layer in the final model gets its own distinct set of LoRA adpaters.
+
 ## Merge adapters
 
 While LoRA is significantly smaller and faster to train, you may encounter latency issues during inference due to separately loading the base model and the LoRA adapter. To eliminate latency, use the [`~LoraModel.merge_and_unload`] function to merge the adapter weights with the base model. This allows you to use the newly merged model as a standalone model. The [`~LoraModel.merge_and_unload`] function doesn't keep the adapter weights in memory.

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -99,6 +99,9 @@ config = LoraConfig(layer_replication=[[0,4], [2,5]], ...)
 Given the original model had 5 layers `[0, 1, 2 ,3, 4]`, this would create a model with 7 layers arranged as `[0, 1, 2, 3, 2, 3, 4]`. This follows the mergekit pass through merge convention where sequences
 of layers specified as start inclusive and end exclusive tuples are stacked to build the final model. It is important to note that each layer in the final model gets its own distinct set of LoRA adpaters.
 
+[Fewshot-Metamath-OrcaVicuna-Mistral-10B](https://huggingface.co/abacusai/Fewshot-Metamath-OrcaVicuna-Mistral-10B) is an example of a model trained using this method on Mistral-7B expanded to 10B. The
+(adapter_config.json)[https://huggingface.co/abacusai/Fewshot-Metamath-OrcaVicuna-Mistral-10B/blob/main/adapter_config.json] shows a sample LoRA adapter config applying this method for fine-tuning.
+
 ## Merge adapters
 
 While LoRA is significantly smaller and faster to train, you may encounter latency issues during inference due to separately loading the base model and the LoRA adapter. To eliminate latency, use the [`~LoraModel.merge_and_unload`] function to merge the adapter weights with the base model. This allows you to use the newly merged model as a standalone model. The [`~LoraModel.merge_and_unload`] function doesn't keep the adapter weights in memory.

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -108,6 +108,10 @@ class LoraConfig(PeftConfig):
             ranks. Right now, DoRA only supports non-quantized linear layers. DoRA introduces a bigger overhead than
             pure LoRA, so it is recommended to merge weights for inference. For more information, see
             https://arxiv.org/abs/2402.09353.
+        layer_replication(`List[Tuple[int, int]]):
+            Build a new stack of layers by stacking the original model layers according to the ranges specified.
+            This allows expanding (or shrinking) the model without duplicating the base model weights.
+            The new layers will all have separate LoRA adapters attached to them.
     """
 
     r: int = field(default=8, metadata={"help": "Lora attention dimension"})
@@ -249,7 +253,7 @@ class LoraConfig(PeftConfig):
         default=None,
         metadata={
             "help": (
-                "This enable using LoRA to effectively expand a model to a larger size by repeating some layers. "
+                "This enables using LoRA to effectively expand a model to a larger size by repeating some layers. "
                 "Base weights are shared so the memory usage is close to the original model."
                 "The format is a list of (start, end) pairs which specify the layer ranges to stack."
             )

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -108,7 +108,7 @@ class LoraConfig(PeftConfig):
             ranks. Right now, DoRA only supports non-quantized linear layers. DoRA introduces a bigger overhead than
             pure LoRA, so it is recommended to merge weights for inference. For more information, see
             https://arxiv.org/abs/2402.09353.
-        layer_replication(`List[Tuple[int, int]]):
+        layer_replication(`List[Tuple[int, int]]`):
             Build a new stack of layers by stacking the original model layers according to the ranges specified. This
             allows expanding (or shrinking) the model without duplicating the base model weights. The new layers will
             all have separate LoRA adapters attached to them.
@@ -254,7 +254,7 @@ class LoraConfig(PeftConfig):
         metadata={
             "help": (
                 "This enables using LoRA to effectively expand a transformer model to a larger size by repeating some layers. "
-                "The transformation handles models (currently Llama, Bert or Falcon compatible architecutres) with "
+                "The transformation handles models (currently Llama, Bert or Falcon compatible architectures) with "
                 "a module list in the model which it modifies to expand the number of modules. "
                 "Base weights are shared so the memory usage is close to the original model. The intended use is these base weights "
                 "remain fixed during finetuning but each layer has a separate LoRA adapter so the layers can be specialed via "

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -109,9 +109,9 @@ class LoraConfig(PeftConfig):
             pure LoRA, so it is recommended to merge weights for inference. For more information, see
             https://arxiv.org/abs/2402.09353.
         layer_replication(`List[Tuple[int, int]]):
-            Build a new stack of layers by stacking the original model layers according to the ranges specified.
-            This allows expanding (or shrinking) the model without duplicating the base model weights.
-            The new layers will all have separate LoRA adapters attached to them.
+            Build a new stack of layers by stacking the original model layers according to the ranges specified. This
+            allows expanding (or shrinking) the model without duplicating the base model weights. The new layers will
+            all have separate LoRA adapters attached to them.
     """
 
     r: int = field(default=8, metadata={"help": "Lora attention dimension"})
@@ -254,8 +254,9 @@ class LoraConfig(PeftConfig):
         metadata={
             "help": (
                 "This enables using LoRA to effectively expand a transformer model to a larger size by repeating some layers. "
-                "The transformation expects a `layers` module list in the model which it modifies to expand the number of modules. "
-                "Base weights are shared so the memory usage is close to the original model. The inteneded use is these base weights "
+                "The transformation handles models (currently Llama, Bert or Falcon compatible architecutres) with "
+                "a module list in the model which it modifies to expand the number of modules. "
+                "Base weights are shared so the memory usage is close to the original model. The intended use is these base weights "
                 "remain fixed during finetuning but each layer has a separate LoRA adapter so the layers can be specialed via "
                 "the adapter layers fit during fine tuning."
                 "The format is a list of [start, end) pairs which specify the layer ranges to stack. For example:\n"

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Literal, Optional, Union
 
 from peft.config import PeftConfig
 from peft.utils import PeftType
@@ -249,13 +249,17 @@ class LoraConfig(PeftConfig):
         },
     )
     # Enables replicating layers in a model to expand it to a larger model.
-    layer_replication: Optional[List[Tuple[int, int]]] = field(
+    layer_replication: Optional[list[tuple[int, int]]] = field(
         default=None,
         metadata={
             "help": (
-                "This enables using LoRA to effectively expand a model to a larger size by repeating some layers. "
+                "This enables using LoRA to effectively expand a transformer model to a larger size by repeating some layers. "
+                "The transformation expects a `layers` module list in the model which it modifies to expand the number of modules. "
                 "Base weights are shared so the memory usage is close to the original model."
-                "The format is a list of (start, end) pairs which specify the layer ranges to stack."
+                "The format is a list of [start, end) pairs which specify the layer ranges to stack. For example:\n"
+                "   original: `[0, 1, 2, 3, 4]`\n"
+                "   layer_replication: `[[0, 4], [2, 5]]`\n"
+                "   final: `[0, 1, 2, 3, 2, 3, 4]`"
             )
         }
     )

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, Optional, Union
+from typing import List, Literal, Optional, Tuple, Union
 
 from peft.config import PeftConfig
 from peft.utils import PeftType
@@ -243,6 +243,17 @@ class LoraConfig(PeftConfig):
                 "information, see  https://arxiv.org/abs/2402.09353."
             )
         },
+    )
+    # Enables replicating layers in a model to expand it to a larger model.
+    layer_replication: Optional[List[Tuple[int, int]]] = field(
+        default=None,
+        metadata={
+            "help": (
+                "This enable using LoRA to effectively expand a model to a larger size by repeating some layers. "
+                "Base weights are shared so the memory usage is close to the original model."
+                "The format is a list of (start, end) pairs which specify the layer ranges to stack."
+            )
+        }
     )
 
     def __post_init__(self):

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -255,13 +255,17 @@ class LoraConfig(PeftConfig):
             "help": (
                 "This enables using LoRA to effectively expand a transformer model to a larger size by repeating some layers. "
                 "The transformation expects a `layers` module list in the model which it modifies to expand the number of modules. "
-                "Base weights are shared so the memory usage is close to the original model."
+                "Base weights are shared so the memory usage is close to the original model. The inteneded use is these base weights "
+                "remain fixed during finetuning but each layer has a separate LoRA adapter so the layers can be specialed via "
+                "the adapter layers fit during fine tuning."
                 "The format is a list of [start, end) pairs which specify the layer ranges to stack. For example:\n"
-                "   original: `[0, 1, 2, 3, 4]`\n"
+                "   Original model has 5 layers labelled by their position in the model: `[0, 1, 2, 3, 4]`\n"
                 "   layer_replication: `[[0, 4], [2, 5]]`\n"
-                "   final: `[0, 1, 2, 3, 2, 3, 4]`"
+                "   Final model will have this arrangement of original layers: `[0, 1, 2, 3, 2, 3, 4]`\n"
+                "This format is based on what is used for pass-through merges in mergekit. It makes it simple to select sequential "
+                "ranges of a model and stack them while reusing layers at either end of each sequence."
             )
-        }
+        },
     )
 
     def __post_init__(self):

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -142,7 +142,7 @@ class LoraModel(BaseTuner):
         Args:
             peft_config (`PeftConfig`):
                 The prepared adapter config.
-            model_config (`nn.Module`):
+            model (`nn.Module`):
                 The model that is going to be adapted.
         """
         if peft_config.layer_replication:

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -362,10 +362,6 @@ class LoraModel(BaseTuner):
         if self.peft_config.get("layer_replication"):
             raise ValueError("Cannot merge LORA layers when base model layers are replicated")
 
-    def merge_adapter(self, adapter_names: Optional[list[str]] = None) -> None:
-        self._check_merge_allowed()
-        super().merge_adapter(adapter_names=adapter_names)
-
     @staticmethod
     def _prepare_adapter_config(peft_config, model_config):
         if peft_config.target_modules is None:

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -33,7 +33,7 @@ from peft.tuners.tuners_utils import (
     BaseTunerLayer,
     check_target_module_exists,
     onload_layer,
-    replicate_layers
+    replicate_layers,
 )
 from peft.utils import (
     TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING,
@@ -359,7 +359,7 @@ class LoraModel(BaseTuner):
         """
         if getattr(self.model, "quantization_method", None) == "gptq":
             raise ValueError("Cannot merge LORA layers when the model is gptq quantized")
-        if self.peft_config.get('layer_replication'):
+        if self.peft_config.get("layer_replication"):
             raise ValueError("Cannot merge LORA layers when base model layers are replicated")
 
     def merge_adapter(self, adapter_names: Optional[list[str]] = None) -> None:

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -353,6 +353,10 @@ class LoraModel(BaseTuner):
         self.active_adapter = adapter_name
 
     def _check_merge_allowed(self):
+        """Verify that the configuration supports merging.
+
+        Currently gptq quantization and replicated layers do not support merging.
+        """
         if getattr(self.model, "quantization_method", None) == "gptq":
             raise ValueError("Cannot merge LORA layers when the model is gptq quantized")
         if self.peft_config.get('layer_replication'):

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -187,7 +187,7 @@ class BaseTuner(nn.Module, ABC):
         Args:
             peft_config (`PeftConfig`):
                 The prepared adapter config.
-            model_config (`nn.Module`):
+            model (`nn.Module`):
                 The model that is going to be adapted.
         """
         pass

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -306,21 +306,21 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
     def test_lora_layer_replication(self):
         model_id = "HuggingFaceM4/tiny-random-LlamaForCausalLM"
         config_kwargs = {
-            "target_modules": ['down_proj', 'up_proj'],
+            "target_modules": ["down_proj", "up_proj"],
             "task_type": "CAUSAL_LM",
             "lora_dropout": 0.0,
-            "layer_replication": [[0, 1], [0, 2], [1, 2]]
+            "layer_replication": [[0, 1], [0, 2], [1, 2]],
         }
         model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
         config = LoraConfig(
             base_model_name_or_path=model_id,
             **config_kwargs,
         )
-        assert 2 == len(model.model.layers), 'Expected 2 layers in original model.'
+        assert len(model.model.layers), "Expected 2 layers in original model." == 2
         model = get_peft_model(model, config)
-        assert 4 == len(model.base_model.model.model.layers), 'Expected 4 layers in adapted model.'
-        assert 8 == len([n for n, _ in model.named_parameters() if '.lora_A.' in n]), (
-            'Expected 8 LoRA adapters since we are adding one each for up and down.'
-        )
+        assert len(model.base_model.model.model.layers) == 4, "Expected 4 layers in adapted model."
+        assert (
+            len([n for n, _ in model.named_parameters() if ".lora_A." in n]) == 8
+        ), "Expected 8 LoRA adapters since we are adding one each for up and down."
         self._test_prepare_for_training(model_id, LoraConfig, config_kwargs)
         self._test_generate(model_id, LoraConfig, config_kwargs)

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -316,8 +316,11 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
             base_model_name_or_path=model_id,
             **config_kwargs,
         )
+        assert 2 == len(model.model.layers), 'Expected 2 layers in original model.'
         model = get_peft_model(model, config)
-        self.assertEquals(4, len(model.base_model.model.model.layers), 'Expected 4 layers in adapted model.')
-        self.assertEquals(8, len([n for n, _ in model.named_parameters() if '.lora_A.' in n]))
+        assert 4 == len(model.base_model.model.model.layers), 'Expected 4 layers in adapted model.'
+        assert 8 == len([n for n, _ in model.named_parameters() if '.lora_A.' in n]), (
+            'Expected 8 LoRA adapters since we are adding one each for up and down.'
+        )
         self._test_prepare_for_training(model_id, LoraConfig, config_kwargs)
         self._test_generate(model_id, LoraConfig, config_kwargs)


### PR DESCRIPTION
This PR adds the ability to duplicate layers in a model according to a layer map
and then fine tune separate lora adapters for the layers post duplication. This
allows expanding a model to larger model and then fine tuning that model with
very little extra memory compared to the original smaller model.