### PR TITLE
itemsize is torch>=2.1, use element_size()

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -540,7 +540,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             # one needs to multiply the number of parameters by 2 to get
             # the correct number of parameters
             if param.__class__.__name__ == "Params4bit":
-                num_bytes = param.quant_storage.itemsize if hasattr(param, "quant_storage") else 1
+                num_bytes = param.quant_storage.element_size() if hasattr(param, "quant_storage") else 1
                 num_params = num_params * 2 * num_bytes
 
             all_param += num_params


### PR DESCRIPTION
PEFT lists torch version as >= 1.13.0 but `.itemsize` is only torch 2.1+. This is unexpectedly breaking for users on torch 2.0.

https://github.com/huggingface/peft/blob/main/setup.py#L63