### PR TITLE
FEAT Show adapter layer and model status

### DIFF
--- a/docs/source/developer_guides/troubleshooting.md
+++ b/docs/source/developer_guides/troubleshooting.md
@@ -156,12 +156,14 @@ The [`~peft.PeftModel.get_layer_status`] method gives you a detailed overview of
                   enabled=True,
                   active_adapters=['default'],
                   merged_adapters=[],
+                  requires_grad={'default': True},
                   available_adapters=['default']),
  TunerLayerStatus(name='model.encoder.block.0.layer.0.SelfAttention.v',
                   module_type='lora.Linear',
                   enabled=True,
                   active_adapters=['default'],
                   merged_adapters=[],
+                  requires_grad={'default': True},
                   available_adapters=['default']),
 ...]
 
@@ -176,6 +178,7 @@ TunerModelStatus(
     enabled=True,
     active_adapters=['default'],
     merged_adapters=[],
+    requires_grad={'default': True},
     available_adapters=['default'],
 )
 ```

--- a/docs/source/developer_guides/troubleshooting.md
+++ b/docs/source/developer_guides/troubleshooting.md
@@ -136,9 +136,11 @@ For inference, load the base model first and resize it the same way you did befo
 
 For a complete example, please check out [this notebook](https://github.com/huggingface/peft/blob/main/examples/causal_language_modeling/peft_lora_clm_with_additional_tokens.ipynb).
 
-### Investigating the status of the PEFT model
+### Check layer and model status
 
-Sometimes, the PEFT model can end up in a bad state, especially when handling multiple adapters. There can be some confusion around what adapters exist, which one is active, which one is merged, etc. To help investigate this issue, you can call the [`~peft.PeftModel.get_layer_status`] and the [`~peft.PeftModel.get_model_status`] methods. The first one gives you a detailed overview about the adapters for each targeted layer. The latter one gives you a high-level overview about the model status.
+Sometimes a PEFT model can end up in a bad state, especially when handling multiple adapters. There can be some confusion around what adapters exist, which one is active, which one is merged, etc. To help investigate this issue, call the [`~peft.PeftModel.get_layer_status`] and the [`~peft.PeftModel.get_model_status`] methods. 
+
+The [`~peft.PeftModel.get_layer_status`] method gives you a detailed overview of each targeted layer's active, merged, and available adapters.
 
 ```python
 >>> from transformers import AutoModel
@@ -178,11 +180,11 @@ TunerModelStatus(
 )
 ```
 
-In the model state output, you should look out especially for entries that say `"irregular"`. This means that PEFT has detected an inconsistent state in the model. For instance, when it says `merged_adapters="irregular"`, it means that for at least one adapter, it was found that it was merged on some target modules but not on others that it targets. If you see this, the inference results will most likely be incorrect.
+In the model state output, you should look out for entries that say `"irregular"`. This means PEFT detected an inconsistent state in the model. For instance, if `merged_adapters="irregular"`, it means that for at least one adapter, it was merged on some target modules but not on others. The inference results will most likely be incorrect as a result.
 
-The best way to resolve this issue is to reload the whole model and the adapter checkpoint(s). Ensure that you don't perform any incorrect operations on the model, e.g. manually merging adapters on some modules but not others.
+The best way to resolve this issue is to reload the whole model and adapter checkpoint(s). Ensure that you don't perform any incorrect operations on the model, e.g. manually merging adapters on some modules but not others.
 
-Tip: You can easily convert the layer status into a pandas `DataFrame` for easier inspection:
+Convert the layer status into a pandas `DataFrame` for an easier visual inspection.
 
 ```python
 from dataclasses import asdict

