### PR TITLE
Bump versions for release 0.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.8.2"
+VERSION = "0.9.0"
 
 extras = {}
 extras["quality"] = [

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.8.2"
+__version__ = "0.9.0"
 
 from .auto import (
     AutoPeftModel,


### PR DESCRIPTION
Note that we did not set a dev version for 0.8.2, so this PR goes directly from 0.8.2 to 0.9.0.

No deprecated code or similar to change.