### PR TITLE
print_trainable_parameters - format `%` to be sensible

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -570,7 +570,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         trainable_params, all_param = self.get_nb_trainable_parameters()
 
         print(
-            f"trainable params: {trainable_params:,d} || all params: {all_param:,d} || trainable%: {100 * trainable_params / all_param}"
+            f"trainable params: {trainable_params:,d} || all params: {all_param:,d} || trainable%: {100 * trainable_params / all_param:.4f}"
         )
 
     def __getattr__(self, name: str):


### PR DESCRIPTION
This PR replaces `trainable%: 0.5916145025956931` with `trainable%: 0.5916` as it's done already in `src/peft/mixed_model.py`

Probably `.2f` is more than enough, but since the other one uses `.4f` using that.