### PR TITLE
MNT: Use BitsAndBytesConfig as load_in_* is deprecated

### DIFF
--- a/examples/feature_extraction/peft_lora_embedding_semantic_search.py
+++ b/examples/feature_extraction/peft_lora_embedding_semantic_search.py
@@ -171,7 +171,9 @@ class AutoModelForSentenceEmbedding(nn.Module):
     def __init__(self, model_name, tokenizer, normalize=True):
         super().__init__()
 
-        self.model = AutoModel.from_pretrained(model_name)  # , quantizaton_config=BitsAndBytesConfig(load_in_8bit=True), device_map={"":0})
+        self.model = AutoModel.from_pretrained(
+            model_name
+        )  # , quantizaton_config=BitsAndBytesConfig(load_in_8bit=True), device_map={"":0})
         self.normalize = normalize
         self.tokenizer = tokenizer
 

--- a/examples/feature_extraction/peft_lora_embedding_semantic_search.py
+++ b/examples/feature_extraction/peft_lora_embedding_semantic_search.py
@@ -171,7 +171,7 @@ class AutoModelForSentenceEmbedding(nn.Module):
     def __init__(self, model_name, tokenizer, normalize=True):
         super().__init__()
 
-        self.model = AutoModel.from_pretrained(model_name)  # , load_in_8bit=True, device_map={"":0})
+        self.model = AutoModel.from_pretrained(model_name)  # , quantizaton_config=BitsAndBytesConfig(load_in_8bit=True), device_map={"":0})
         self.normalize = normalize
         self.tokenizer = tokenizer
 

--- a/examples/feature_extraction/peft_lora_embedding_semantic_similarity_inference.ipynb
+++ b/examples/feature_extraction/peft_lora_embedding_semantic_similarity_inference.ipynb
@@ -82,7 +82,7 @@
     "    def __init__(self, model_name, tokenizer, normalize=True):\n",
     "        super(AutoModelForSentenceEmbedding, self).__init__()\n",
     "\n",
-    "        self.model = AutoModel.from_pretrained(model_name)  # , load_in_8bit=True, device_map={\"\":0})\n",
+    "        self.model = AutoModel.from_pretrained(model_name)  # , quantizaton_config=BitsAndBytesConfig(load_in_8bit=True), device_map={\"\":0})\n",
     "        self.normalize = normalize\n",
     "        self.tokenizer = tokenizer\n",
     "\n",

--- a/examples/fp4_finetuning/finetune_fp4_opt_bnb_peft.py
+++ b/examples/fp4_finetuning/finetune_fp4_opt_bnb_peft.py
@@ -165,11 +165,11 @@ You can also directly load adapters from the Hub using the commands below:
 
 # import torch
 # from peft import PeftModel, PeftConfig
-# from transformers import AutoModelForCausalLM, AutoTokenizer
+# from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 #
 # peft_model_id = "ybelkada/opt-6.7b-lora"
 # config = PeftConfig.from_pretrained(peft_model_id)
-# model = AutoModelForCausalLM.from_pretrained(config.base_model_name_or_path, return_dict=True, load_in_8bit=True, device_map='auto')
+# model = AutoModelForCausalLM.from_pretrained(config.base_model_name_or_path, return_dict=True, quantization_config=BitsAndBytesConfig(load_in_8bit=True), device_map='auto')
 # tokenizer = AutoTokenizer.from_pretrained(config.base_model_name_or_path)
 #
 ## Load the Lora model

--- a/examples/int8_training/Finetune_flan_t5_large_bnb_peft.ipynb
+++ b/examples/int8_training/Finetune_flan_t5_large_bnb_peft.ipynb
@@ -301,11 +301,11 @@
     "os.environ[\"CUDA_VISIBLE_DEVICES\"] = \"0\"\n",
     "\n",
     "from datasets import load_dataset\n",
-    "from transformers import AutoModelForSeq2SeqLM, AutoTokenizer\n",
+    "from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, BitsAndBytesConfig\n",
     "\n",
     "model_name = \"google/flan-t5-large\"\n",
     "\n",
-    "model = AutoModelForSeq2SeqLM.from_pretrained(model_name, load_in_8bit=True)\n",
+    "model = AutoModelForSeq2SeqLM.from_pretrained(model_name, quantization_config=BitsAndBytesConfig(load_in_8bit=True))\n",
     "tokenizer = AutoTokenizer.from_pretrained(model_name)"
    ]
   },

