### PR TITLE
Add generic PeftConfig constructor from kwargs

### DIFF
--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -35,6 +35,7 @@ class PeftConfigMixin(PushToHubMixin):
     Args:
         peft_type (Union[[`~peft.utils.config.PeftType`], `str`]): The type of Peft method to use.
     """
+
     peft_type: Optional[PeftType] = field(default=None, metadata={"help": "The type of PEFT model."})
     auto_mapping: Optional[dict] = field(
         default=None, metadata={"help": "An auto mapping dict to help retrieve the base model class if needed."}
@@ -80,6 +81,44 @@ class PeftConfigMixin(PushToHubMixin):
             writer.write(json.dumps(output_dict, indent=2, sort_keys=True))
 
     @classmethod
+    def from_peft_type(cls, **kwargs):
+        r"""
+        This method loads the configuration of your adapter model from a set of kwargs.
+
+        The appropriate configuration type is determined by the `peft_type` argument. If `peft_type` is not provided,
+        the calling class type is instantiated.
+
+        Args:
+            kwargs (configuration keyword arguments):
+                Keyword arguments passed along to the configuration initialization.
+        """
+        # Avoid circular dependency .. TODO: fix this with a larger refactor
+        from peft.mapping import PEFT_TYPE_TO_CONFIG_MAPPING
+
+        # TODO: this hack is needed to fix the following issue (on commit 702f937):
+        # if someone saves a default config and loads it back with `PeftConfig` class it yields to
+        # not loading the correct config class.
+
+        # from peft import AdaLoraConfig, PeftConfig
+        # peft_config = AdaLoraConfig()
+        # print(peft_config)
+        # >>> AdaLoraConfig(peft_type=<PeftType.ADALORA: 'ADALORA'>, auto_mapping=None, base_model_name_or_path=None,
+        # revision=None, task_type=None, inference_mode=False, r=8, target_modules=None, lora_alpha=8, lora_dropout=0.0, ...
+        #
+        # peft_config.save_pretrained("./test_config")
+        # peft_config = PeftConfig.from_pretrained("./test_config")
+        # print(peft_config)
+        # >>> PeftConfig(peft_type='ADALORA', auto_mapping=None, base_model_name_or_path=None, revision=None, task_type=None, inference_mode=False)
+
+        if "peft_type" in kwargs:
+            peft_type = kwargs["peft_type"]
+            config_cls = PEFT_TYPE_TO_CONFIG_MAPPING[peft_type]
+        else:
+            config_cls = cls
+
+        return config_cls(**kwargs)
+
+    @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: str, subfolder: Optional[str] = None, **kwargs):
         r"""
         This method loads the configuration of your adapter model from a directory.
@@ -90,9 +129,6 @@ class PeftConfigMixin(PushToHubMixin):
             kwargs (additional keyword arguments, *optional*):
                 Additional keyword arguments passed along to the child class initialization.
         """
-        # Avoid circular dependency .. TODO: fix this with a larger refactor
-        from peft.mapping import PEFT_TYPE_TO_CONFIG_MAPPING
-
         path = (
             os.path.join(pretrained_model_name_or_path, subfolder)
             if subfolder is not None
@@ -112,30 +148,8 @@ class PeftConfigMixin(PushToHubMixin):
                 raise ValueError(f"Can't find '{CONFIG_NAME}' at '{pretrained_model_name_or_path}'")
 
         loaded_attributes = cls.from_json_file(config_file)
-
-        # TODO: this hack is needed to fix the following issue (on commit 702f937):
-        # if someone saves a default config and loads it back with `PeftConfig` class it yields to
-        # not loading the correct config class.
-
-        # from peft import AdaLoraConfig, PeftConfig
-        # peft_config = AdaLoraConfig()
-        # print(peft_config)
-        # >>> AdaLoraConfig(peft_type=<PeftType.ADALORA: 'ADALORA'>, auto_mapping=None, base_model_name_or_path=None,
-        # revision=None, task_type=None, inference_mode=False, r=8, target_modules=None, lora_alpha=8, lora_dropout=0.0, ...
-        #
-        # peft_config.save_pretrained("./test_config")
-        # peft_config = PeftConfig.from_pretrained("./test_config")
-        # print(peft_config)
-        # >>> PeftConfig(peft_type='ADALORA', auto_mapping=None, base_model_name_or_path=None, revision=None, task_type=None, inference_mode=False)
-        if "peft_type" in loaded_attributes:
-            peft_type = loaded_attributes["peft_type"]
-            config_cls = PEFT_TYPE_TO_CONFIG_MAPPING[peft_type]
-        else:
-            config_cls = cls
-
         kwargs = {**class_kwargs, **loaded_attributes}
-        config = config_cls(**kwargs)
-        return config
+        return cls.from_peft_type(**kwargs)
 
     @classmethod
     def from_json_file(cls, path_json_file: str, **kwargs):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ from peft import (
     MultitaskPromptTuningConfig,
     OFTConfig,
     PeftConfig,
+    PeftType,
     PolyConfig,
     PrefixTuningConfig,
     PromptEncoder,
@@ -76,6 +77,18 @@ class PeftConfigTester(unittest.TestCase):
     @parameterized.expand(ALL_CONFIG_CLASSES)
     def test_task_type(self, config_class):
         config_class(task_type="test")
+
+    def test_from_peft_type(self):
+        r"""
+        Test if the config is correctly loaded using:
+        - from_peft_type
+        """
+        from peft.mapping import PEFT_TYPE_TO_CONFIG_MAPPING
+
+        for peft_type in PeftType:
+            expected_cls = PEFT_TYPE_TO_CONFIG_MAPPING[peft_type]
+            config = PeftConfig.from_peft_type(peft_type=peft_type)
+            assert type(config) is expected_cls
 
     @parameterized.expand(ALL_CONFIG_CLASSES)
     def test_from_pretrained(self, config_class):


### PR DESCRIPTION
This PR introduces a new constructor `PeftConfig.from_peft_type`that accepts a set of kwargs. The appropriate config class is determined by the `peft_type` argument. The logic for this was already buried within `from_pretrained`, so I've done a small refactor to pull that out into its own method.

Usage is as follows:
```
>>> from peft import PeftConfig
>>> peft_kwargs = {"peft_type": "LORA", "r": 8, "lora_alpha": 16}
>>> peft_config = PeftConfig.from_peft_type(**peft_kwargs)
>>> print(type(peft_config))
<class 'peft.tuners.lora.config.LoraConfig'>
```

I am new to contributing to this repo, so please let me know which PR steps I am missing (e.g., do I need to version bump in `setup.py`, or add any further documentation?)

