### PR TITLE
Update docstring at peft_types.py

### DIFF
--- a/src/peft/utils/peft_types.py
+++ b/src/peft/utils/peft_types.py
@@ -58,7 +58,7 @@ class TaskType(str, enum.Enum):
     Overview of the supported task types:
     - SEQ_CLS: Text classification.
     - SEQ_2_SEQ_LM: Sequence-to-sequence language modeling.
-    - Causal LM: Causal language modeling.
+    - Causal_LM: Causal language modeling.
     - TOKEN_CLS: Token classification.
     - QUESTION_ANS: Question answering.
     - FEATURE_EXTRACTION: Feature extraction. Provides the hidden states which can be used as embeddings or features

--- a/src/peft/utils/peft_types.py
+++ b/src/peft/utils/peft_types.py
@@ -58,7 +58,7 @@ class TaskType(str, enum.Enum):
     Overview of the supported task types:
     - SEQ_CLS: Text classification.
     - SEQ_2_SEQ_LM: Sequence-to-sequence language modeling.
-    - Causal_LM: Causal language modeling.
+    - CAUSAL_LM: Causal language modeling.
     - TOKEN_CLS: Token classification.
     - QUESTION_ANS: Question answering.
     - FEATURE_EXTRACTION: Feature extraction. Provides the hidden states which can be used as embeddings or features


### PR DESCRIPTION
Docstring shows a missing underscore at TaskType "Causal LM"