--- a/examples/int8_training/Finetune_opt_bnb_peft.ipynb
+++ b/examples/int8_training/Finetune_opt_bnb_peft.ipynb
@@ -219,9 +219,9 @@
     "import torch\n",
     "import torch.nn as nn\n",
     "import bitsandbytes as bnb\n",
-    "from transformers import AutoTokenizer, AutoConfig, AutoModelForCausalLM\n",
+    "from transformers import AutoTokenizer, AutoConfig, AutoModelForCausalLM, BitsAndBytesConfig\n",
     "\n",
-    "model = AutoModelForCausalLM.from_pretrained(\"facebook/opt-6.7b\", load_in_8bit=True)\n",
+    "model = AutoModelForCausalLM.from_pretrained(\"facebook/opt-6.7b\", quantization_config=BitsAndBytesConfig(load_in_8bit=True))\n",
     "\n",
     "tokenizer = AutoTokenizer.from_pretrained(\"facebook/opt-6.7b\")"
    ]
@@ -1459,12 +1459,12 @@
    "source": [
     "import torch\n",
     "from peft import PeftModel, PeftConfig\n",
-    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig\n",
     "\n",
     "peft_model_id = \"ybelkada/opt-6.7b-lora\"\n",
     "config = PeftConfig.from_pretrained(peft_model_id)\n",
     "model = AutoModelForCausalLM.from_pretrained(\n",
-    "    config.base_model_name_or_path, return_dict=True, load_in_8bit=True, device_map=\"auto\"\n",
+    "    config.base_model_name_or_path, return_dict=True, quantization_config=BitsAndBytesConfig(load_in_8bit=True), device_map=\"auto\"\n",
     ")\n",
     "tokenizer = AutoTokenizer.from_pretrained(config.base_model_name_or_path)\n",
     "\n",

--- a/examples/int8_training/fine_tune_blip2_int8.py
+++ b/examples/int8_training/fine_tune_blip2_int8.py
@@ -14,7 +14,7 @@
 import torch
 from datasets import load_dataset
 from torch.utils.data import DataLoader, Dataset
-from transformers import AutoModelForVision2Seq, AutoProcessor
+from transformers import AutoModelForVision2Seq, AutoProcessor, BitsAndBytesConfig
 
 from peft import LoraConfig, get_peft_model
 
@@ -28,7 +28,7 @@ config = LoraConfig(
 )
 
 # We load our model and processor using `transformers`
-model = AutoModelForVision2Seq.from_pretrained("Salesforce/blip2-opt-2.7b", load_in_8bit=True)
+model = AutoModelForVision2Seq.from_pretrained("Salesforce/blip2-opt-2.7b", quantization_config=BitsAndBytesConfig(load_in_8bit=True))
 processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
 
 # Get our peft model and print the number of trainable parameters

--- a/examples/int8_training/fine_tune_blip2_int8.py
+++ b/examples/int8_training/fine_tune_blip2_int8.py
@@ -28,7 +28,9 @@ config = LoraConfig(
 )
 
 # We load our model and processor using `transformers`
-model = AutoModelForVision2Seq.from_pretrained("Salesforce/blip2-opt-2.7b", quantization_config=BitsAndBytesConfig(load_in_8bit=True))
+model = AutoModelForVision2Seq.from_pretrained(
+    "Salesforce/blip2-opt-2.7b", quantization_config=BitsAndBytesConfig(load_in_8bit=True)
+)
 processor = AutoProcessor.from_pretrained("Salesforce/blip2-opt-2.7b")
 
 # Get our peft model and print the number of trainable parameters

--- a/examples/int8_training/peft_adalora_whisper_large_training.py
+++ b/examples/int8_training/peft_adalora_whisper_large_training.py
@@ -30,6 +30,7 @@ from huggingface_hub import Repository
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import (
+    BitsAndBytesConfig,
     SchedulerType,
     WhisperForConditionalGeneration,
     WhisperProcessor,
@@ -533,7 +534,7 @@ def main():
     metric = evaluate.load("wer")
 
     # model
-    model = WhisperForConditionalGeneration.from_pretrained(args.model_name_or_path, load_in_8bit=True)
+    model = WhisperForConditionalGeneration.from_pretrained(args.model_name_or_path, quantization_config=BitsAndBytesConfig(load_in_8bit=True))
     model.config.forced_decoder_ids = None
     model.config.suppress_tokens = []
     if len(set(model.hf_device_map.values()).intersection({"cpu", "disk"})) > 0:

--- a/examples/int8_training/peft_adalora_whisper_large_training.py
+++ b/examples/int8_training/peft_adalora_whisper_large_training.py
@@ -534,7 +534,9 @@ def main():
     metric = evaluate.load("wer")
 
     # model
-    model = WhisperForConditionalGeneration.from_pretrained(args.model_name_or_path, quantization_config=BitsAndBytesConfig(load_in_8bit=True))
+    model = WhisperForConditionalGeneration.from_pretrained(
+        args.model_name_or_path, quantization_config=BitsAndBytesConfig(load_in_8bit=True)
+    )
     model.config.forced_decoder_ids = None
     model.config.suppress_tokens = []
     if len(set(model.hf_device_map.values()).intersection({"cpu", "disk"})) > 0:

--- a/examples/int8_training/peft_bnb_whisper_large_v2_training.ipynb
+++ b/examples/int8_training/peft_bnb_whisper_large_v2_training.ipynb
@@ -1102,9 +1102,9 @@
    },
    "outputs": [],
    "source": [
-    "from transformers import WhisperForConditionalGeneration\n",
+    "from transformers import WhisperForConditionalGeneration, BitsAndBytesConfig\n",
     "\n",
-    "model = WhisperForConditionalGeneration.from_pretrained(model_name_or_path, load_in_8bit=True)\n",
+    "model = WhisperForConditionalGeneration.from_pretrained(model_name_or_path, quantization_config=BitsAndBytesConfig(load_in_8bit=True))\n",
     "\n",
     "# model.hf_device_map - this should be {\" \": 0}"
    ]
@@ -1645,7 +1645,7 @@
     "peft_model_id = \"smangrul/openai-whisper-large-v2-LORA-colab\"\n",
     "peft_config = PeftConfig.from_pretrained(peft_model_id)\n",
     "model = WhisperForConditionalGeneration.from_pretrained(\n",
-    "    peft_config.base_model_name_or_path, load_in_8bit=True, device_map=\"auto\"\n",
+    "    peft_config.base_model_name_or_path, quantization_config=BitsAndBytesConfig(load_in_8bit=True), device_map=\"auto\"\n",
     ")\n",
     "model = PeftModel.from_pretrained(model, peft_model_id)"
    ]
