### PR TITLE
FEAT: Allow ignoring mismatched sizes when loading

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -839,7 +839,10 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         adapters_weights = load_peft_weights(model_id, device=torch_device, **hf_hub_download_kwargs)
 
         # load the weights into the model
-        load_result = set_peft_model_state_dict(self, adapters_weights, adapter_name=adapter_name)
+        ignore_mismatched_sizes = kwargs.get("ignore_mismatched_sizes", False)
+        load_result = set_peft_model_state_dict(
+            self, adapters_weights, adapter_name=adapter_name, ignore_mismatched_sizes=ignore_mismatched_sizes
+        )
         if (
             (getattr(self, "hf_device_map", None) is not None)
             and (len(set(self.hf_device_map.values()).intersection({"cpu", "disk"})) > 0)

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import os
 import warnings
 from typing import Optional

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -186,13 +186,49 @@ def get_peft_model_state_dict(
     return to_return
 
 
-def set_peft_model_state_dict(model, peft_model_state_dict, adapter_name="default"):
+def _find_mismatched_keys(
+    model: torch.nn.Module, peft_model_state_dict: dict[str, torch.Tensor], ignore_mismatched_sizes: bool = False
+) -> tuple[dict[str, torch.Tensor], list[tuple[str, tuple[int, ...], tuple[int, ...]]]]:
+    if not ignore_mismatched_sizes:
+        return peft_model_state_dict, []
+
+    mismatched = []
+    state_dict = model.state_dict()
+    for key, tensor in peft_model_state_dict.items():
+        if key not in state_dict:
+            continue
+
+        # see https://github.com/huggingface/transformers/blob/09f9f566de83eef1f13ee83b5a1bbeebde5c80c1/src/transformers/modeling_utils.py#L3858-L3864
+        if (state_dict[key].shape[-1] == 1) and (state_dict[key].numel() * 2 == tensor.numel()):
+            # This skips size mismatches for 4-bit weights. Two 4-bit values share an 8-bit container, causing size
+            # differences. Without matching with module type or paramter type it seems like a practical way to detect
+            # valid 4bit weights.
+            continue
+
+        if state_dict[key].shape != tensor.shape:
+            mismatched.append((key, tensor.shape, state_dict[key].shape))
+
+    for key, _, _ in mismatched:
+        del peft_model_state_dict[key]
+
+    return peft_model_state_dict, mismatched
+
+
+def set_peft_model_state_dict(
+    model, peft_model_state_dict, adapter_name="default", ignore_mismatched_sizes: bool = False
+):
     """
     Set the state dict of the Peft model.
 
     Args:
-        model ([`PeftModel`]): The Peft model.
-        peft_model_state_dict (`dict`): The state dict of the Peft model.
+        model ([`PeftModel`]):
+            The Peft model.
+        peft_model_state_dict (`dict`):
+            The state dict of the Peft model.
+        adapter_name (`str`, *optional*, defaults to `"default"`):
+            The name of the adapter whose state dict should be set.
+        ignore_mismatched_sizes (`bool`, *optional*, defaults to `False`):
+            Whether to ignore mismatched in the state dict.
     """
     config = model.peft_config[adapter_name]
     state_dict = {}
@@ -246,6 +282,9 @@ def set_peft_model_state_dict(model, peft_model_state_dict, adapter_name="defaul
     else:
         raise NotImplementedError
 
+    peft_model_state_dict, mismatched_keys = _find_mismatched_keys(
+        model, peft_model_state_dict, ignore_mismatched_sizes=ignore_mismatched_sizes
+    )
     load_result = model.load_state_dict(peft_model_state_dict, strict=False)
     if config.is_prompt_learning:
         model.prompt_encoder[adapter_name].embedding.load_state_dict(
@@ -254,6 +293,20 @@ def set_peft_model_state_dict(model, peft_model_state_dict, adapter_name="defaul
 
     if config.peft_type == PeftType.MULTITASK_PROMPT_TUNING:
         model.prompt_encoder[adapter_name].load_state_dict(peft_model_state_dict, strict=False)
+
+    if mismatched_keys:
+        # see https://github.com/huggingface/transformers/blob/09f9f566de83eef1f13ee83b5a1bbeebde5c80c1/src/transformers/modeling_utils.py#L4039
+        mismatched_warning = "\n".join(
+            [
+                f"- {key}: found shape {shape1} in the checkpoint and {shape2} in the model instantiated"
+                for key, shape1, shape2 in mismatched_keys
+            ]
+        )
+        msg = (
+            f"Some weights of {model.__class__.__name__} were not initialized from the model checkpoint "
+            f"and are being ignored because you passed `ignore_mismatched_sizes=True`: {mismatched_warning}."
+        )
+        warnings.warn(msg)
     return load_result
 
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -352,9 +352,9 @@ class DeepMLP(nn.Module):
 
 
 class ModelEmbConv1D(nn.Module):
-    def __init__(self):
+    def __init__(self, emb_size=100):
         super().__init__()
-        self.emb = nn.Embedding(100, 5)
+        self.emb = nn.Embedding(emb_size, 5)
         self.conv1d = Conv1D(1, 5)
         self.relu = nn.ReLU()
         self.flat = nn.Flatten()
@@ -900,6 +900,27 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
             state_dict = safe_load_file(os.path.join(tmp_dirname, "adapter_model.safetensors"))
             assert "base_model.model.emb.base_layer.weight" not in state_dict
             del state_dict
+
+    def test_load_resized_embedding_ignore_mismatched_sizes(self):
+        # issue #1605
+        # Make it possible to load a LoRA layer that targets an embedding layer even if the sizes mismatch by passing
+        # ignore_mismatched_sizes=True
+        model = ModelEmbConv1D(emb_size=100)
+        config = LoraConfig(target_modules=["emb", "lin0"], init_lora_weights=False)
+        model = get_peft_model(model, config)
+
+        with tempfile.TemporaryDirectory() as tmp_dirname:
+            model.save_pretrained(tmp_dirname)
+            model = ModelEmbConv1D(emb_size=105)
+
+            # first check that this raises
+            with pytest.raises(RuntimeError) as exc:
+                PeftModel.from_pretrained(model, tmp_dirname)
+            msg = exc.value.args[0]
+            assert "size mismatch" in msg and "100" in msg and "105" in msg
+
+            # does not raise
+            PeftModel.from_pretrained(model, tmp_dirname, ignore_mismatched_sizes=True)
 
     @parameterized.expand(
         [

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -921,9 +921,11 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
             assert "size mismatch" in msg and "100" in msg and "105" in msg
 
             # does not raise
-            PeftModel.from_pretrained(model, tmp_dirname, ignore_mismatched_sizes=True)
-            # clean up of temp file fails on Windows, try gc to fix it.
+            model = PeftModel.from_pretrained(model, tmp_dirname, ignore_mismatched_sizes=True)
+            # clean up of temp file fails on Windows, try thisfix
+            del model
             gc.collect()
+            time.sleep(0.5)
 
     @parameterized.expand(
         [

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import gc
 import os
 import tempfile
 import time
@@ -921,6 +922,8 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
 
             # does not raise
             PeftModel.from_pretrained(model, tmp_dirname, ignore_mismatched_sizes=True)
+            # clean up of temp file fails on Windows, try gc to fix it.
+            gc.collect()
 
     @parameterized.expand(
         [

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-import gc
 import os
 import tempfile
 import time


### PR DESCRIPTION
Resolves #1605

When users pass `ignore_mismatched_sizes=True` to `PeftModel.from_pretrained`, the mismatched tensors will be ignored instead of raising an error. This is in line with how transformers handles this argument.