### PR TITLE
[`core` / `get_peft_state_dict`] Ignore all exceptions to avoid unexpected errors

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -576,7 +576,7 @@ def check_file_exists_on_hf_hub(repo_id: str, filename: str, **kwargs) -> Option
         pass
     except Exception as e:
         warnings.warn(
-            f"War not able to fetch remote file due to the following error {e} - silently ignoring the lookup"
+            f"Unable to fetch remote file due to the following error {e} - silently ignoring the lookup"
             f" for the file {filename} in {repo_id}."
         )
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -574,5 +574,10 @@ def check_file_exists_on_hf_hub(repo_id: str, filename: str, **kwargs) -> Option
     except (HFValidationError, EntryNotFoundError):
         # error, exists stays None
         pass
+    except Exception as e:
+        warnings.warn(
+            f"War not able to fetch remote file due to the following error {e} - silently ignoring the lookup"
+            f" for the file {filename} in {repo_id}."
+        )
 
     return exists


### PR DESCRIPTION
# What does this PR do?

As discussed offline, a follow up PR to: https://github.com/huggingface/peft/pull/1454 
As other errors might be raised such as : https://github.com/huggingface/peft/pull/1414#issuecomment-1925821921 I propose to simply silently ignore the raised exceptions in case users face a different exception than the ones we listed from HF hub

cc @BenjaminBossan @pacman100 