### PR TITLE
FIX Safe merging with LoHa and LoKr

### DIFF
--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -128,9 +128,8 @@ class LycorisLayer(BaseTunerLayer):
         for active_adapter in adapter_names:
             if active_adapter in self._available_adapters:
                 base_layer = self.get_base_layer()
-
                 if safe_merge:
-                    orig_weights = base_layer.weight.data
+                    orig_weights = base_layer.weight.data.clone()
                     orig_weights += self.get_delta_weight(active_adapter)
 
                     if not torch.isfinite(orig_weights).all():

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -499,6 +499,18 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         self._test_merge_layers_is_idempotent(model_id, config_cls, config_kwargs)
 
     @parameterized.expand(TEST_CASES)
+    def test_safe_merge(self, test_name, model_id, config_cls, config_kwargs):
+        # calling merge twice with the same arguments should not change the output
+        config_kwargs = config_kwargs.copy()
+        if issubclass(config_cls, LoraConfig):
+            config_kwargs["init_lora_weights"] = False
+        elif issubclass(config_cls, IA3Config):
+            config_kwargs["init_ia3_weights"] = False
+        else:
+            config_kwargs["init_weights"] = False
+        self._test_safe_merge(model_id, config_cls, config_kwargs)
+
+    @parameterized.expand(TEST_CASES)
     def test_generate(self, test_name, model_id, config_cls, config_kwargs):
         # Custom models do not (necessarily) have a generate method, so this test is not performed
         pass

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -28,6 +28,8 @@ from diffusers import StableDiffusionPipeline
 from peft import (
     AdaLoraConfig,
     IA3Config,
+    LoHaConfig,
+    LoKrConfig,
     LoraConfig,
     PeftModel,
     PeftType,
@@ -431,7 +433,7 @@ class PeftCommonTester:
             assert model_from_pretrained.peft_config["default"] is config
 
     def _test_merge_layers_fp16(self, model_id, config_cls, config_kwargs):
-        if config_cls not in (LoraConfig, IA3Config):
+        if config_cls not in (LoraConfig, IA3Config, AdaLoraConfig, LoHaConfig, LoKrConfig):
             # Merge layers only supported for LoRA and IA³
             return pytest.skip(f"Test not applicable for {config_cls}")
 
@@ -452,7 +454,7 @@ class PeftCommonTester:
         _ = model.merge_and_unload()
 
     def _test_merge_layers_nan(self, model_id, config_cls, config_kwargs):
-        if config_cls not in (LoraConfig, IA3Config, AdaLoraConfig):
+        if config_cls not in (LoraConfig, IA3Config, AdaLoraConfig, LoHaConfig, LoKrConfig):
             # Merge layers only supported for LoRA and IA³
             return
         if ("gpt2" in model_id.lower()) and (config_cls != LoraConfig):
@@ -647,6 +649,30 @@ class PeftCommonTester:
         logits_1 = model(**self.prepare_inputs_for_testing())[0]
 
         assert torch.allclose(logits_0, logits_1, atol=1e-6, rtol=1e-6)
+
+    def _test_safe_merge(self, model_id, config_cls, config_kwargs):
+        torch.manual_seed(0)
+        model = self.transformers_class.from_pretrained(model_id)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = model.to(self.torch_device).eval()
+
+        inputs = self.prepare_inputs_for_testing()
+        logits_base = model(**inputs)[0]
+
+        model = get_peft_model(model, config).eval()
+        logits_peft = model(**inputs)[0]
+
+        # sanity check that the logits are different
+        assert not torch.allclose(logits_base, logits_peft, atol=1e-6, rtol=1e-6)
+
+        model_unloaded = model.merge_and_unload(safe_merge=True)
+        logits_unloaded = model_unloaded(**inputs)[0]
+
+        # check that the logits are the same after unloading
+        assert torch.allclose(logits_peft, logits_unloaded, atol=1e-6, rtol=1e-6)
 
     def _test_generate(self, model_id, config_cls, config_kwargs):
         model = self.transformers_class.from_pretrained(model_id)


### PR DESCRIPTION
There was a small bug when merging the LoHa and LoKr tuners with `safe_merge=True` due to a missing `clone` call. This is now fixed.

Furthermore, the test coverage for merging with LoHa and LoKr has been extended, as there were a few tests where these methods were excluded unnecessarily.