### PR TITLE
[`CI`] Add CI tests on transformers main to catch early bugs

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -1,0 +1,27 @@
+name: tests on transformers main
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    needs: check_code_quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # cpu version of pytorch
+          pip install -U git+https://github.com/huggingface/transformers.git
+          pip install -e .[test]
+      - name: Test with pytest
+        run: |
+          make test

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   tests:
-    needs: check_code_quality
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
As per title and as discussed offline, let's run CIs on transformers main, only on push PEFT main branch in order to check bugs such as https://github.com/huggingface/peft/pull/1459 early.

IMO for that workflow, no need to make things complicated, let's just test it on a speciifc python / OS version

cc @BenjaminBossan @pacman100 