### PR TITLE
supports learning the combination weights of pre-trained LoRA modules

### DIFF
--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -253,18 +253,23 @@ class LoraConfig(PeftConfig):
         default=None,
         metadata={
             "help": (
-                "This enables using LoRA to effectively expand a transformer model to a larger size by repeating some layers. "
-                "The transformation handles models (currently Llama, Bert or Falcon compatible architectures) with "
-                "a module list in the model which it modifies to expand the number of modules. "
-                "Base weights are shared so the memory usage is close to the original model. The intended use is these base weights "
-                "remain fixed during finetuning but each layer has a separate LoRA adapter so the layers can be specialed via "
-                "the adapter layers fit during fine tuning."
-                "The format is a list of [start, end) pairs which specify the layer ranges to stack. For example:\n"
-                "   Original model has 5 layers labelled by their position in the model: `[0, 1, 2, 3, 4]`\n"
-                "   layer_replication: `[[0, 4], [2, 5]]`\n"
-                "   Final model will have this arrangement of original layers: `[0, 1, 2, 3, 2, 3, 4]`\n"
-                "This format is based on what is used for pass-through merges in mergekit. It makes it simple to select sequential "
-                "ranges of a model and stack them while reusing layers at either end of each sequence."
+                "Enable 'Weight-Decomposed Low-Rank Adaptation' (DoRA). This technique decomposes the updates of the "
+                "weights into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the "
+                "magnitude is handled by a separate learnable parameter. This can improve the performance of LoRA, "
+                "especially at low ranks. Right now, DoRA only supports linear and Conv2D layers. DoRA introduces a bigger"
+                "overhead than pure LoRA, so it is recommended to merge weights for inference. For more information, "
+                "see  https://arxiv.org/abs/2402.09353."
+            )
+        },
+    )
+    use_wlora: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Enable learning the combination weights of pre-trained LoRAs. This technique adds a learnable weight "
+                "to each of the pre-trained LoRA module in each layer to learn the weighted sum of those moduels. "
+                "This can allow to learn the best combination of pre-trained LoRA for few-shot adaptation. Right now,"
+                "WLoRA only supports linear layers. For more information, see https://arxiv.org/abs/2402.15414."
             )
         },
     )

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -147,10 +147,6 @@ class LoraLayer(BaseTunerLayer):
             # add `wlora_weights`` to the list of learnable parameters
             self.adapter_layer_names = self.adapter_layer_names[:] + ("wlora_weights",)
             self.use_wlora[adapter_name] = True
-            # remove `lora_A` and `lora_B` from the list of trainable parameters
-            self.adapter_layer_names = tuple(
-                layer for layer in self.adapter_layer_names if layer != "lora_A" and layer != "lora_B"
-            )
         else:
             self.use_wlora[adapter_name] = False
 

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -193,6 +193,7 @@ class LoraModel(BaseTuner):
             "init_lora_weights": lora_config.init_lora_weights,
             "use_rslora": lora_config.use_rslora,
             "use_dora": lora_config.use_dora,
+            "use_wlora": lora_config.use_wlora,
             "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
             "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
         }
@@ -215,6 +216,7 @@ class LoraModel(BaseTuner):
                 init_lora_weights=lora_config.init_lora_weights,
                 use_rslora=lora_config.use_rslora,
                 use_dora=lora_config.use_dora,
+                use_wlora=lora_config.use_wlora,
             )
         else:
             new_module = self._create_new_module(lora_config, adapter_name, target, **kwargs)

--- a/src/peft/tuners/multitask_prompt_tuning/model.py
+++ b/src/peft/tuners/multitask_prompt_tuning/model.py
@@ -66,11 +66,15 @@ class MultitaskPromptEmbedding(PromptEmbedding):
                     "init method"
                 )
 
-            # TODO: There should be an option for safetensors
-            state_dict: dict = torch.load(
-                config.prompt_tuning_init_state_dict_path,
-                map_location=word_embeddings.weight.device,
-            )
+            if config.prompt_tuning_init_state_dict_path.endswith(".safetensors"):
+                from safetensors.torch import load_file
+
+                state_dict: dict = load_file(config.prompt_tuning_init_state_dict_path)
+            else:
+                state_dict: dict = torch.load(
+                    config.prompt_tuning_init_state_dict_path,
+                    map_location=word_embeddings.weight.device,
+                )
 
         if config.prompt_tuning_init in [
             MultitaskPromptTuningInit.AVERAGE_SOURCE_TASKS,


### PR DESCRIPTION
Based on #1655

Adds a use_wlora config to `LoraLayer` that allows learning the combination weights (i.e. `wlora_weights) of pre-trained LoRAs.