### PR TITLE
Add add_weighted_adapter to IA3 adapters

### DIFF
--- a/docs/source/developer_guides/model_merging.md
+++ b/docs/source/developer_guides/model_merging.md
@@ -141,11 +141,17 @@ print(tokenizer.decode(outputs[0]))
 
 
 ## Merging (IA)³ Models
-(IA)³ models support linear model merging. To merge (IA)³ models, you can use the [`~IA3Model.add_weighted_adapter`] method. This method is similar to the [`~LoraModel.add_weighted_adapter`] method, but it doesn't accept the `combination_type` parameter. Assuming we have a PEFT model and three (IA)³ adapters, we can merge them as follows:
+The (IA)³ models facilitate linear merging of adapters. To merge adapters in an (IA)³ model, utilize the `add_weighted_adapter` method from the `IA3Model` class. This method is analogous to the `add_weighted_adapter` method used in `LoraModel`, with the key difference being the absence of the `combination_type` parameter. For example, to merge three (IA)³ adapters into a PEFT model, you would proceed as follows:
 
 ```py
 adapters = ["adapter1", "adapter2", "adapter3"]
 weights = [0.4, 0.3, 0.3]
 adapter_name = "merge"
 model.add_weighted_adapter(adapters, weights, adapter_name)
+```
+
+It is recommended that the weights sum to 1.0 to preserve the scale of the model. The merged model can then be set as the active model using the `set_adapter` method:
+
+```py
+model.set_adapter("merge")
 ```

--- a/docs/source/developer_guides/model_merging.md
+++ b/docs/source/developer_guides/model_merging.md
@@ -141,7 +141,7 @@ print(tokenizer.decode(outputs[0]))
 
 
 ## Merging (IA)³ Models
-$(IA)^3$ models support linear model merging. To merge $(IA)^3$ models, you can use the `~IA3Model.add_weighted_adapter` method. This method is similar to the `~LoraModel.add_weighted_adapter` method, but it doesn't accept the `combination_type` parameter. Assuming we have a PEFT model and three $(IA)^3$ adapters, we can merge them as follows:
+(IA)³ models support linear model merging. To merge (IA)³ models, you can use the [`~IA3Model.add_weighted_adapter`] method. This method is similar to the [`~LoraModel.add_weighted_adapter`] method, but it doesn't accept the `combination_type` parameter. Assuming we have a PEFT model and three (IA)³ adapters, we can merge them as follows:
 
 ```py
 adapters = ["adapter1", "adapter2", "adapter3"]

--- a/docs/source/developer_guides/model_merging.md
+++ b/docs/source/developer_guides/model_merging.md
@@ -138,3 +138,14 @@ print(tokenizer.decode(outputs[0]))
 
 </hfoption>
 </hfoptions>
+
+
+## Merging $(IA)^3$ Models
+$(IA)^3$ models support linear model merging. To merge $(IA)^3$ models, you can use the `~IA3Model.add_weighted_adapter` method. This method is similar to the `~LoraModel.add_weighted_adapter` method, but it doesn't accept the `combination_type` parameter. Assuming we have a PEFT model and three $(IA)^3$ adapters, we can merge them as follows:
+
+```py
+adapters = ["adapter1", "adapter2", "adapter3"]
+weights = [0.4, 0.3, 0.3]
+adapter_name = "merge"
+model.add_weighted_adapter(adapters, weights, adapter_name)
+```

--- a/docs/source/developer_guides/model_merging.md
+++ b/docs/source/developer_guides/model_merging.md
@@ -140,7 +140,7 @@ print(tokenizer.decode(outputs[0]))
 </hfoptions>
 
 
-## Merging $(IA)^3$ Models
+## Merging (IA)³ Models
 $(IA)^3$ models support linear model merging. To merge $(IA)^3$ models, you can use the `~IA3Model.add_weighted_adapter` method. This method is similar to the `~LoraModel.add_weighted_adapter` method, but it doesn't accept the `combination_type` parameter. Assuming we have a PEFT model and three $(IA)^3$ adapters, we can merge them as follows:
 
 ```py

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -481,7 +481,7 @@ class IA3Model(BaseTuner):
                 else:
                     continue
 
