### PR TITLE
ENH [`CI`] Run tests only when relevant files are modified

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -3,6 +3,8 @@ name: tests on transformers main
 on:
   push:
     branches: [main]
+    paths-ignore:
+        - 'docs/**'
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,11 @@ name: tests
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   check_code_quality:


### PR DESCRIPTION
Let's run the whole tests CI only when relevant files are changed, for minor PRs such as doc PR, there should be no need to run the testing suite IMO

Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

cc @pacman100 @BenjaminBossan 