### PR TITLE
FEAT Helper to check if a model is a PEFT model

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -106,6 +106,8 @@
       title: Layernorm tuning
     - local: package_reference/vera
       title: VeRA
+    - local: package_reference/helpers
+      title: Helpers
     title: Adapters
   - sections:
     - local: package_reference/merge_utils

--- a/docs/source/package_reference/helpers.md
+++ b/docs/source/package_reference/helpers.md
@@ -1,0 +1,12 @@
+<!--⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# Document Title
+
+A collection of helper functions for PEFT.
+
+## Checking if a model is a PEFT model
+
+[[autodoc]] helpers.check_is_peft_model
+    - all

--- a/docs/source/package_reference/helpers.md
+++ b/docs/source/package_reference/helpers.md
@@ -8,5 +8,5 @@ A collection of helper functions for PEFT.
 
 ## Checking if a model is a PEFT model
 
-[[autodoc]] helpers.check_is_peft_model
+[[autodoc]] helpers.check_if_peft_model
     - all

--- a/src/peft/helpers.py
+++ b/src/peft/helpers.py
@@ -111,3 +111,24 @@ def update_signature(model: PeftModel, method: str = "all") -> None:
         update_generate_signature(model)
     else:
         raise ValueError(f"method {method} is not supported please choose one of ['forward', 'generate', 'all']")
+
+
+def check_is_peft_model(model_name_or_path: str) -> bool:
+    """
+    Check if the model is a PEFT model.
+
+    Args:
+        model_name_or_path (`str`):
+            Model id to check, can be local or on the Hugging Face Hub.
+
+    Returns:
+        `bool`: True if the model is a PEFT model, False otherwise.
+    """
+    is_peft_model = True
+    try:
+        PeftConfig.from_pretrained(model_name_or_path)
+    except Exception:
+        # allow broad exceptions so that this works even if new exceptions are added on HF Hub side
+        is_peft_model = False
+
+    return is_peft_model

--- a/src/peft/helpers.py
+++ b/src/peft/helpers.py
@@ -113,7 +113,7 @@ def update_signature(model: PeftModel, method: str = "all") -> None:
         raise ValueError(f"method {method} is not supported please choose one of ['forward', 'generate', 'all']")
 
 
