### PR TITLE
account for the new merged/unmerged weight to perform the quantization again

### DIFF
--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -267,7 +267,8 @@ if is_bnb_4bit_available():
                     raise ValueError(
                         f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                     )
-
+                if "bnb_quantized" in kwargs:
+                    kwargs["bnb_quantized"] = False
                 self.get_base_layer().weight = bnb.nn.Params4bit(w_data.to("cpu"), requires_grad=False, **kwargs).to(
                     weight.device
                 )
@@ -292,6 +293,8 @@ if is_bnb_4bit_available():
                 kwargs = weight.__dict__
                 lora_data = self.get_delta_weight(active_adapter)
                 w_data = bnb.functional.dequantize_4bit(weight.data, weight.quant_state) - lora_data
+                if "bnb_quantized" in kwargs:
+                    kwargs["bnb_quantized"] = False
                 self.get_base_layer().weight = bnb.nn.Params4bit(w_data.to("cpu"), requires_grad=False, **kwargs).to(
                     weight.device
                 )


### PR DESCRIPTION
### What does this PR do?

BNB has CI failures with 2 tests failing due to the following:
In merge method, the following things happens wherein the lora delta weights are added to the dequantized base layer weights. This is followed by setting the weight of the base layer to a new instance of  Params4bit with the new merged weights:
```
w_data = bnb.functional.dequantize_4bit(weight.data, weight.quant_state) + lora_data
self.get_base_layer().weight = bnb.nn.Params4bit(w_data.to("cpu"), requires_grad=False,**kwargs).to(weight.device)            
```
Now, kwargs copies the ones currently there which has bnb_quantized=True and the old quant_state so the new merged weights aren't quantized and the old quant state remains.  After this, during Linear4bit forward call, the old quant state is used while the weights are unquantized. This happens due to changes of the PR https://github.com/TimDettmers/bitsandbytes/pull/970.

This PR fixes the failures by setting `bnb_quantized=False` when merging/unmerging 4-bit layers.