@@ -1884,7 +1884,7 @@
     "task = \"transcribe\"\n",
     "peft_config = PeftConfig.from_pretrained(peft_model_id)\n",
     "model = WhisperForConditionalGeneration.from_pretrained(\n",
-    "    peft_config.base_model_name_or_path, load_in_8bit=True, device_map=\"auto\"\n",
+    "    peft_config.base_model_name_or_path, quantization_config=BitsAndBytesConfig(load_in_8bit=True), device_map=\"auto\"\n",
     ")\n",
     "\n",
     "model = PeftModel.from_pretrained(model, peft_model_id)\n",

--- a/examples/multi_adapter_examples/PEFT_Multi_LoRA_Inference.ipynb
+++ b/examples/multi_adapter_examples/PEFT_Multi_LoRA_Inference.ipynb
@@ -56,11 +56,11 @@
    "outputs": [],
    "source": [
     "from peft import PeftModel\n",
-    "from transformers import LlamaTokenizer, LlamaForCausalLM, GenerationConfig\n",
+    "from transformers import LlamaTokenizer, LlamaForCausalLM, GenerationConfig, BitsAndBytesConfig\n",
     "\n",
     "model_name = \"decapoda-research/llama-7b-hf\"\n",
     "tokenizer = LlamaTokenizer.from_pretrained(model_name)\n",
-    "model = LlamaForCausalLM.from_pretrained(model_name, load_in_8bit=True, device_map=\"auto\", use_auth_token=True)"
+    "model = LlamaForCausalLM.from_pretrained(model_name, quantization_config=BitsAndBytesConfig(load_in_8bit=True), device_map=\"auto\", use_auth_token=True)"
    ]
   },
   {

--- a/examples/sft/train.py
+++ b/examples/sft/train.py
@@ -51,7 +51,7 @@ class ModelArguments:
         default=False,
         metadata={"help": "Enables PEFT LoRA for training."},
     )