-                target_ia3_l.data = target_ia3_l.data * 0.0
+                target_ia3_l.data = target_ia3_l.data.zero_()
                 for adapter, weight in zip(adapters, weights):
                     if adapter in target.ia3_l:
                         current_adapter_ia3_l = target.ia3_l[adapter]

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -575,9 +575,6 @@ class LoraModel(BaseTuner):
 
         if adapter_name in list(self.peft_config.keys()):
             return
-        for adapter in adapters:
-            if adapter not in list(self.peft_config.keys()):
-                raise ValueError(f"Adapter {adapter} does not exist")
 
         combination_type, new_rank, new_target_modules = self._check_add_weighted_adapter(
             adapters=adapters,

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -296,6 +296,7 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
             {
                 "model_ids": PEFT_DECODER_MODELS_TO_TEST,
                 "lora_kwargs": {"init_lora_weights": [False]},
+                "ia3_kwargs": {"init_ia3_weights": [False]},
                 "boft_kwargs": {"init_weights": [False]},
                 "task_type": "CAUSAL_LM",
             },

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -184,6 +184,7 @@ class PeftEncoderDecoderModelTester(unittest.TestCase, PeftCommonTester):
             {
                 "model_ids": PEFT_ENCODER_DECODER_MODELS_TO_TEST,
                 "lora_kwargs": {"init_lora_weights": [False]},
+                "ia3_kwargs": {"init_ia3_weights": [False]},
                 "task_type": "SEQ_2_SEQ_LM",
             },
         )

--- a/tests/test_feature_extraction_models.py
+++ b/tests/test_feature_extraction_models.py
@@ -174,6 +174,7 @@ class PeftFeatureExtractionModelTester(unittest.TestCase, PeftCommonTester):
             {
                 "model_ids": PEFT_FEATURE_EXTRACTION_MODELS_TO_TEST,
                 "lora_kwargs": {"init_lora_weights": [False]},
+                "ia3_kwargs": {"init_ia3_weights": [False]},
                 "boft_kwargs": {"init_weights": [False]},
                 "task_type": "FEATURE_EXTRACTION",
             },

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -1150,193 +1150,228 @@ class PeftCommonTester:
             base_model_name_or_path=model_id,
             **config_kwargs,
         )
-        if not isinstance(config, LoraConfig):
+        if not isinstance(config, (LoraConfig, IA3Config)):
             return pytest.skip(f"Test not applicable for {config}")
 
         model = self.transformers_class.from_pretrained(model_id)
         model = get_peft_model(model, config, adapter_list[0])
-        model.add_adapter(adapter_list[1], config)
-        model.add_adapter(adapter_list[2], replace(config, r=20))
-        model = model.to(self.torch_device)
 
-        # test re-weighting single adapter
-        model.add_weighted_adapter([adapter_list[0]], [weight_list[0]], "single_adapter_reweighting")
+        if isinstance(config, IA3Config):
+            model.add_adapter(adapter_list[1], config)
+            model.add_adapter(adapter_list[2], config)
+            model = model.to(self.torch_device)
 
-        # test svd re-weighting with multiple adapters
-        model.add_weighted_adapter(adapter_list[1:], weight_list[1:], "multi_adapter_svd_reweighting")
+            # test re-weighting single adapter
+            model.add_weighted_adapter([adapter_list[0]], [weight_list[0]], "single_adapter_reweighting")
 
-        # test ties_svd re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[1:],
-            weight_list[1:],
-            "multi_adapter_ties_svd_reweighting",
-            combination_type="ties_svd",
-            density=0.5,
-        )
+            # test re-weighting with multiple adapters
+            model.add_weighted_adapter(adapter_list[1:], weight_list[1:], "multi_adapter_reweighting")
 
-        # test dare_linear_svd re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[1:],
-            weight_list[1:],
-            "multi_adapter_dare_linear_svd_reweighting",
-            combination_type="dare_linear_svd",
-            density=0.5,
-        )
+            new_adapters = [
+                "single_adapter_reweighting",
+                "multi_adapter_reweighting",
+            ]
+            for new_adapter in new_adapters:
+                assert new_adapter in model.peft_config
 
