### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml

--- a/docs/source/developer_guides/contributing.md
+++ b/docs/source/developer_guides/contributing.md
@@ -41,6 +41,14 @@ make quality  # just check
 make style  # check and fix
 ```
 
+You can also set up [`pre-commit`](https://pre-commit.com/) to run these fixes
+automatically as Git commit hooks.
+
+```bash
+$ pip install pre-commit
+$ pre-commit install
+```
+
 Running all the tests can take a couple of minutes, so during development it can be more efficient to only run tests specific to your change:
 
 ```sh


### PR DESCRIPTION
# What does this PR do?

This PR adds a [pre-commit](https://pre-commit.com/) configuration, so developers may opt in to running `ruff` and `ruff-format` as a pre-commit hook.

Should reduce the need for "fix lint" commits and `check_code_quality` CI failures.

Sibling of https://github.com/huggingface/accelerate/pull/2451