-    use_8bit_qunatization: Optional[bool] = field(
+    use_8bit_quantization: Optional[bool] = field(
         default=False,
         metadata={"help": "Enables loading model in 8bit."},
     )

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -79,14 +79,21 @@ class LoraModel(BaseTuner):
         ```
 
         ```py
+        >>> import torch
         >>> import transformers
         >>> from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_int8_training
 
+        >>> rank = ...
         >>> target_modules = ["q_proj", "k_proj", "v_proj", "out_proj", "fc_in", "fc_out", "wte"]
         >>> config = LoraConfig(
         ...     r=4, lora_alpha=16, target_modules=target_modules, lora_dropout=0.1, bias="none", task_type="CAUSAL_LM"
         ... )
+        >>> quantization_config = transformers.BitsAndBytesConfig(load_in_8bit=True)
 
+        >>> tokenizer = transformers.AutoTokenizer.from_pretrained(
+        ...    'kakaobrain/kogpt', revision='KoGPT6B-ryan1.5b-float16',  # or float32 version: revision=KoGPT6B-ryan1.5b
+        ...    bos_token='[BOS]', eos_token='[EOS]', unk_token='[UNK]', pad_token='[PAD]', mask_token='[MASK]'
+        ... )
         >>> model = transformers.GPTJForCausalLM.from_pretrained(
         ...     "kakaobrain/kogpt",
         ...     revision="KoGPT6B-ryan1.5b-float16",  # or float32 version: revision=KoGPT6B-ryan1.5b
@@ -94,7 +101,7 @@ class LoraModel(BaseTuner):
         ...     use_cache=False,
         ...     device_map={"": rank},
         ...     torch_dtype=torch.float16,
-        ...     load_in_8bit=True,
+        ...     quantization_config=quantization_config,
         ... )
         >>> model = prepare_model_for_int8_training(model)
         >>> lora_model = get_peft_model(model, config)

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -91,8 +91,13 @@ class LoraModel(BaseTuner):
         >>> quantization_config = transformers.BitsAndBytesConfig(load_in_8bit=True)
 
         >>> tokenizer = transformers.AutoTokenizer.from_pretrained(
-        ...    'kakaobrain/kogpt', revision='KoGPT6B-ryan1.5b-float16',  # or float32 version: revision=KoGPT6B-ryan1.5b
-        ...    bos_token='[BOS]', eos_token='[EOS]', unk_token='[UNK]', pad_token='[PAD]', mask_token='[MASK]'
+        ...     "kakaobrain/kogpt",
+        ...     revision="KoGPT6B-ryan1.5b-float16",  # or float32 version: revision=KoGPT6B-ryan1.5b
+        ...     bos_token="[BOS]",
+        ...     eos_token="[EOS]",
+        ...     unk_token="[UNK]",
+        ...     pad_token="[PAD]",
+        ...     mask_token="[MASK]",
         ... )
         >>> model = transformers.GPTJForCausalLM.from_pretrained(
         ...     "kakaobrain/kogpt",

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -528,7 +528,7 @@ class TestOpt8bitBnb(RegressionTester):
         self.fix_seed()
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-350m",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
         return model
 

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -89,19 +89,19 @@ class PeftGPUCommonTests(unittest.TestCase):
         whisper_8bit = WhisperForConditionalGeneration.from_pretrained(
             self.audio_model_id,
             device_map="auto",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
 
         opt_8bit = AutoModelForCausalLM.from_pretrained(
             self.causal_lm_model_id,
             device_map="auto",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
 
         flan_8bit = AutoModelForSeq2SeqLM.from_pretrained(
             self.seq2seq_model_id,
             device_map="auto",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
 
         flan_lora_config = LoraConfig(
@@ -138,19 +138,19 @@ class PeftGPUCommonTests(unittest.TestCase):
         whisper_8bit = WhisperForConditionalGeneration.from_pretrained(
             self.audio_model_id,
             device_map="auto",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
 
         opt_8bit = AutoModelForCausalLM.from_pretrained(
             self.causal_lm_model_id,
             device_map="auto",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
 
         flan_8bit = AutoModelForSeq2SeqLM.from_pretrained(
             self.seq2seq_model_id,
             device_map="auto",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
 
         flan_ia3_config = IA3Config(target_modules=["q", "v"], task_type="SEQ_2_SEQ_LM")
@@ -184,9 +184,9 @@ class PeftGPUCommonTests(unittest.TestCase):
         peft_model_id = "ybelkada/test-st-lora"
         kwargs = {"device_map": "auto"}
         if quantization == "4bit":
-            kwargs["load_in_4bit"] = True
+            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_4bit=True)
         else:
-            kwargs["load_in_8bit"] = True
+            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_8bit=True)
 
         model = AutoModelForCausalLM.from_pretrained(model_id, **kwargs)
         model = PeftModel.from_pretrained(model, peft_model_id)
@@ -213,9 +213,9 @@ class PeftGPUCommonTests(unittest.TestCase):
         model_id = "facebook/opt-350m"
         kwargs = {"device_map": "auto"}
         if quantization == "4bit":
-            kwargs["load_in_4bit"] = True
+            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_4bit=True)
         else:
-            kwargs["load_in_8bit"] = True
+            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_8bit=True)
 
         model = AutoModelForCausalLM.from_pretrained(model_id, **kwargs)
         config = AdaLoraConfig(task_type=TaskType.CAUSAL_LM)
@@ -250,9 +250,9 @@ class PeftGPUCommonTests(unittest.TestCase):
         model_id = "facebook/opt-350m"
         kwargs = {"device_map": "auto"}
         if quantization == "4bit":
-            kwargs["load_in_4bit"] = True
+            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_4bit=True)
         else:
-            kwargs["load_in_8bit"] = True
+            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_8bit=True)
 
         model = AutoModelForCausalLM.from_pretrained(model_id, **kwargs)
         config = IA3Config(task_type=TaskType.CAUSAL_LM)
@@ -324,19 +324,19 @@ class PeftGPUCommonTests(unittest.TestCase):
         whisper_4bit = WhisperForConditionalGeneration.from_pretrained(
             self.audio_model_id,
             device_map="auto",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
 
         opt_4bit = AutoModelForCausalLM.from_pretrained(
             self.causal_lm_model_id,
             device_map="auto",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
 
         flan_4bit = AutoModelForSeq2SeqLM.from_pretrained(
             self.seq2seq_model_id,
             device_map="auto",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
 
         flan_lora_config = LoraConfig(
@@ -373,19 +373,19 @@ class PeftGPUCommonTests(unittest.TestCase):
         whisper_4bit = WhisperForConditionalGeneration.from_pretrained(
             self.audio_model_id,
             device_map="auto",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
 
         opt_4bit = AutoModelForCausalLM.from_pretrained(
             self.causal_lm_model_id,
             device_map="auto",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
 
         flan_4bit = AutoModelForSeq2SeqLM.from_pretrained(
             self.seq2seq_model_id,
             device_map="auto",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
 
         flan_ia3_config = IA3Config(target_modules=["q", "v"], task_type="SEQ_2_SEQ_LM")
@@ -447,7 +447,7 @@ class PeftGPUCommonTests(unittest.TestCase):
             r=16, lora_alpha=32, target_modules=["q", "v"], lora_dropout=0.05, bias="none", task_type="SEQ_2_SEQ_LM"
         )
 
-        model = AutoModelForSeq2SeqLM.from_pretrained(self.seq2seq_model_id, device_map="balanced", load_in_8bit=True)
+        model = AutoModelForSeq2SeqLM.from_pretrained(self.seq2seq_model_id, device_map="balanced", quantization_config=BitsAndBytesConfig(load_in_8bit=True))
         tokenizer = AutoTokenizer.from_pretrained(self.seq2seq_model_id)
 
         assert set(model.hf_device_map.values()) == set(range(torch.cuda.device_count()))
@@ -468,7 +468,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_adaption_prompt_8bit(self):
         model = LlamaForCausalLM.from_pretrained(
             "HuggingFaceM4/tiny-random-LlamaForCausalLM",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             torch_dtype=torch.float16,
             device_map="auto",
         )
@@ -491,7 +491,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_adaption_prompt_4bit(self):
         model = LlamaForCausalLM.from_pretrained(
             "HuggingFaceM4/tiny-random-LlamaForCausalLM",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             torch_dtype=torch.float16,
             device_map="auto",
         )
@@ -517,7 +517,7 @@ class PeftGPUCommonTests(unittest.TestCase):
 
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
 
         config = LoraConfig(
@@ -531,7 +531,7 @@ class PeftGPUCommonTests(unittest.TestCase):
 
         # test with double quant
         bnb_config = BitsAndBytesConfig(
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             bnb_4bit_use_double_quant=True,
         )
 
@@ -554,11 +554,10 @@ class PeftGPUCommonTests(unittest.TestCase):
     @require_bitsandbytes
     def test_modules_to_save_grad(self):
         model_id = "bigscience/bloomz-560m"
-        load_in_4bit = True
 
         model = AutoModelForSequenceClassification.from_pretrained(
             model_id,
-            load_in_4bit=load_in_4bit,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             torch_dtype=torch.float32,
         )
 
@@ -593,7 +592,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         torch.manual_seed(1000)
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
         random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
         out_base = F.softmax(model(random_input).logits, dim=-1)
@@ -626,7 +625,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         torch.manual_seed(1000)
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
         random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
         # compare outputs in probability space, because logits can have outliers
@@ -661,7 +660,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_4bit_merge_lora(self):
         torch.manual_seed(3000)
         bnb_config = BitsAndBytesConfig(
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             bnb_4bit_use_double_quant=False,
             bnb_4bit_compute_type=torch.float32,
         )
@@ -703,7 +702,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_4bit_merge_and_disable_lora(self):
         torch.manual_seed(3000)
         bnb_config = BitsAndBytesConfig(
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             bnb_4bit_use_double_quant=False,
             bnb_4bit_compute_type=torch.float32,
         )

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -447,7 +447,9 @@ class PeftGPUCommonTests(unittest.TestCase):
             r=16, lora_alpha=32, target_modules=["q", "v"], lora_dropout=0.05, bias="none", task_type="SEQ_2_SEQ_LM"
         )
 
-        model = AutoModelForSeq2SeqLM.from_pretrained(self.seq2seq_model_id, device_map="balanced", quantization_config=BitsAndBytesConfig(load_in_8bit=True))
+        model = AutoModelForSeq2SeqLM.from_pretrained(
+            self.seq2seq_model_id, device_map="balanced", quantization_config=BitsAndBytesConfig(load_in_8bit=True)
+        )
         tokenizer = AutoTokenizer.from_pretrained(self.seq2seq_model_id)
 
         assert set(model.hf_device_map.values()) == set(range(torch.cuda.device_count()))

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -331,7 +331,9 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         model_id = "facebook/opt-350m"
 
         # for >3 GPUs, might need: device_map={"": "cuda:0"}
-        model = AutoModelForCausalLM.from_pretrained(model_id, quantization_config=BitsAndBytesConfig(load_in_4bit=True))
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id, quantization_config=BitsAndBytesConfig(load_in_4bit=True)
+        )
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         model.gradient_checkpointing_enable()
@@ -394,7 +396,9 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         """
         model_id = "facebook/opt-350m"
 
-        model = AutoModelForCausalLM.from_pretrained(model_id, quantization_config=BitsAndBytesConfig(load_in_8bit=True))
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id, quantization_config=BitsAndBytesConfig(load_in_8bit=True)
+        )
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         model.gradient_checkpointing_enable()

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -31,6 +31,7 @@ from transformers import (
     AutoModelForCausalLM,
     AutoModelForSeq2SeqLM,
     AutoTokenizer,
+    BitsAndBytesConfig,
     DataCollatorForLanguageModeling,
     Seq2SeqTrainer,
     Seq2SeqTrainingArguments,
@@ -155,7 +156,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = AutoModelForCausalLM.from_pretrained(
                 self.causal_lm_model_id,
-                load_in_8bit=True,
+                quantization_config=BitsAndBytesConfig(load_in_8bit=True),
                 device_map="auto",
             )
 
@@ -213,7 +214,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = AutoModelForCausalLM.from_pretrained(
                 self.causal_lm_model_id,
-                load_in_4bit=True,
+                quantization_config=BitsAndBytesConfig(load_in_4bit=True),
                 device_map="auto",
             )
 
@@ -271,7 +272,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
             model = AutoModelForCausalLM.from_pretrained(
                 self.causal_lm_model_id,
                 device_map="auto",
-                load_in_4bit=True,
+                quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             )
 
             assert set(model.hf_device_map.values()) == set(range(torch.cuda.device_count()))
@@ -330,7 +331,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         model_id = "facebook/opt-350m"
 
         # for >3 GPUs, might need: device_map={"": "cuda:0"}
-        model = AutoModelForCausalLM.from_pretrained(model_id, load_in_4bit=True)
+        model = AutoModelForCausalLM.from_pretrained(model_id, quantization_config=BitsAndBytesConfig(load_in_4bit=True))
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         model.gradient_checkpointing_enable()
@@ -393,7 +394,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         """
         model_id = "facebook/opt-350m"
 
-        model = AutoModelForCausalLM.from_pretrained(model_id, load_in_8bit=True)
+        model = AutoModelForCausalLM.from_pretrained(model_id, quantization_config=BitsAndBytesConfig(load_in_8bit=True))
         tokenizer = AutoTokenizer.from_pretrained(model_id)
 
         model.gradient_checkpointing_enable()
@@ -460,7 +461,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = AutoModelForCausalLM.from_pretrained(
                 self.causal_lm_model_id,
-                load_in_8bit=True,
+                quantization_config=BitsAndBytesConfig(load_in_8bit=True),
                 device_map="auto",
             )
 
@@ -523,7 +524,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = AutoModelForSeq2SeqLM.from_pretrained(
                 self.seq2seq_model_id,
-                load_in_8bit=True,
+                quantization_config=BitsAndBytesConfig(load_in_8bit=True),
                 device_map={"": 0},
             )
 
@@ -584,7 +585,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             model = AutoModelForSeq2SeqLM.from_pretrained(
                 self.seq2seq_model_id,
-                load_in_8bit=True,
+                quantization_config=BitsAndBytesConfig(load_in_8bit=True),
                 device_map="balanced",
             )
 
@@ -676,7 +677,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
             data_collator = DataCollatorSpeechSeq2SeqWithPadding(processor=processor)
 
             model = WhisperForConditionalGeneration.from_pretrained(
-                self.audio_model_id, load_in_8bit=True, device_map="auto"
+                self.audio_model_id, quantization_config=BitsAndBytesConfig(load_in_8bit=True), device_map="auto"
             )
 
             model.config.forced_decoder_ids = None
@@ -745,7 +746,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
             device_map="auto",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
         model = prepare_model_for_kbit_training(model)
         model = get_peft_model(model, config)
@@ -755,7 +756,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
             device_map="auto",
-            load_in_4bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
         model = prepare_model_for_kbit_training(model)
         model = get_peft_model(model, config, adapter_name="other")
@@ -780,7 +781,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
             device_map="auto",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
         model = prepare_model_for_kbit_training(model)
         model = get_peft_model(model, config)
@@ -790,7 +791,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
             device_map="auto",
-            load_in_8bit=True,
+            quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
         model = prepare_model_for_kbit_training(model)
         model = get_peft_model(model, config, adapter_name="other")
@@ -1162,9 +1163,9 @@ class LoftQTests(unittest.TestCase):
         lora_config = LoraConfig(task_type=task_type)
         kwargs = {}
         if bits == 4:
-            kwargs["load_in_4bit"] = True
+            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_4bit=True)
         elif bits == 8:
-            kwargs["load_in_8bit"] = True
+            kwargs["quantization_config"] = BitsAndBytesConfig(load_in_8bit=True)
         else:
             raise ValueError("bits must be 4 or 8")
 

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -21,7 +21,7 @@ import pytest
 from diffusers import StableDiffusionPipeline
 from parameterized import parameterized
 from torch import nn
-from transformers import AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM
+from transformers import AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM, BitsAndBytesConfig
 
 from peft import IA3Config, LoHaConfig, LoraConfig, get_peft_model
 from peft.tuners.tuners_utils import (
@@ -254,9 +254,9 @@ class PeftCustomKwargsTester(unittest.TestCase):
         self, model_id, model_type, initial_target_modules, expected_target_modules, quantization
     ):
         if quantization == "4bit":
-            config_kwargs = {"load_in_4bit": True}
+            config_kwargs = {"quantization_config": BitsAndBytesConfig(load_in_4bit=True)}
         elif quantization == "8bit":
-            config_kwargs = {"load_in_8bit": True}
+            config_kwargs = {"quantization_config": BitsAndBytesConfig(load_in_8bit=True)}
         model = self.transformers_class_map[model_type].from_pretrained(model_id, device_map="auto", **config_kwargs)
         config_cls = LoraConfig
         self._check_match_with_expected_target_modules(


### PR DESCRIPTION
Don't pass `load_in_4bit` or `load_in_8bit` to `AutoModel*.from_pretrained`, as it is deprecated. Instead, pass the appropriate `BitsAndBytesConfig` to the `quantization_config` argument of `from_pretrained`.