-        # test dare_ties_svd re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[1:],
-            weight_list[1:],
-            "multi_adapter_dare_ties_svd_reweighting",
-            combination_type="dare_ties_svd",
-            density=0.5,
-        )
+            dummy_input = self.prepare_inputs_for_testing()
+            model.eval()
+            for adapter_name in new_adapters:
+                # ensuring new adapters pass the forward loop
+                model.set_adapter(adapter_name)
+                assert model.active_adapter == adapter_name
+                assert model.active_adapters == [adapter_name]
+                model(**dummy_input)[0]
 
-        # test magnitude_prune_svd re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[1:],
-            weight_list[1:],
-            "multi_adapter_magnitude_prune_svd_reweighting",
-            combination_type="magnitude_prune_svd",
-            density=0.5,
-        )
+        if isinstance(config, LoraConfig):
+            model.add_adapter(adapter_list[1], config)
+            model.add_adapter(adapter_list[2], replace(config, r=20))
+            model = model.to(self.torch_device)
 
-        # test cat re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[1:], weight_list[1:], "multi_adapter_cat_reweighting", combination_type="cat"
-        )
+            # test re-weighting single adapter
+            model.add_weighted_adapter([adapter_list[0]], [weight_list[0]], "single_adapter_reweighting")
 
-        # test linear re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[:2], weight_list[:2], "multi_adapter_linear_reweighting", combination_type="linear"
-        )
+            # test svd re-weighting with multiple adapters
+            model.add_weighted_adapter(adapter_list[1:], weight_list[1:], "multi_adapter_svd_reweighting")
 
-        # test ties re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[:2], weight_list[:2], "multi_adapter_ties_reweighting", combination_type="ties", density=0.5
-        )
-
-        # test dare_linear re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[:2],
-            weight_list[:2],
-            "multi_adapter_dare_linear_reweighting",
-            combination_type="dare_linear",
-            density=0.5,
-        )
-
-        # test dare_ties re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[:2],
-            weight_list[:2],
-            "multi_adapter_dare_ties_reweighting",
-            combination_type="dare_ties",
-            density=0.5,
-        )
-
-        # test magnitude_prune re-weighting with multiple adapters
-        model.add_weighted_adapter(
-            adapter_list[:2],
-            weight_list[:2],
-            "multi_adapter_magnitude_prune_reweighting",
-            combination_type="magnitude_prune",
-            density=0.5,
-        )
-
-        # test linear re-weighting with multiple adapters with only first adapter having non zero weight
-        model.add_weighted_adapter(
-            adapter_list[:2],
-            [weight_list[0], 0],
-            "multi_adapter_linear_reweighting_single_enabled",
-            combination_type="linear",
-        )
-
-        with pytest.raises(ValueError):
+            # test ties_svd re-weighting with multiple adapters
             model.add_weighted_adapter(
                 adapter_list[1:],
                 weight_list[1:],
-                "multi_adapter_linear_reweighting_uneven_r",
-                combination_type="linear",
+                "multi_adapter_ties_svd_reweighting",
+                combination_type="ties_svd",
+                density=0.5,
             )
 
-        with pytest.raises(ValueError):
+            # test dare_linear_svd re-weighting with multiple adapters
             model.add_weighted_adapter(
                 adapter_list[1:],
                 weight_list[1:],
-                "multi_adapter_ties_reweighting_uneven_r",
+                "multi_adapter_dare_linear_svd_reweighting",
+                combination_type="dare_linear_svd",
+                density=0.5,
+            )
+
+            # test dare_ties_svd re-weighting with multiple adapters
+            model.add_weighted_adapter(
+                adapter_list[1:],
+                weight_list[1:],
+                "multi_adapter_dare_ties_svd_reweighting",
+                combination_type="dare_ties_svd",
+                density=0.5,
+            )
+
+            # test magnitude_prune_svd re-weighting with multiple adapters
+            model.add_weighted_adapter(
+                adapter_list[1:],
+                weight_list[1:],
+                "multi_adapter_magnitude_prune_svd_reweighting",
+                combination_type="magnitude_prune_svd",
+                density=0.5,
+            )
+
+            # test cat re-weighting with multiple adapters
+            model.add_weighted_adapter(
+                adapter_list[1:], weight_list[1:], "multi_adapter_cat_reweighting", combination_type="cat"
+            )
+
+            # test linear re-weighting with multiple adapters
+            model.add_weighted_adapter(
+                adapter_list[:2], weight_list[:2], "multi_adapter_linear_reweighting", combination_type="linear"
+            )
+
+            # test ties re-weighting with multiple adapters
+            model.add_weighted_adapter(
+                adapter_list[:2],
+                weight_list[:2],
+                "multi_adapter_ties_reweighting",
                 combination_type="ties",
                 density=0.5,
             )
 
