### PR TITLE
FIX: fix for dimension mismatch when using adaption prompt in Llama2

### DIFF
--- a/src/peft/tuners/adaption_prompt/utils.py
+++ b/src/peft/tuners/adaption_prompt/utils.py
@@ -68,7 +68,7 @@ def llama_compute_query_states(model: nn.Module, **kwargs) -> torch.Tensor:
     past_key_value = kwargs.get("past_key_value")
     bsz, q_len, _ = hidden_states.size()
     query_states = model.q_proj(hidden_states).view(bsz, q_len, model.num_heads, model.head_dim).transpose(1, 2)
-    value_states = model.v_proj(hidden_states).view(bsz, q_len, model.num_heads, model.head_dim).transpose(1, 2)
+    value_states = model.v_proj(hidden_states).view(bsz, q_len, model.num_key_value_heads, model.head_dim).transpose(1, 2)
 
     seq_len = q_len
     if past_key_value is not None:


### PR DESCRIPTION
Fix the dimension mismatch when using adaption prompt in Llama2-34B and Llama2-70B for solving [https://github.com/huggingface/peft/issues/1362](url).

Group query attention(GQA) is used in Llama2-34B and Llama2-70B, and adaption prompt create `key` and `value` with `k_proj` and `v_proj`. So the dimension of them is `(adapter_len, num_kv_heads, head_dim)` which is mismatched when running `key.view(1, self.adapter_len, self.model.num_key_value_heads, self.model.head_dim)`

My solution is change the parameters in `view` function and add a `repeated_kv` function with is similar with the processing in `transformers.models.llama.modeling_llama.py`. `adaption_prompt.utils.llama_compute_query_states` is updated for the same reason.

A test function named `test_llama_gqa` is added in `test_adaption_prompt.py` for testing that adaption prompt works when the base model llama use GQA or not.