### PR TITLE
save and load base model with revision

### DIFF
--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -62,7 +62,7 @@ class _BaseAutoPeftModel:
         adapter_name: str = "default",
         is_trainable: bool = False,
         config: Optional[PeftConfig] = None,
-        revision: Optional[str] = "main",
+        revision: Optional[str] = None,
         **kwargs,
     ):
         r"""

--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -71,7 +71,7 @@ class _BaseAutoPeftModel:
         """
         peft_config = PeftConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
         base_model_path = peft_config.base_model_name_or_path
-        base_model_revision = peft_config.base_model_revision
+        base_model_revision = peft_config.revision
 
         task_type = getattr(peft_config, "task_type", None)
 

--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -71,6 +71,7 @@ class _BaseAutoPeftModel:
         """
         peft_config = PeftConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
         base_model_path = peft_config.base_model_name_or_path
+        base_model_revision = peft_config.base_model_revision
 
         task_type = getattr(peft_config, "task_type", None)
 
@@ -101,7 +102,7 @@ class _BaseAutoPeftModel:
                 "Cannot infer the auto class from the config, please make sure that you are loading the correct model for your task type."
             )
 
-        base_model = target_class.from_pretrained(base_model_path, **kwargs)
+        base_model = target_class.from_pretrained(base_model_path, revision=base_model_revision, **kwargs)
 
         tokenizer_exists = False
         if os.path.exists(os.path.join(pretrained_model_name_or_path, TOKENIZER_CONFIG_NAME)):

--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -62,6 +62,7 @@ class _BaseAutoPeftModel:
         adapter_name: str = "default",
         is_trainable: bool = False,
         config: Optional[PeftConfig] = None,
+        revision: Optional[str] = "main",
         **kwargs,
     ):
         r"""
