### PR TITLE
[docs] Doc maintenance

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -40,13 +40,13 @@
   - local: developer_guides/lora
     title: LoRA
   - local: developer_guides/custom_models
-    title: Working with custom models
+    title: Custom models
   - local: developer_guides/low_level_api
-    title: PEFT low level API
+    title: Adapter injection
   - local: developer_guides/mixed_models
-    title: Mixing different adapter types
+    title: Mixed adapter types
   - local: developer_guides/contributing
-    title: Contributing to PEFT
+    title: Contribute to PEFT
   - local: developer_guides/troubleshooting
     title: Troubleshooting
 

--- a/docs/source/developer_guides/contributing.md
+++ b/docs/source/developer_guides/contributing.md
@@ -14,79 +14,70 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Contributing to PEFT
+# Contribute to PEFT
 
-We are happy to accept contributions to PEFT. If you plan to contribute, please read this document to make the process as smooth as possible.
+We are happy to accept contributions to PEFT. If you plan to contribute, please read this to make the process as smooth as possible.
 
 ## Installation
 
-The installation instructions can be found [here](https://huggingface.co/docs/peft/install). If you want to provide code contributions to PEFT, you should choose the "source" installation method.
+For code contributions to PEFT, you should choose the ["source"](../install#source) installation method.
 
-If you are new to creating a pull request, follow [these instructions from GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+If you are new to creating a pull request, follow the [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) guide by GitHub.
 
-## Running tests and code quality checks
+## Tests and code quality checks
 
-Regardless of the type of contribution (unless it’s only about the docs), you should run tests and code quality checks before creating a PR to ensure that your contribution doesn’t break anything and follows the standards of the project.
+Regardless of the contribution type (unless it’s only about the docs), you should run tests and code quality checks before creating a PR to ensure your contribution doesn’t break anything and follows the project standards.
 
-We provide a Makefile to facilitate those steps. Run the code below for the unit test:
+We provide a Makefile to execute the necessary tests. Run the code below for the unit test:
 
 ```sh
 make test
 ```
 
-Run one of the following to either check or check and fix code quality and style:
+Run one of the following to either only check or check and fix code quality and style:
 
 ```sh
 make quality  # just check
 make style  # check and fix
 ```
 
-
-Running all the tests can take a couple of minutes. Therefore, during development, it can be useful to run only those tests specific to your change:
+Running all the tests can take a couple of minutes so during development, it can be useful to only run tests specific to your change:
 
 ```sh
 pytest tests/ -k <name-of-test>
 ```
 
-This should finish much quicker and allow faster iteration. Before creating the PR, however, please still run the whole test suite, as some changes can inadvertently break tests that at first glance are unrelated.
+This should finish much quicker and allow faster iteration. However, you should still run the whole test suite as some changes before creating a PR because it can inadvertently break tests that at first glance are unrelated.
 
-If your change is specific to a hardware setting (e.g. it requires CUDA), take a look at `tests/test_gpu_examples.py` and `tests/test_common_gpu.py` – maybe it makes sense to add a test there. If your change could have an effect on saving and loading models, please run the tests with the `--regression` flag to trigger regression tests.
+If your change is specific to a hardware setting (e.g., it requires CUDA), take a look at [tests/test_gpu_examples.py](https://github.com/huggingface/peft/blob/1c1c7fdaa6e6abaa53939b865dee1eded82ad032/tests/test_gpu_examples.py) and [tests/test_common_gpu.py](https://github.com/huggingface/peft/blob/1c1c7fdaa6e6abaa53939b865dee1eded82ad032/tests/test_common_gpu.py) to see if it makes sense to add tests there. If your change could have an effect on saving and loading models, please run the tests with the `--regression` flag to trigger regression tests.
 
-It can happen that while you’re working on your PR, the underlying code base changes due to other changes being merged. If that happens – especially when there is a merge conflict – please update your branch to be on the latest changes. This can be a merge or a rebase, whatever you prefer. We will squash and merge the PR once it’s ready.
+It can happen that while you’re working on your PR, the underlying code base changes due to other changes being merged. If that happens – especially when there is a merge conflict – please update your branch with the latest changes. This can be a merge or a rebase, and we'll squash and merge the PR once it’s ready.
 
 ## PR description
 
-When opening the PR, please provide a nice description of the change you provide. If it relates to other issues or PRs, please reference them. Providing a good description will not only help the reviewers review your code better and faster, it can also later be used (as a basis) for the commit message, which helps with long term maintenance of the project.
+When opening a PR, please provide a nice description of the change you're proposing. If it relates to other issues or PRs, please reference them. Providing a good description not only helps the reviewers review your code better and faster, it can also later be used (as a basis) for the commit message which helps with long term maintenance of the project.
 
-If your code makes some non-trivial changes, it can also be a good idea to add comments to the code to explain those changes. For example, if you had to iterate on your implementation multiple times because the most obvious way didn’t work, it’s a good indication that a code comment is needed.
+If your code makes some non-trivial changes, it may also be a good idea to add comments to the code to explain those changes. For example, if you had to iterate on your implementation multiple times because the most obvious way didn’t work, it’s a good indication that a code comment is needed.
 
-## Providing a bugfix
+## Bugfixes
 
-Please give a description of the circumstances that lead to the bug. If there is an existing issue, please link to it (e.g. “Resolves #12345”).
+Please give a description of the circumstances that led to the bug. If there is an existing issue, please link to it (e.g., “Resolves #12345”).
 
-Ideally, when a bugfix is provided, it should be accompanied by a test for this bug. The test should fail with the current code and pass with the bugfix. Add a comment to the test that references the issue or PR. Without such a test, it is difficult to prevent regressions in the future.
+Ideally when a bugfix is provided, it should be accompanied by a test for the bug. The test should fail with the current code and pass with the bugfix. Add a comment to the test that references the issue or PR. Without a test, it is more difficult to prevent regressions in the future.
 
-## Adding a new fine-tuning method
+## Add a new fine-tuning method
 
-New parameter-efficient fine-tuning methods are developed all the time. If you would like to add a new, promising method to PEFT, please follow these steps.
+New parameter-efficient fine-tuning methods are developed all the time. If you would like to add a new and promising method to PEFT, please follow these steps.
 
-**Requirements**
+1. Before you start to implement the new method, please open a GitHub issue with your proposal. This way, the maintainers can give you some early feedback.
+2. Please add a link to the source (usually a paper) of the method. Some evidence should be provided there is general interest in using the method. We will not add new methods that are freshly published and there is no evidence of demand for it.
+3. When implementing the method, it makes sense to look for existing implementations that already exist as a guide. Moreover, when you structure your code, please take inspiration from the other PEFT methods. For example, if your method is similar to LoRA, it makes sense to structure your code similarly or even reuse some functions or classes where it makes sense (some code duplication is okay, but don’t overdo it).
+4. Ideally, in addition to the implementation of the new method, there should also be examples (notebooks, scripts), documentation, and an extensive test suite that proves the method works with a variety of tasks. However, this can be more challenging so it is acceptable to only provide the implementation and at least one working example. Documentation and tests can be added in follow up PRs.
+5. Once you have something that seems to be working, don’t hesitate to create a draft PR even if it’s not in a mergeable state yet. The maintainers are happy to give you feedback and guidance along the way.
 
-1. Please add a link to the source (usually a paper) of the method.
-2. Some evidence should be provided that there is general interest in using the method. We will not add new methods that are freshly published but without evidence that there is demand for it.
-3. Ideally, we want to not only add the implementation of the new method, but also examples (notebooks, scripts), documentation, and an extensive test suite that proves that the method works with a variety of tasks. However, this can be very daunting. Therefore, it is also acceptable to only provide the implementation and at least one working example. Documentation and tests can be added in follow up PRs.
+## Add other features
 
-**Steps**
-
-Before you start to implement the new method, please open an issue on GitHub with your proposal. That way, the maintainers can give you some early feedback.
-
-When implementing the method, it makes sense to look for existing implementations that already exist as a guide. Moreover, when you structure your code, please take inspiration from the other PEFT methods. For example, if your method is similar to LoRA, it makes sense to structure your code similarly or even re-use some functions or classes where it makes sense (but don’t overdo it, some code duplication is okay).
-
-Once you have something that seems to be working, don’t hesitate to create a draft PR, even if it’s not in a mergeable state yet. The maintainers will be happy to give you feedback and guidance along the way.
-
-## Adding other features
-
-It is best if you first open an issue on GitHub with a proposal to add the new feature. That way, you can discuss with the maintainers if it makes sense to add the feature before spending too much time on implementing it.
+It is best if you first open an issue on GitHub with a proposal to add the new feature. This way, you can discuss with the maintainers if it makes sense to add the feature before spending too much time on implementing it.
 
 New features should generally be accompanied by tests and documentation or examples. Without the latter, users will have a hard time discovering your cool new feature.
 

--- a/docs/source/developer_guides/contributing.md
+++ b/docs/source/developer_guides/contributing.md
@@ -41,13 +41,13 @@ make quality  # just check
 make style  # check and fix
 ```
 
-Running all the tests can take a couple of minutes so during development, it can be useful to only run tests specific to your change:
+Running all the tests can take a couple of minutes, so during development it can be more efficient to only run tests specific to your change:
 
 ```sh
 pytest tests/ -k <name-of-test>
 ```
 
-This should finish much quicker and allow faster iteration. However, you should still run the whole test suite as some changes before creating a PR because it can inadvertently break tests that at first glance are unrelated.
+This should finish much quicker and allow for faster iteration. However, you should still run the whole test suite before creating a PR because your change can inadvertently break tests that at first glance are unrelated.
 
 If your change is specific to a hardware setting (e.g., it requires CUDA), take a look at [tests/test_gpu_examples.py](https://github.com/huggingface/peft/blob/1c1c7fdaa6e6abaa53939b865dee1eded82ad032/tests/test_gpu_examples.py) and [tests/test_common_gpu.py](https://github.com/huggingface/peft/blob/1c1c7fdaa6e6abaa53939b865dee1eded82ad032/tests/test_common_gpu.py) to see if it makes sense to add tests there. If your change could have an effect on saving and loading models, please run the tests with the `--regression` flag to trigger regression tests.
 
@@ -55,7 +55,7 @@ It can happen that while you’re working on your PR, the underlying code base c
 
 ## PR description
 
-When opening a PR, please provide a nice description of the change you're proposing. If it relates to other issues or PRs, please reference them. Providing a good description not only helps the reviewers review your code better and faster, it can also later be used (as a basis) for the commit message which helps with long term maintenance of the project.
+When opening a PR, please provide a nice description of the change you're proposing. If it relates to other issues or PRs, please reference them. Providing a good description not only helps the reviewers review your code better and faster, it can also be used later (as a basis) for the commit message which helps with long term maintenance of the project.
 
 If your code makes some non-trivial changes, it may also be a good idea to add comments to the code to explain those changes. For example, if you had to iterate on your implementation multiple times because the most obvious way didn’t work, it’s a good indication that a code comment is needed.
 
@@ -70,7 +70,7 @@ Ideally when a bugfix is provided, it should be accompanied by a test for the bu
 New parameter-efficient fine-tuning methods are developed all the time. If you would like to add a new and promising method to PEFT, please follow these steps.
 
 1. Before you start to implement the new method, please open a GitHub issue with your proposal. This way, the maintainers can give you some early feedback.
-2. Please add a link to the source (usually a paper) of the method. Some evidence should be provided there is general interest in using the method. We will not add new methods that are freshly published and there is no evidence of demand for it.
+2. Please add a link to the source (usually a paper) of the method. Some evidence should be provided there is general interest in using the method. We will not add new methods that are freshly published, but there is no evidence of demand for it.
 3. When implementing the method, it makes sense to look for existing implementations that already exist as a guide. Moreover, when you structure your code, please take inspiration from the other PEFT methods. For example, if your method is similar to LoRA, it makes sense to structure your code similarly or even reuse some functions or classes where it makes sense (some code duplication is okay, but don’t overdo it).
 4. Ideally, in addition to the implementation of the new method, there should also be examples (notebooks, scripts), documentation, and an extensive test suite that proves the method works with a variety of tasks. However, this can be more challenging so it is acceptable to only provide the implementation and at least one working example. Documentation and tests can be added in follow up PRs.
 5. Once you have something that seems to be working, don’t hesitate to create a draft PR even if it’s not in a mergeable state yet. The maintainers are happy to give you feedback and guidance along the way.

--- a/docs/source/developer_guides/custom_models.md
+++ b/docs/source/developer_guides/custom_models.md
@@ -14,13 +14,13 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Working with custom models
+# Custom models
 
 Some fine-tuning techniques, such as prompt tuning, are specific to language models. That means in 🤗 PEFT, it is
 assumed a 🤗 Transformers model is being used. However, other fine-tuning techniques - like
 [LoRA](../conceptual_guides/lora) - are not restricted to specific model types.
 
-In this guide, we will see how LoRA can be applied to a multilayer perceptron, a computer vision model from the [timm](https://huggingface.co/docs/timm/index) library, or a new 🤗 Transformers architectures.
+In this guide, we will see how LoRA can be applied to a multilayer perceptron, a computer vision model from the [timm](https://huggingface.co/docs/timm/index) library, or a new 🤗 Transformers architecture.
 
 ## Multilayer perceptron
 
@@ -46,7 +46,7 @@ class MLP(nn.Module):
         return self.seq(X)
 ```
 
-This is a straightforward multilayer perceptron with an input layer, a hidden layer, and an output layer. 
+This is a straightforward multilayer perceptron with an input layer, a hidden layer, and an output layer.
 
 <Tip>
 
@@ -223,20 +223,18 @@ Additionally, linear layers are common targets to be adapted (e.g. in [QLoRA pap
 
 If you want to add a new model to PEFT, please create an entry in [constants.py](https://github.com/huggingface/peft/blob/main/src/peft/utils/constants.py) and open a pull request on the [repository](https://github.com/huggingface/peft/pulls). Don't forget to update the [README](https://github.com/huggingface/peft#models-support-matrix) as well.
 
-## Checking the result
+## Verify parameters and layers
 
-When you think that you have correctly specified the `target_modules` and called `get_peft_model`, you can check the fraction of parameters that will be trainable like this:
+You can verify whether you've correctly applied a PEFT method to your model in a few ways.
 
-```python
+* Check the fraction of parameters that are trainable with the [`~PeftModel.print_trainable_parameters`] method. If this number is lower or higher than expected, check the model `repr` by printing the model. This shows the names of all the layer types in the model. Ensure that only the intended target layers are replaced by the adapter layers. For example, if LoRA is applied to `nn.Linear` layers, then you should only see `lora.Linear` layers being used.
+
+```py
 peft_model.print_trainable_parameters()
 ```
 
-If this number is too low or high, check the model `repr` by printing the model. This will show you the names and type of all of all the layers in the model. Ensure that the intended layers, and only those, are replaced by adapter layers. For instance, for LoRA applied to `nn.Linear` layers, you should see that `lora.Linear` layers are being used.
-
-To get a quick overview of all layers that were adapted, you can also use the the `targeted_module_names` attribute:
+* Another way you can view the adapted layers is to use the `targeted_module_names` attribute to list the name of each module that was adapted.
 
 ```python
 print(peft_model.targeted_module_names)
 ```
-
-This lists the names of each module that was actually adapted.

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -69,6 +69,14 @@ from peft import LoraConfig
 config = LoraConfig(use_rslora=True, ...)
 ```
 
+### QLoRA-style training
+
+The default LoRA settings in PEFT add trainable weights to the query and value layers of each attention block. But [QLoRA](https://hf.co/papers/2305.14314), which adds trainable weights to all the linear layers of a transformer model, can provide performance equal to a fully finetuned model. To apply LoRA to all the linear layers, like in QLoRA, set `target_modules="all-linear"` (easier than specifying individual modules by name which can vary depending on the architecture).
+
+```py
+config = LoraConfig(target_modules="all-linear", ...)
+```
+
 ## Merge adapters
 
 While LoRA is significantly smaller and faster to train, you may encounter latency issues during inference due to separately loading the base model and the LoRA adapter. To eliminate latency, use the [`~LoraModel.merge_and_unload`] function to merge the adapter weights with the base model. This allows you to use the newly merged model as a standalone model. The [`~LoraModel.merge_and_unload`] function doesn't keep the adapter weights in memory.
@@ -179,12 +187,4 @@ model.unload()
 
 # delete adapter
 model.delete_adapter("dpo")
-```
-
-## QLoRA-style training
-
-The default LoRA settings in 🤗PEFT follow the [original paper](https://hf.co/papers/2106.09685) and add trainable weights to the query and value layers of each attention block. However, in [QLoRA](https://hf.co/papers/2305.14314), it was found that adding trainable weights to all the linear layers of a transformer model is beneficial to match full-finetuning performance. Since the list of modules to add will vary depending on the architecture, we provided a convenient shorthand : simple specify `target_modules='all-linear'` and let 🤗PEFT handle the rest: 
-
-```py
-config = LoraConfig(target_modules="all-linear", ...) # adds LoRA to all linear layers like in QLoRA
 ```

--- a/docs/source/developer_guides/low_level_api.md
+++ b/docs/source/developer_guides/low_level_api.md
@@ -14,24 +14,24 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# PEFT as a utility library
+# Adapter injection
 
-Let's cover in this section how you can leverage PEFT's low level API to inject trainable adapters into any `torch` module. 
-The development of this API has been motivated by the need for super users to not rely on modeling classes that are exposed in PEFT library and still be able to use adapter methods such as LoRA, IA3 and AdaLoRA.
+With PEFT, you can inject trainable adapters into any `torch` module which allows you to use adapter methods without relying on the modeling classes in PEFT. Currently, PEFT supports injecting [LoRA](../conceptual_guides/adapter#low-rank-adaptation-lora), [AdaLoRA](../conceptual_guides/adapter#adaptive-low-rank-adaptation-adalora), and [IA3](../conceptual_guides/ia3) into models because for these adapters, inplace modification of the model is sufficient for finetuning it.
 
-## Supported tuner types
+Check the table below to see when you should inject adapters.
 
-Currently the supported adapter types are the 'injectable' adapters, meaning adapters where an inplace modification of the model is sufficient to correctly perform the fine tuning. As such, only [LoRA](../conceptual_guides/lora), AdaLoRA and [IA3](../conceptual_guides/ia3) are currently supported in this API.
+| Pros | Cons |
+|---|---|
+| the model is modified inplace, keeping all the original attributes and methods | manually write the `from_pretrained` and `save_pretrained` utility functions from Hugging Face to save and load adapters |
+| works for any `torch` module and modality | doesn't work with any of the utility methods provided by `PeftModel` such as disabling and merging adapters |
 
-## `inject_adapter_in_model` method 
+To perform the adapter injection, use the [`inject_adapter_in_model`] method. This method takes 3 arguments, the PEFT config, the model, and an optional adapter name. You can also attach multiple adapters to the model if you call [`inject_adapter_in_model`] multiple times with different adapter names.
 
-To perform the adapter injection, simply use `inject_adapter_in_model` method that takes 3 arguments, the PEFT config and the model itself and an optional adapter name. You can also attach multiple adapters in the model if you call multiple times `inject_adapter_in_model` with different adapter names.
+For example, to inject LoRA adapters into the `linear` submodule of the `DummyModel` module:
 
-Below is a basic example usage of how to inject LoRA adapters into the submodule `linear` of the module `DummyModel`.
 ```python
 import torch
 from peft import inject_adapter_in_model, LoraConfig
-
 
 class DummyModel(torch.nn.Module):
     def __init__(self):
@@ -62,7 +62,7 @@ dummy_inputs = torch.LongTensor([[0, 1, 2, 3, 4, 5, 6, 7]])
 dummy_outputs = model(dummy_inputs)
 ```
 
-If you print the model, you will notice that the adapters have been correctly injected into the model
+Print the model to see that the adapters have been correctly injected.
 
 ```bash
 DummyModel(
@@ -84,8 +84,8 @@ DummyModel(
   (lm_head): Linear(in_features=10, out_features=10, bias=True)
 )
 ```
-Note that it should be up to users to properly take care of saving the adapters (in case they want to save adapters only), as `model.state_dict()` will return the full state dict of the model.
-In case you want to extract the adapters state dict you can use the `get_peft_model_state_dict` method:
+
+To only save the adapter, use the [`get_peft_model_state_dict`] function
 
 ```python
 from peft import get_peft_model_state_dict
@@ -94,14 +94,5 @@ peft_state_dict = get_peft_model_state_dict(model)
 print(peft_state_dict)
 ```
 
-## Pros and cons 
+Otherwise, `model.state_dict()` returns the full state dict of the model.
 
-When to use this API and when to not use it? Let's discuss in this section the pros and cons 
-
-Pros:
-- The model gets modified in-place, meaning the model will preserve all its original attributes and methods
-- Works for any torch module, and any modality (vision, text, multi-modal)
-
-Cons:
-- You need to manually writing Hugging Face `from_pretrained` and `save_pretrained` utility methods if you want to easily save / load adapters from the Hugging Face Hub.
-- You cannot use any of the utility method provided by `PeftModel` such as disabling adapters, merging adapters, etc.

--- a/docs/source/developer_guides/low_level_api.md
+++ b/docs/source/developer_guides/low_level_api.md
@@ -85,7 +85,7 @@ DummyModel(
 )
 ```
 
-To only save the adapter, use the [`get_peft_model_state_dict`] function
+To only save the adapter, use the [`get_peft_model_state_dict`] function:
 
 ```python
 from peft import get_peft_model_state_dict

--- a/docs/source/developer_guides/low_level_api.md
+++ b/docs/source/developer_guides/low_level_api.md
@@ -95,4 +95,3 @@ print(peft_state_dict)
 ```
 
 Otherwise, `model.state_dict()` returns the full state dict of the model.
-

--- a/docs/source/developer_guides/mixed_models.md
+++ b/docs/source/developer_guides/mixed_models.md
@@ -26,7 +26,7 @@ peft_model.load_adapter(<path_to_adapter2>, adapter_name="other")
 peft_model.set_adapter(["default", "other"])
 ```
 
-The [`~PeftMixedModel.set_adapter`] method is necessary to activate both adapters, otherwise only the first adapter would be active. You can keep adding more adapter by calling [`~PeftModel.add_adapter`] repeatedly.
+The [`~PeftMixedModel.set_adapter`] method is necessary to activate both adapters, otherwise only the first adapter would be active. You can keep adding more adapters by calling [`~PeftModel.add_adapter`] repeatedly.
 
 [`PeftMixedModel`] does not support saving and loading mixed adapters. The adapters should already be trained, and loading the model requires a script to be run each time.
 
@@ -34,4 +34,4 @@ The [`~PeftMixedModel.set_adapter`] method is necessary to activate both adapter
 
 - Not all adapter types can be combined. See [`peft.tuners.mixed.COMPATIBLE_TUNER_TYPES`](https://github.com/huggingface/peft/blob/1c1c7fdaa6e6abaa53939b865dee1eded82ad032/src/peft/tuners/mixed/model.py#L35) for a list of compatible types. An error will be raised if you try to combine incompatible adapter types.
 - It is possible to mix multiple adapters of the same type which can be useful for combining adapters with very different configs.
-- If you want to combine a lot of different adapters, the most performant way to do it is to add the same types of adapters consecutively. For example, add LoRA1, LoRA2, LoHa1, LoHa2 in this order, instead of LoRA1, LoHa1, LoRA2, and LoHa2. While the order can affect the output, there is no inherently *best* order, so it is best to choose the fastest one.
+- If you want to combine a lot of different adapters, the most performant way to do it is to consecutively add the same adapter types. For example, add LoRA1, LoRA2, LoHa1, LoHa2 in this order, instead of LoRA1, LoHa1, LoRA2, and LoHa2. While the order can affect the output, there is no inherently *best* order, so it is best to choose the fastest one.

--- a/docs/source/developer_guides/mixed_models.md
+++ b/docs/source/developer_guides/mixed_models.md
@@ -10,13 +10,11 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Working with mixed adapter types
+# Mixed adapter types
 
-Normally, it is not possible to mix different adapter types in 🤗 PEFT. For example, even though it is possible to create a PEFT model that has two different LoRA adapters (that can have different config options), it is not possible to combine a LoRA adapter with a LoHa adapter. However, by using a mixed model, this works as long as the adapter types are compatible.
+Normally, it isn't possible to mix different adapter types in 🤗 PEFT. You can create a PEFT model with two different LoRA adapters (which can have different config options), but it is not possible to combine a LoRA and LoHa adapter. With [`PeftMixedModel`] however, this works as long as the adapter types are compatible. The main purpose of allowing mixed adapter types is to combine trained adapters for inference. While it is possible to train a mixed adapter model, this has not been tested and is not recommended.
 
-## Loading different adapter types into a PEFT model
-
-To load different adapter types into a PEFT model, proceed the same as if you were loading two adapters of the same type, but use `PeftMixedModel` instead of `PeftModel`:
+To load different adapter types into a PEFT model, use [`PeftMixedModel`] instead of [`PeftModel`]:
 
 ```py
 from peft import PeftMixedModel
@@ -28,12 +26,12 @@ peft_model.load_adapter(<path_to_adapter2>, adapter_name="other")
 peft_model.set_adapter(["default", "other"])
 ```
 
-The last line is necessary if you want to activate both adapters, otherwise, only the first adapter would be active. Of course, you can add more different adapters by calling `add_adapter` repeatedly.
+The [`~PeftMixedModel.set_adapter`] method is necessary to activate both adapters, otherwise only the first adapter would be active. You can keep adding more adapter by calling [`~PeftModel.add_adapter`] repeatedly.
 
-Currently, the main purpose of mixed adapter types is to combine trained adapters for inference. Although it is technically also possible to train a mixed adapter model, this has not been tested and is not recommended.
+[`PeftMixedModel`] does not support saving and loading mixed adapters. The adapters should already be trained, and loading the model requires a script to be run each time.
 
 ## Tips
 
-- Not all adapter types can be combined. See `peft.tuners.mixed.COMPATIBLE_TUNER_TYPES` for a list of compatible types. An error will be raised if you are trying to combine incompatible adapter types.
-- It is possible to mix multiple adapters of the same type. This can be useful to combine adapters with very different configs.
-- If you want to combine a lot of different adapters, it is most performant to add the same types of adapters consecutively. E.g., add LoRA1, LoRA2, LoHa1, LoHa2 in this order, instead of LoRA1, LoHa1, LoRA2, LoHa2. The order will make a difference for the outcome in most cases, but since no order is better a priori, it is best to choose the order that is most performant.
+- Not all adapter types can be combined. See [`peft.tuners.mixed.COMPATIBLE_TUNER_TYPES`](https://github.com/huggingface/peft/blob/1c1c7fdaa6e6abaa53939b865dee1eded82ad032/src/peft/tuners/mixed/model.py#L35) for a list of compatible types. An error will be raised if you try to combine incompatible adapter types.
+- It is possible to mix multiple adapters of the same type which can be useful for combining adapters with very different configs.
+- If you want to combine a lot of different adapters, the most performant way to do it is to add the same types of adapters consecutively. For example, add LoRA1, LoRA2, LoHa1, LoHa2 in this order, instead of LoRA1, LoHa1, LoRA2, and LoHa2. While the order can affect the output, there is no inherently *best* order, so it is best to choose the fastest one.

--- a/docs/source/developer_guides/quantization.md
+++ b/docs/source/developer_guides/quantization.md
@@ -129,13 +129,12 @@ lora_config = LoraConfig(
 model = get_peft_model(model, lora_config)
 ```
 
-
-
 ### QLoRA-style training
-QLoRA adds trainable weights to all the linear layers in the transformer architecture. Since the attribute names for these linear layers can vary across architectures, we provide a convenient flag `'all-linear'` for this setting:
+
+QLoRA adds trainable weights to all the linear layers in the transformer architecture. Since the attribute names for these linear layers can vary across architectures, set `target_modules` to `"all-linear"` to add LoRA to all the linear layers:
 
 ```py
-config = LoraConfig(target_modules="all-linear", ...) # adds LoRA to all linear layers like in QLoRA
+config = LoraConfig(target_modules="all-linear", ...)
 ```
 
 ## Next steps

--- a/docs/source/developer_guides/troubleshooting.md
+++ b/docs/source/developer_guides/troubleshooting.md
@@ -20,7 +20,7 @@ If you encounter any issue when using PEFT, please check the following list of c
 
 ## Examples don't work
 
-Examples often rely on the most recent package versions, so please ensure they're up-to-date. In particular, check the followin package versions:
+Examples often rely on the most recent package versions, so please ensure they're up-to-date. In particular, check the following package versions:
 
 - `peft`
 - `transformers`
@@ -56,7 +56,7 @@ trainer = Trainer(model=peft_model, fp16=True, ...)
 trainer.train()
 ```
 
-Alternatively, you can use the [`~utils.cast_mixed_precision_params`] function to correctlt cast the weights:
+Alternatively, you can use the [`~utils.cast_mixed_precision_params`] function to correctly cast the weights:
 
 ```python
 from peft import cast_mixed_precision_params

--- a/docs/source/developer_guides/troubleshooting.md
+++ b/docs/source/developer_guides/troubleshooting.md
@@ -20,7 +20,7 @@ If you encounter any issue when using PEFT, please check the following list of c
 
 ## Examples don't work
 
-Examples often rely on the most recent package versions, so please ensure they're up-to-date. In particular, check the version of the following packages:
+Examples often rely on the most recent package versions, so please ensure they're up-to-date. In particular, check the followin package versions:
 
 - `peft`
 - `transformers`
@@ -39,11 +39,9 @@ Installing PEFT from source is useful for keeping up with the latest development
 python -m pip install git+https://github.com/huggingface/peft
 ```
 
-## Training errors
+## ValueError: Attempting to unscale FP16 gradients
 
-### Getting: ValueError: Attempting to unscale FP16 gradients
-
-This error probably occurred because the model was loaded with `torch_dtype=torch.float16` and then used in an automatic mixed precision (AMP) context, e.g. by setting `fp16=True` in the `Trainer` class from 🤗 Transformers. The reason is that when using AMP, trainable weights should never use fp16. To make this work without having to load the whole model in FP32, add the following snippet to your code:
+This error probably occurred because the model was loaded with `torch_dtype=torch.float16` and then used in an automatic mixed precision (AMP) context, e.g. by setting `fp16=True` in the [`~transformers.Trainer`] class from 🤗 Transformers. The reason is that when using AMP, trainable weights should never use fp16. To make this work without loading the whole model in fp32, add the following to your code:
 
 ```python
 peft_model = get_peft_model(...)
@@ -58,7 +56,8 @@ trainer = Trainer(model=peft_model, fp16=True, ...)
 trainer.train()
 ```
 
-Alternatively, you can use the utility function `cast_mixed_precision_params` from peft as shown below:
+Alternatively, you can use the [`~utils.cast_mixed_precision_params`] function to correctlt cast the weights:
+
 ```python
 from peft import cast_mixed_precision_params
 
@@ -70,10 +69,9 @@ trainer = Trainer(model=peft_model, fp16=True, ...)
 trainer.train()
 ```
 
-
 ## Bad results from a loaded PEFT model
 
-There can be several reasons for getting a poor result from a loaded PEFT model, which are listed below. If you're still unable to troubleshoot the problem, see if anyone else had a similar [issue](https://github.com/huggingface/peft/issues) on GitHub, and if you can't find any, open a new issue.
+There can be several reasons for getting a poor result from a loaded PEFT model which are listed below. If you're still unable to troubleshoot the problem, see if anyone else had a similar [issue](https://github.com/huggingface/peft/issues) on GitHub, and if you can't find any, open a new issue.
 
 When opening an issue, it helps a lot if you provide a minimal code example that reproduces the issue. Also, please report if the loaded model performs at the same level as the model did before fine-tuning, if it performs at a random level, or if it is only slightly worse than expected. This information helps us identify the problem more quickly.
 
@@ -87,7 +85,7 @@ If your model outputs are not exactly the same as previous runs, there could be 
 
 ### Incorrectly loaded model
 
-Please ensure that you load the model correctly. A common error is trying to load a _trained_ model with `get_peft_model`, which is incorrect. Instead, the loading code should look like this:
+Please ensure that you load the model correctly. A common error is trying to load a _trained_ model with [`get_peft_model`] which is incorrect. Instead, the loading code should look like this:
 
 ```python
 from peft import PeftModel, PeftConfig
@@ -103,7 +101,7 @@ For some tasks, it is important to correctly configure `modules_to_save` in the 
 
 As an example, this is necessary if you use LoRA to fine-tune a language model for sequence classification because 🤗 Transformers adds a randomly initialized classification head on top of the model. If you do not add this layer to `modules_to_save`, the classification head won't be saved. The next time you load the model, you'll get a _different_ randomly initialized classification head, resulting in completely different results.
 
-In PEFT, we try to correctly guess the `modules_to_save` if you provide the `task_type` argument in the config. This should work for transformers models that follow the standard naming scheme. It is always a good idea to double check though because we can't guarantee all models follow the naming scheme.
+PEFT tries to correctly guess the `modules_to_save` if you provide the `task_type` argument in the config. This should work for transformers models that follow the standard naming scheme. It is always a good idea to double check though because we can't guarantee all models follow the naming scheme.
 
 When you load a transformers model that has randomly initialized layers, you should see a warning along the lines of:
 

--- a/docs/source/package_reference/multitask_prompt_tuning.md
+++ b/docs/source/package_reference/multitask_prompt_tuning.md
@@ -14,9 +14,9 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Multitask Prompt Tuning
+# Multitask prompt tuning
 
-[Multitask Prompt Tuning](https://huggingface.co/papers/2303.02861)  decomposes the soft prompts of each task into a single learned transferable prompt instead of a separate prompt for each task. The single learned prompt can be adapted for each task by multiplicative low rank updates.
+[Multitask prompt tuning](https://huggingface.co/papers/2303.02861)  decomposes the soft prompts of each task into a single learned transferable prompt instead of a separate prompt for each task. The single learned prompt can be adapted for each task by multiplicative low rank updates.
 
 The abstract from the paper is:
 

--- a/docs/source/package_reference/peft_model.md
+++ b/docs/source/package_reference/peft_model.md
@@ -62,6 +62,12 @@ A `PeftModel` for mixing different adapter types (e.g. LoRA and LoHa).
 
 ## Utilities
 
+[[autodoc]] utils.cast_mixed_precision_model
+
 [[autodoc]] get_peft_model
+
+[[autodoc]] inject_adapter_in_model
+
+[[autodoc]] utils.get_peft_model_state_dict
 
 [[autodoc]] utils.prepare_model_for_kbit_training

--- a/docs/source/package_reference/peft_model.md
+++ b/docs/source/package_reference/peft_model.md
@@ -62,7 +62,7 @@ A `PeftModel` for mixing different adapter types (e.g. LoRA and LoHa).
 
 ## Utilities
 
-[[autodoc]] utils.cast_mixed_precision_model
+[[autodoc]] utils.cast_mixed_precision_params
 
 [[autodoc]] get_peft_model
 

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -88,6 +88,15 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
     This class does not support loading/saving, and it shouldn't usually be initialized directly. Instead, use
     `get_peft_model` with the argument `mixed=True`.
 
+    <Tip>
+
+    Read the [Mixed adapter types](https://huggingface.co/docs/peft/en/developer_guides/mixed_models) guide to learn
+    more about using different adapter types.
+
+    </Tip>
+
+    Example:
+
     ```py
     >>> from peft import get_peft_model
 

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -83,18 +83,10 @@ def _check_config_compatible(peft_config: PeftConfig) -> None:
 
 class PeftMixedModel(PushToHubMixin, torch.nn.Module):
     """
-    Peft model for mixing different types of adapters.
+    PeftMixedModel for loading mixing different types of adapters for inference.
 
-    This class currently does not support saving and loading. Instead, it is assumed that the adapters are already
-    trained and loading the model requires a script to be run each time.
-
-    Currently, the main purpose of mixed adapter types is to combine trained adapters for inference. Although it is
-    technically possible to train a mixed adapter model, this has not been tested and is not recommended.
-
-    Note: This class should usually not be initialized directly. Instead, use `get_peft_model` with the argument
-    `mixed=True`.
-
-    Below is an example that shows how to load a mixed model with two different types of adapters.
+    This class does not support loading/saving, and it shouldn't usually be initialized directly. Instead, use
+    `get_peft_model` with the argument `mixed=True`.
 
     ```py
     >>> from peft import get_peft_model
@@ -105,16 +97,6 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
     >>> peft_model.set_adapter(["adapter1", "adapter2"])  # activate both adapters
     >>> peft_model(data)  # forward pass using both adapters
     ```
-
-    Tips:
-
-    - Not all adapter types can be combined. See `peft.tuners.mixed.COMPATIBLE_TUNER_TYPES` for a list of compatible
-      types. An error will be raised if you are trying to combine incompatible adapter types.
-    - It is possible to mix multiple adapters of the same type. This can be useful to combine adapters with very
-      different configs.
-    - If you want to combine a lot of different adapters, it is most performant to add the same types of adapters
-      consecutively. E.g., add LoRA1, LoRA2, LoHa1, LoHa2 in this order, instead of LoRA1, LoHa1, LoRA2, LoHa2. As long
-      as the adapters are commutative, the order does not matter for the final result.
 
     Args:
         model (`torch.nn.Module`):


### PR DESCRIPTION
This PR adds a batch of minor docs improvements that include:

- make `toctree` titles more concise and descriptive
- provide numbered steps to follow in `contributing.md`
- add pro/con table to `low_level_api` doc so its easy to skim at first glance
- add methods/functions discussed in the docs to the API section