### PR TITLE
Release: v0.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.10.1.dev0"
+VERSION = "0.11.0"
 
 extras = {}
 extras["quality"] = [

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.10.1.dev0"
+__version__ = "0.11.0"
 
 from .auto import (
     AutoPeftModel,


### PR DESCRIPTION
Preparing for release of PEFT v0.11.0. AFAICT, there are no deprecations for this release.