@@ -69,7 +70,7 @@ class _BaseAutoPeftModel:
         are passed along to `PeftConfig` that automatically takes care of filtering the kwargs of the Hub methods and
         the config object init.
         """
-        peft_config = PeftConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        peft_config = PeftConfig.from_pretrained(pretrained_model_name_or_path, revision=revision, **kwargs)
         base_model_path = peft_config.base_model_name_or_path
         base_model_revision = peft_config.revision
 
@@ -115,7 +116,7 @@ class _BaseAutoPeftModel:
             tokenizer_exists = check_file_exists_on_hf_hub(
                 repo_id=pretrained_model_name_or_path,
                 filename=TOKENIZER_CONFIG_NAME,
-                revision=kwargs.get("revision", None),
+                revision=revision,
                 repo_type=kwargs.get("repo_type", None),
                 token=token,
             )

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -97,6 +97,7 @@ class PeftConfigMixin(PushToHubMixin):
         # TODO: this hack is needed to fix the following issue (on commit 702f937):
         # if someone saves a default config and loads it back with `PeftConfig` class it yields to
         # not loading the correct config class.
+        #
         # from peft import AdaLoraConfig, PeftConfig
         # peft_config = AdaLoraConfig()
         # print(peft_config)

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -97,7 +97,6 @@ class PeftConfigMixin(PushToHubMixin):
         # TODO: this hack is needed to fix the following issue (on commit 702f937):
         # if someone saves a default config and loads it back with `PeftConfig` class it yields to
         # not loading the correct config class.
-
         # from peft import AdaLoraConfig, PeftConfig
         # peft_config = AdaLoraConfig()
         # print(peft_config)
@@ -232,7 +231,9 @@ class PeftConfig(PeftConfigMixin):
     base_model_name_or_path: Optional[str] = field(
         default=None, metadata={"help": "The name of the base model to use."}
     )
-    revision: Optional[str] = field(default=None, metadata={"help": "The specific model version to use."})
+    base_model_revision: Optional[str] = field(
+        default=None, metadata={"help": "The specific base model version to use."}
+    )
     peft_type: Optional[Union[str, PeftType]] = field(default=None, metadata={"help": "Peft type"})
     task_type: Optional[Union[str, TaskType]] = field(default=None, metadata={"help": "Task type"})
     inference_mode: bool = field(default=False, metadata={"help": "Whether to use inference mode"})

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -231,7 +231,7 @@ class PeftConfig(PeftConfigMixin):
     base_model_name_or_path: Optional[str] = field(
         default=None, metadata={"help": "The name of the base model to use."}
     )
-    revision: Optional[str] = field(default=None, metadata={"help": "The specific base model version to use."})
+    revision: Optional[str] = field(default="main", metadata={"help": "The specific base model version to use."})
     peft_type: Optional[Union[str, PeftType]] = field(default=None, metadata={"help": "Peft type"})
     task_type: Optional[Union[str, TaskType]] = field(default=None, metadata={"help": "Task type"})
     inference_mode: bool = field(default=False, metadata={"help": "Whether to use inference mode"})

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -232,7 +232,7 @@ class PeftConfig(PeftConfigMixin):
     base_model_name_or_path: Optional[str] = field(
         default=None, metadata={"help": "The name of the base model to use."}
     )
-    revision: Optional[str] = field(default="main", metadata={"help": "The specific base model version to use."})
+    revision: Optional[str] = field(default=None, metadata={"help": "The specific base model version to use."})
     peft_type: Optional[Union[str, PeftType]] = field(default=None, metadata={"help": "Peft type"})
     task_type: Optional[Union[str, TaskType]] = field(default=None, metadata={"help": "Task type"})
     inference_mode: bool = field(default=False, metadata={"help": "Whether to use inference mode"})

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -231,9 +231,7 @@ class PeftConfig(PeftConfigMixin):
     base_model_name_or_path: Optional[str] = field(
         default=None, metadata={"help": "The name of the base model to use."}
     )
-    base_model_revision: Optional[str] = field(
-        default=None, metadata={"help": "The specific base model version to use."}
-    )
+    revision: Optional[str] = field(default=None, metadata={"help": "The specific base model version to use."})
     peft_type: Optional[Union[str, PeftType]] = field(default=None, metadata={"help": "Peft type"})
     task_type: Optional[Union[str, TaskType]] = field(default=None, metadata={"help": "Task type"})
     inference_mode: bool = field(default=False, metadata={"help": "Whether to use inference mode"})

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -52,6 +52,7 @@ from .tuners import (
 )
 from .utils import _prepare_prompt_learning_config
 
+
 if TYPE_CHECKING:
     from transformers import PreTrainedModel
 

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -124,6 +124,7 @@ def get_peft_model(
         model_config = model_config.to_dict()
 
     peft_config.base_model_name_or_path = model.__dict__.get("name_or_path", None)
+    peft_config.base_model_revision = model.__dict__.get("revision", None)
 
     if mixed:
         return PeftMixedModel(model, peft_config, adapter_name=adapter_name)

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -109,7 +109,7 @@ def get_peft_model(
     peft_config: PeftConfig,
     adapter_name: str = "default",
     mixed: bool = False,
-    revision: Optional[str] = "main",
+    revision: Optional[str] = None,
 ) -> PeftModel | PeftMixedModel:
     """
     Returns a Peft model object from a model and a config.

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -53,6 +53,7 @@ from .tuners import (
 )
 from .utils import _prepare_prompt_learning_config
 
+
 if TYPE_CHECKING:
     from transformers import PreTrainedModel
 