-        with pytest.raises(ValueError):
+            # test dare_linear re-weighting with multiple adapters
             model.add_weighted_adapter(
-                adapter_list[1:],
-                weight_list[1:],
-                "multi_adapter_dare_linear_reweighting_uneven_r",
+                adapter_list[:2],
+                weight_list[:2],
+                "multi_adapter_dare_linear_reweighting",
                 combination_type="dare_linear",
                 density=0.5,
             )
 
-        with pytest.raises(ValueError):
+            # test dare_ties re-weighting with multiple adapters
             model.add_weighted_adapter(
-                adapter_list[1:],
-                weight_list[1:],
-                "multi_adapter_dare_ties_reweighting_uneven_r",
+                adapter_list[:2],
+                weight_list[:2],
+                "multi_adapter_dare_ties_reweighting",
                 combination_type="dare_ties",
                 density=0.5,
             )
 
-        with pytest.raises(ValueError):
+            # test magnitude_prune re-weighting with multiple adapters
             model.add_weighted_adapter(
-                adapter_list[1:],
-                weight_list[1:],
-                "multi_adapter_magnitude_prune_reweighting_uneven_r",
+                adapter_list[:2],
+                weight_list[:2],
+                "multi_adapter_magnitude_prune_reweighting",
                 combination_type="magnitude_prune",
                 density=0.5,
             )
 
-        new_adapters = [
-            "single_adapter_reweighting",
-            "multi_adapter_svd_reweighting",
-            "multi_adapter_ties_svd_reweighting",
-            "multi_adapter_dare_linear_svd_reweighting",
-            "multi_adapter_dare_ties_svd_reweighting",
-            "multi_adapter_magnitude_prune_svd_reweighting",
-            "multi_adapter_cat_reweighting",
-            "multi_adapter_linear_reweighting",
-            "multi_adapter_linear_reweighting_single_enabled",
-            "multi_adapter_ties_reweighting",
-            "multi_adapter_dare_linear_reweighting",
-            "multi_adapter_dare_ties_reweighting",
-            "multi_adapter_magnitude_prune_reweighting",
-        ]
-        for new_adapter in new_adapters:
-            assert new_adapter in model.peft_config
+            # test linear re-weighting with multiple adapters with only first adapter having non zero weight
+            model.add_weighted_adapter(
+                adapter_list[:2],
+                [weight_list[0], 0],
+                "multi_adapter_linear_reweighting_single_enabled",
+                combination_type="linear",
+            )
 
-        key_list = [key for key, _ in model.named_modules()]
-        for key in key_list:
-            _, target, _ = _get_submodules(model, key)
-            if isinstance(target, LoraLayer):
-                for adapter_name in new_adapters:
-                    if "single" in adapter_name:
-                        new_delta_weight = target.get_delta_weight(adapter_name)
-                        weighted_original_delta_weights = target.get_delta_weight(adapter_list[0]) * weight_list[0]
-                        assert torch.allclose(new_delta_weight, weighted_original_delta_weights, atol=1e-4, rtol=1e-4)
-                    elif "svd" in adapter_name:
-                        assert target.r[adapter_name] == 20
-                    elif "linear" in adapter_name:
-                        assert target.r[adapter_name] == 8
-                    elif "cat" in adapter_name:
-                        assert target.r[adapter_name] == 28
+            with pytest.raises(ValueError):
+                model.add_weighted_adapter(
+                    adapter_list[1:],
+                    weight_list[1:],
+                    "multi_adapter_linear_reweighting_uneven_r",
+                    combination_type="linear",
+                )
 
