### PR TITLE
[`core`] fix critical bug in diffusers

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -400,7 +400,7 @@ class Embedding(nn.Module, LoraLayer):
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
-                    orig_weights = base_layer.weight.data.copy()
+                    orig_weights = base_layer.weight.data.clone()
                     orig_weights += self.get_delta_weight(active_adapter)
 
                     if not torch.isfinite(orig_weights).all():
@@ -575,7 +575,7 @@ class Conv2d(nn.Module, LoraLayer):
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
-                    orig_weights = base_layer.weight.data.copy()
+                    orig_weights = base_layer.weight.data.clone()
                     orig_weights += self.get_delta_weight(active_adapter)
 
                     if not torch.isfinite(orig_weights).all():


### PR DESCRIPTION
Fixes https://github.com/huggingface/diffusers/issues/6809

Indeeed `copy` does not exist in PyTorch 🤯 one needs to use `clone()` .. that code path was never tested so I added some CI tests for that so that it'll never happen in the future

cc @pacman100 @apolinario 