### PR TITLE
Chunk adapter for fused qkv_proj

### DIFF
--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -112,6 +112,10 @@ class LoraConfig(PeftConfig):
             Build a new stack of layers by stacking the original model layers according to the ranges specified. This
             allows expanding (or shrinking) the model without duplicating the base model weights. The new layers will
             all have separate LoRA adapters attached to them.
+        chunk_pattern(`Optional[dict]`):
+            Apply LoRA to each chunk of the dense matrix. This is used when q_proj, v_proj, v_proj are fused into one
+            big qkv_proj. key: the module name need to be chunked, value: number of chunks, e.g., {'qkv_proj': 3,
+            'gate_up_proj': 2}."
     """
 
     r: int = field(default=8, metadata={"help": "Lora attention dimension"})
@@ -265,6 +269,17 @@ class LoraConfig(PeftConfig):
                 "   Final model will have this arrangement of original layers: `[0, 1, 2, 3, 2, 3, 4]`\n"
                 "This format is based on what is used for pass-through merges in mergekit. It makes it simple to select sequential "
                 "ranges of a model and stack them while reusing layers at either end of each sequence."
+            )
+        },
+    )
+    chunk_pattern: Optional[dict] = field(
+        default_factory=dict,
+        metadata={
+            "help": (
+                "Apply LoRA to each chunk of the dense matrix. "
+                "This is used when q_proj, v_proj, v_proj are fused into one big qkv_proj. "
+                "key: the module name need to be chunked, value: number of chunks, "
+                "e.g., {'qkv_proj': 3, 'gate_up_proj': 2}."
             )
         },
     )

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -574,7 +574,7 @@ class Linear(nn.Module, LoraLayer):
                         chunk_id = int(active_adapter[-1])
                         lora_result = lora_B(lora_A(dropout(x))) * scaling
                         dim = lora_result.shape[-1]
-                        result[..., dim * chunk_id: dim * (chunk_id + 1)] += lora_result
+                        result[..., dim * chunk_id : dim * (chunk_id + 1)] += lora_result
                     else:
                         result = result + lora_B(lora_A(dropout(x))) * scaling
                 else:

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -181,7 +181,9 @@ class LoraModel(BaseTuner):
             raise ValueError("Current Key shouldn't be `None`")
 
         # Regexp matching - Find key which matches current target_name in patterns provided
-        pattern_keys = list(chain(lora_config.rank_pattern.keys(), lora_config.alpha_pattern.keys()))
+        pattern_keys = list(
+            chain(lora_config.rank_pattern.keys(), lora_config.alpha_pattern.keys(), lora_config.chunk_pattern.keys())
+        )
         target_name_key = next(filter(lambda key: re.match(rf".*\.{key}$", current_key), pattern_keys), current_key)
         r = lora_config.rank_pattern.get(target_name_key, lora_config.r)
         alpha = lora_config.alpha_pattern.get(target_name_key, lora_config.lora_alpha)

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -185,6 +185,8 @@ class LoraModel(BaseTuner):
         target_name_key = next(filter(lambda key: re.match(rf".*\.{key}$", current_key), pattern_keys), current_key)
         r = lora_config.rank_pattern.get(target_name_key, lora_config.r)
         alpha = lora_config.alpha_pattern.get(target_name_key, lora_config.lora_alpha)
+        # make each chunk of the dense matrix has the same rank
+        n_chunk = lora_config.chunk_pattern.get(target_name_key, None)
 
         kwargs = {
             "r": r,
@@ -196,6 +198,7 @@ class LoraModel(BaseTuner):
             "use_dora": lora_config.use_dora,
             "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
             "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
+            "n_chunk": n_chunk,
         }
 
         quant_methods = ["gptq", "aqlm", "awq"]


### PR DESCRIPTION
As `microsoft/Phi-3-mini-4k-instruct` is using fused `qkv_proj` and `up_gate_proj`, LoRA adapters should be applied to each chunk instead of the entire fused matrix. 

The change lies in (1) adapter initialization and (2) forward computing. 

For (1), we create `n_chunk` adapters for one fused matrix, `default-chunk-0`, `default-chunk-1`, ... for both lora_A and lora_B.

For (2), we iterate the adapter by `adapter_name`. Once we find its chunk, we only update the associated dense result.

We have run the `make style` and `make quality`.
