### PR TITLE
FIX [`CI` / `bnb`] Fix failing bnb workflow

### DIFF
--- a/.github/workflows/nightly-bnb.yml
+++ b/.github/workflows/nightly-bnb.yml
@@ -36,6 +36,7 @@ jobs:
           source activate peft
           pip install -e . --no-deps
           pip install pytest-reportlog pytest-cov parameterized datasets scipy einops
+          pip install "pytest>=7.2.0,<8.0.0" # see: https://github.com/huggingface/transformers/blob/ce4fff0be7f6464d713f7ac3e0bbaafbc6959ae5/setup.py#L148C6-L148C26
           mkdir transformers-clone && git clone https://github.com/huggingface/transformers.git transformers-clone # rename to transformers clone to avoid modules conflict
           if [ "${{ matrix.docker-image-name }}" == "huggingface/peft-gpu-bnb-latest:latest" ]; then
             cd transformers-clone
@@ -91,6 +92,7 @@ jobs:
           source activate peft
           pip install -e . --no-deps
           pip install pytest-reportlog pytest-cov parameterized datasets scipy einops
+          pip install "pytest>=7.2.0,<8.0.0" # see: https://github.com/huggingface/transformers/blob/ce4fff0be7f6464d713f7ac3e0bbaafbc6959ae5/setup.py#L148C6-L148C26
           mkdir transformers-clone && git clone https://github.com/huggingface/transformers.git transformers-clone
           if [ "${{ matrix.docker-image-name }}" == "huggingface/peft-gpu-bnb-latest:latest" ]; then
             cd transformers-clone

--- a/.github/workflows/nightly-bnb.yml
+++ b/.github/workflows/nightly-bnb.yml
@@ -1,9 +1,8 @@
 name: BNB from source self-hosted runner with slow tests (scheduled)
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * *"
+  push:
+    branches: [younesbelkada-patch-3]
 
 env:
   RUN_SLOW: "yes"

--- a/.github/workflows/nightly-bnb.yml
+++ b/.github/workflows/nightly-bnb.yml
@@ -1,8 +1,9 @@
 name: BNB from source self-hosted runner with slow tests (scheduled)
 
 on:
-  push:
-    branches: [younesbelkada-patch-3]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
 
 env:
   RUN_SLOW: "yes"


### PR DESCRIPTION
This PR fixes the current bnb workflow that is broken due to an incompatible pytest version with transformers leading to transformers tests being silently skipped: https://github.com/huggingface/peft/actions/runs/7945902843/job/21693054056

cc @pacman100 @BenjaminBossan @Titus-von-Koeller FYI