### PR TITLE
Set experimental dynamo config for compile tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,6 +10,11 @@ if os.environ.get("PEFT_DEBUG_WITH_TORCH_COMPILE") == "1":
     import peft
     from peft.mapping import get_peft_model as get_peft_model_original
 
+    # TODO: Experimental dynamo feature that should allow correct compilation of more PEFT modules. This should be
+    # removed once PyTorch has found a better solution, as this incurs a performance penalty.
+    # https://github.com/pytorch/pytorch/issues/124717#issuecomment-2083235776
+    torch._dynamo.config.guard_nn_modules = True
+
     def get_peft_model_new(*args, **kwargs):
         """Make get_peft_model() return a compiled model."""
         peft_model = get_peft_model_original(*args, **kwargs)


### PR DESCRIPTION
Right now, a lot of tests fail when applying torch.compile to PEFT models. One of the main reasons is that attribute checks (e.g. `if self.foo`) on `nn.Module`s are not correctly considered.

This PR sets an experimental flag that should fix this. However, this is not public PyTorch API (yet) and incurs a performance penalty. Still, it's interesting to see how this affects our tests.

More context:
https://github.com/pytorch/pytorch/issues/124717#issuecomment-2083235776