### PR TITLE
FIX Correctly call element_size

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -540,7 +540,12 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             # one needs to multiply the number of parameters by 2 to get
             # the correct number of parameters
             if param.__class__.__name__ == "Params4bit":
-                num_bytes = param.quant_storage.element_size() if hasattr(param, "quant_storage") else 1
+                if hasattr(param, "element_size"):
+                    num_bytes = param.element_size()
+                elif not hasattr(param, "quant_storage"):
+                    num_bytes = 1
+                else:
+                    num_bytes = param.quant_storage.itemsize
                 num_params = num_params * 2 * num_bytes
 
             all_param += num_params


### PR DESCRIPTION
Should fix the error introduced by #1630.

AFAICT, `element_size` should be called on the parameter, not the `dtype`. Unfortunately, I had issues getting older PyTorch versions to work with bnb, so I haven't tested the initial issue.

To be safe, I also re-added the previous code path using `itemsize`, although it might be unnecessary (we would have to check the PyTorch code to verify when the different attributes/methods were added).