### PR TITLE
FIX / Workflow: Always notify on slack for docker image workflows

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -46,6 +46,7 @@ jobs:
           tags: huggingface/peft-cpu
 
       - name: Post to a Slack channel
+        if: always()
         id: slack
         #uses: slackapi/slack-github-action@v1.25.0
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001
@@ -102,6 +103,7 @@ jobs:
           tags: huggingface/peft-gpu
 
       - name: Post to a Slack channel
+        if: always()
         id: slack
         #uses: slackapi/slack-github-action@v1.25.0
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001
@@ -159,6 +161,7 @@ jobs:
 
 
       - name: Post to a Slack channel
+        if: always()
         id: slack
         #uses: slackapi/slack-github-action@v1.25.0
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001
@@ -216,6 +219,7 @@ jobs:
           tags: huggingface/peft-gpu-bnb-latest
 
       - name: Post to a Slack channel
+        if: always()
         id: slack
         #uses: slackapi/slack-github-action@v1.25.0
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001
@@ -272,6 +276,7 @@ jobs:
           tags: huggingface/peft-gpu-bnb-multi-source
 
       - name: Post to a Slack channel
+        if: always()
         id: slack
         #uses: slackapi/slack-github-action@v1.25.0
         uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001


### PR DESCRIPTION
# What does this PR do?

As per title, we were not posting on slack when the docker image build fails, this PR enables it

cc @pacman100 @BenjaminBossan 