### PR TITLE
Fix issue with unloading double wrapped modules

### DIFF
--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -327,7 +327,13 @@ class IA3Model(BaseTuner):
                 self._replace_module(parent, target_name, target.get_base_layer(), target)
             elif isinstance(target, ModulesToSaveWrapper):
                 # save any additional trainable modules part of `modules_to_save`
-                setattr(parent, target_name, target.modules_to_save[target.active_adapter])
+                new_module = target.modules_to_save[target.active_adapter]
+                if hasattr(new_module, "base_layer"):
+                    # check if the module is itself a tuner layer
+                    if merge:
+                        new_module.merge(safe_merge=safe_merge, adapter_names=adapter_names)
+                    new_module = new_module.get_base_layer()
+                setattr(parent, target_name, new_module)
 
         return self.model
 

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -365,7 +365,13 @@ class LoraModel(BaseTuner):
                     self._replace_module(parent, target_name, target.get_base_layer(), target)
                 elif isinstance(target, ModulesToSaveWrapper):
                     # save any additional trainable modules part of `modules_to_save`
-                    setattr(parent, target_name, target.modules_to_save[target.active_adapter])
+                    new_module = target.modules_to_save[target.active_adapter]
+                    if hasattr(new_module, "base_layer"):
+                        # check if the module is itself a tuner layer
+                        if merge:
+                            new_module.merge(safe_merge=safe_merge, adapter_names=adapter_names)
+                        new_module = new_module.get_base_layer()
+                    setattr(parent, target_name, new_module)
 
         return self.model
 

--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -331,7 +331,13 @@ class LycorisTuner(BaseTuner):
                 self._replace_module(parent, target_name, target.get_base_layer(), target)
             elif isinstance(target, ModulesToSaveWrapper):
                 # save any additional trainable modules part of `modules_to_save`
-                setattr(parent, target_name, target.modules_to_save[target.active_adapter])
+                new_module = target.modules_to_save[target.active_adapter]
+                if hasattr(new_module, "base_layer"):
+                    # check if the module is itself a tuner layer
+                    if merge:
+                        new_module.merge(safe_merge=safe_merge, adapter_names=adapter_names)
+                    new_module = new_module.get_base_layer()
+                setattr(parent, target_name, new_module)
 
         return self.model
 

--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -262,7 +262,13 @@ class MixedModel(BaseTuner):
                 self._replace_module(parent, target_name, target.get_base_layer(), target)
             elif isinstance(target, ModulesToSaveWrapper):
                 # save any additional trainable modules part of `modules_to_save`
-                setattr(parent, target_name, target.modules_to_save[target.active_adapter])
+                new_module = target.modules_to_save[target.active_adapter]
+                if hasattr(new_module, "base_layer"):
+                    # check if the module is itself a tuner layer
+                    if merge:
+                        new_module.merge(safe_merge=safe_merge, adapter_names=adapter_names)
+                    new_module = new_module.get_base_layer()
+                setattr(parent, target_name, new_module)
 
         return self.model
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -26,6 +26,7 @@ from torch import nn
 from transformers.pytorch_utils import Conv1D
 
 from peft import AdaLoraConfig, IA3Config, LoHaConfig, LoKrConfig, LoraConfig, OFTConfig, PeftModel, get_peft_model
+from peft.utils import ModulesToSaveWrapper
 from peft.tuners.tuners_utils import BaseTunerLayer
 
 from .testing_common import PeftCommonTester
@@ -922,6 +923,29 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         assert not torch.allclose(output_base, output_custom2)
         assert torch.allclose(output_custom1, output_custom2)
         assert torch.allclose(output_default, output_custom1)
+
+    @parameterized.expand(["merge_and_unload", "unload"])
+    def test_double_wrapping_merge_and_unload(self, method):
+        # see issue #1485
+        from transformers import AutoModelForTokenClassification
+
+        model = AutoModelForTokenClassification.from_pretrained("hf-internal-testing/tiny-random-RobertaModel")
+        config = LoraConfig(task_type="TOKEN_CLS", target_modules="all-linear")
+        model = get_peft_model(model, config)
+
+        # first check that double-wrapping happened
+        # Note: this may get fixed in a future PR, in which case this test can be removed
+        assert isinstance(model.base_model.model.classifier, ModulesToSaveWrapper)
+        assert hasattr(model.base_model.model.classifier.original_module, "lora_A")
+        assert hasattr(model.base_model.model.classifier.modules_to_save.default, "lora_A")
+
+        # after unloading, despite double wrapping, the classifier module should be a normal nn.Linear layer
+        if method == "merge_and_unload":
+            unloaded = model.merge_and_unload()
+        else:
+            unloaded = model.unload()
+
+        assert isinstance(unloaded.classifier, nn.Linear)
 
 
 class TestMultiRankAdapter(unittest.TestCase):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -26,8 +26,8 @@ from torch import nn
 from transformers.pytorch_utils import Conv1D
 
 from peft import AdaLoraConfig, IA3Config, LoHaConfig, LoKrConfig, LoraConfig, OFTConfig, PeftModel, get_peft_model
-from peft.utils import ModulesToSaveWrapper
 from peft.tuners.tuners_utils import BaseTunerLayer
+from peft.utils import ModulesToSaveWrapper
 
 from .testing_common import PeftCommonTester
 from .testing_utils import get_state_dict


### PR DESCRIPTION
Resolves #1485, but note that some additional solutions are mentioned in thet issue.

This checks that when unloading a PEFT model, if the ModulesToSaveWrapper contains a tuner module, it is correctly unloaded. The unloaded model should not have PEFT layers at the end.