### PR TITLE
CUSTOM_TOKEN Tuner

### DIFF
--- a/src/peft/tuners/custom_tokens/config.py
+++ b/src/peft/tuners/custom_tokens/config.py
@@ -1,0 +1,22 @@
+from dataclasses import asdict, dataclass, field
+from typing import List, Optional, Union
+from peft import PeftConfig
+from peft.utils import PeftType
+
+
+@dataclass
+class CustomTokensConfig(PeftConfig):
+    token_indices: List[int] = field(default_factory=list)
+    target_modules: Optional[Union[list[str], str]] = field(
+        default='embedding',
+        metadata={
+            "help": (
+                "List of module names or regex expression of the module names to replace with our CustomTokensLayer."
+                "This is by default the `embedding` layer.",
+                "But could be multiple embedding-like layers, such as `encoder.embeddings` or `decoder.embeddings`."
+            ),
+        },
+    )
+
+    def __post_init__(self):
+        self.peft_type = PeftType.CUSTOM_TOKENS

--- a/src/peft/tuners/custom_tokens/layer.py
+++ b/src/peft/tuners/custom_tokens/layer.py
@@ -1,0 +1,99 @@
+from typing import List, Optional
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
+import warnings
+
+
+class CustomTokensLayer(nn.Module, BaseTunerLayer):
+    def __init__(self, 
+    base_layer: nn.Module, 
+    adapter_name: str,
+    token_indices: List[int],
+    **kwargs,
+    ) -> None:
+        super().__init__()
+
+        self.base_layer = base_layer
+        self._active_adapter = adapter_name
+        self.token_indices = token_indices
+        self.kwargs = kwargs
+
+        # we store the delta weight on particular tokens
+        self.delta_tokens = nn.ParameterDict({})
+        self.sparse_delta_tokens = {}
+
+        # Mark the weight as unmerged
+        self._disable_adapters = False
+        self.merged_adapters = []
+
+        # we set parameters on layer sizing
+        self.num_trainable_embeddings = len(token_indices) # this is similar to `num_embeddings`
+        self.embedding_dim = base_layer.embedding_dim # token from the embedding
+        self.num_total_embeddings = base_layer.num_embeddings # total number of tokens in the vocabulary
+
+        # we set the number of trainable tokens
+        self.update_layer(adapter_name)
+
+    def update_layer(self, adapter_name):
+        # we initialize the delta embedding weights and store them in a trainable parameter
+        values = torch.rand((self.num_trainable_embeddings * self.base_layer.weight.shape[-1], )) # we initialize the values from a normal distribution N(0, 1), as in https://pytorch.org/docs/stable/generated/torch.nn.Embedding.html
+
+        # cause safetensors doesn't support sparse tensors, we need to store the values in a dense tensor and then convert it to a sparse tensor when called
+        self.delta_tokens[adapter_name] = nn.Parameter(values, requires_grad=True)
+
+        # we created the indices of the sparse tensor
+        r = torch.Tensor(self.token_indices).long()
+        c = torch.arange(self.embedding_dim)
+        indices = torch.stack([r.repeat(self.embedding_dim), c.repeat(self.num_trainable_embeddings , 1).t().reshape(-1)], dim=1).T
+
+        # we create the sparse tensor from our `delta_tokens` and `indices
+        self.sparse_delta_tokens[adapter_name] = torch.sparse_coo_tensor(indices=indices, values=self.delta_tokens[adapter_name], size=(self.num_total_embeddings, self.embedding_dim))
+
+
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+
+        if not adapter_names:
+            # no adapter to merge
+            return
+    
+        for active_adapter in adapter_names:
+            orig_weights = self.base_layer.weight.data
+            orig_weights += self.sparse_delta_tokens[active_adapter] 
+
+            if safe_merge and not torch.isfinite(orig_weights).all():
+                raise ValueError(
+                    f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
+                )
+
+            else:
+                self.base_layer.weight.data = orig_weights
+
+    def unmerge(self) -> None:
+        if not self.merged:
+            warnings.warn("Already unmerged. Nothing to do.")
+            return
+        
+        while len(self.merged_adapters) > 0:
+            active_adapter = self.merged_adapters.pop()
+            self.base_layer.weight.data -= self.sparse_delta_tokens[active_adapter]
+        
+    def forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        if self.disable_adapters:
+            if self.merged:
+                self.unmerge()
+            result = self.base_layer(x, *args, **kwargs)
+        elif self.merged:
+            result = self.base_layer(x, *args, **kwargs)
+        else:
+            W = self.base_layer.weight
+            for active_adapter in self.active_adapters:
+                W += self.sparse_delta_tokens[active_adapter]
+                
+            result = F.embedding(
+            x, W, self.base_layer.padding_idx, self.base_layer.max_norm,
+            self.base_layer.norm_type, self.base_layer.scale_grad_by_freq, self.base_layer.sparse)
+
+        return result