--- a/docs/source/developer_guides/troubleshooting.md
+++ b/docs/source/developer_guides/troubleshooting.md
@@ -181,3 +181,12 @@ TunerModelStatus(
 In the model state output, you should look out especially for entries that say `"irregular"`. This means that PEFT has detected an inconsistent state in the model. For instance, when it says `merged_adapters="irregular"`, it means that for at least one adapter, it was found that it was merged on some target modules but not on others that it targets. If you see this, the inference results will most likely be incorrect.
 
 The best way to resolve this issue is to reload the whole model and the adapter checkpoint(s). Ensure that you don't perform any incorrect operations on the model, e.g. manually merging adapters on some modules but not others.
+
+Tip: You can easily convert the layer status into a pandas `DataFrame` for easier inspection:
+
+```python
+from dataclasses import asdict
+import pandas as pd
+
+df = pd.DataFrame(asdict(layer) for layer in model.get_layer_status())
+```

--- a/docs/source/package_reference/peft_model.md
+++ b/docs/source/package_reference/peft_model.md
@@ -71,3 +71,7 @@ A `PeftModel` for mixing different adapter types (e.g. LoRA and LoHa).
 [[autodoc]] utils.get_peft_model_state_dict
 
 [[autodoc]] utils.prepare_model_for_kbit_training
+
+[[autodoc]] get_layer_status
+
+[[autodoc]] get_model_status

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -44,6 +44,8 @@ from .peft_model import (
     PeftModelForTokenClassification,
     PeftModelForQuestionAnswering,
     PeftModelForFeatureExtraction,
+    get_layer_status,
+    get_model_status,
 )
 from .tuners import (
     AdaptionPromptConfig,

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -311,6 +311,12 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
         """
         return self.base_model.unload(*args, **kwargs)
 
+    def get_layer_status(self):
+        raise TypeError(f"get_layer_status is not supported for {self.__class__.__name__}.")
+
+    def get_model_status(self):
+        raise TypeError(f"get_model_status is not supported for {self.__class__.__name__}.")
+
     @classmethod
     def _split_kwargs(cls, kwargs: dict[str, Any]):
         return PeftModel._split_kwargs(kwargs)

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2353,7 +2353,7 @@ def get_layer_status(model: torch.nn.Module) -> list[TunerLayerStatus]:
        The names of the available adapters, e.g. `["default"]`.
 
     Args:
-        model ([`~PeftModel`]):
+        model ([Union[`~PeftModel`, `nn.Module`]]):
             The model to get the adapter layer status from.
 
     Returns:
@@ -2412,7 +2412,7 @@ def get_layer_status(model: torch.nn.Module) -> list[TunerLayerStatus]:
         layer_status.append(status)
 
     if not layer_status:
-        raise ValueError("No adapter layers found in the model, please ensure that it's a PEFT model")
+        raise ValueError("No adapter layers found in the model, please ensure that it's a PEFT model or that you have PEFT adapters injected in the model")
 
     return layer_status
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2425,10 +2425,10 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
             A dataclass containing the status of the model.
 
     """
-    if not isinstance(model, PeftModel):
+    if not isinstance(model, PeftModel) or not isinstance(model.base_model, BaseTuner):
         raise TypeError(
             "get_model_status() expects a PeftModel instance; you can get this e.g. by calling `get_peft_model` "
-            "or `PeftModel.from_pretrained()`."
+            "or `PeftModel.from_pretrained()`; prefix tuning is not supported."
         )
 
     base_model_type = model.get_base_model().__class__.__name__

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2353,7 +2353,7 @@ def get_layer_status(model: torch.nn.Module) -> list[TunerLayerStatus]:
        The names of the available adapters, e.g. `["default"]`.
 
     Args:
-        model ([Union[`~PeftModel`, `nn.Module`]]):
+        model ([Union[`~PeftModel`, `~transformers.PreTrainedModel`, `nn.Module`]]):
             The model to get the adapter layer status from.
 
     Returns:
@@ -2469,7 +2469,7 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
        The names of the available adapters, e.g. `["default"]`.
 
     Args:
-        model ([Union[`~PeftModel`, `nn.Module`]]):
+        model ([Union[`~PeftModel`, `~transformers.PreTrainedModel`, `nn.Module`]]):
             The model to get the adapter layer status from.
 
     Returns:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2412,7 +2412,10 @@ def get_layer_status(model: torch.nn.Module) -> list[TunerLayerStatus]:
         layer_status.append(status)
 
     if not layer_status:
-        raise ValueError("No adapter layers found in the model, please ensure that it's a PEFT model or that you have PEFT adapters injected in the model")
+        raise ValueError(
+            "No adapter layers found in the model, please ensure that it's a PEFT model or that you have PEFT adapters "
+            "injected in the model."
+        )
 
     return layer_status
 
@@ -2466,7 +2469,7 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
        The names of the available adapters, e.g. `["default"]`.
 
     Args:
-        model ([`~PeftModel`]):
+        model ([Union[`~PeftModel`, `nn.Module`]]):
             The model to get the adapter layer status from.
 
     Returns:
@@ -2492,10 +2495,11 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
         peft_types = {}
         adapter_model_type = "None"
     else:
-        raise TypeError(
-            f"get_model_status() expects a PeftModel or a PreTrainedModel instance; got {model.__class__.__name__} "
-            "instead."
-        )
+        base_model_type = "other"
+        trainable_params, total_params = PeftModel.get_nb_trainable_parameters(model)
+        base_model = model
+        peft_types = {}
+        adapter_model_type = "None"
 
     layer_status = get_layer_status(model)
     num_adapter_layers = len(layer_status)

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -976,6 +976,66 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         assert model.base_model.active_adapter == ["default", "other"]
 
     @parameterized.expand(TEST_CASES)
+    def test_disable_adapters_exiting_context_restores_previous_state(
+        self, test_name, model_id, config_cls, config_kwargs
+    ):
+        # Test that when we exit the disable_adapter context, we correctly restore the enabled state of the modules as
+        # they were before the context.
+        model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config)
+        tuner_modules = [module for module in model.modules() if isinstance(module, BaseTunerLayer)]
+
+        # all layers should be enabled
+        assert all(not module.disable_adapters for module in tuner_modules)
+        with model.disable_adapter():
+            pass
+        # this should not change after exiting the context
+        assert all(not module.disable_adapters for module in tuner_modules)
+
+        # now disable all layers
+        model.disable_adapter_layers()
+        assert all(module.disable_adapters for module in tuner_modules)
+        with model.disable_adapter():
+            pass
+        assert all(module.disable_adapters for module in tuner_modules)
+
+    @parameterized.expand(TEST_CASES)
+    def test_disable_adapters_exiting_context_irregular_state(self, test_name, model_id, config_cls, config_kwargs):
+        # When we have a model where some adapters are enabled and others are disabled, we should get a warning when
+        # entering the disable_adapter context because we cannot correctly restore the state of the adapters from
+        # before the context. After exiting the context, all adapters will be enabled, which is the status quo of how
+        # we deal with this.
+        model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config)
+        tuner_modules = [module for module in model.modules() if isinstance(module, BaseTunerLayer)]
+
+        # now we mix the states, some enabled some not
+        if len(tuner_modules) < 2:
+            # next check only works with more than 1 tuner module
+            return
+
+        # disable a single layer
+        tuner_modules[0].enable_adapters(False)
+        # sanity check that we have both enabled and disabled layers
+        assert {module.disable_adapters for module in tuner_modules} == {True, False}
+        # check that we get a warning with irregular states
+        msg = "The model contains some adapter layers that are enabled and others that are disabled"
+        with self.assertWarnsRegex(UserWarning, expected_regex=msg):
+            with model.disable_adapter():
+                pass
+
+        # when encountering irregular adapters, we enable all adapters at the end of the context
+        assert all(not module.disable_adapters for module in tuner_modules)
+
+    @parameterized.expand(TEST_CASES)
     def test_delete_adapter(self, test_name, model_id, config_cls, config_kwargs):
         self._test_delete_adapter(model_id, config_cls, config_kwargs)
 

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -383,6 +383,7 @@ class TestModelAndLayerStatus:
     corresponding features like merging).
 
     """
+
     @pytest.fixture
     def small_model(self):
         class SmallModel(nn.Module):
@@ -559,11 +560,11 @@ class TestModelAndLayerStatus:
 
     def test_peft_types_small(self, small_model):
         model_status = small_model.get_model_status()
-        assert model_status.peft_types == {'default': 'LORA'}
+        assert model_status.peft_types == {"default": "LORA"}
 
     def test_peft_types_large(self, large_model):
         model_status = large_model.get_model_status()
-        assert model_status.peft_types == {'default': 'LORA', "other": "LORA"}
+        assert model_status.peft_types == {"default": "LORA", "other": "LORA"}
 
     def test_nb_params_small(self, small_model):
         model_status = small_model.get_model_status()

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -24,7 +24,7 @@ from parameterized import parameterized
 from torch import nn
 from transformers import AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM, BitsAndBytesConfig
 
-from peft import IA3Config, LoHaConfig, LoraConfig, PromptTuningConfig, get_peft_model
+from peft import AdaptionPromptConfig, IA3Config, LoHaConfig, LoraConfig, PromptTuningConfig, get_peft_model
 from peft.tuners.tuners_utils import (
     BaseTunerLayer,
     _maybe_include_all_linear_layers,
@@ -694,6 +694,19 @@ class TestModelAndLayerStatus:
         config = PromptTuningConfig(task_type="SEQ_2_SEQ_LM", num_virtual_tokens=10)
         model = get_peft_model(model, config)
 
+        # note: full error message is longer
+        with pytest.raises(TypeError, match=re.escape("get_layer_status() expects a PeftModel instance")):
+            model.get_layer_status()
+
+        with pytest.raises(TypeError, match=re.escape("get_model_status() expects a PeftModel instance")):
+            model.get_model_status()
+
+    def test_adaption_prompt(self):
+        model = AutoModelForCausalLM.from_pretrained("HuggingFaceH4/tiny-random-LlamaForCausalLM")
+        config = AdaptionPromptConfig(adapter_layers=1, adapter_len=4)
+        model = get_peft_model(model, config)
+
+        # note: full error message is longer
         with pytest.raises(TypeError, match=re.escape("get_layer_status() expects a PeftModel instance")):
             model.get_layer_status()
 
@@ -722,6 +735,7 @@ class TestModelAndLayerStatus:
         model = get_peft_model(base_model, config0, adapter_name="adapter0", mixed="mixed")
         model.add_adapter("adapter1", config1)
 
+        # note: full error message is longer
         with pytest.raises(TypeError, match="get_layer_status is not supported for PeftMixedModel"):
             model.get_layer_status()
 


### PR DESCRIPTION
This PR adds a new feature to PEFT models that allows to better understand the status of adapter(s) on the model. Quoting from the doc entry that I added:

> Sometimes, the PEFT model can end up in a bad state, especially when handling multiple adapters. There can be some confusion around what adapters exist, which one is active, which one is merged, etc. To help investigate this issue, you can call the `peft.PeftModel.get_layer_status` and the `peft.PeftModel.get_model_status` methods. The first one gives you a detailed overview about the adapters for each targeted layer. The latter one gives you a high-level overview about the model status.

**Example PEFT**:

```python
>>> from transformers import AutoModel
>>> from peft import get_peft_model, LoraConfig

>>> model_id = "google/flan-t5-small"
>>> model = AutoModel.from_pretrained(model_id)
>>> model = get_peft_model(model, LoraConfig())

>>> model.get_layer_status()
[TunerLayerStatus(name='model.encoder.block.0.layer.0.SelfAttention.q',
                  module_type='lora.Linear',
                  enabled=True,
                  active_adapters=['default'],
                  merged_adapters=[],
                  requires_grad={'default': True},
                  available_adapters=['default']),
 TunerLayerStatus(name='model.encoder.block.0.layer.0.SelfAttention.v',
                  module_type='lora.Linear',
                  enabled=True,
                  active_adapters=['default'],
                  merged_adapters=[],
                  requires_grad={'default': True},
                  available_adapters=['default']),
...]

>>> model.get_model_status()
TunerModelStatus(
    base_model_type='T5Model',
    adapter_model_type='LoraModel',
    peft_types={'default': 'LORA'},
    trainable_params=344064,
    total_params=60855680,
    num_adapter_layers=48,
    enabled=True,
    active_adapters=['default'],
    merged_adapters=[],
    available_adapters=['default'],
)

>>> model.add_adapter("other", LoraConfig())
>>> model.merge_adapter(["default"])
>>> model.get_model_status()
TunerModelStatus(
    base_model_type='T5Model',
    adapter_model_type='LoraModel',
    peft_types={'default': 'LORA', 'other': 'LORA'},
    trainable_params=344064,
    total_params=61199744,
    num_adapter_layers=48,
    enabled=True,
    active_adapters=['default'],
    merged_adapters=['default'],
    requires_grad={'default': True},
    available_adapters=['default', 'other'],
)
```

**Example transformers:**

This also works when loading a transformers model with PEFT adapters injected directly. However, that requires importing the "private" `get_model_status`  and `get_layer_status` functions:

```python
>>> from transformers import AutoModelForCausalLM
>>> from peft.peft_model import get_model_status, get_layer_status

>>> peft_model_id = "ybelkada/opt-350m-lora"
>>> model = AutoModelForCausalLM.from_pretrained(peft_model_id)
>>> get_layer_status(model)
[TunerLayerStatus(name='model.decoder.layers.0.self_attn.v_proj',
                  module_type='lora.Linear',
                  enabled=True,
                  active_adapters=['default'],
                  merged_adapters=[],
                  requires_grad={'default': False},
                  available_adapters=['default']),
 TunerLayerStatus(name='model.decoder.layers.0.self_attn.q_proj',
                  module_type='lora.Linear',
                  enabled=True,
                  active_adapters=['default'],
                  merged_adapters=[],
                  requires_grad={'default': False},
                  available_adapters=['default']),
...]
>>> get_model_status(model)
TunerModelStatus(
    base_model_type='OPTForCausalLM',
    adapter_model_type='None',
    peft_types={},
    trainable_params=0,
    total_params=332769280,
    num_adapter_layers=48,
    enabled=True,
    active_adapters=['default'],
    merged_adapters=[],
    requires_grad={'default': False},
    available_adapters=['default'],
)
```

Maybe if we find this useful enough, we can make these functions "public".

**Also changed in this PR**:

- Fix a bug that when adapters where disabled, when entering and exiting  the `disable_adapter` context, suddenly all these adapters are enabled. This is a changing behavior and should be highlighted in the next release notes. Fixing this bug was the initial motivation that led me to work on this this feature.
- Add a warning when using the `disable_adapter` context and having irregular activation of adapters, as the correct status cannot be restored (but behavior stays the same as currently).
- Add abstract methods for `disable_adapter_layers` and `enable_adapter_layers` (those are required for subclasses)
- Add a check in `check_adapters_to_merge` for `str`.
- Fix a bug when adding a 2nd adapter that targets different layers than the existing adapter, resulting in those layers being active. As an example, say I create the "default" LoRA adapter and it targets layers 0 and 1. Then I call `add_adapter("other", config2)` targeting layers 1 and 2. The "other" adapter should be inactive. This is true for layer 1, where both "default" and "other" exist, but for layer 2, where only "other" exists, it would currently be active. With the fix, it will be inactive.