@@ -123,7 +124,8 @@ def get_peft_model(
         mixed (`bool`, `optional`, defaults to `False`):
             Whether to allow mixing different (compatible) adapter types.
         revision (`str`, `optional`, defaults to `None`):
-            The revision of the base model. If this isn't set, the saved peft model will load the `main` revision for the base model
+            The revision of the base model. If this isn't set, the saved peft model will load the `main` revision for
+            the base model
     """
     model_config = getattr(model, "config", {"model_type": "custom"})
     if hasattr(model_config, "to_dict"):

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -51,7 +52,6 @@ from .tuners import (
     PromptTuningConfig,
 )
 from .utils import _prepare_prompt_learning_config
-
 
 if TYPE_CHECKING:
     from transformers import PreTrainedModel
@@ -104,7 +104,11 @@ def get_peft_config(config_dict: dict[str, Any]) -> PeftConfig:
 
 
 def get_peft_model(
-    model: PreTrainedModel, peft_config: PeftConfig, adapter_name: str = "default", mixed: bool = False
+    model: PreTrainedModel,
+    peft_config: PeftConfig,
+    adapter_name: str = "default",
+    mixed: bool = False,
+    revision: str = None,
 ) -> PeftModel | PeftMixedModel:
     """
     Returns a Peft model object from a model and a config.
@@ -118,13 +122,21 @@ def get_peft_model(
             The name of the adapter to be injected, if not provided, the default adapter name is used ("default").
         mixed (`bool`, `optional`, defaults to `False`):
             Whether to allow mixing different (compatible) adapter types.
+        revision (`str`, `optional`, defaults to `None`):
+            The revision of the base model. If this isn't set, the saved peft model will load the `main` revision for the base model
     """
     model_config = getattr(model, "config", {"model_type": "custom"})
     if hasattr(model_config, "to_dict"):
         model_config = model_config.to_dict()
 
     peft_config.base_model_name_or_path = model.__dict__.get("name_or_path", None)
-    peft_config.revision = model.__dict__.get("revision", None)
+
+    if revision is not None:
+        if peft_config.revision is not None:
+            warnings.warn(
+                f"peft config has already set base model revision to {peft_config.revision}, overwriting with revision {revision}"
+            )
+        peft_config.revision = revision
 
     if mixed:
         return PeftMixedModel(model, peft_config, adapter_name=adapter_name)

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -52,7 +52,6 @@ from .tuners import (
 )
 from .utils import _prepare_prompt_learning_config
 
-
 if TYPE_CHECKING:
     from transformers import PreTrainedModel
 
@@ -124,7 +123,7 @@ def get_peft_model(
         model_config = model_config.to_dict()
 
     peft_config.base_model_name_or_path = model.__dict__.get("name_or_path", None)
-    peft_config.base_model_revision = model.__dict__.get("revision", None)
+    peft_config.revision = model.__dict__.get("revision", None)
 
     if mixed:
         return PeftMixedModel(model, peft_config, adapter_name=adapter_name)

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -134,7 +134,7 @@ def get_peft_model(
     peft_config.base_model_name_or_path = model.__dict__.get("name_or_path", None)
 
     if revision is not None:
-        if peft_config.revision is not None:
+        if peft_config.revision is not None and peft_config.revision != revision:
             warnings.warn(
                 f"peft config has already set base model revision to {peft_config.revision}, overwriting with revision {revision}"
             )

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
@@ -52,7 +52,6 @@ from .tuners import (
     PromptTuningConfig,
 )
 from .utils import _prepare_prompt_learning_config
-
 
 if TYPE_CHECKING:
     from transformers import PreTrainedModel
@@ -109,7 +108,7 @@ def get_peft_model(
     peft_config: PeftConfig,
     adapter_name: str = "default",
     mixed: bool = False,
-    revision: str = None,
+    revision: Optional[str] = "main",
 ) -> PeftModel | PeftMixedModel:
     """
     Returns a Peft model object from a model and a config.
@@ -123,7 +122,7 @@ def get_peft_model(
             The name of the adapter to be injected, if not provided, the default adapter name is used ("default").
         mixed (`bool`, `optional`, defaults to `False`):
             Whether to allow mixing different (compatible) adapter types.
-        revision (`str`, `optional`, defaults to `None`):
+        revision (`str`, `optional`, defaults to `main`):
             The revision of the base model. If this isn't set, the saved peft model will load the `main` revision for
             the base model
     """

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -53,6 +53,7 @@ from .tuners import (
 )
 from .utils import _prepare_prompt_learning_config
 
+
 if TYPE_CHECKING:
     from transformers import PreTrainedModel
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -71,7 +71,6 @@ from .utils import (
     shift_tokens_right,
 )
 
-
 PEFT_TYPE_TO_MODEL_MAPPING = {
     PeftType.LORA: LoraModel,
     PeftType.LOHA: LoHaModel,
@@ -264,8 +263,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     if peft_config.is_prompt_learning
                     else self.base_model.model.__dict__.get("name_or_path", None)
                 )
-            if peft_config.base_model_revision is None:
-                peft_config.base_model_revision = (
+            if peft_config.revision is None:
+                peft_config.revision = (
                     self.base_model.__dict__.get("revision", None)
                     if peft_config.is_prompt_learning
                     else self.base_model.model.__dict__.get("revision", None)

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -71,7 +71,6 @@ from .utils import (
     shift_tokens_right,
 )
 
-
 PEFT_TYPE_TO_MODEL_MAPPING = {
     PeftType.LORA: LoraModel,
     PeftType.LOHA: LoHaModel,
@@ -263,12 +262,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     self.base_model.__dict__.get("name_or_path", None)
                     if peft_config.is_prompt_learning
                     else self.base_model.model.__dict__.get("name_or_path", None)
-                )
-            if peft_config.revision is None:
-                peft_config.revision = (
-                    self.base_model.__dict__.get("revision", None)
-                    if peft_config.is_prompt_learning
-                    else self.base_model.model.__dict__.get("revision", None)
                 )
             inference_mode = peft_config.inference_mode
             peft_config.inference_mode = True

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -71,6 +71,7 @@ from .utils import (
     shift_tokens_right,
 )
 
+
 PEFT_TYPE_TO_MODEL_MAPPING = {
     PeftType.LORA: LoraModel,
     PeftType.LOHA: LoHaModel,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -264,6 +264,12 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     if peft_config.is_prompt_learning
                     else self.base_model.model.__dict__.get("name_or_path", None)
                 )
+            if peft_config.base_model_revision is None:
+                peft_config.base_model_revision = (
+                    self.base_model.__dict__.get("revision", None)
+                    if peft_config.is_prompt_learning
+                    else self.base_model.model.__dict__.get("revision", None)
+                )
             inference_mode = peft_config.inference_mode
             peft_config.inference_mode = True
 

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 import unittest
 
+import torch
 from transformers import AutoModelForCausalLM
 
-from peft import PeftConfig, PeftModel
-
+from peft import AutoPeftModelForCausalLM, LoraConfig, PeftConfig, PeftModel, get_peft_model
 
 PEFT_MODELS_TO_TEST = [("peft-internal-testing/test-lora-subfolder", "test")]
+
+BASE_REVISION_MODELS_TO_TEST = [("peft-internal-testing/tiny-random-BertModel", "v2.0.0")]
 
 
 class PeftHubFeaturesTester(unittest.TestCase):
@@ -35,3 +37,34 @@ class PeftHubFeaturesTester(unittest.TestCase):
             model = PeftModel.from_pretrained(model, model_id, subfolder=subfolder)
 
             assert isinstance(model, PeftModel)
+
+
+class TestBaseModelRevision:
+    def test_save_and_load_base_model_revision(self, tmp_path):
+        r"""
+        Test if subfolder argument works as expected
+        """
+        lora_config = LoraConfig(r=8, lora_alpha=16, lora_dropout=0.0, init_lora_weights=False)
+        test_inputs = torch.arange(10).reshape(-1, 1)
+
+        for model_id, revision in BASE_REVISION_MODELS_TO_TEST:
+            original_base_model = AutoModelForCausalLM.from_pretrained(model_id, revision="main").eval()
+            original_peft_model = get_peft_model(original_base_model, lora_config)
+            original_peft_sum = original_peft_model(test_inputs).logits.sum()
+
+            revised_base_model = AutoModelForCausalLM.from_pretrained(model_id, revision=revision).eval()
+            revised_peft_model = get_peft_model(revised_base_model, lora_config)
+            revised_peft_sum = revised_peft_model(test_inputs).logits.sum()
+
+            assert not torch.eq(
+                original_peft_sum, revised_peft_sum
+            ), f"revision 'main' and {revision} of base model {model_id} must differ"
+
+            revised_peft_model.save_pretrained(tmp_path / f"base_{revision}_model")
+
+            reload_revised_peft_model = AutoPeftModelForCausalLM.from_pretrained(
+                tmp_path / f"base_{revision}_model"
+            ).eval()
+            reload_revised_sum = reload_revised_peft_model(test_inputs).logits.sum()
+
+            assert torch.eq(reload_revised_sum, reload_revised_sum)

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -59,6 +59,7 @@ class TestBaseModelRevision:
         base_model_no_revision = AutoModelForCausalLM.from_pretrained(base_model_id, revision="main").eval()
         # we need a copy of the config because otherwise, we are changing in-place the `revision` of the previous config and model
         lora_config_no_revision = copy.deepcopy(lora_config)
+        lora_config_no_revision.revision = "main"
         peft_model_no_revision = get_peft_model(base_model_no_revision, lora_config_no_revision, revision="main")
         output_no_revision = peft_model_no_revision(test_inputs).logits
         assert not torch.allclose(output_no_revision, output_revision)

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -19,6 +19,7 @@ from transformers import AutoModelForCausalLM
 
 from peft import AutoPeftModelForCausalLM, LoraConfig, PeftConfig, PeftModel, get_peft_model
 
+
 PEFT_MODELS_TO_TEST = [("peft-internal-testing/test-lora-subfolder", "test")]
 
 

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -18,6 +18,7 @@ from transformers import AutoModelForCausalLM
 
 from peft import AutoPeftModelForCausalLM, LoraConfig, PeftConfig, PeftModel, get_peft_model
 
+
 PEFT_MODELS_TO_TEST = [("peft-internal-testing/test-lora-subfolder", "test")]
 
 BASE_REVISION_MODELS_TO_TEST = [("peft-internal-testing/tiny-random-BertModel", "v2.0.0")]

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -18,10 +18,7 @@ from transformers import AutoModelForCausalLM
 
 from peft import AutoPeftModelForCausalLM, LoraConfig, PeftConfig, PeftModel, get_peft_model
 
-
 PEFT_MODELS_TO_TEST = [("peft-internal-testing/test-lora-subfolder", "test")]
-
-BASE_REVISION_MODELS_TO_TEST = [("peft-internal-testing/tiny-random-BertModel", "v2.0.0")]
 
 
 class PeftHubFeaturesTester(unittest.TestCase):
@@ -45,27 +42,30 @@ class TestBaseModelRevision:
         r"""
         Test if subfolder argument works as expected
         """
-        lora_config = LoraConfig(r=8, lora_alpha=16, lora_dropout=0.0, init_lora_weights=False)
+        lora_config = LoraConfig(r=8, lora_alpha=16, lora_dropout=0.0)
         test_inputs = torch.arange(10).reshape(-1, 1)
 
-        for model_id, revision in BASE_REVISION_MODELS_TO_TEST:
-            original_base_model = AutoModelForCausalLM.from_pretrained(model_id, revision="main").eval()
-            original_peft_model = get_peft_model(original_base_model, lora_config)
-            original_peft_sum = original_peft_model(test_inputs).logits.sum()
+        base_model_id = "peft-internal-testing/tiny-random-BertModel"
+        base_model_revision = "v2.0.0"
 
-            revised_base_model = AutoModelForCausalLM.from_pretrained(model_id, revision=revision).eval()
-            revised_peft_model = get_peft_model(revised_base_model, lora_config)
-            revised_peft_sum = revised_peft_model(test_inputs).logits.sum()
+        base_model_revision = AutoModelForCausalLM.from_pretrained(base_model_id, revision=base_model_revision).eval()
+        peft_model_revision = get_peft_model(base_model_revision, lora_config)
+        output_revision = peft_model_revision(test_inputs).logits
 
-            assert not torch.eq(
-                original_peft_sum, revised_peft_sum
-            ), f"revision 'main' and {revision} of base model {model_id} must differ"
+        # sanity check: the model without revision should be different
+        base_model_no_revision = AutoModelForCausalLM.from_pretrained(base_model_id, revision="main").eval()
+        peft_model_no_revision = get_peft_model(base_model_no_revision, lora_config)
+        output_no_revision = peft_model_no_revision(test_inputs).logits
+        assert not torch.allclose(output_no_revision, output_revision)
 
-            revised_peft_model.save_pretrained(tmp_path / f"base_{revision}_model")
+        # check that if we save and load the model, the output corresponds to the one with revision
+        peft_model_revision.save_pretrained(tmp_path / "peft_model_revision")
+        peft_model_revision_loaded = AutoPeftModelForCausalLM.from_pretrained(tmp_path / "peft_model_revision").eval()
 
-            reload_revised_peft_model = AutoPeftModelForCausalLM.from_pretrained(
-                tmp_path / f"base_{revision}_model"
-            ).eval()
-            reload_revised_sum = reload_revised_peft_model(test_inputs).logits.sum()
+        import pdb
 
-            assert torch.eq(reload_revised_sum, reload_revised_sum)
+        pdb.set_trace()
+        assert peft_model_revision_loaded.peft_config["default"].revision == base_model_revision
+
+        output_revision_loaded = peft_model_revision_loaded(test_inputs).logits
+        assert torch.allclose(output_revision, output_revision_loaded)

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -42,7 +42,8 @@ class PeftHubFeaturesTester(unittest.TestCase):
 class TestBaseModelRevision:
     def test_save_and_load_base_model_revision(self, tmp_path):
         r"""
-        Test if subfolder argument works as expected
+        Test saving a PeftModel with a base model revision and loading with AutoPeftModel to recover the same base
+        model
         """
         lora_config = LoraConfig(r=8, lora_alpha=16, lora_dropout=0.0)
         test_inputs = torch.arange(10).reshape(-1, 1)
@@ -70,3 +71,17 @@ class TestBaseModelRevision:
 
         output_revision_loaded = peft_model_revision_loaded(test_inputs).logits
         assert torch.allclose(output_revision, output_revision_loaded)
+
+    def test_load_different_peft_and_base_model_revision(self, tmp_path):
+        r"""
+        Test loading an AutoPeftModel from the hub where the base model revision and peft revision differ
+        """
+        base_model_id = "hf-internal-testing/tiny-random-BertModel"
+        base_model_revision = None
+        peft_model_id = "peft-internal-testing/tiny-random-BertModel-lora"
+        peft_model_revision = "v1.2.3"
+
+        peft_model = AutoPeftModelForCausalLM.from_pretrained(peft_model_id, revision=peft_model_revision).eval()
+
+        assert peft_model.peft_config["default"].base_model_name_or_path == base_model_id
+        assert peft_model.peft_config["default"].revision == base_model_revision

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -15,6 +15,7 @@
 import pytest
 import torch
 from torch import nn
+from transformers import AutoModelForCausalLM
 
 from peft import LoraConfig, get_peft_model
 
@@ -73,3 +74,15 @@ def test_modules_to_save_targets_module_dict_raises(cls):
     msg = "modules_to_save cannot be applied to modules of type"
     with pytest.raises(TypeError, match=msg):
         get_peft_model(model=model, peft_config=peft_config)
+
+
+def test_get_peft_model_revision_warning(tmp_path):
+    base_model_id = "peft-internal-testing/tiny-random-BertModel"
+    base_revision = "v2.0.0"
+    base_model = AutoModelForCausalLM.from_pretrained(base_model_id, revision=base_revision).eval()
+    lora_config = LoraConfig(revision=base_revision)
+
+    overwrite_revision = "main"
+    overwrite_warning = f"peft config has already set base model revision to {base_revision}, overwriting with revision {overwrite_revision}"
+    with pytest.warns(UserWarning, match=overwrite_warning):
+        _ = get_peft_model(base_model, lora_config, revision=overwrite_revision)


### PR DESCRIPTION
addresses #1567 

changed name of parameter from `revision` to `base_model_revision` for clarity

can add unit tests if someone gives pointers to similar ones to extend
may need to add a model to `hf-internal-testing` with a base model with revision for these unit tests