### PR TITLE
FIX In the image classification example, Change the model to the LoRA…

### DIFF
--- a/examples/image_classification/image_classification_peft_lora.ipynb
+++ b/examples/image_classification/image_classification_peft_lora.ipynb
@@ -1743,7 +1743,7 @@
    ],
    "source": [
     "trainer = Trainer(\n",
-    "    model,\n",
+    "    lora_model,\n",
     "    args,\n",
     "    train_dataset=train_ds,\n",
     "    eval_dataset=val_ds,\n",


### PR DESCRIPTION
- FIX In the image classification example, Change the model to the LoRA model in Train.
- Referred to "https://huggingface.co/docs/peft/main/en/task_guides/image_classification_lora#image-classification-using-lora"