### PR TITLE
QDoRA: Support DoRA with BnB quantization

### DIFF
--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -71,7 +71,7 @@ config = LoraConfig(use_rslora=True, ...)
 
 ### Weight-Decomposed Low-Rank Adaptation (DoRA)
 
-This technique decomposes the updates of the weights into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is handled by a separate learnable parameter. This can improve the performance of LoRA, especially at low ranks. Right now, DoRA only supports linear layers. DoRA introduces a bigger overhead than pure LoRA, so it is recommended to merge weights for inference, see [`LoraModel.merge_and_unload`]. For more information on DoRA, see  https://arxiv.org/abs/2402.09353.
+This technique decomposes the updates of the weights into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is handled by a separate learnable parameter. This can improve the performance of LoRA, especially at low ranks. For more information on DoRA, see  https://arxiv.org/abs/2402.09353.
 
 ```py
 from peft import LoraConfig
@@ -79,7 +79,11 @@ from peft import LoraConfig
 config = LoraConfig(use_dora=True, ...)
 ```
 
-DoRA should work with weights quantized with bitsandbytes ("QDoRA"). Issues have been reported when using QDoRA with DeepSpeed Zero2.
+#### Caveats
+
+- DoRA only supports linear layers at the momement.
+- DoRA introduces a bigger overhead than pure LoRA, so it is recommended to merge weights for inference, see [`LoraModel.merge_and_unload`]. 
+- DoRA should work with weights quantized with bitsandbytes ("QDoRA"). However, issues have been reported when using QDoRA with DeepSpeed Zero2.
 
 ### QLoRA-style training
 

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -71,13 +71,15 @@ config = LoraConfig(use_rslora=True, ...)
 
 ### Weight-Decomposed Low-Rank Adaptation (DoRA)
 
-This technique decomposes the updates of the weights into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is handled by a separate learnable parameter. This can improve the performance of LoRA, especially at low ranks. Right now, DoRA only supports only linear layers. DoRA introduces a bigger overhead than pure LoRA, so it is recommended to merge weights for inference, see [`LoraModel.merge_and_unload`]. For more information on DoRA, see  https://arxiv.org/abs/2402.09353.
+This technique decomposes the updates of the weights into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is handled by a separate learnable parameter. This can improve the performance of LoRA, especially at low ranks. Right now, DoRA only supports linear layers. DoRA introduces a bigger overhead than pure LoRA, so it is recommended to merge weights for inference, see [`LoraModel.merge_and_unload`]. For more information on DoRA, see  https://arxiv.org/abs/2402.09353.
 
 ```py
 from peft import LoraConfig
 
 config = LoraConfig(use_dora=True, ...)
 ```
+
+DoRA should work with weights quantized with bitsandbytes ("QDoRA"). Issues have been reported when using QDoRA with DeepSpeed Zero2.
 
 ### QLoRA-style training
 

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -71,7 +71,7 @@ config = LoraConfig(use_rslora=True, ...)
 
 ### Weight-Decomposed Low-Rank Adaptation (DoRA)
 
