### PR TITLE
Fix LoftQ docs and tests

### DIFF
--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -42,16 +42,7 @@ config = LoraConfig(init_lora_weights=False, ...)
 
 ### LoftQ
 
-When quantizing the base model for QLoRA training, consider using the [LoftQ initialization](https://arxiv.org/abs/2310.08659), which has been shown to improve performance when training quantized models. The idea is that the LoRA weights are initialized such that the quantization error is minimized. If you're using LoftQ, *do not* quantize the base model. You should set up a [`LoftQConfig`] instead:
-
-```python
-from peft import LoftQConfig, LoraConfig, get_peft_model
-
-base_model = AutoModelForCausalLM.from_pretrained(...)  # don't quantize here
-loftq_config = LoftQConfig(loftq_bits=4, ...)           # set 4bit quantization
-lora_config = LoraConfig(..., init_lora_weights="loftq", loftq_config=loftq_config)
-peft_model = get_peft_model(base_model, lora_config)
-```
+When quantizing the base model for QLoRA training, consider using the [LoftQ initialization](https://arxiv.org/abs/2310.08659), which has been shown to improve performance when training quantized models. The idea is that the LoRA weights are initialized such that the quantization error is minimized. To use LoftQ, follow [these instructions](https://github.com/huggingface/peft/tree/main/examples/loftq_finetuning).
 
 <Tip>
 

--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -44,6 +44,8 @@ config = LoraConfig(init_lora_weights=False, ...)
 
 When quantizing the base model for QLoRA training, consider using the [LoftQ initialization](https://arxiv.org/abs/2310.08659), which has been shown to improve performance when training quantized models. The idea is that the LoRA weights are initialized such that the quantization error is minimized. To use LoftQ, follow [these instructions](https://github.com/huggingface/peft/tree/main/examples/loftq_finetuning).
 
+In general, for LoftQ to work best, it is recommended to target as many layers with LoRA as possible, since those not targeted cannot have LoftQ applied. This means that passing `LoraConfig(..., target_modules="all-linear")` will most likely give the best results. Also, you should use `nf4` as quant type in your quantization config when using 4bit quantization, i.e. `BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type="nf4")`.
+
 <Tip>
 
 Learn more about how PEFT works with quantization in the [Quantization](quantization) guide.

--- a/docs/source/developer_guides/quantization.md
+++ b/docs/source/developer_guides/quantization.md
@@ -97,6 +97,8 @@ You're all set for training with whichever training method you prefer!
 
 [LoftQ](https://hf.co/papers/2310.08659) initializes LoRA weights such that the quantization error is minimized, and it can improve performance when training quantized models. To get started, follow [these instructions](https://github.com/huggingface/peft/tree/main/examples/loftq_finetuning).
 
+In general, for LoftQ to work best, it is recommended to target as many layers with LoRA as possible, since those not targeted cannot have LoftQ applied. This means that passing `LoraConfig(..., target_modules="all-linear")` will most likely give the best results. Also, you should use `nf4` as quant type in your quantization config when using 4bit quantization, i.e. `BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type="nf4")`.
+
 ### QLoRA-style training
 
 QLoRA adds trainable weights to all the linear layers in the transformer architecture. Since the attribute names for these linear layers can vary across architectures, set `target_modules` to `"all-linear"` to add LoRA to all the linear layers:

--- a/docs/source/developer_guides/quantization.md
+++ b/docs/source/developer_guides/quantization.md
@@ -95,40 +95,7 @@ You're all set for training with whichever training method you prefer!
 
 ### LoftQ initialization
 
-[LoftQ](https://hf.co/papers/2310.08659) initializes LoRA weights such that the quantization error is minimized, and it can improve performance when training quantized models. To get started, create a [`LoftQConfig`] and set `loftq_bits=4` for 4-bit quantization.
-
-<Tip warning={true}>
-
-LoftQ initialization does not require quantizing the base model with the `load_in_4bits` parameter in the [`~transformers.AutoModelForCausalLM.from_pretrained`] method! Learn more about LoftQ initialization in the [Initialization options](../developer_guides/lora#initialization) section.
-
-Note: You can only perform LoftQ initialization on a GPU.
-
-</Tip>
-
-```py
-from transformers import AutoModelForCausalLM
-from peft import LoftQConfig, LoraConfig, get_peft_model
-
-model = AutoModelForCausalLM.from_pretrained("mistralai/Mistral-7B-v0.1", device_map="auto")
-loftq_config = LoftQConfig(loftq_bits=4)
-```
-
-Now pass the `loftq_config` to the [`LoraConfig`] to enable LoftQ initialization, and create a [`PeftModel`] for training.
-
-```py
-lora_config = LoraConfig(
-    init_lora_weights="loftq",
-    loftq_config=loftq_config,
-    r=16,
-    lora_alpha=8,
-    target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
-    lora_dropout=0.05,
-    bias="none",
-    task_type="CAUSAL_LM"
-)
-
-model = get_peft_model(model, lora_config)
-```
+[LoftQ](https://hf.co/papers/2310.08659) initializes LoRA weights such that the quantization error is minimized, and it can improve performance when training quantized models. To get started, follow [these instructions](https://github.com/huggingface/peft/tree/main/examples/loftq_finetuning).
 
 ### QLoRA-style training
 

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -1516,7 +1516,7 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
-    @pytest.mark.xfail  # failing for now, see discussion in #1532
+    # @pytest.mark.xfail  # failing for now, see discussion in #1532
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_bloomz_loftq_8bit_iter_5(self, device, tmp_path):
         # Same test as test_bloomz_loftq_4bit_iter_5 but with 8 bits.
@@ -1534,7 +1534,7 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
-    @pytest.mark.xfail  # failing for now, see discussion in #1532
+    # @pytest.mark.xfail  # failing for now, see discussion in #1532
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_t5_loftq_4bit(self, device, tmp_path):
         mae_quantized, mse_quantized, mae_loftq, mse_loftq = self.get_errors(
@@ -1565,7 +1565,7 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
-    @pytest.mark.xfail  # failing for now, see discussion in #1532
+    # @pytest.mark.xfail  # failing for now, see discussion in #1532
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_bloomz_loftq_4bit_dora(self, device, tmp_path):
         # same as test_bloomz_loftq_4bit but with DoRA

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -1404,7 +1404,7 @@ class TestLoftQ:
         torch.cuda.empty_cache()
 
         # logits from the normal quantized LoRA model
-        target_modules="all-linear" if task_type != TaskType.SEQ_2_SEQ_LM else ['o', 'k', 'wi', 'q', 'v']
+        target_modules = "all-linear" if task_type != TaskType.SEQ_2_SEQ_LM else ["o", "k", "wi", "q", "v"]
         lora_config = LoraConfig(task_type=task_type, use_dora=use_dora, target_modules=target_modules)
         kwargs = {}
         if bits == 4:
@@ -1427,7 +1427,11 @@ class TestLoftQ:
         # logits from quantized LoRA model using LoftQ
         loftq_config = LoftQConfig(loftq_bits=bits, loftq_iter=loftq_iter)
         lora_config = LoraConfig(
-            task_type=task_type, init_lora_weights="loftq", loftq_config=loftq_config, use_dora=use_dora, target_modules=target_modules
+            task_type=task_type,
+            init_lora_weights="loftq",
+            loftq_config=loftq_config,
+            use_dora=use_dora,
+            target_modules=target_modules,
         )
         model = self.get_base_model(model_id, device)
         if device == "cuda":
@@ -1516,7 +1520,6 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
-    # @pytest.mark.xfail  # failing for now, see discussion in #1532
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_bloomz_loftq_8bit_iter_5(self, device, tmp_path):
         # Same test as test_bloomz_loftq_4bit_iter_5 but with 8 bits.
@@ -1534,7 +1537,6 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
-    # @pytest.mark.xfail  # failing for now, see discussion in #1532
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_t5_loftq_4bit(self, device, tmp_path):
         mae_quantized, mse_quantized, mae_loftq, mse_loftq = self.get_errors(
@@ -1565,7 +1567,7 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
-    # @pytest.mark.xfail  # failing for now, see discussion in #1532
+    @pytest.mark.xfail  # failing for now, see discussion in #1532
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_bloomz_loftq_4bit_dora(self, device, tmp_path):
         # same as test_bloomz_loftq_4bit but with DoRA

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -1431,7 +1431,7 @@ class TestLoftQ:
         lora_config = LoraConfig(task_type=task_type, use_dora=use_dora)
         kwargs = {}
         if bits == 4:
-            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_4bit=True)
+            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type="nf4")
         elif bits == 8:
             kwargs["quantization_config"] = BitsAndBytesConfig(load_in_8bit=True)
         else:
@@ -1539,6 +1539,7 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
+    @pytest.mark.xfail  # failing for now, see discussion in #1532
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_bloomz_loftq_8bit_iter_5(self, device, tmp_path):
         # Same test as test_bloomz_loftq_4bit_iter_5 but with 8 bits.
@@ -1556,6 +1557,7 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
+    @pytest.mark.xfail  # failing for now, see discussion in #1532
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_t5_loftq_4bit(self, device, tmp_path):
         mae_quantized, mse_quantized, mae_loftq, mse_loftq = self.get_errors(
@@ -1586,6 +1588,7 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
+    @pytest.mark.xfail  # failing for now, see discussion in #1532
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_bloomz_loftq_4bit_dora(self, device, tmp_path):
         # same as test_bloomz_loftq_4bit but with DoRA

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -1357,7 +1357,10 @@ class TestLoftQ:
     Tests for LoftQ to ensure that it reduces the quantization error compared to normal LoRA quantization.
     """
 
-    error_factor = 1  # FIXME should be > 1
+    # The error factor indicates by how much the quantization error should be decreased when using LoftQ compared to
+    # quantization without LoftQ. Thus 1.03 means that the error should be decreased by 3% at least. This is a very
+    # conservative value to prevent flakiness, in practice most gains are > 1.5
+    error_factor = 1.03
 
     def get_input(self, model_id, device):
         tokenizer = AutoTokenizer.from_pretrained(model_id)
@@ -1567,7 +1570,7 @@ class TestLoftQ:
         assert mse_loftq < (mse_quantized / self.error_factor)
         assert mae_loftq < (mae_quantized / self.error_factor)
 
-    @pytest.mark.xfail  # failing for now, see discussion in #1532
+    @pytest.mark.xfail  # failing for now, but having DoRA pass is only a nice-to-have, not a must, so we're good
     @pytest.mark.parametrize("device", ["cuda", "cpu"])
     def test_bloomz_loftq_4bit_dora(self, device, tmp_path):
         # same as test_bloomz_loftq_4bit but with DoRA


### PR DESCRIPTION
Relates to #1525

_Don't merge this, some GPU tests are failing_

Unfortunately, the docs I wrote about how to use LoftQ were incorrect, based on a misunderstanding I had. In reality, it is quite a bit more involved to get LoftQ working, requiring a complete roundtrip first loading a non-quantized model with LoftQ, saving the LoRA weights and the modified base model, loading the just stored base model again but this time with quantization, and finally loading the LoftQ-initialized adapter on top. The docs now link to the example which demonstrates how to move through these steps.

The unit tests have been adjusted to go through these same steps but now most of them fail, i.e. the quantization error is _greater_ with LoftQ than without. This needs to be investigated.