### PR TITLE
FIX Use trl version of tiny random llama

### DIFF
--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -469,7 +469,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     @require_bitsandbytes
     def test_adaption_prompt_8bit(self):
         model = LlamaForCausalLM.from_pretrained(
-            "HuggingFaceM4/tiny-random-LlamaForCausalLM",
+            "trl-internal-testing/tiny-random-LlamaForCausalLM",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             torch_dtype=torch.float16,
             device_map="auto",
@@ -492,7 +492,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     @require_bitsandbytes
     def test_adaption_prompt_4bit(self):
         model = LlamaForCausalLM.from_pretrained(
-            "HuggingFaceM4/tiny-random-LlamaForCausalLM",
+            "trl-internal-testing/tiny-random-LlamaForCausalLM",
             quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             torch_dtype=torch.float16,
             device_map="auto",
@@ -982,7 +982,7 @@ class PeftGPUCommonTests(unittest.TestCase):
             bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
-            "HuggingFaceM4/tiny-random-LlamaForCausalLM",
+            "trl-internal-testing/tiny-random-LlamaForCausalLM",
             quantization_config=bnb_config,
             torch_dtype=torch.float32,
         ).eval()

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -32,7 +32,7 @@ PEFT_DECODER_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-gpt_neo",
     "hf-internal-testing/tiny-random-GPTJForCausalLM",
     "hf-internal-testing/tiny-random-GPTBigCodeForCausalLM",
-    "HuggingFaceM4/tiny-random-LlamaForCausalLM",
+    "trl-internal-testing/tiny-random-LlamaForCausalLM",
 ]
 
 FULL_GRID = {
@@ -340,7 +340,7 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
         self._test_passing_input_embeds_works(test_name, model_id, config_cls, config_kwargs)
 
     def test_lora_layer_replication(self):
-        model_id = "HuggingFaceM4/tiny-random-LlamaForCausalLM"
+        model_id = "trl-internal-testing/tiny-random-LlamaForCausalLM"
         config_kwargs = {
             "target_modules": ["down_proj", "up_proj"],
             "task_type": "CAUSAL_LM",


### PR DESCRIPTION
Using the version from HuggingFaceM4 broke our tests because it was updated. Although the update is reverted, we still better switch to this version, which is explicitly for testing and should be stable.