-This technique decomposes the updates of the weights into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is handled by a separate learnable parameter. This can improve the performance of LoRA, especially at low ranks. Right now, DoRA only supports non-quantized linear layers. DoRA introduces a bigger overhead than pure LoRA, so it is recommended to merge weights for inference, see [`LoraModel.merge_and_unload`]. For more information on DoRA, see  https://arxiv.org/abs/2402.09353.
+This technique decomposes the updates of the weights into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is handled by a separate learnable parameter. This can improve the performance of LoRA, especially at low ranks. Right now, DoRA only supports only linear layers. DoRA introduces a bigger overhead than pure LoRA, so it is recommended to merge weights for inference, see [`LoraModel.merge_and_unload`]. For more information on DoRA, see  https://arxiv.org/abs/2402.09353.
 
 ```py
 from peft import LoraConfig

--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -20,6 +20,7 @@ import torch
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
 from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
+from peft.utils.integrations import dequantize_bnb_weight
 from peft.utils.other import transpose
 
 from .layer import LoraLayer
@@ -43,9 +44,7 @@ if is_bnb_available():
         ) -> None:
             super().__init__()
             LoraLayer.__init__(self, base_layer)
-
-            if use_dora:
-                raise ValueError(f"{self.__class__.__name__} does not support DoRA yet, please set it to False")
+            self.fan_in_fan_out = False
 
             self._active_adapter = adapter_name
             self.update_layer(
@@ -79,6 +78,12 @@ if is_bnb_available():
             for active_adapter in adapter_names:
                 if active_adapter not in self.lora_A.keys():
                     continue
+
+                if self.use_dora[active_adapter]:
+                    raise ValueError(
+                        f"{self.__class__.__name__} does not support merging with use_dora=True yet, please set it to False"
+                    )
+
                 warnings.warn(
                     "Merge lora module to 8-bit linear may get different generations due to rounding errors."
                 )
@@ -91,14 +96,7 @@ if is_bnb_available():
 
                 # Dequantize the result of identity matrix and int8 weight because bitsandbytes does not support int8
                 # dequantization directly
-                im = torch.eye(weight.data.shape[-1]).contiguous().half().to(weight.device)
-                im, imt, SCim, SCimt, coo_tensorim = bnb.functional.double_quant(im)
-                im, Sim = bnb.functional.transform(im, "col32")
-                if state.CxB is None:
-                    state.CxB, state.SB = bnb.functional.transform(weight.data, to_order=state.formatB)
-                out32, Sout32 = bnb.functional.igemmlt(im, state.CxB, Sim, state.SB)
-                output = bnb.functional.mm_dequant(out32, Sout32, SCim, state.SCB, bias=None).t()
-
+                output = dequantize_bnb_weight(weight, state=state)
                 w_data = output.to(lora_data.dtype).to(lora_data.device) + lora_data
                 if safe_merge and not torch.isfinite(w_data).all():
                     raise ValueError(
@@ -132,14 +130,7 @@ if is_bnb_available():
                 state = self.get_base_layer().state
                 if state.SCB is None:
                     state.SCB = weight.SCB
-                im = torch.eye(weight.data.shape[-1]).contiguous().half().to(weight.device)
-                im, imt, SCim, SCimt, coo_tensorim = bnb.functional.double_quant(im)
-                im, Sim = bnb.functional.transform(im, "col32")
-
-                if state.CxB is None:
-                    state.CxB, state.SB = bnb.functional.transform(weight.data, to_order=state.formatB)
-                out32, Sout32 = bnb.functional.igemmlt(im, state.CxB, Sim, state.SB)
-                output = bnb.functional.mm_dequant(out32, Sout32, SCim, state.SCB, bias=None).t()
+                output = dequantize_bnb_weight(weight, state=state)
 
                 w_data = output.to(lora_data.dtype).to(lora_data.device) - lora_data
                 self.get_base_layer().weight = bnb.nn.Int8Params(
@@ -179,10 +170,14 @@ if is_bnb_available():
                         compute_dtype = lora_A.weight.dtype
                         if x.dtype != compute_dtype:
                             x = x.to(compute_dtype)
-                    output = lora_B(lora_A(dropout(x)))
+
+                    if not self.use_dora[active_adapter]:
+                        output = lora_B(lora_A(dropout(x))) * scaling
+                    else:
+                        output = self._apply_dora(x, lora_A, lora_B, scaling, active_adapter)
                     if requires_conversion:
                         output = output.to(expected_dtype)
-                    output = output * scaling
+
                     result = result + output
 
             return result
@@ -233,9 +228,7 @@ if is_bnb_4bit_available():
         ) -> None:
             super().__init__()
             LoraLayer.__init__(self, base_layer)
-
-            if use_dora:
-                raise ValueError(f"{self.__class__.__name__} does not support DoRA yet, please set it to False")
+            self.fan_in_fan_out = False
 
             self._active_adapter = adapter_name
             self.update_layer(
@@ -269,6 +262,12 @@ if is_bnb_4bit_available():
             for active_adapter in adapter_names:
                 if active_adapter not in self.lora_A.keys():
                     continue
+
+                if self.use_dora[active_adapter]:
+                    raise ValueError(
+                        f"{self.__class__.__name__} does not support merging with use_dora=True yet, please set it to False"
+                    )
+
                 warnings.warn(
                     "Merge lora module to 4-bit linear may get different generations due to rounding errors."
                 )
@@ -352,10 +351,13 @@ if is_bnb_4bit_available():
                         expected_dtype = result.dtype
                         x = x.to(lora_A.weight.dtype)
 
-                    output = lora_B(lora_A(dropout(x)))
+                    if not self.use_dora[active_adapter]:
+                        output = lora_B(lora_A(dropout(x))) * scaling
+                    else:
+                        output = self._apply_dora(x, lora_A, lora_B, scaling, active_adapter)
                     if requires_conversion:
                         output = output.to(expected_dtype)
-                    output = output * scaling
+
                     result = result + output
 
             return result

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -105,9 +105,8 @@ class LoraConfig(PeftConfig):
             Enable 'Weight-Decomposed Low-Rank Adaptation' (DoRA). This technique decomposes the updates of the weights
             into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is
             handled by a separate learnable parameter. This can improve the performance of LoRA, especially at low
-            ranks. Right now, DoRA only supports only linear layers. DoRA introduces a bigger overhead than pure LoRA,
-            so it is recommended to merge weights for inference. For more information, see
-            https://arxiv.org/abs/2402.09353.
+            ranks. Right now, DoRA only supports linear layers. DoRA introduces a bigger overhead than pure LoRA, so it
+            is recommended to merge weights for inference. For more information, see https://arxiv.org/abs/2402.09353.
     """
 
     r: int = field(default=8, metadata={"help": "Lora attention dimension"})
@@ -238,7 +237,7 @@ class LoraConfig(PeftConfig):
                 "Enable 'Weight-Decomposed Low-Rank Adaptation' (DoRA). This technique decomposes the updates of the "
                 "weights into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the "
                 "magnitude is handled by a separate learnable parameter. This can improve the performance of LoRA, "
-                "especially at low ranks. Right now, DoRA only supports only linear layers. DoRA introduces a bigger"
+                "especially at low ranks. Right now, DoRA only supports linear layers. DoRA introduces a bigger"
                 "overhead than pure LoRA, so it is recommended to merge weights for inference. For more information, "
                 "see  https://arxiv.org/abs/2402.09353."
             )

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -105,8 +105,8 @@ class LoraConfig(PeftConfig):
             Enable 'Weight-Decomposed Low-Rank Adaptation' (DoRA). This technique decomposes the updates of the weights
             into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is
             handled by a separate learnable parameter. This can improve the performance of LoRA, especially at low
-            ranks. Right now, DoRA only supports non-quantized linear layers. DoRA introduces a bigger overhead than
-            pure LoRA, so it is recommended to merge weights for inference. For more information, see
+            ranks. Right now, DoRA only supports only linear layers. DoRA introduces a bigger overhead than pure LoRA,
+            so it is recommended to merge weights for inference. For more information, see
             https://arxiv.org/abs/2402.09353.
     """
 
@@ -238,9 +238,9 @@ class LoraConfig(PeftConfig):
                 "Enable 'Weight-Decomposed Low-Rank Adaptation' (DoRA). This technique decomposes the updates of the "
                 "weights into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the "
                 "magnitude is handled by a separate learnable parameter. This can improve the performance of LoRA, "
-                "especially at low ranks. Right now, DoRA only supports non-quantized linear layers. DoRA introduces "
-                "a bigger overhead than pure LoRA, so it is recommended to merge weights for inference. For more "
-                "information, see  https://arxiv.org/abs/2402.09353."
+                "especially at low ranks. Right now, DoRA only supports only linear layers. DoRA introduces a bigger"
+                "overhead than pure LoRA, so it is recommended to merge weights for inference. For more information, "
+                "see  https://arxiv.org/abs/2402.09353."
             )
         },
     )

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -258,8 +258,8 @@ class LoraConfig(PeftConfig):
         if isinstance(self.target_modules, str) and self.layers_pattern is not None:
             raise ValueError("`layers_pattern` cannot be used when `target_modules` is a str.")
 
-        if self.use_dora and (self.megatron_config or self.init_lora_weights == "loftq"):
-            raise ValueError("DoRA does not support megatron_core or LoftQ. Please set `use_dora=False`.")
+        if self.use_dora and self.megatron_config:
+            raise ValueError("DoRA does not support megatron_core, please set `use_dora=False`.")
 
         # handle init_lora_weights and loftq_config
         if self.init_lora_weights == "loftq":

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -172,7 +172,7 @@ class LoraLayer(BaseTunerLayer):
     def _get_weight_norm(self, weight, lora_weight, scaling) -> torch.Tensor:
         # calculate L2 norm of weight matrix, column-wise
         weight = weight + scaling * lora_weight
-        weight_norm = torch.linalg.norm(weight, dim=1)
+        weight_norm = torch.linalg.norm(weight, dim=1).to(weight.dtype)
         return weight_norm
 
     def dora_init(self, adapter_name: str) -> None:

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -22,7 +22,7 @@ import torch.nn.functional as F
 from transformers.pytorch_utils import Conv1D
 
 from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
-from peft.utils.integrations import gather_params_ctx
+from peft.utils.integrations import dequantize_bnb_weight, gather_params_ctx
 from peft.utils.other import transpose
 
 from .config import LoraConfig
@@ -181,6 +181,8 @@ class LoraLayer(BaseTunerLayer):
         scaling = self.scaling[adapter_name]
         with gather_params_ctx(self.get_base_layer()):
             weight = self.get_base_layer().weight
+            quant_state = getattr(self.get_base_layer(), "state", None)
+            weight = dequantize_bnb_weight(weight, state=quant_state)  # no-op if not bnb
             lora_weight = lora_B.weight @ lora_A.weight
             weight_norm = self._get_weight_norm(weight, lora_weight, scaling)
         self.lora_magnitude_vector = nn.ParameterDict()
@@ -203,6 +205,9 @@ class LoraLayer(BaseTunerLayer):
         lora_weight = lora_B.weight @ lora_A.weight
         magnitude = self.lora_magnitude_vector[active_adapter]
         weight = self.get_base_layer().weight
+        quant_state = getattr(self.get_base_layer(), "state", None)
+        weight = dequantize_bnb_weight(weight, state=quant_state)  # no-op if not bnb
+        weight = weight.to(x.dtype)
         weight_norm = self._get_weight_norm(weight, lora_weight, scaling)
         # see section 4.3 of DoRA (https://arxiv.org/abs/2402.09353)
         # "[...] we suggest treating ||V +∆V ||_c in

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -37,3 +37,30 @@ def gather_params_ctx(module: torch.nn.Module, modifier_rank: int = 0):
     with deepspeed.zero.GatheredParameters(params_to_gather, modifier_rank=modifier_rank):
         yield
     return
+
+
+def dequantize_bnb_weight(weight, state=None):
+    """
+    Helper functin to dequantize 4bit or 8bit weights.
+
+    If the weight is not a bnb quantized weight, it will be returned as is.
+    """
+    cls_name = weight.__class__.__name__
+    if cls_name not in ("Params4bit", "Int8Params"):
+        return weight
+
+    import bitsandbytes as bnb
+
+    if cls_name == "Params4bit":
+        return bnb.functional.dequantize_4bit(weight.data, weight.quant_state)
+
+    if state.SCB is None:
+        state.SCB = weight.SCB
+
+    im = torch.eye(weight.data.shape[-1]).contiguous().half().to(weight.device)
+    im, imt, SCim, SCimt, coo_tensorim = bnb.functional.double_quant(im)
+    im, Sim = bnb.functional.transform(im, "col32")
+    if state.CxB is None:
+        state.CxB, state.SB = bnb.functional.transform(weight.data, to_order=state.formatB)
+    out32, Sout32 = bnb.functional.igemmlt(im, state.CxB, Sim, state.SB)
+    return bnb.functional.mm_dequant(out32, Sout32, SCim, state.SCB, bias=None).t()

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -41,7 +41,7 @@ def gather_params_ctx(module: torch.nn.Module, modifier_rank: int = 0):
 
 def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
     """
-    Helper functin to dequantize 4bit or 8bit weights.
+    Helper function to dequantize 4bit or 8bit bnb weights.
 
     If the weight is not a bnb quantized weight, it will be returned as is.
     """

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -39,12 +39,15 @@ def gather_params_ctx(module: torch.nn.Module, modifier_rank: int = 0):
     return
 
 
-def dequantize_bnb_weight(weight, state=None):
+def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
     """
     Helper functin to dequantize 4bit or 8bit weights.
 
     If the weight is not a bnb quantized weight, it will be returned as is.
     """
+    if not isinstance(weight, torch.nn.Parameter):
+        raise TypeError(f"Input weight should be of type nn.Parameter, got {type(weight)} instead")
+
     cls_name = weight.__class__.__name__
     if cls_name not in ("Params4bit", "Int8Params"):
         return weight

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -755,7 +755,8 @@ class PeftGPUCommonTests(unittest.TestCase):
     @require_torch_gpu
     @pytest.mark.single_gpu_tests
     @require_bitsandbytes
-    def test_4bit_dora(self):
+    def test_4bit_dora_inference(self):
+        # check for same result with and without DoRA when initializing with init_lora_weights=False
         bnb_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_use_double_quant=False,
@@ -769,10 +770,10 @@ class PeftGPUCommonTests(unittest.TestCase):
 
         torch.manual_seed(0)
         config_lora = LoraConfig(r=8, init_lora_weights=False, use_dora=False)
-        model = get_peft_model(model, config_lora)
+        model = get_peft_model(model, config_lora).eval()
 
         random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
-        out_lora = model(random_input).logits
+        logits_lora = model(random_input).logits
 
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
@@ -783,12 +784,9 @@ class PeftGPUCommonTests(unittest.TestCase):
         config_dora = LoraConfig(r=8, init_lora_weights=False, use_dora=True)
         model = get_peft_model(model, config_dora)
 
-        out_dora = model(random_input).logits
+        logits_dora = model(random_input).logits
 
-        # tolerances are pretty high because some deviations are expected with quantization
-        atol = 1e-6
-        rtol = 1e-6
-        assert torch.allclose(out_lora, out_dora, atol=atol, rtol=rtol)
+        assert torch.allclose(logits_lora, logits_dora)
         # sanity check
         assert isinstance(model.base_model.model.model.decoder.layers[0].self_attn.q_proj, LoraLinear4bit)
         assert isinstance(model.base_model.model.model.decoder.layers[0].self_attn.v_proj, LoraLinear4bit)
@@ -796,19 +794,20 @@ class PeftGPUCommonTests(unittest.TestCase):
     @require_torch_gpu
     @pytest.mark.single_gpu_tests
     @require_bitsandbytes
-    def test_8bit_dora(self):
+    def test_8bit_dora_inference(self):
+        # check for same result with and without DoRA when initializing with init_lora_weights=False
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
             load_in_8bit=True,
             torch_dtype=torch.float32,
-        )
+        ).eval()
 
         torch.manual_seed(0)
         config_lora = LoraConfig(r=8, init_lora_weights=False, use_dora=False)
-        model = get_peft_model(model, config_lora)
+        model = get_peft_model(model, config_lora).eval()
 
         random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
-        out_lora = model(random_input).logits
+        logits_lora = model(random_input).logits
 
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
@@ -819,12 +818,118 @@ class PeftGPUCommonTests(unittest.TestCase):
         config_dora = LoraConfig(r=8, init_lora_weights=False, use_dora=True)
         model = get_peft_model(model, config_dora)
 
-        out_dora = model(random_input).logits
+        logits_dora = model(random_input).logits
 
-        # tolerances are pretty high because some deviations are expected with quantization
-        atol = 1e-6
-        rtol = 1e-6
-        assert torch.allclose(out_lora, out_dora, atol=atol, rtol=rtol)
+        assert torch.allclose(logits_lora, logits_dora)
         # sanity check
         assert isinstance(model.base_model.model.model.decoder.layers[0].self_attn.q_proj, LoraLinear8bitLt)
         assert isinstance(model.base_model.model.model.decoder.layers[0].self_attn.v_proj, LoraLinear8bitLt)
+
+    @require_torch_gpu
+    @pytest.mark.single_gpu_tests
+    @require_bitsandbytes
+    def test_4bit_dora_merging(self):
+        # Check results for merging, unmerging, unloading
+        torch.manual_seed(0)
+        bnb_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_use_double_quant=False,
+            bnb_4bit_compute_type=torch.float32,
+        )
+        model = AutoModelForCausalLM.from_pretrained(
+            "HuggingFaceM4/tiny-random-LlamaForCausalLM",
+            quantization_config=bnb_config,
+            torch_dtype=torch.float32,
+        ).eval()
+        random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
+        # compare outputs in probability space, because logits can have outliers
+        # and token ids are not precise enough
+        out_base = F.softmax(model(random_input).logits, dim=-1)
+
+        config = LoraConfig(
+            r=8,
+            init_lora_weights=False,
+            use_dora=True,
+        )
+        model = get_peft_model(model, config).eval()
+
+        # Note: By default, DoRA is a no-op before training, even if we set init_lora_weights=False. In order to
+        # measure any differences, we need to change the magnitude vector.
+        for name, module in model.named_modules():
+            if isinstance(module, LoraLinear4bit):
+                module.lora_magnitude_vector["default"] = torch.nn.Parameter(
+                    10 * torch.rand_like(module.lora_magnitude_vector["default"])
+                )
+
+        with torch.inference_mode():
+            out_dora = F.softmax(model(random_input).logits, dim=-1)
+
+            model.merge_adapter()
+            out_merged = F.softmax(model(random_input).logits, dim=-1)
+
+            model.unmerge_adapter()
+            out_unmerged = F.softmax(model(random_input).logits, dim=-1)
+
+            model = model.merge_and_unload()
+            out_unloaded = F.softmax(model(random_input).logits, dim=-1)
+
+        atol = 1e-5
+        rtol = 1e-3
+        # sanity check that using DoRA changes the results
+        assert not torch.allclose(out_base, out_dora, atol=atol, rtol=rtol)
+        assert torch.allclose(out_dora, out_merged, atol=atol, rtol=rtol)
+        assert torch.allclose(out_dora, out_unmerged, atol=atol, rtol=rtol)
+        assert torch.allclose(out_dora, out_unloaded, atol=atol, rtol=rtol)
+
+    @require_torch_gpu
+    @pytest.mark.single_gpu_tests
+    @require_bitsandbytes
+    def test_8bit_dora_merging(self):
+        # Check results for merging, unmerging, unloading
+        torch.manual_seed(0)
+        model = AutoModelForCausalLM.from_pretrained(
+            "facebook/opt-125m",
+            load_in_8bit=True,
+            torch_dtype=torch.float32,
+        ).eval()
+
+        random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
+        # compare outputs in probability space, because logits can have outliers
+        # and token ids are not precise enough
+        out_base = F.softmax(model(random_input).logits, dim=-1)
+
+        config = LoraConfig(
+            r=8,
+            init_lora_weights=False,
+            use_dora=True,
+        )
+        model = get_peft_model(model, config).eval()
+
+        # Note: By default, DoRA is a no-op before training, even if we set init_lora_weights=False. In order to
+        # measure any differences, we need to change the magnitude vector.
+        for name, module in model.named_modules():
+            if isinstance(module, LoraLinear8bitLt):
+                module.lora_magnitude_vector["default"] = torch.nn.Parameter(
+                    10 * torch.rand_like(module.lora_magnitude_vector["default"])
+                )
+
+        with torch.inference_mode():
+            out_dora = F.softmax(model(random_input).logits, dim=-1)
+
+            model.merge_adapter()
+            out_merged = F.softmax(model(random_input).logits, dim=-1)
+
+            model.unmerge_adapter()
+            out_unmerged = F.softmax(model(random_input).logits, dim=-1)
+
+            model = model.merge_and_unload()
+            out_unloaded = F.softmax(model(random_input).logits, dim=-1)
+
+        # 8bit merging less precise than 4bit
+        atol = 0.01
+        rtol = 10
+        # sanity check that using DoRA changes the results
+        assert not torch.allclose(out_base, out_dora, atol=atol, rtol=rtol)
+        assert torch.allclose(out_dora, out_merged, atol=atol, rtol=rtol)
+        assert torch.allclose(out_dora, out_unmerged, atol=atol, rtol=rtol)
+        assert torch.allclose(out_dora, out_unloaded, atol=atol, rtol=rtol)

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -801,6 +801,240 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         assert n_trainable_default == n_trainable_other
         assert n_total_default == n_total_other
 
+    @pytest.mark.single_gpu_tests
+    def test_causal_lm_training_4bit_dora(self):
+        r"""
+        Same as test_causal_lm_training_4bit but with DoRA
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = AutoModelForCausalLM.from_pretrained(
+                self.causal_lm_model_id,
+                load_in_4bit=True,
+                device_map="auto",
+            )
+
+            tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
+            model = prepare_model_for_kbit_training(model)
+
+            config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=["q_proj", "v_proj"],
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+                use_dora=True,
+            )
+
+            model = get_peft_model(model, config)
+
+            data = load_dataset("ybelkada/english_quotes_copy")
+            data = data.map(lambda samples: tokenizer(samples["quote"]), batched=True)
+
+            trainer = Trainer(
+                model=model,
+                train_dataset=data["train"],
+                args=TrainingArguments(
+                    per_device_train_batch_size=4,
+                    gradient_accumulation_steps=4,
+                    warmup_steps=2,
+                    max_steps=3,
+                    learning_rate=2e-4,
+                    fp16=True,
+                    logging_steps=1,
+                    output_dir=tmp_dir,
+                ),
+                data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False),
+            )
+            model.config.use_cache = False
+            trainer.train()
+
+            model.cpu().save_pretrained(tmp_dir)
+
+            assert "adapter_config.json" in os.listdir(tmp_dir)
+            assert SAFETENSORS_WEIGHTS_NAME in os.listdir(tmp_dir)
+
+            # assert loss is not None
+            assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    @pytest.mark.multi_gpu_tests
+    def test_causal_lm_training_multi_gpu_4bit_dora(self):
+        r"""
+        Same as test_causal_lm_training_multi_gpu_4bit but with DoRA
+        """
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = AutoModelForCausalLM.from_pretrained(
+                self.causal_lm_model_id,
+                device_map="auto",
+                load_in_4bit=True,
+            )
+
+            assert set(model.hf_device_map.values()) == set(range(torch.cuda.device_count()))
+
+            model = prepare_model_for_kbit_training(model)
+
+            setattr(model, "model_parallel", True)
+            setattr(model, "is_parallelizable", True)
+
+            config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=["q_proj", "v_proj"],
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+                use_dora=True,
+            )
+
+            model = get_peft_model(model, config)
+
+            data = load_dataset("Abirate/english_quotes")
+            data = data.map(lambda samples: self.tokenizer(samples["quote"]), batched=True)
+
+            trainer = Trainer(
+                model=model,
+                train_dataset=data["train"],
+                args=TrainingArguments(
+                    per_device_train_batch_size=4,
+                    gradient_accumulation_steps=4,
+                    warmup_steps=2,
+                    max_steps=3,
+                    learning_rate=2e-4,
+                    fp16=True,
+                    logging_steps=1,
+                    output_dir=tmp_dir,
+                ),
+                data_collator=DataCollatorForLanguageModeling(self.tokenizer, mlm=False),
+            )
+            model.config.use_cache = False
+            trainer.train()
+
+            model.cpu().save_pretrained(tmp_dir)
+
+            assert "adapter_config.json" in os.listdir(tmp_dir)
+            assert SAFETENSORS_WEIGHTS_NAME in os.listdir(tmp_dir)
+
+            # assert loss is not None
+            assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    @pytest.mark.single_gpu_tests
+    def test_causal_lm_training_8bit_dora(self):
+        r"""
+        Same as test_causal_lm_training_4bit_dora but with 8bit
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = AutoModelForCausalLM.from_pretrained(
+                self.causal_lm_model_id,
+                load_in_8bit=True,
+                device_map="auto",
+            )
+
+            tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
+            model = prepare_model_for_kbit_training(model)
+
+            config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=["q_proj", "v_proj"],
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+                use_dora=True,
+            )
+
+            model = get_peft_model(model, config)
+
+            data = load_dataset("ybelkada/english_quotes_copy")
+            data = data.map(lambda samples: tokenizer(samples["quote"]), batched=True)
+
+            trainer = Trainer(
+                model=model,
+                train_dataset=data["train"],
+                args=TrainingArguments(
+                    per_device_train_batch_size=4,
+                    gradient_accumulation_steps=4,
+                    warmup_steps=2,
+                    max_steps=3,
+                    learning_rate=2e-4,
+                    fp16=True,
+                    logging_steps=1,
+                    output_dir=tmp_dir,
+                ),
+                data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False),
+            )
+            model.config.use_cache = False
+            trainer.train()
+
+            model.cpu().save_pretrained(tmp_dir)
+
+            assert "adapter_config.json" in os.listdir(tmp_dir)
+            assert SAFETENSORS_WEIGHTS_NAME in os.listdir(tmp_dir)
+
+            # assert loss is not None
+            assert trainer.state.log_history[-1]["train_loss"] is not None
+
+    @pytest.mark.multi_gpu_tests
+    def test_causal_lm_training_multi_gpu_8bit_dora(self):
+        r"""
+        Same as test_causal_lm_training_multi_gpu_4bit_dora but with 8bit
+        """
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = AutoModelForCausalLM.from_pretrained(
+                self.causal_lm_model_id,
+                device_map="auto",
+                load_in_8bit=True,
+            )
+
+            assert set(model.hf_device_map.values()) == set(range(torch.cuda.device_count()))
+
+            model = prepare_model_for_kbit_training(model)
+
+            setattr(model, "model_parallel", True)
+            setattr(model, "is_parallelizable", True)
+
+            config = LoraConfig(
+                r=16,
+                lora_alpha=32,
+                target_modules=["q_proj", "v_proj"],
+                lora_dropout=0.05,
+                bias="none",
+                task_type="CAUSAL_LM",
+                use_dora=True,
+            )
+
+            model = get_peft_model(model, config)
+
+            data = load_dataset("Abirate/english_quotes")
+            data = data.map(lambda samples: self.tokenizer(samples["quote"]), batched=True)
+
+            trainer = Trainer(
+                model=model,
+                train_dataset=data["train"],
+                args=TrainingArguments(
+                    per_device_train_batch_size=4,
+                    gradient_accumulation_steps=4,
+                    warmup_steps=2,
+                    max_steps=3,
+                    learning_rate=2e-4,
+                    fp16=True,
+                    logging_steps=1,
+                    output_dir=tmp_dir,
+                ),
+                data_collator=DataCollatorForLanguageModeling(self.tokenizer, mlm=False),
+            )
+            model.config.use_cache = False
+            trainer.train()
+
+            model.cpu().save_pretrained(tmp_dir)
+
+            assert "adapter_config.json" in os.listdir(tmp_dir)
+            assert SAFETENSORS_WEIGHTS_NAME in os.listdir(tmp_dir)
+
+            # assert loss is not None
+            assert trainer.state.log_history[-1]["train_loss"] is not None
+
 
 @require_torch_gpu
 @require_auto_gptq
@@ -1142,7 +1376,12 @@ class LoftQTests(unittest.TestCase):
         return model(**inputs).logits
 
     def get_errors(
-        self, bits=4, loftq_iter=1, device="cuda", model_id="hf-internal-testing/tiny-random-BloomForCausalLM"
+        self,
+        bits=4,
+        loftq_iter=1,
+        device="cuda",
+        model_id="hf-internal-testing/tiny-random-BloomForCausalLM",
+        use_dora=False,
     ):
         # Helper function that returns the quantization errors (MAE and MSE) when comparing the quantized LoRA model
         # to the base model, vs the LoftQ quantized model to the base model. We expect the LoftQ quantized model to
@@ -1159,7 +1398,7 @@ class LoftQTests(unittest.TestCase):
         torch.cuda.empty_cache()
 
         # logits from the normal quantized LoRA model
-        lora_config = LoraConfig(task_type=task_type)
+        lora_config = LoraConfig(task_type=task_type, use_dora=use_dora)
         kwargs = {}
         if bits == 4:
             kwargs["load_in_4bit"] = True
@@ -1180,7 +1419,9 @@ class LoftQTests(unittest.TestCase):
 
         # logits from quantized LoRA model using LoftQ
         loftq_config = LoftQConfig(loftq_bits=bits, loftq_iter=loftq_iter)
-        lora_config = LoraConfig(task_type=TaskType.CAUSAL_LM, init_lora_weights="loftq", loftq_config=loftq_config)
+        lora_config = LoraConfig(
+            task_type=TaskType.CAUSAL_LM, init_lora_weights="loftq", loftq_config=loftq_config, use_dora=use_dora
+        )
         model = self.get_base_model(model_id, device)
         if device == "cuda":
             model = model.to("cuda")
@@ -1296,6 +1537,36 @@ class LoftQTests(unittest.TestCase):
         factor = 3
         assert mae_loftq < (mae_quantized / factor)
         assert mse_loftq < (mse_quantized / factor)
+
+    @parameterized.expand(["cuda", "cpu"])
+    def test_bloomz_loftq_4bit_dora(self, device):
+        # same as test_bloomz_loftq_4bit but with DoRA
+        mae_quantized, mse_quantized, mae_loftq, mse_loftq = self.get_errors(bits=4, device=device, use_dora=True)
+        # first, sanity check that all errors are > 0.0
+        assert mae_quantized > 0.0
+        assert mse_quantized > 0.0
+        assert mae_loftq > 0.0
+        assert mse_loftq > 0.0
+
+        # next, check that LoftQ quantization errors are smaller than LoRA errors by a certain margin
+        factor = 3
+        assert mae_loftq < (mae_quantized / factor)
+        assert mse_loftq < (mse_quantized / factor)
+
+    @parameterized.expand(["cuda", "cpu"])
+    def test_bloomz_loftq_8bit_dora(self, device):
+        # same as test_bloomz_loftq_8bit but with DoRA
+        mae_quantized, mse_quantized, mae_loftq, mse_loftq = self.get_errors(bits=8, device=device, use_dora=True)
+
+        # first, sanity check that all errors are > 0.0
+        assert mae_quantized > 0.0
+        assert mse_quantized > 0.0
+        assert mae_loftq > 0.0
+        assert mse_loftq > 0.0
+
+        # next, check that LoftQ quantization errors are smaller than LoRA errors by a certain margin
+        assert mae_loftq < (mae_quantized / self.error_factor)
+        assert mse_loftq < (mse_quantized / self.error_factor)
 
 
 @require_bitsandbytes

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -355,11 +355,7 @@ class TestInitialization:
         assert torch.allclose(output_base, output_disabled)
         assert not torch.allclose(output_base, output_dora)
 
-    def test_use_dora_with_loftq_raises(self):
-        with pytest.raises(ValueError, match="DoRA does not support megatron_core or LoftQ"):
-            LoraConfig(target_modules=["linear"], use_dora=True, init_lora_weights="loftq")
-
     def test_use_dora_with_megatron_core_raises(self):
         megatron_config = {"does-not": "matter-here"}
-        with pytest.raises(ValueError, match="DoRA does not support megatron_core or LoftQ"):
+        with pytest.raises(ValueError, match="DoRA does not support megatron_core"):
             LoraConfig(target_modules=["linear"], use_dora=True, megatron_config=megatron_config)


### PR DESCRIPTION
Adds support for DoRA on 4bit and 8bit quantized models with bitsandbytes. Merging also works, with the usual caveats for quantized weights (results are not 100% identical), but it's not worse than vanialla LoRA.

I did some quick tests and could see the expected memory savings with bnb. Same as with DoRA on non-quantized layers, using DoRA on quantized layers leads to a moderate increase in runtime.