### PR TITLE
FIX Bug in prompt learning after disabling adapter

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -570,7 +570,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         finally:
             if self.peft_config[self.active_adapter].is_prompt_learning:
                 self.forward = old_forward
-                self.old_prepare_inputs_for_generation = old_prepare_inputs_for_generation
+                self.prepare_inputs_for_generation = old_prepare_inputs_for_generation
             else:
                 self.base_model.enable_adapter_layers()
 

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -1282,6 +1282,11 @@ class PeftCommonTester:
                 output_peft_disabled = get_output(peft_model)
             assert torch.allclose(output_before, output_peft_disabled, atol=1e-6, rtol=1e-6)
 
+            # after leaving the disable_adapter context, the output should be the same as with enabled adapter again
+            # see #1501
+            output_peft_after_disabled = get_output(peft_model)
+            assert torch.allclose(output_peft, output_peft_after_disabled, atol=1e-6, rtol=1e-6)
+
         # TODO: add tests to check if disabling adapters works after calling merge_adapter
 
     def _test_adding_multiple_adapters_with_bias_raises(self, model_id, config_cls, config_kwargs):


### PR DESCRIPTION
Resolves #1501

There was a big that after using the `disable_adapter` context, the prepare method was not correctly restored, meaning that generations were incorrect once the context was exited. This is now fixed.