-        dummy_input = self.prepare_inputs_for_testing()
-        model.eval()
-        for adapter_name in new_adapters:
-            # ensuring new adapters pass the forward loop
-            model.set_adapter(adapter_name)
-            assert model.active_adapter == adapter_name
-            assert model.active_adapters == [adapter_name]
-            model(**dummy_input)[0]
+            with pytest.raises(ValueError):
+                model.add_weighted_adapter(
+                    adapter_list[1:],
+                    weight_list[1:],
+                    "multi_adapter_ties_reweighting_uneven_r",
+                    combination_type="ties",
+                    density=0.5,
+                )
+
+            with pytest.raises(ValueError):
+                model.add_weighted_adapter(
+                    adapter_list[1:],
+                    weight_list[1:],
+                    "multi_adapter_dare_linear_reweighting_uneven_r",
+                    combination_type="dare_linear",
+                    density=0.5,
+                )
+
+            with pytest.raises(ValueError):
+                model.add_weighted_adapter(
+                    adapter_list[1:],
+                    weight_list[1:],
+                    "multi_adapter_dare_ties_reweighting_uneven_r",
+                    combination_type="dare_ties",
+                    density=0.5,
+                )
+
+            with pytest.raises(ValueError):
+                model.add_weighted_adapter(
+                    adapter_list[1:],
+                    weight_list[1:],
+                    "multi_adapter_magnitude_prune_reweighting_uneven_r",
+                    combination_type="magnitude_prune",
+                    density=0.5,
+                )
+
+            new_adapters = [
+                "single_adapter_reweighting",
+                "multi_adapter_svd_reweighting",
+                "multi_adapter_ties_svd_reweighting",
+                "multi_adapter_dare_linear_svd_reweighting",
+                "multi_adapter_dare_ties_svd_reweighting",
+                "multi_adapter_magnitude_prune_svd_reweighting",
+                "multi_adapter_cat_reweighting",
+                "multi_adapter_linear_reweighting",
+                "multi_adapter_linear_reweighting_single_enabled",
+                "multi_adapter_ties_reweighting",
+                "multi_adapter_dare_linear_reweighting",
+                "multi_adapter_dare_ties_reweighting",
+                "multi_adapter_magnitude_prune_reweighting",
+            ]
+            for new_adapter in new_adapters:
+                assert new_adapter in model.peft_config
+
+            key_list = [key for key, _ in model.named_modules()]
+            for key in key_list:
+                _, target, _ = _get_submodules(model, key)
+                if isinstance(target, LoraLayer):
+                    for adapter_name in new_adapters:
+                        if "single" in adapter_name:
+                            new_delta_weight = target.get_delta_weight(adapter_name)
+                            weighted_original_delta_weights = target.get_delta_weight(adapter_list[0]) * weight_list[0]
+                            assert torch.allclose(
+                                new_delta_weight, weighted_original_delta_weights, atol=1e-4, rtol=1e-4
+                            )
+                        elif "svd" in adapter_name:
+                            assert target.r[adapter_name] == 20
+                        elif "linear" in adapter_name:
+                            assert target.r[adapter_name] == 8
+                        elif "cat" in adapter_name:
+                            assert target.r[adapter_name] == 28
+
+            dummy_input = self.prepare_inputs_for_testing()
+            model.eval()
+            for adapter_name in new_adapters:
+                # ensuring new adapters pass the forward loop
+                model.set_adapter(adapter_name)
+                assert model.active_adapter == adapter_name
+                assert model.active_adapters == [adapter_name]
+                model(**dummy_input)[0]
 
     def _test_disable_adapter(self, model_id, config_cls, config_kwargs):
         task_type = config_kwargs.get("task_type")


### PR DESCRIPTION
(Partially) Resolves: https://github.com/huggingface/peft/issues/1688
See https://github.com/huggingface/peft/pull/980 for context.

### What
$(IA)^3$ adapters can't be combined. This option, however, is available for other PEFT adapters such as LoRA.

### Solution
Implement `add_weighted_adapter` method for $(IA)^3$ models supporting only weighted average of adapters for now.


