### PR TITLE
FIX Loading with AutoPeftModel.from_pretrained

### DIFF
--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -43,7 +43,7 @@ class PeftAutoModelTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dirname:
             model.save_pretrained(tmp_dirname)
 
-            model = AutoPeftModelForCausalLM.from_pretrained(model_id)
+            model = AutoPeftModelForCausalLM.from_pretrained(tmp_dirname)
             self.assertTrue(isinstance(model, PeftModelForCausalLM))
 
         # check if kwargs are passed correctly
@@ -79,7 +79,7 @@ class PeftAutoModelTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dirname:
             model.save_pretrained(tmp_dirname)
 
-            model = AutoPeftModelForSeq2SeqLM.from_pretrained(model_id)
+            model = AutoPeftModelForSeq2SeqLM.from_pretrained(tmp_dirname)
             self.assertTrue(isinstance(model, PeftModelForSeq2SeqLM))
 
         # check if kwargs are passed correctly
@@ -100,7 +100,7 @@ class PeftAutoModelTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dirname:
             model.save_pretrained(tmp_dirname)
 
-            model = AutoPeftModelForSequenceClassification.from_pretrained(model_id)
+            model = AutoPeftModelForSequenceClassification.from_pretrained(tmp_dirname)
             self.assertTrue(isinstance(model, PeftModelForSequenceClassification))
 
         # check if kwargs are passed correctly
@@ -123,7 +123,7 @@ class PeftAutoModelTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dirname:
             model.save_pretrained(tmp_dirname)
 
-            model = AutoPeftModelForTokenClassification.from_pretrained(model_id)
+            model = AutoPeftModelForTokenClassification.from_pretrained(tmp_dirname)
             self.assertTrue(isinstance(model, PeftModelForTokenClassification))
 
         # check if kwargs are passed correctly
@@ -146,7 +146,7 @@ class PeftAutoModelTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dirname:
             model.save_pretrained(tmp_dirname)
 
-            model = AutoPeftModelForQuestionAnswering.from_pretrained(model_id)
+            model = AutoPeftModelForQuestionAnswering.from_pretrained(tmp_dirname)
             self.assertTrue(isinstance(model, PeftModelForQuestionAnswering))
 
         # check if kwargs are passed correctly
@@ -169,7 +169,7 @@ class PeftAutoModelTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dirname:
             model.save_pretrained(tmp_dirname)
 
-            model = AutoPeftModelForFeatureExtraction.from_pretrained(model_id)
+            model = AutoPeftModelForFeatureExtraction.from_pretrained(tmp_dirname)
             self.assertTrue(isinstance(model, PeftModelForFeatureExtraction))
 
         # check if kwargs are passed correctly
@@ -192,7 +192,7 @@ class PeftAutoModelTester(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dirname:
             model.save_pretrained(tmp_dirname)
 
-            model = AutoPeftModel.from_pretrained(model_id)
+            model = AutoPeftModel.from_pretrained(tmp_dirname)
             self.assertTrue(isinstance(model, PeftModel))
 
         # check if kwargs are passed correctly


### PR DESCRIPTION
Fixes #1430

When Using `AutoPeftModel.from_pretrained`, there is a check to see if a tokenizer can be found. This check will include a search for the tokenizer on HF Hub. However, when the model is stored locally, the path may not be a valid HF Hub repo ID. In that case, an error is raised by `huggingface_hub`.

This PR consists of catching that error, and assuming that if the error occurs, the tokenizer does not exist. This resolves the issue.

Note

We do have tests for `AutoPeftModel.from_pretrained`, so why did they not catch the error? I think there was a mistake in the tests. The tests did something like this:

```python
    model_id = "peft-internal-testing/tiny-OPTForCausalLM-lora"
    model = AutoPeftModelForCausalLM.from_pretrained(model_id)

    with tempfile.TemporaryDirectory() as tmp_dirname:
        model.save_pretrained(tmp_dirname)
        model = AutoPeftModelForCausalLM.from_pretrained(model_id)  # <==
```

As you can see, the model is loaded twice from the hub. I think the intent was that the 2nd time around, it should be loaded from the temporary directory (otherwise, why save it there?). I thus changed all the tests to load the model from the temporary directory. This way, the bug is triggered and the bug fix makes the tests pass again.

Please let me know if I misinterpreted the intent of the tests, then I will revert them and add a new test instead.