### PR TITLE
[`core`/`TPLinear`] Fix breaking change

### DIFF
--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -83,6 +83,7 @@ class LoraParallelLinear(nn.Module, LoraLayer):
 
     @property
     def is_paralle_a(self):
+        # TODO: remove it in PEFT 0.10.0
         # See https://github.com/huggingface/peft/pull/1439 for more details
         warnings.warn(
             "`is_paralle_a` is going to be deprecated in a future release. Please use `is_parallel_a`", FutureWarning

--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -83,6 +83,7 @@ class LoraParallelLinear(nn.Module, LoraLayer):
 
     @property
     def is_paralle_a(self):
+        # See https://github.com/huggingface/peft/pull/1439 for more details
         warnings.warn(
             "`is_paralle_a` is going to be deprecated in a future release. Please use `is_parallel_a`", FutureWarning
         )

--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -81,6 +81,13 @@ class LoraParallelLinear(nn.Module, LoraLayer):
 
         self.is_target_conv_1d_layer = False
 
+    @property
+    def is_paralle_a(self):
+        warnings.warn(
+            "`is_paralle_a` is going to be deprecated in a future release. Please use `is_parallel_a`", FutureWarning
+        )
+        return self.is_parallel_a
+
     def update_layer(
         self,
         adapter_name,


### PR DESCRIPTION
Addresses: https://github.com/huggingface/peft/pull/1435#discussion_r1479110527
Fixes a breaking change introduced by #1435 

since `is_paralle_a` is a public attribute, it is a breaking change to completely remove it as some users might be using it already 

cc @pacman100 @BenjaminBossan 