### PR TITLE
FIX [`PromptTuning`] Simple fix for transformers >= 4.38

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1205,8 +1205,8 @@ class PeftModelForCausalLM(PeftModel):
                     model_kwargs["inputs_embeds"] = torch.cat((prompts, inputs_embeds), dim=1)
                     model_kwargs["input_ids"] = None
 
-        # For transformers>=4.38.0 - for some architectures such as Llama, `cache_position` is 
-        # passed in the forward pass to keep track of the position ids of the cache. We have to 
+        # For transformers>=4.38.0 - for some architectures such as Llama, `cache_position` is
+        # passed in the forward pass to keep track of the position ids of the cache. We have to
         # pop that from `model_kwargs` as `cache_position` is properly created by the model, using the passed
         # `inputs_embeds`: https://github.com/huggingface/transformers/blob/593230f0a1150ea9c0477b9d859f25daf73c8c33/src/transformers/models/llama/modeling_llama.py#L956
         _ = model_kwargs.pop("cache_position", None)

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1205,6 +1205,12 @@ class PeftModelForCausalLM(PeftModel):
                     model_kwargs["inputs_embeds"] = torch.cat((prompts, inputs_embeds), dim=1)
                     model_kwargs["input_ids"] = None
 
+        # For transformers>=4.38.0 - for some architectures such as Llama, `cache_position` is 
+        # passed in the forward pass to keep track of the position ids of the cache. We have to 
+        # pop that from `model_kwargs` as `cache_position` is properly created by the model, using the passed
+        # `inputs_embeds`: https://github.com/huggingface/transformers/blob/593230f0a1150ea9c0477b9d859f25daf73c8c33/src/transformers/models/llama/modeling_llama.py#L956
+        _ = model_kwargs.pop("cache_position", None)
+
         return model_kwargs
 
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes the current failing CI on transformers main. 

Recent commits on transformers main introduced a new way to compute the position ids of the input embeddings or input ids. Cos / Sin for RoPE do not use `position_ids` anymore but uses `cache_position` which now can be passed in case one uses cache, which is the case for prompt encoder models in PEFT. 

The fix is simply to pop `"cache_position"` from `model_kwargs` as `cache_position` is automatically re-computed on architectures that uses it, such as llama (only llama for now supports `cache_positon`), in the model's forward pass: https://github.com/huggingface/transformers/blob/593230f0a1150ea9c0477b9d859f25daf73c8c33/src/transformers/models/llama/modeling_llama.py#L956 

With this simple fix, I can confirm all failing tests pass on transformers main and the fix is totally backward compatible

cc @pacman100 @BenjaminBossan 