### PR TITLE
TST Report slowest tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ doctest_optionflags = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/peft --cov-report=term-missing --durations=10 -k dora"
+addopts = "--cov=src/peft --cov-report=term-missing --durations=10"
 markers = [
     "single_gpu_tests: tests that run on a single GPU",
     "multi_gpu_tests: tests that run on multiple GPUs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ doctest_optionflags = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/peft --cov-report=term-missing"
+addopts = "--cov=src/peft --cov-report=term-missing --durations=10 -k dora"
 markers = [
     "single_gpu_tests: tests that run on a single GPU",
     "multi_gpu_tests: tests that run on multiple GPUs",


### PR DESCRIPTION
Just a small addition so that we know which tests are the slowest. This can be helpful to identify tests to optimize, or to catch early if a new PR adds a particularly slow test.