### PR TITLE
Fixing the example by providing correct tokenized seq length

### DIFF
--- a/docs/source/task_guides/prompt_based_methods.md
+++ b/docs/source/task_guides/prompt_based_methods.md
@@ -90,7 +90,7 @@ def preprocess_function(examples, text_column="Tweet text", label_column="text_l
         model_inputs["attention_mask"][i] = [0] * (max_length - len(sample_input_ids)) + model_inputs[
             "attention_mask"
         ][i]
-        labels["input_ids"][i] = [-100] * (max_length - len(sample_input_ids)) + label_input_ids
+        labels["input_ids"][i] = [-100] * (max_length - len(label_input_ids)) + label_input_ids
         model_inputs["input_ids"][i] = torch.tensor(model_inputs["input_ids"][i][:max_length])
         model_inputs["attention_mask"][i] = torch.tensor(model_inputs["attention_mask"][i][:max_length])
         labels["input_ids"][i] = torch.tensor(labels["input_ids"][i][:max_length])


### PR DESCRIPTION
Fixes #1685 

Using correct sequence to determine initial length will allow for proper padding to be applied.
