### PR TITLE
ENH: [`CI` / `Docker`]: Create a workflow to temporarly build docker images in case dockerfiles are modified

### DIFF
--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -31,4 +31,12 @@ jobs:
         for file in ${CHANGED_FILES}; do
           echo "$file was changed"
         done
+    - name: Build Docker images
+      strategy:
+        matrix:
+          docker-file: ${{ steps.changed-files.outputs.all_changed_files}}
+      uses: docker/build-push-action@v4
+      with:
+        context: ${{ matrix.docker-file }}
+        push: False
 

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -1,0 +1,34 @@
+name: Test Docker images (scheduled)
+
+on:
+  pull_request:
+  paths:
+    # Run only when python files are modified
+    - "docker/**"
+
+concurrency:
+  group: docker-image-builds
+  cancel-in-progress: false
+
+jobs:
+  name: "Build all modified docker images"
+  runs-on: ubuntu-latest
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Get changed files
+      id: changed-files
+      uses: jitterbit/get-changed-files@v24
+      with:
+        files: docker/**
+    - name: Run step if only the files listed above change
+      if: steps.changed-files.outputs.only_changed == 'true'
+      env:
+        CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files}}
+      run: |
+        for file in ${CHANGED_FILES}; do
+          echo "$file was changed"
+        done
+

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -3,7 +3,7 @@ name: Test Docker images (scheduled)
 on:
   pull_request:
   paths:
-    # Run only when python files are modified
+    # Run only when DockerFile files are modified
     - "docker/**"
 
 concurrency:

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Get changed files
       id: changed-files
-      uses: jitterbit/get-changed-files@v24
+      uses: tj-actions/changed-files@3f54ebb830831fc121d3263c1857cfbdc310cdb9 #v42
       with:
         files: docker/**
     - name: Run step if only the files listed above change

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -1,0 +1,26 @@
+name: tests on transformers main
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: "pip"
+          cache-dependency-path: "setup.py"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # cpu version of pytorch
+          pip install -U git+https://github.com/huggingface/transformers.git
+          pip install -e .[test]
+      - name: Test with pytest
+        run: |
+          make test


### PR DESCRIPTION
Hi !

I would like to enhance the current way of testing docker build workflow, right now I need to manually change the rules for triggering the build docker image job to test if a PR leads to potential failure on docker build. In this PR I propose to simply trigger a simple workflow that just builds (without pushing) docker images that are modified by a PR

cc @pacman100 @BenjaminBossan 