--- a/src/peft/tuners/custom_tokens/model.py
+++ b/src/peft/tuners/custom_tokens/model.py
@@ -1,0 +1,84 @@
+import torch.nn as nn
+from peft import PeftConfig
+from peft.tuners.tuners_utils import BaseTuner, BaseTunerLayer, check_target_module_exists
+from .layer import CustomTokensLayer
+
+
+
+class CustomTokensModel(BaseTuner):
+    prefix: str = "custom_tokens"
+
+    def __init__(self, model, config, adapter_name):
+        super().__init__(model, config, adapter_name)
+
+    def __getattr__(self, name: str):
+        """Forward missing attributes to the wrapped module."""
+        try:
+            return super().__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            return getattr(self.model, name)
+        
+    def _prepare_adapter_config(self, peft_config, model_config):
+        return peft_config
+
+    def _create_and_replace(
+        self,
+        peft_config: PeftConfig,
+        adapter_name: str,
+        target: nn.Module,
+        target_name: str,
+        parent: nn.Module,
+        current_key: str,
+    ) -> None:
+        """
+        A private method to create and replace the target module with the adapter module.
+        """
+        kwargs = peft_config.to_dict()
+
+        if isinstance(target, CustomTokensLayer):
+            target.update_layer(adapter_name, **kwargs)
+        else:
+            new_module = self._create_new_module(peft_config, adapter_name, target, **kwargs)
+            self._replace_module(parent, target_name, new_module, target)
+
+    def _check_target_module_exists(self, peft_config: PeftConfig, key: str) -> bool:
+        return check_target_module_exists(peft_config, key)
+    
+    @staticmethod
+    def _create_new_module(peft_config, adapter_name, target, **kwargs):
+        # Collect dispatcher functions to decide what backend to use for the replaced LoRA layer. The order matters,
+        # because the first match is always used. Therefore, the default layers should be checked last.
+        new_module = CustomTokensLayer(target, adapter_name, **kwargs)
+
+        return new_module
+    
+    def _replace_module(self, parent, child_name, new_module, child): # see https://github.com/huggingface/peft/blob/e5973883057b723b3f0fe3982bfa9d1e0c0fd8ec/src/peft/tuners/lycoris_utils.py#L300C4-L300C47
+        setattr(parent, child_name, new_module)
+        # It's not necessary to set requires_grad here, as that is handled by
+        # _mark_only_adapters_as_trainable
+
+        # child layer wraps the original module, unpack it
+        if hasattr(child, "base_layer"):
+            child = child.base_layer
+
+        if not hasattr(new_module, "base_layer"):
+            new_module.weight = child.weight
+            if hasattr(child, "bias"):
+                new_module.bias = child.bias
+
+        if getattr(child, "state", None) is not None:
+            if hasattr(new_module, "base_layer"):
+                new_module.base_layer.state = child.state
+            else:
+                new_module.state = child.state
+            new_module.to(child.weight.device)
+
+        # dispatch to correct device
+        for name, module in new_module.named_modules():
+            if self.prefix in name:
+                module.to(child.weight.device)
+    
+    def _mark_only_adapters_as_trainable(self, model: nn.Module) -> None:
+        for n, p in model.named_parameters():
+            if self.prefix not in n:
+                p.requires_grad = False

--- a/src/peft/utils/peft_types.py
+++ b/src/peft/utils/peft_types.py
@@ -49,6 +49,7 @@ class PeftType(str, enum.Enum):
     LOKR = "LOKR"
     OFT = "OFT"
     POLY = "POLY"
+    CUSTOM_TOKENS = "CUSTOM_TOKENS"
 
 
 class TaskType(str, enum.Enum):

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -99,6 +99,9 @@ def get_peft_model_state_dict(
     elif config.peft_type == PeftType.LOHA:
         to_return = {k: state_dict[k] for k in state_dict if "hada_" in k}
 
+    elif config.peft_type == PeftType.CUSTOM_TOKENS:
+        to_return = {k: state_dict[k] for k in state_dict if "custom_tokens" in k}
+
     elif config.peft_type == PeftType.LOKR:
         to_return = {k: state_dict[k] for k in state_dict if "lokr_" in k}
 
@@ -215,6 +218,7 @@ def set_peft_model_state_dict(model, peft_model_state_dict, adapter_name="defaul
         PeftType.IA3,
         PeftType.OFT,
         PeftType.POLY,
+        PeftType.CUSTOM_TOKENS
     ):
         peft_model_state_dict = {}
         parameter_prefix = {
@@ -225,6 +229,7 @@ def set_peft_model_state_dict(model, peft_model_state_dict, adapter_name="defaul
             PeftType.LOKR: "lokr_",
             PeftType.OFT: "oft_",
             PeftType.POLY: "poly_",
+            PeftType.CUSTOM_TOKENS: "custom_tokens",
         }[config.peft_type]
         for k, v in state_dict.items():
             if parameter_prefix in k:


### PR DESCRIPTION
We may want to train just a subset of our token's while leaving the rest frozen. This may be done when we have token's for named entities, or special tokens for chat assistants. While you can train only certain token's by registering a custom gradient hook, to 'zero-out' the frozen token embedding, this still requires us to store in memory and on-disk a large embedding matrix, which can take up ~30% of the total model size. A more efficient approach, would be to wrap embedding weight deltas for trainable token's in a Sparse Matrix, making merging, unmerging and delta operations fast. 

Please see https://github.com/huggingface/peft/issues/1462. 

ToDo:

- [ ] Tests
- [ ] Documentation
- [ ] Examples
