### PR TITLE
Use peft_doc as notebook path as doc-builder expects <package>_doc for the Google Colab and AWS Studio links

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: peft
-      notebook_folder: peft_docs
+      notebook_folder: peft_doc
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}


### PR DESCRIPTION
At the moment, the peft notebooks are generated in a path containing 'peft_docs', with the 's' at the end. This results in broken links in the online documentation.

For example: https://huggingface.co/docs/peft/main/en/task_guides/clm-prompt-tuning : the link to the pytorch version of the google colab notebook is https://colab.research.google.com/github/huggingface/notebooks/blob/main/peft_doc/en/pytorch/clm-prompt-tuning.ipynb , which uses 'peft_doc' without the trailing 's'.

The 'resolv_open_in_colab' method in doc-builder has the path <package>_doc hardcoded at https://github.com/huggingface/doc-builder/blob/3543e0aca2029201051373e3b6ec871ef44d0d93/src/doc_builder/build_doc.py#L52 . This means it always uses a 'peft_doc' path for peft when generating the google colab and aws studio links. There's even a test which checks that the links use _doc for another package at https://github.com/huggingface/doc-builder/blob/main/tests/test_build_doc.py

It's likely the easiest to simply use peft_doc instead of peft_docs so that the automatically generated links are correct.

