### PR TITLE
Remove future annotation for LoraConfig to fix compatibility with `HfArgumentParser`

### DIFF
--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -71,7 +71,7 @@ class LoraConfig(PeftConfig):
             Otherwise, it will use the original default value of `lora_alpha/r`.
         modules_to_save (`List[str]`):
             List of modules apart from adapter layers to be set as trainable and saved in the final checkpoint.
-        init_lora_weights (`bool` | `Literal["gaussian", "loftq"]`):
+        init_lora_weights (`Union[bool, Literal["gaussian", "loftq"]]`):
             How to initialize the weights of the adapter layers. Passing True (default) results in the default
             initialization from the reference implementation from Microsoft. Passing 'gaussian' results in Gaussian
             initialization scaled by the LoRA rank for linear and layers. Setting the initialization to False leads to

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from typing import Literal, Optional, Union
 
@@ -151,7 +149,7 @@ class LoraConfig(PeftConfig):
             "the final layer `classifier/score` are randomly initialized and as such need to be trainable and saved."
         },
     )
-    init_lora_weights: bool | Literal["gaussian", "loftq"] = field(
+    init_lora_weights: Union[bool, Literal["gaussian", "loftq"]] = field(
         default=True,
         metadata={
             "help": (


### PR DESCRIPTION
Inside LoraConfig we imported `annotations` from `__future__` to use `|` to define union type for Python version < 3.10.

Unfortunately, this will break `HfArgumentParser` from `transformers` because of [this line](https://github.com/huggingface/transformers/blob/a69cbf4e64c7bc054d814d64f6877180f7cd3a25/src/transformers/hf_argparser.py#L250). This change revert to use `Union` from `typing` to define Union type instead of `|`.