### PR TITLE
Fixed saving for models that don't have _name_or_path in config

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -784,7 +784,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         model_config = getattr(self, "config", None)
         if hasattr(model_config, "to_dict"):
             model_config = model_config.to_dict()
-        if model_config is not None:
+        if model_config is not None and "_name_or_path" in model_config:
             card.data["base_model"] = model_config["_name_or_path"]
 
         lines = card.text.splitlines()


### PR DESCRIPTION
Hi, PEFT team!

I noticed a small bug when I was trying to save LoRA for SDXL UNet model, loaded with `from_single_file` method. 
Apparently, `from_single_file` does not add `_name_or_path `  to the child model config (at least for `diffusers==0.26.0).`

```python
from diffusers import StableDiffusionXLPipeline
from peft import get_peft_model, LoraConfig

pipe = StableDiffusionXLPipeline.from_single_file(
    "/data/checkpoints/civitai/sdxl/realvisxlV30Turbo_v30Bakedvae.safetensors"
)


config = LoraConfig(
    target_modules=["conv_in"],
    lora_alpha=8,
    r=8
)

pipe.unet = get_peft_model(pipe.unet, config, adapter_name="default")
pipe.unet.save_pretrained("./unet")
```

```
...
File /opt/conda/envs/peft/lib/python3.8/site-packages/peft/peft_model.py:782, in PeftModel.create_or_update_model_card(self, output_dir)
    780     model_config = model_config.to_dict()
    781 if model_config is not None:
--> 782     card.data["base_model"] = model_config["_name_or_path"]
    784 lines = card.text.splitlines()
    786 quantization_config = None

KeyError: '_name_or_path'
```

This specific PR fixes this issue.

@BenjaminBossan your review is kindly appreciated.