### PR TITLE
make `all-linear` as default for `target_modules`

### DIFF
--- a/src/peft/tuners/loha/config.py
+++ b/src/peft/tuners/loha/config.py
@@ -42,7 +42,7 @@ class LoHaConfig(LycorisConfig):
             of the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
             excluding the output layer. If this is not specified, modules will be chosen according to the model
             architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
-            the target modules manually.
+            the target modules manually. Default is `all-linear`.
         init_weights (`bool`):
             Whether to perform initialization of adapter weights. This defaults to `True`, passing `False` is
             discouraged.
@@ -77,7 +77,7 @@ class LoHaConfig(LycorisConfig):
         },
     )
     target_modules: Optional[Union[List[str], str]] = field(
-        default=None,
+        default="all-linear",
         metadata={
             "help": "List of module names or regex expression of the module names to replace with LoHa."
             "For example, ['q', 'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$' "

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -46,7 +46,7 @@ class LoKrConfig(LycorisConfig):
             of the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
             excluding the output layer. If this is not specified, modules will be chosen according to the model
             architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
-            the target modules manually.
+            the target modules manually. Default is `all-linear`.
         init_weights (`bool`):
             Whether to perform initialization of adapter weights. This defaults to `True`, passing `False` is
             discouraged.
@@ -86,7 +86,7 @@ class LoKrConfig(LycorisConfig):
     )
     decompose_factor: int = field(default=-1, metadata={"help": "Kronecker product decomposition factor."})
     target_modules: Optional[Union[List[str], str]] = field(
-        default=None,
+        default="all-linear",
         metadata={
             "help": "List of module names or regex expression of the module names to replace with LoKr."
             "For example, ['q', 'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$' "

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -55,7 +55,7 @@ class LoraConfig(PeftConfig):
             of the passed strings. If this is specified as 'all-linear', then all linear/Conv1D modules are chosen,
             excluding the output layer. If this is not specified, modules will be chosen according to the model
             architecture. If the architecture is not known, an error will be raised -- in this case, you should specify
-            the target modules manually.
+            the target modules manually. Default is `all-linear`.
         lora_alpha (`int`):
             The alpha parameter for Lora scaling.
         lora_dropout (`float`):
@@ -105,7 +105,7 @@ class LoraConfig(PeftConfig):
 
     r: int = field(default=8, metadata={"help": "Lora attention dimension"})
     target_modules: Optional[Union[list[str], str]] = field(
-        default=None,
+        default="all-linear",
         metadata={
             "help": (
                 "List of module names or regex expression of the module names to replace with LoRA."


### PR DESCRIPTION
### What does this PR do?
1. Make `all-linear` as default for `target_modules`. This should make LoRA and variants work for any new model out-of-the-box.