### PR TITLE
MNT: Check only selected directories with ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: quality style test docs
 
-check_dirs := .
+check_dirs := src tests examples docs scripts docker
 
 # Check that source code meets quality standards
 


### PR DESCRIPTION
In PR #1421, ruff was extended to check all directories. This is fine for those directories that come with PEFT. However, developers may have other local directories that they do not want to be checked. Therefore, it is better to list the directories to be checked rather than checking all.