### PR TITLE
TST: Improve test coverage by skipping fewer tests

### DIFF
--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -473,6 +473,8 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
             config_kwargs["init_lora_weights"] = False
         elif issubclass(config_cls, IA3Config):
             config_kwargs["init_ia3_weights"] = False
+        else:
+            config_kwargs["init_weights"] = False
         self._test_merge_layers(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(TEST_CASES)

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -515,8 +515,7 @@ class PeftCommonTester:
         )
 
     def _test_merge_layers(self, model_id, config_cls, config_kwargs):
-        if config_cls not in (LoraConfig, IA3Config):
-            # Merge layers only supported for LoRA and IA³
+        if issubclass(config_cls, PromptLearningConfig):
             return
         if ("gpt2" in model_id.lower()) and (config_cls != LoraConfig):
             self.skipTest("Merging GPT2 adapters not supported for IA³ (yet)")
@@ -528,10 +527,6 @@ class PeftCommonTester:
         )
         model = get_peft_model(model, config)
         model = model.to(self.torch_device)
-
-        if config.peft_type not in ("IA3", "LORA"):
-            with self.assertRaises(AttributeError):
-                model = model.merge_and_unload()
 
         dummy_input = self.prepare_inputs_for_testing()
         model.eval()
@@ -728,8 +723,11 @@ class PeftCommonTester:
         self.assertEqual(model.base_model_torch_dtype, torch.float16)
 
     def _test_training(self, model_id, config_cls, config_kwargs):
-        if config_cls not in (IA3Config, LoraConfig):
+        if issubclass(config_cls, PromptLearningConfig):
             return
+        if (config_cls == AdaLoraConfig) and ("roberta" in model_id.lower()):
+            # TODO: no gradients on the "dense" layer, other layers work, not sure why
+            self.skipTest("AdaLora with RoBERTa does not work correctly")
 
         model = self.transformers_class.from_pretrained(model_id)
         config = config_cls(
@@ -745,7 +743,7 @@ class PeftCommonTester:
         output = model(**inputs)[0]
         loss = output.sum()
         loss.backward()
-        parameter_prefix = "ia3" if config_cls == IA3Config else "lora"
+        parameter_prefix = model.prefix
         for n, param in model.named_parameters():
             if (parameter_prefix in n) or ("modules_to_save" in n):
                 self.assertIsNotNone(param.grad)
@@ -753,8 +751,10 @@ class PeftCommonTester:
                 self.assertIsNone(param.grad)
 
     def _test_inference_safetensors(self, model_id, config_cls, config_kwargs):
-        if config_cls not in (LoraConfig,):
-            return
+        if (config_cls == PrefixTuningConfig) and ("deberta" in model_id.lower()):
+            # TODO: raises an error:
+            # TypeError: DebertaModel.forward() got an unexpected keyword argument 'past_key_values'
+            self.skipTest("DeBERTa with PrefixTuning does not work correctly")
 
         config = config_cls(
             base_model_name_or_path=model_id,
@@ -843,8 +843,11 @@ class PeftCommonTester:
         self.assertLess(nb_trainable, nb_trainable_all)
 
     def _test_training_gradient_checkpointing(self, model_id, config_cls, config_kwargs):
-        if config_cls not in (LoraConfig, IA3Config):
+        if issubclass(config_cls, PromptLearningConfig):
             return
+        if (config_cls == AdaLoraConfig) and ("roberta" in model_id.lower()):
+            # TODO: no gradients on the "dense" layer, other layers work, not sure why
+            self.skipTest("AdaLora with RoBERTa does not work correctly")
 
         model = self.transformers_class.from_pretrained(model_id)
 


### PR DESCRIPTION
Many of the common tests are skipped because of lines such as:

```python
if config_cls not in (LoraConfig, IA3Config):
    return
```

These lines were often added before we had more PEFT methods like OFT, LoHa, etc. However, these new methods should also pass the common tests. Therefore, I relaxed many of these conditions so that they would not skip the new methods.

Note:

There were a handful of test cases that failed. I added TODO comments for those, as it was unclear to me why they failed. As investigating this could take some time, I chose not to fix those cases in this PR.