### PR TITLE
FIX: bnb config wrong argument names

### DIFF
--- a/examples/loftq_finetuning/LoftQ_weight_replacement.ipynb
+++ b/examples/loftq_finetuning/LoftQ_weight_replacement.ipynb
@@ -221,7 +221,7 @@
     "bnb_config = BitsAndBytesConfig(\n",
     "    load_in_4bit=True,\n",
     "    bnb_4bit_use_double_quant=True,\n",
-    "    bnb_4bit_compute_type=torch.float16,\n",
+    "    bnb_4bit_compute_dtype=torch.float16,\n",
     ")"
    ]
   },

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -579,7 +579,7 @@ class TestOpt4bitBnb(RegressionTester):
         bnb_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_use_double_quant=False,
-            bnb_4bit_compute_type=torch.float32,
+            bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-350m",

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -533,7 +533,7 @@ class PeftGPUCommonTests(unittest.TestCase):
 
         # test with double quant
         bnb_config = BitsAndBytesConfig(
-            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
+            load_in_4bit=True,
             bnb_4bit_use_double_quant=True,
         )
 
@@ -662,7 +662,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_4bit_merge_lora(self):
         torch.manual_seed(3000)
         bnb_config = BitsAndBytesConfig(
-            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
+            load_in_4bit=True,
             bnb_4bit_use_double_quant=False,
             bnb_4bit_compute_dtype=torch.float32,
         )
@@ -704,7 +704,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_4bit_merge_and_disable_lora(self):
         torch.manual_seed(3000)
         bnb_config = BitsAndBytesConfig(
-            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
+            load_in_4bit=True,
             bnb_4bit_use_double_quant=False,
             bnb_4bit_compute_dtype=torch.float32,
         )

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -664,7 +664,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         bnb_config = BitsAndBytesConfig(
             quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             bnb_4bit_use_double_quant=False,
-            bnb_4bit_compute_type=torch.float32,
+            bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
@@ -706,7 +706,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         bnb_config = BitsAndBytesConfig(
             quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             bnb_4bit_use_double_quant=False,
-            bnb_4bit_compute_type=torch.float32,
+            bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
@@ -749,7 +749,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         bnb_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_use_double_quant=False,
-            bnb_4bit_compute_type=torch.float32,
+            bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
@@ -821,7 +821,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         bnb_config = BitsAndBytesConfig(
             load_in_8bit=True,
             bnb_4bit_use_double_quant=False,
-            bnb_4bit_compute_type=torch.float32,
+            bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
@@ -905,7 +905,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         bnb_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_use_double_quant=False,
-            bnb_4bit_compute_type=torch.float32,
+            bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",
@@ -979,7 +979,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         bnb_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_use_double_quant=False,
-            bnb_4bit_compute_type=torch.float32,
+            bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
             "HuggingFaceM4/tiny-random-LlamaForCausalLM",


### PR DESCRIPTION
Several tests were using `bnb_4bit_compute_type` but the argument should be called `bnb_4bit_compute_dtype`. Now the 
correct name is used.

This change should not affect the tests, because they were passing the default value anyway. Therefore, the fact that this argument was passed incorrectly (and thus, presumably, ignored) should not affect the results.

Also, in some tests `quantization_config=BitsAndBytesConfig(load_in_4bit=True)` was passed as argument to `BitsAndBytesConfig` due to an overeager search and replace in #1552. Fixing those changes the test outcome but locally they still passed for me.

It is a bit unfortunate that this sort of typo passes completely silently.