### PR TITLE
[feat] Add `lru_cache` to `import_utils` calls that did not previously have it

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -18,12 +18,12 @@ from functools import lru_cache
 import packaging.version
 
 
-@lru_cache(maxsize=None)
+@lru_cache
 def is_bnb_available() -> bool:
     return importlib.util.find_spec("bitsandbytes") is not None
 
 
-@lru_cache(maxsize=None)
+@lru_cache
 def is_bnb_4bit_available() -> bool:
     if not is_bnb_available():
         return False
@@ -33,7 +33,7 @@ def is_bnb_4bit_available() -> bool:
     return hasattr(bnb.nn, "Linear4bit")
 
 
-@lru_cache(maxsize=None)
+@lru_cache
 def is_auto_gptq_available():
     if importlib.util.find_spec("auto_gptq") is not None:
         AUTOGPTQ_MINIMUM_VERSION = packaging.version.parse("0.5.0")
@@ -47,7 +47,7 @@ def is_auto_gptq_available():
             )
 
 
-@lru_cache(maxsize=None)
+@lru_cache
 def is_optimum_available() -> bool:
     return importlib.util.find_spec("optimum") is not None
 
@@ -69,11 +69,11 @@ def is_torch_tpu_available(check_device=True):
     return False
 
 
-@lru_cache(maxsize=None)
+@lru_cache
 def is_aqlm_available():
     return importlib.util.find_spec("aqlm") is not None
 
 
-@lru_cache(maxsize=None)
+@lru_cache
 def is_auto_awq_available():
     return importlib.util.find_spec("awq") is not None

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 import importlib
 import importlib.metadata as importlib_metadata
-from functools import lru_cache
+from functools import cache, lru_cache
 
 import packaging.version
 
-
+@cache
 def is_bnb_available() -> bool:
     return importlib.util.find_spec("bitsandbytes") is not None
 
-
+@cache
 def is_bnb_4bit_available() -> bool:
     if not is_bnb_available():
         return False
@@ -30,7 +30,7 @@ def is_bnb_4bit_available() -> bool:
 
     return hasattr(bnb.nn, "Linear4bit")
 
-
+@cache
 def is_auto_gptq_available():
     if importlib.util.find_spec("auto_gptq") is not None:
         AUTOGPTQ_MINIMUM_VERSION = packaging.version.parse("0.5.0")
@@ -43,7 +43,7 @@ def is_auto_gptq_available():
                 f"but only versions above {AUTOGPTQ_MINIMUM_VERSION} are supported"
             )
 
-
+@cache
 def is_optimum_available() -> bool:
     return importlib.util.find_spec("optimum") is not None
 
@@ -64,10 +64,10 @@ def is_torch_tpu_available(check_device=True):
         return True
     return False
 
-
+@cache
 def is_aqlm_available():
     return importlib.util.find_spec("aqlm") is not None
 
-
+@cache
 def is_auto_awq_available():
     return importlib.util.find_spec("awq") is not None

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 import importlib
 import importlib.metadata as importlib_metadata
-from functools import cache, lru_cache
+from functools import lru_cache
 
 import packaging.version
 
 
-@cache
+@lru_cache(maxsize=None)
 def is_bnb_available() -> bool:
     return importlib.util.find_spec("bitsandbytes") is not None
 
 
-@cache
+@lru_cache(maxsize=None)
 def is_bnb_4bit_available() -> bool:
     if not is_bnb_available():
         return False
@@ -33,7 +33,7 @@ def is_bnb_4bit_available() -> bool:
     return hasattr(bnb.nn, "Linear4bit")
 
 
-@cache
+@lru_cache(maxsize=None)
 def is_auto_gptq_available():
     if importlib.util.find_spec("auto_gptq") is not None:
         AUTOGPTQ_MINIMUM_VERSION = packaging.version.parse("0.5.0")
@@ -47,7 +47,7 @@ def is_auto_gptq_available():
             )
 
 
-@cache
+@lru_cache(maxsize=None)
 def is_optimum_available() -> bool:
     return importlib.util.find_spec("optimum") is not None
 
@@ -69,11 +69,11 @@ def is_torch_tpu_available(check_device=True):
     return False
 
 
-@cache
+@lru_cache(maxsize=None)
 def is_aqlm_available():
     return importlib.util.find_spec("aqlm") is not None
 
 
-@cache
+@lru_cache(maxsize=None)
 def is_auto_awq_available():
     return importlib.util.find_spec("awq") is not None

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -17,9 +17,11 @@ from functools import cache, lru_cache
 
 import packaging.version
 
+
 @cache
 def is_bnb_available() -> bool:
     return importlib.util.find_spec("bitsandbytes") is not None
+
 
 @cache
 def is_bnb_4bit_available() -> bool:
@@ -29,6 +31,7 @@ def is_bnb_4bit_available() -> bool:
     import bitsandbytes as bnb
 
     return hasattr(bnb.nn, "Linear4bit")
+
 
 @cache
 def is_auto_gptq_available():
@@ -42,6 +45,7 @@ def is_auto_gptq_available():
                 f"Found an incompatible version of auto-gptq. Found version {version_autogptq}, "
                 f"but only versions above {AUTOGPTQ_MINIMUM_VERSION} are supported"
             )
+
 
 @cache
 def is_optimum_available() -> bool:
@@ -64,9 +68,11 @@ def is_torch_tpu_available(check_device=True):
         return True
     return False
 
+
 @cache
 def is_aqlm_available():
     return importlib.util.find_spec("aqlm") is not None
+
 
 @cache
 def is_auto_awq_available():


### PR DESCRIPTION
Fixes #1576 

Adding @cache to the functions in `import_utils` results in a constant time for LORA loading, regardless of the length of python path. Have verified this using a python path with 50,000 directories - previously the lora load time was 259 seconds, now it's down to a constant time of 1.3 seconds 👍🏻 

With some flamegraphs to prove! Before:
![profile](https://github.com/huggingface/peft/assets/54301847/99d42c8f-b9f8-4259-a5df-3f067823c860)


After: 
![profile_fixed](https://github.com/huggingface/peft/assets/54301847/c64fe63c-e9ca-4a6d-a975-24c905e65ba8)
