### PR TITLE
fix: fail when required args not passed when prompt_tuning_init==TEXT

### DIFF
--- a/src/peft/tuners/prompt_tuning/config.py
+++ b/src/peft/tuners/prompt_tuning/config.py
@@ -75,9 +75,9 @@ class PromptTuningConfig(PromptLearningConfig):
                 f"When prompt_tuning_init='{PromptTuningInit.TEXT.value}', "
                 f"tokenizer_name_or_path can't be {self.tokenizer_name_or_path}."
             )
-        if (self.prompt_tuning_init == PromptTuningInit.TEXT) and not self.prompt_tuning_init_text:
+        if (self.prompt_tuning_init == PromptTuningInit.TEXT) and self.prompt_tuning_init_text is None:
             raise ValueError(
-                f"when prompt_tuning_init='{PromptTuningInit.TEXT.value}', "
+                f"When prompt_tuning_init='{PromptTuningInit.TEXT.value}', "
                 f"prompt_tuning_init_text can't be {self.prompt_tuning_init_text}."
             )
         if self.tokenizer_kwargs and (self.prompt_tuning_init != PromptTuningInit.TEXT):

--- a/src/peft/tuners/prompt_tuning/config.py
+++ b/src/peft/tuners/prompt_tuning/config.py
@@ -70,7 +70,16 @@ class PromptTuningConfig(PromptLearningConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.PROMPT_TUNING
-
+        if (self.prompt_tuning_init == PromptTuningInit.TEXT) and not self.tokenizer_name_or_path:
+            raise ValueError(
+                f"when prompt_tuning_init='{PromptTuningInit.TEXT.value}', "
+                f"tokenizer_name_or_path can't be {self.tokenizer_name_or_path}."
+            )
+        if (self.prompt_tuning_init == PromptTuningInit.TEXT) and not self.prompt_tuning_init_text:
+            raise ValueError(
+                f"when prompt_tuning_init='{PromptTuningInit.TEXT.value}', "
+                f"prompt_tuning_init_text can't be {self.prompt_tuning_init_text}."
+            )
         if self.tokenizer_kwargs and (self.prompt_tuning_init != PromptTuningInit.TEXT):
             raise ValueError(
                 f"tokenizer_kwargs only valid when using prompt_tuning_init='{PromptTuningInit.TEXT.value}'."

--- a/src/peft/tuners/prompt_tuning/config.py
+++ b/src/peft/tuners/prompt_tuning/config.py
@@ -72,7 +72,7 @@ class PromptTuningConfig(PromptLearningConfig):
         self.peft_type = PeftType.PROMPT_TUNING
         if (self.prompt_tuning_init == PromptTuningInit.TEXT) and not self.tokenizer_name_or_path:
             raise ValueError(
-                f"when prompt_tuning_init='{PromptTuningInit.TEXT.value}', "
+                f"When prompt_tuning_init='{PromptTuningInit.TEXT.value}', "
                 f"tokenizer_name_or_path can't be {self.tokenizer_name_or_path}."
             )
         if (self.prompt_tuning_init == PromptTuningInit.TEXT) and not self.prompt_tuning_init_text:

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -17,7 +17,7 @@ import torch
 from scipy import stats
 from torch import nn
 
-from peft import LoraConfig, get_peft_model
+from peft import LoraConfig, PromptTuningConfig, get_peft_model
 from peft.utils import infer_device
 
 
@@ -363,3 +363,9 @@ class TestInitialization:
         megatron_config = {"does-not": "matter-here"}
         with pytest.raises(ValueError, match="DoRA does not support megatron_core or LoftQ"):
             LoraConfig(target_modules=["linear"], use_dora=True, megatron_config=megatron_config)
+
+    def test_use_prompt_tuning_init_text_raises(self):
+        with pytest.raises(ValueError, match="when prompt_tuning_init='TEXT', tokenizer_name_or_path can't be None"):
+            PromptTuningConfig(prompt_tuning_init="TEXT", prompt_tuning_init_text="prompt tuning init text")
+        with pytest.raises(ValueError, match="when prompt_tuning_init='TEXT', prompt_tuning_init_text can't be None"):
+            PromptTuningConfig(prompt_tuning_init="TEXT", tokenizer_name_or_path="t5-base")

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -365,7 +365,7 @@ class TestInitialization:
             LoraConfig(target_modules=["linear"], use_dora=True, megatron_config=megatron_config)
 
     def test_use_prompt_tuning_init_text_raises(self):
-        with pytest.raises(ValueError, match="when prompt_tuning_init='TEXT', tokenizer_name_or_path can't be None"):
+        with pytest.raises(ValueError, match="When prompt_tuning_init='TEXT', tokenizer_name_or_path can't be None"):
             PromptTuningConfig(prompt_tuning_init="TEXT", prompt_tuning_init_text="prompt tuning init text")
-        with pytest.raises(ValueError, match="when prompt_tuning_init='TEXT', prompt_tuning_init_text can't be None"):
+        with pytest.raises(ValueError, match="When prompt_tuning_init='TEXT', prompt_tuning_init_text can't be None"):
             PromptTuningConfig(prompt_tuning_init="TEXT", tokenizer_name_or_path="t5-base")


### PR DESCRIPTION
When `prompt_tuning_init==TEXT` is set, there are some args needed to be provided. For instance, `tokenizer_name_or_path` should be set to some tokenizer name or path, failing which would result in errors such as

```
HTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/None/resolve/main/tokenizer_config.json
```
tokenizer_name_or_path is taken as `None`. Such errors can be handled and reported meaningfully post config initialization and this PR makes that contribution.