### PR TITLE
[docs] Minor fixes to tutorial on semantic segmentation with LoRA

### DIFF
--- a/docs/source/task_guides/semantic_segmentation_lora.md
+++ b/docs/source/task_guides/semantic_segmentation_lora.md
@@ -403,7 +403,7 @@ upsampled_logits = nn.functional.interpolate(
 pred_seg = upsampled_logits.argmax(dim=1)[0]
 ```
 
-Next, visualize the results.  We need a color palette for this. Here, we use ade_palette(). As it is a long array, so
+Next, visualize the results.  We need a color palette for this. Here, we use `create_ade20k_label_colormap()`. As it returns a long array,
 we don't include it in this guide, please copy it from [the TensorFlow Model Garden repository](https://github.com/tensorflow/models/blob/3f1ca33afe3c1631b733ea7e40c294273b9e406d/research/deeplab/utils/get_dataset_colormap.py#L51).
 
 ```python

--- a/docs/source/task_guides/semantic_segmentation_lora.md
+++ b/docs/source/task_guides/semantic_segmentation_lora.md
@@ -260,19 +260,13 @@ Let's review the `LoraConfig`. To enable LoRA technique, we must define the targ
 attention blocks of the base model. These matrices are identified by their respective names, "query" and "value". 
 Therefore, we should specify these names in the `target_modules` argument of `LoraConfig`.
 
-After we wrap our base model `model` with `PeftModel` along with the config, we get 
-a new model where only the LoRA parameters are trainable (so-called "update matrices") while the pre-trained parameters 
-are kept frozen. These include the parameters of the randomly initialized classifier parameters too. This is NOT we want 
-when fine-tuning the base model on our custom dataset. To ensure that the classifier parameters are also trained, we 
-specify `modules_to_save`. This also ensures that these modules are serialized alongside the LoRA trainable parameters 
-when using utilities like `save_pretrained()` and `push_to_hub()`.
-
 In addition to specifying the `target_modules` within `LoraConfig`, we also need to specify the `modules_to_save`. When 
 we wrap our base model with `PeftModel` and pass the configuration, we obtain a new model in which only the LoRA parameters 
-are trainable, while the pre-trained parameters and the randomly initialized classifier parameters are kept frozen. 
-However, we do want to train the classifier parameters. By specifying the `modules_to_save` argument, we ensure that the 
+are trainable (the so-called "update matrices"), while the pre-trained parameters and the randomly initialized classifier parameters are kept frozen. 
+However, we do want to train the classifier parameters for finetuning. By specifying the `modules_to_save` argument, we ensure that the 
 classifier parameters are also trainable, and they will be serialized alongside the LoRA trainable parameters when we 
 use utility functions like `save_pretrained()` and `push_to_hub()`.
+
 
 Let's review the rest of the parameters:
 
@@ -362,7 +356,7 @@ total 2.2M
 Let's now prepare an `inference_model` and run inference.
 
 ```python
-from peft import PeftConfig
+from peft import PeftConfig, PeftModel
 
 config = PeftConfig.from_pretrained(model_id)
 model = AutoModelForSemanticSegmentation.from_pretrained(
@@ -415,8 +409,10 @@ we don't include it in this guide, please copy it from [the TensorFlow Model Gar
 ```python
 import matplotlib.pyplot as plt
 
+# < paste the `create_ade20k_label_colormap` function here >
+
 color_seg = np.zeros((pred_seg.shape[0], pred_seg.shape[1], 3), dtype=np.uint8)
-palette = np.array(ade_palette())
+palette = np.array(create_ade20k_label_colormap()) 
 
 for label, color in enumerate(palette):
     color_seg[pred_seg == label, :] = color

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
This PR includes fixes to 3 issues that I found while going through [Semantic segmentation using LoRA](https://huggingface.co/docs/peft/task_guides/semantic_segmentation_lora).

**1. Fixed duplicate paragraphs**

Original doc looked like this, [see here](https://huggingface.co/docs/peft/task_guides/semantic_segmentation_lora#wrap-the-base-model-as-a-peftmodel-for-lora-training).
> ...
> After we wrap our base model `model` with `PeftModel` along with the config, we get a new model where only the LoRA parameters are trainable (so-called “update matrices”) while the pre-trained parameters are kept frozen. These include the parameters of the randomly initialized classifier parameters too. This is NOT we want when fine-tuning the base model on our custom dataset. To ensure that the classifier parameters are also trained, we specify `modules_to_save`. This also ensures that these modules are serialized alongside the LoRA trainable parameters when using utilities like `save_pretrained()` and `push_to_hub()`.
> 
> In addition to specifying the `target_modules` within `LoraConfig`, we also need to specify the `modules_to_save`. When we wrap our base model with `PeftModel` and pass the configuration, we obtain a new model in which only the LoRA parameters are trainable, while the pre-trained parameters and the randomly initialized classifier parameters are kept frozen. However, we do want to train the classifier parameters. By specifying the `modules_to_save` argument, we ensure that the classifier parameters are also trainable, and they will be serialized alongside the LoRA trainable parameters when we use utility functions like `save_pretrained()` and `push_to_hub()`.
> ...

I believe that one of these paragraphs was intended to be removed but the original author missed it. It is now one paragraph (mostly just the second paragraph with some additional info taken from the first):

> In addition to specifying the `target_modules` within `LoraConfig`, we also need to specify the `modules_to_save`. When we wrap our base model with `PeftModel` and pass the configuration, we obtain a new model in which only the LoRA parameters are trainable (the so-called "update matrices"), while the pre-trained parameters and the randomly initialized classifier parameters are kept frozen. However, we do want to train the classifier parameters for finetuning. By specifying the `modules_to_save` argument, we ensure that the classifier parameters are also trainable, and they will be serialized alongside the LoRA trainable parameters when we use utility functions like `save_pretrained()` and `push_to_hub()`.


**2. Added missing PeftModel import**

The original doc has a snippet [here](https://huggingface.co/docs/peft/task_guides/semantic_segmentation_lora#save-the-model-and-run-inference):
```py
from peft import PeftConfig

config = PeftConfig.from_pretrained(model_id)
model = AutoModelForSemanticSegmentation.from_pretrained(
    checkpoint, id2label=id2label, label2id=label2id, ignore_mismatched_sizes=True
)

inference_model = PeftModel.from_pretrained(model, model_id)
````

Running that leads to a `NameError` for `PeftModel` which is never defined in the tutorial. Changed import to:

```py
from peft import PeftConfig, PeftModel
```


**3. Palette function name fix**

The original doc looks like this [here](https://huggingface.co/docs/peft/task_guides/semantic_segmentation_lora#save-the-model-and-run-inference):

> Next, visualize the results. We need a color palette for this. Here, we use ade_palette(). As it is a long array, so we don’t include it in this guide, please copy it from [the TensorFlow Model Garden repository](https://github.com/tensorflow/models/blob/3f1ca33afe3c1631b733ea7e40c294273b9e406d/research/deeplab/utils/get_dataset_colormap.py#L51).
> ```py
> import matplotlib.pyplot as plt
> 
> color_seg = np.zeros((pred_seg.shape[0], pred_seg.shape[1], 3), dtype=np.uint8)
> palette = np.array(ade_palette())
> ...
> ```

The modified section looks like this:

> Next, visualize the results.  We need a color palette for this. Here, we use `create_ade20k_label_colormap()`. As it returns a long array, we don't include it in this guide, please copy it from [the TensorFlow Model Garden repository](https://github.com/tensorflow/models/blob/3f1ca33afe3c1631b733ea7e40c294273b9e406d/research/deeplab/utils/get_dataset_colormap.py#L51).
> 
> ```py
> import matplotlib.pyplot as plt
> 
> # < paste the `create_ade20k_label_colormap` function here >
> 
> color_seg = np.zeros((pred_seg.shape[0], pred_seg.shape[1], 3), dtype=np.uint8)
> palette = np.array(create_ade20k_label_colormap())

The TensorFlow Model Garden repository has the function we use named as `create_ade20k_label_colormap`, while the tutorial uses it as `ade_palette()`, hence the change. Also specified where to paste the copied function as a comment for clarity. Kind of my first PR so I apologize for any oversight.