-def check_is_peft_model(model_name_or_path: str) -> bool:
+def check_if_peft_model(model_name_or_path: str) -> bool:
     """
     Check if the model is a PEFT model.
 

--- a/src/peft/helpers.py
+++ b/src/peft/helpers.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from functools import update_wrapper
 from types import MethodType
 
-from .peft_model import PeftModel
+from .peft_model import PeftConfig, PeftModel
 
 
 def update_forward_signature(model: PeftModel) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,20 +16,20 @@
 from transformers import AutoModelForCausalLM
 
 from peft import LoraConfig, get_peft_model
-from peft.helpers import check_is_peft_model
+from peft.helpers import check_if_peft_model
 
 
 class TestCheckIsPeftModel:
     def test_valid_hub_model(self):
-        result = check_is_peft_model("peft-internal-testing/gpt2-lora-random")
+        result = check_if_peft_model("peft-internal-testing/gpt2-lora-random")
         assert result is True
 
     def test_invalid_hub_model(self):
-        result = check_is_peft_model("gpt2")
+        result = check_if_peft_model("gpt2")
         assert result is False
 
     def test_nonexisting_hub_model(self):
-        result = check_is_peft_model("peft-internal-testing/non-existing-model")
+        result = check_if_peft_model("peft-internal-testing/non-existing-model")
         assert result is False
 
     def test_local_model_valid(self, tmp_path):
@@ -37,20 +37,20 @@ class TestCheckIsPeftModel:
         config = LoraConfig()
         model = get_peft_model(model, config)
         model.save_pretrained(tmp_path / "peft-gpt2-valid")
-        result = check_is_peft_model(tmp_path / "peft-gpt2-valid")
+        result = check_if_peft_model(tmp_path / "peft-gpt2-valid")
         assert result is True
 
     def test_local_model_invalid(self, tmp_path):
         model = AutoModelForCausalLM.from_pretrained("gpt2")
         model.save_pretrained(tmp_path / "peft-gpt2-invalid")
-        result = check_is_peft_model(tmp_path / "peft-gpt2-invalid")
+        result = check_if_peft_model(tmp_path / "peft-gpt2-invalid")
         assert result is False
 
     def test_local_model_broken_config(self, tmp_path):
         with open(tmp_path / "adapter_config.json", "w") as f:
             f.write('{"foo": "bar"}')
 
-        result = check_is_peft_model(tmp_path)
+        result = check_if_peft_model(tmp_path)
         assert result is False
 
     def test_local_model_non_default_name(self, tmp_path):
@@ -60,9 +60,9 @@ class TestCheckIsPeftModel:
         model.save_pretrained(tmp_path / "peft-gpt2-other")
 
         # no default adapter here
-        result = check_is_peft_model(tmp_path / "peft-gpt2-other")
+        result = check_if_peft_model(tmp_path / "peft-gpt2-other")
         assert result is False
 
         # with adapter name
-        result = check_is_peft_model(tmp_path / "peft-gpt2-other" / "other")
+        result = check_if_peft_model(tmp_path / "peft-gpt2-other" / "other")
         assert result is True

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -14,6 +14,7 @@
 
 
 from transformers import AutoModelForCausalLM
+
 from peft import LoraConfig, get_peft_model
 from peft.helpers import check_is_peft_model
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,67 @@
+# Copyright 2024-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from transformers import AutoModelForCausalLM
+from peft import LoraConfig, get_peft_model
+from peft.helpers import check_is_peft_model
+
+
+class TestCheckIsPeftModel:
+    def test_valid_hub_model(self):
+        result = check_is_peft_model("peft-internal-testing/gpt2-lora-random")
+        assert result is True
+
+    def test_invalid_hub_model(self):
+        result = check_is_peft_model("gpt2")
+        assert result is False
+
+    def test_nonexisting_hub_model(self):
+        result = check_is_peft_model("peft-internal-testing/non-existing-model")
+        assert result is False
+
+    def test_local_model_valid(self, tmp_path):
+        model = AutoModelForCausalLM.from_pretrained("gpt2")
+        config = LoraConfig()
+        model = get_peft_model(model, config)
+        model.save_pretrained(tmp_path / "peft-gpt2-valid")
+        result = check_is_peft_model(tmp_path / "peft-gpt2-valid")
+        assert result is True
+
+    def test_local_model_invalid(self, tmp_path):
+        model = AutoModelForCausalLM.from_pretrained("gpt2")
+        model.save_pretrained(tmp_path / "peft-gpt2-invalid")
+        result = check_is_peft_model(tmp_path / "peft-gpt2-invalid")
+        assert result is False
+
+    def test_local_model_broken_config(self, tmp_path):
+        with open(tmp_path / "adapter_config.json", "w") as f:
+            f.write('{"foo": "bar"}')
+
+        result = check_is_peft_model(tmp_path)
+        assert result is False
+
+    def test_local_model_non_default_name(self, tmp_path):
+        model = AutoModelForCausalLM.from_pretrained("gpt2")
+        config = LoraConfig()
+        model = get_peft_model(model, config, adapter_name="other")
+        model.save_pretrained(tmp_path / "peft-gpt2-other")
+
+        # no default adapter here
+        result = check_is_peft_model(tmp_path / "peft-gpt2-other")
+        assert result is False
+
+        # with adapter name
+        result = check_is_peft_model(tmp_path / "peft-gpt2-other" / "other")
+        assert result is True


### PR DESCRIPTION
After internal discussion, we decided to add this convenience function.

```python
>>> from peft.helpers import check_is_peft_model
>>> check_is_peft_model("gpt2")
False
>>> check_is_peft_model("peft-internal-testing/gpt2-lora-random")
True
>>> check_is_peft_model("peft-internal-testing/non-existing-model")
False
>>> check_is_peft_model("path/to/local/model/also/works")
```