### PR TITLE
Apply deprecated `evaluation_strategy`

### DIFF
--- a/docs/source/accelerate/deepspeed.md
+++ b/docs/source/accelerate/deepspeed.md
@@ -96,7 +96,7 @@ accelerate launch --config_file "configs/deepspeed_config.yaml"  train.py \
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \
@@ -219,7 +219,7 @@ accelerate launch --config_file "configs/deepspeed_config_z3_qlora.yaml"  train.
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \

--- a/docs/source/accelerate/fsdp.md
+++ b/docs/source/accelerate/fsdp.md
@@ -74,7 +74,7 @@ accelerate launch --config_file "configs/fsdp_config.yaml"  train.py \
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \
@@ -218,7 +218,7 @@ accelerate launch --config_file "configs/fsdp_config_qlora.yaml"  train.py \
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \

--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -76,7 +76,7 @@ training_args = TrainingArguments(
     per_device_eval_batch_size=32,
     num_train_epochs=2,
     weight_decay=0.01,
-    evaluation_strategy="epoch",
+    eval_strategy="epoch",
     save_strategy="epoch",
     load_best_model_at_end=True,
 )

--- a/docs/source/task_guides/lora_based_methods.md
+++ b/docs/source/task_guides/lora_based_methods.md
@@ -257,7 +257,7 @@ batch_size = 128
 args = TrainingArguments(
     peft_model_id,
     remove_unused_columns=False,
-    evaluation_strategy="epoch",
+    eval_strategy="epoch",
     save_strategy="epoch",
     learning_rate=5e-3,
     per_device_train_batch_size=batch_size,

--- a/examples/conditional_generation/peft_prompt_tuning_seq2seq_with_generate.ipynb
+++ b/examples/conditional_generation/peft_prompt_tuning_seq2seq_with_generate.ipynb
@@ -558,7 +558,7 @@
     "    per_device_train_batch_size=batch_size,\n",
     "    learning_rate=lr,\n",
     "    num_train_epochs=num_epochs,\n",
-    "    evaluation_strategy=\"epoch\",\n",
+    "    eval_strategy=\"epoch\",\n",
     "    logging_strategy=\"epoch\",\n",
     "    save_strategy=\"no\",\n",
     "    report_to=[],\n",

--- a/examples/image_classification/image_classification_peft_lora.ipynb
+++ b/examples/image_classification/image_classification_peft_lora.ipynb
@@ -1008,7 +1008,7 @@
     "args = TrainingArguments(\n",
     "    f\"{model_name}-finetuned-lora-food101\",\n",
     "    remove_unused_columns=False,\n",
-    "    evaluation_strategy=\"epoch\",\n",
+    "    eval_strategy=\"epoch\",\n",
     "    save_strategy=\"epoch\",\n",
     "    learning_rate=5e-3,\n",
     "    per_device_train_batch_size=batch_size,\n",

--- a/examples/int8_training/Finetune_flan_t5_large_bnb_peft.ipynb
+++ b/examples/int8_training/Finetune_flan_t5_large_bnb_peft.ipynb
@@ -819,7 +819,7 @@
     "\n",
     "training_args = TrainingArguments(\n",
     "    \"temp\",\n",
-    "    evaluation_strategy=\"epoch\",\n",
+    "    eval_strategy=\"epoch\",\n",
     "    learning_rate=1e-3,\n",
     "    gradient_accumulation_steps=1,\n",
     "    auto_find_batch_size=True,\n",

--- a/examples/int8_training/peft_bnb_whisper_large_v2_training.ipynb
+++ b/examples/int8_training/peft_bnb_whisper_large_v2_training.ipynb
@@ -1246,7 +1246,7 @@
     "    learning_rate=1e-3,\n",
     "    warmup_steps=50,\n",
     "    num_train_epochs=3,\n",
-    "    evaluation_strategy=\"epoch\",\n",
+    "    eval_strategy=\"epoch\",\n",
     "    fp16=True,\n",
     "    per_device_eval_batch_size=8,\n",
     "    generation_max_length=128,\n",

--- a/examples/poly/peft_poly_seq2seq_with_generate.ipynb
+++ b/examples/poly/peft_poly_seq2seq_with_generate.ipynb
@@ -973,7 +973,7 @@
     "    per_device_eval_batch_size=batch_size,\n",
     "    learning_rate=lr,\n",
     "    num_train_epochs=num_epochs,\n",
-    "    evaluation_strategy=\"epoch\",\n",
+    "    eval_strategy=\"epoch\",\n",
     "    logging_strategy=\"epoch\",\n",
     "    save_strategy=\"no\",\n",
     "    report_to=[],\n",

--- a/examples/semantic_segmentation/semantic_segmentation_peft_lora.ipynb
+++ b/examples/semantic_segmentation/semantic_segmentation_peft_lora.ipynb
@@ -587,7 +587,7 @@
     "    per_device_train_batch_size=4,\n",
     "    per_device_eval_batch_size=2,\n",
     "    save_total_limit=3,\n",
-    "    evaluation_strategy=\"epoch\",\n",
+    "    eval_strategy=\"epoch\",\n",
     "    save_strategy=\"epoch\",\n",
     "    logging_steps=5,\n",
     "    remove_unused_columns=False,\n",

--- a/examples/sft/run_peft.sh
+++ b/examples/sft/run_peft.sh
@@ -11,7 +11,7 @@ python train.py \
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \

--- a/examples/sft/run_peft_deepspeed.sh
+++ b/examples/sft/run_peft_deepspeed.sh
@@ -11,7 +11,7 @@ accelerate launch --config_file "configs/deepspeed_config.yaml"  train.py \
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \

--- a/examples/sft/run_peft_fsdp.sh
+++ b/examples/sft/run_peft_fsdp.sh
@@ -11,7 +11,7 @@ accelerate launch --config_file "configs/fsdp_config.yaml"  train.py \
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \

--- a/examples/sft/run_peft_multigpu.sh
+++ b/examples/sft/run_peft_multigpu.sh
@@ -11,7 +11,7 @@ torchrun --nproc_per_node 8 --nnodes 1 train.py \
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \

--- a/examples/sft/run_peft_qlora_deepspeed_stage3.sh
+++ b/examples/sft/run_peft_qlora_deepspeed_stage3.sh
@@ -11,7 +11,7 @@ accelerate launch --config_file "configs/deepspeed_config_z3_qlora.yaml"  train.
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \

--- a/examples/sft/run_peft_qlora_fsdp.sh
+++ b/examples/sft/run_peft_qlora_fsdp.sh
@@ -11,7 +11,7 @@ accelerate launch --config_file "configs/fsdp_config_qlora.yaml"  train.py \
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \

--- a/examples/sft/run_unsloth_peft.sh
+++ b/examples/sft/run_unsloth_peft.sh
@@ -11,7 +11,7 @@ python train.py \
 --logging_steps 5 \
 --log_level "info" \
 --logging_strategy "steps" \
---evaluation_strategy "epoch" \
+--eval_strategy "epoch" \
 --save_strategy "epoch" \
 --push_to_hub \
 --hub_private_repo True \


### PR DESCRIPTION
This PR applies the deprecated `evaluation_strategy` from https://github.com/huggingface/transformers/pull/30190.

TL;DR: `evaluation_strategy` -> `eval_strategy`

(Should go live in v4.41.0, but opening now so it's here when ready!)