### PR TITLE
FIX Allow same layer adapters on different devices

### DIFF
--- a/src/peft/tuners/adalora/layer.py
+++ b/src/peft/tuners/adalora/layer.py
@@ -72,11 +72,7 @@ class AdaLoraLayer(LoraLayer):
         if init_lora_weights:
             self.reset_lora_parameters(adapter_name)
 
-        if hasattr(self.get_base_layer(), "qweight"):
-            # QuantLinear
-            self.to(self.get_base_layer().qweight.device)
-        else:
-            self.to(self.get_base_layer().weight.device)
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def reset_lora_parameters(self, adapter_name):

--- a/src/peft/tuners/boft/layer.py
+++ b/src/peft/tuners/boft/layer.py
@@ -310,18 +310,11 @@ class BOFTLayer(BaseTunerLayer):
 
         self.reset_boft_parameters(adapter_name, init_weights)
 
-        weight = getattr(self, "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                self.to(weight.device, dtype=weight.dtype)
-            else:
-                self.to(weight.device)
-
         # set the boft block size and number
         self.boft_block_size[adapter_name] = boft_block_size
         self.boft_block_num[adapter_name] = boft_block_num
 
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def reset_boft_parameters(self, adapter_name, init_weights):
@@ -742,18 +735,12 @@ class Conv2d(nn.Module, BOFTLayer):
 
         self.reset_boft_parameters(adapter_name, init_weights)
 
-        weight = getattr(self, "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                self.to(weight.device, dtype=weight.dtype)
-            else:
-                self.to(weight.device)
-        self.set_adapter(self.active_adapters)
-
         # set the boft block size and number
         self.boft_block_size[adapter_name] = boft_block_size
         self.boft_block_num[adapter_name] = boft_block_num
+
+        self._move_adapter_to_device_of_base_layer(adapter_name)
+        self.set_adapter(self.active_adapters)
 
     def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """

--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -61,7 +61,7 @@ class IA3Layer(BaseTunerLayer):
         self.ia3_l[adapter_name] = nn.Parameter(weight)
         if init_ia3_weights:
             self.reset_ia3_parameters(adapter_name)
-        self.to(self.get_base_layer().weight.device)
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def reset_ia3_parameters(self, adapter_name):
@@ -210,7 +210,7 @@ class Conv2d(nn.Module, IA3Layer):
         self.ia3_l[adapter_name] = nn.Parameter(weight)
         if init_ia3_weights:
             self.reset_ia3_parameters(adapter_name)
-        self.to(self.get_base_layer().weight.device)
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:

--- a/src/peft/tuners/loha/layer.py
+++ b/src/peft/tuners/loha/layer.py
@@ -148,13 +148,7 @@ class LoHaLayer(nn.Module, LycorisLayer):
             self.reset_adapter_parameters_random(adapter_name)
 
         # Move new weights to device
-        weight = getattr(self.get_base_layer(), "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                self.to(weight.device, dtype=weight.dtype)
-            else:
-                self.to(weight.device)
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def get_delta_weight(self, adapter_name: str) -> torch.Tensor:

--- a/src/peft/tuners/lokr/layer.py
+++ b/src/peft/tuners/lokr/layer.py
@@ -197,13 +197,7 @@ class LoKrLayer(nn.Module, LycorisLayer):
             self.reset_adapter_parameters_random(adapter_name)
 
         # Move new weights to device
-        weight = getattr(self.get_base_layer(), "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                self.to(weight.device, dtype=weight.dtype)
-            else:
-                self.to(weight.device)
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def get_delta_weight(self, adapter_name: str) -> torch.Tensor:

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -120,16 +120,8 @@ class LoraLayer(BaseTunerLayer):
         elif init_lora_weights:
             self.reset_lora_parameters(adapter_name, init_lora_weights)
 
-        # check weight and qweight (for GPTQ)
-        for weight_name in ("weight", "qweight"):
-            weight = getattr(self.get_base_layer(), weight_name, None)
-            if weight is not None:
-                # the layer is already completely initialized, this is an update
-                if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                    self.to(weight.device, dtype=weight.dtype)
-                else:
-                    self.to(weight.device)
-                break
+        # call this before dora_init
+        self._move_adapter_to_device_of_base_layer(adapter_name)
 
         if use_dora:
             self.dora_init(adapter_name)
@@ -245,7 +237,8 @@ class LoraLayer(BaseTunerLayer):
                 lora_weight = lora_weight.half()
             weight_norm = self._get_weight_norm(weight, lora_weight, scaling)
 
-        self.lora_magnitude_vector = nn.ParameterDict()
+        if self.lora_magnitude_vector is None:
+            self.lora_magnitude_vector = nn.ParameterDict()
         self.lora_magnitude_vector[adapter_name] = nn.Parameter(weight_norm, requires_grad=True)
         # add lora_magnitude_vector to the list of learnable parameters
         self.adapter_layer_names = self.adapter_layer_names[:] + ("lora_magnitude_vector",)
@@ -638,12 +631,7 @@ class Embedding(nn.Module, LoraLayer):
         elif init_lora_weights:
             self.reset_lora_parameters(adapter_name, init_lora_weights)
 
-        base_layer = self.get_base_layer()
-        weight = getattr(base_layer, "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            self.to(base_layer.weight.device, dtype=weight.dtype)
-
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
@@ -861,10 +849,8 @@ class Conv2d(nn.Module, LoraLayer):
         elif init_lora_weights:
             self.reset_lora_parameters(adapter_name, init_lora_weights)
 
-        weight = getattr(base_layer, "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            self.to(base_layer.weight.device, dtype=weight.dtype)
+        # call this before dora_init
+        self._move_adapter_to_device_of_base_layer(adapter_name)
 
         if use_dora:
             self.dora_init(adapter_name)

--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -143,13 +143,7 @@ class LoraParallelLinear(nn.Module, LoraLayer):
         if init_lora_weights:
             self.reset_lora_parameters(adapter_name, init_lora_weights)
 
-        weight = getattr(self.get_base_layer(), "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                self.to(weight.device, dtype=weight.dtype)
-            else:
-                self.to(weight.device)
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any):

--- a/src/peft/tuners/oft/layer.py
+++ b/src/peft/tuners/oft/layer.py
@@ -108,13 +108,7 @@ class OFTLayer(nn.Module, LycorisLayer):
             self.reset_adapter_parameters_random(adapter_name)
 
         # Move new weights to device
-        weight = getattr(self.get_base_layer(), "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                self.to(weight.device, dtype=weight.dtype)
-            else:
-                self.to(weight.device)
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def unscale_layer(self, scale=None) -> None:

--- a/src/peft/tuners/poly/layer.py
+++ b/src/peft/tuners/poly/layer.py
@@ -81,13 +81,7 @@ class PolyLayer(BaseTunerLayer):
 
         self.reset_poly_parameters(adapter_name, init_weights=poly_config.init_weights)
 
-        weight = getattr(self.get_base_layer(), "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                self.to(weight.device, dtype=weight.dtype)
-            else:
-                self.to(weight.device)
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def reset_poly_parameters(self, adapter_name, init_weights):

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -629,6 +629,38 @@ class BaseTunerLayer(ABC):
                     )
                     self.set_adapter(remaining_adapters[0])
 
+    def _move_adapter_to_device_of_base_layer(self, adapter_name: str, device: Optional[torch.device] = None) -> None:
+        """
+        Move the adapter of the given name to the device of the base layer.
+        """
+        from peft.tuners.vera.buffer_dict import BufferDict
+
+        if device is None:
+            # check weight and qweight (for GPTQ)
+            for weight_name in ("weight", "qweight"):
+                weight = getattr(self.get_base_layer(), weight_name, None)
+                if weight is not None:
+                    device = weight.device
+                    dtype = weight.dtype
+                    break
+            else:
+                # no break encountered: could not determine the device
+                return
+
+        # loop through all potential adapter layers and move them to the device of the base layer; be careful to only
+        # move this specific adapter to the device, as the other adapters could be on different devices
+        # see #1639
+        for adapter_layer_name in self.adapter_layer_names + self.other_param_names:
+            adapter_layer = getattr(self, adapter_layer_name, None)
+            if not isinstance(adapter_layer, (nn.ModuleDict, nn.ParameterDict, BufferDict)):
+                continue
+            if adapter_name not in adapter_layer:
+                continue
+            if weight.dtype.is_floating_point or weight.dtype.is_complex:
+                adapter_layer[adapter_name] = adapter_layer[adapter_name].to(device, dtype=dtype)
+            else:
+                adapter_layer[adapter_name] = adapter_layer[adapter_name].to(device)
+
 
 def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
     """A helper method to check if the passed module's key name matches any of the target modules in the adapter_config.

--- a/src/peft/tuners/vera/layer.py
+++ b/src/peft/tuners/vera/layer.py
@@ -106,14 +106,7 @@ class VeraLayer(BaseTunerLayer):
         if init_weights:
             self.reset_vera_parameters(adapter_name, d_initial=d_initial)
 
-        weight = getattr(self.get_base_layer(), "weight", None)
-        if weight is not None:
-            # the layer is already completely initialized, this is an update
-            if weight.dtype.is_floating_point or weight.dtype.is_complex:
-                self.to(weight.device, dtype=weight.dtype)
-            else:
-                self.to(weight.device)
-
+        self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
     def reset_vera_parameters(self, adapter_name, d_initial: float = 0.1):

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 from parameterized import parameterized
+from torch import nn
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForSeq2SeqLM,
@@ -29,14 +30,21 @@ from transformers import (
     LlamaForCausalLM,
     WhisperForConditionalGeneration,
 )
+from transformers.pytorch_utils import Conv1D
 
 from peft import (
     AdaLoraConfig,
     AdaptionPromptConfig,
+    BOFTConfig,
     IA3Config,
+    LNTuningConfig,
+    LoHaConfig,
+    LoKrConfig,
     LoraConfig,
+    OFTConfig,
     PeftModel,
     TaskType,
+    VeraConfig,
     get_peft_model,
     prepare_model_for_kbit_training,
 )
@@ -1078,3 +1086,326 @@ class PeftGPUCommonTests(unittest.TestCase):
         assert torch.allclose(out_dora, out_merged, atol=atol, rtol=rtol)
         assert torch.allclose(out_dora, out_unmerged, atol=atol, rtol=rtol)
         assert torch.allclose(out_dora, out_unloaded, atol=atol, rtol=rtol)
+
+
+class TestSameAdapterDifferentDevices:
+    # 1639
+    # The original issue comes down to the following problem: If the user has a base layer on CUDA, moves the adapter to
+    # CPU, then adds another adapter (which will automatically be moved to CUDA), then the first adapter will also be
+    # moved to CUDA.
+    @pytest.fixture
+    def mlp(self):
+        class MLP(nn.Module):
+            def __init__(self, bias=True):
+                super().__init__()
+                self.lin0 = nn.Linear(8, 32, bias=bias)
+                self.lin1 = nn.Linear(32, 2, bias=bias)
+
+        return MLP()
+
+    @pytest.fixture
+    def emb_conv1d(self):
+        class ModelEmbConv1D(nn.Module):
+            def __init__(self, emb_size=100):
+                super().__init__()
+                self.emb = nn.Embedding(emb_size, 5)
+                self.conv1d = Conv1D(1, 5)
+
+        return ModelEmbConv1D()
+
+    @pytest.fixture
+    def conv2d(self):
+        class ModelConv2D(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv2d = nn.Conv2d(5, 10, 3)
+
+        return ModelConv2D()
+
+    def test_lora_one_target_add_new_adapter_does_not_change_device(self, mlp):
+        config = LoraConfig(target_modules=["lin0"])
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.lora_A.cpu()
+        model.lin0.lora_B.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.lora_A.default.weight.device.type == "cpu"
+        assert model.lin0.lora_B.default.weight.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.lora_A.default.weight.device.type == "cpu"
+        assert model.lin0.lora_B.default.weight.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.lora_A.other.weight.device.type == "cuda"
+        assert model.lin0.lora_B.other.weight.device.type == "cuda"
+
+    def test_lora_multiple_targets_add_new_adapater_does_not_change_device(self, mlp):
+        # same as the previous test, but targeting multiple layers
+        config = LoraConfig(target_modules=["lin0", "lin1"])
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        # move lin1 to CPU but leave lin0 on GPU
+        model.lin1.lora_A.cpu()
+        model.lin1.lora_B.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin1.lora_A.default.weight.device.type == "cpu"
+        assert model.lin1.lora_B.default.weight.device.type == "cpu"
+        assert model.lin1.base_layer.weight.device.type == "cuda"
+        assert model.lin0.lora_A.default.weight.device.type == "cuda"
+        assert model.lin0.lora_B.default.weight.device.type == "cuda"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin1.lora_A.default.weight.device.type == "cpu"
+        assert model.lin1.lora_B.default.weight.device.type == "cpu"
+        assert model.lin1.base_layer.weight.device.type == "cuda"
+        # the rest should be on GPU
+        assert model.lin0.lora_A.default.weight.device.type == "cuda"
+        assert model.lin0.lora_B.default.weight.device.type == "cuda"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.lora_A.other.weight.device.type == "cuda"
+        assert model.lin0.lora_B.other.weight.device.type == "cuda"
+        assert model.lin1.lora_A.other.weight.device.type == "cuda"
+        assert model.lin1.lora_B.other.weight.device.type == "cuda"
+
+    def test_lora_embedding_target_add_new_adapter_does_not_change_device(self, emb_conv1d):
+        # same as first test, but targeting the embedding layer
+        config = LoraConfig(target_modules=["emb"])
+        model = get_peft_model(emb_conv1d, config)
+        model = model.cuda()
+        model.emb.lora_embedding_A.cpu()
+        model.emb.lora_embedding_B.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.emb.lora_embedding_A.default.device.type == "cpu"
+        assert model.emb.lora_embedding_B.default.device.type == "cpu"
+        assert model.emb.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.emb.lora_embedding_A.default.device.type == "cpu"
+        assert model.emb.lora_embedding_B.default.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.emb.weight.device.type == "cuda"
+        assert model.emb.lora_embedding_A.other.device.type == "cuda"
+        assert model.emb.lora_embedding_B.other.device.type == "cuda"
+
+    def test_lora_conv1d_target_add_new_adapter_does_not_change_device(self, emb_conv1d):
+        # same as first test, but targeting the Conv1D layer
+        config = LoraConfig(target_modules=["conv1d"])
+        model = get_peft_model(emb_conv1d, config)
+        model = model.cuda()
+        model.conv1d.lora_A.cpu()
+        model.conv1d.lora_B.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.conv1d.lora_A.default.weight.device.type == "cpu"
+        assert model.conv1d.lora_B.default.weight.device.type == "cpu"
+        assert model.conv1d.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.conv1d.lora_A.default.weight.device.type == "cpu"
+        assert model.conv1d.lora_B.default.weight.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.conv1d.weight.device.type == "cuda"
+        assert model.conv1d.lora_A.other.weight.device.type == "cuda"
+        assert model.conv1d.lora_B.other.weight.device.type == "cuda"
+
+    def test_lora_dora_add_new_adapter_does_not_change_device(self, mlp):
+        # same as first test, but also using DoRA
+        config = LoraConfig(target_modules=["lin0"], use_dora=True)
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.lora_A.cpu()
+        model.lin0.lora_B.cpu()
+        model.lin0.lora_magnitude_vector.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.lora_A.default.weight.device.type == "cpu"
+        assert model.lin0.lora_B.default.weight.device.type == "cpu"
+        assert model.lin0.lora_magnitude_vector.default.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.lora_A.default.weight.device.type == "cpu"
+        assert model.lin0.lora_B.default.weight.device.type == "cpu"
+        assert model.lin0.lora_magnitude_vector.default.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.lora_A.other.weight.device.type == "cuda"
+        assert model.lin0.lora_B.other.weight.device.type == "cuda"
+        assert model.lin0.lora_magnitude_vector.other.device.type == "cuda"
+
+    def test_adalora_add_new_adapter_does_not_change_device(self, mlp):
+        # same as first test, but using AdaLORA
+        # AdaLora does not like multiple trainable adapters, hence inference_mode=True
+        config = AdaLoraConfig(target_modules=["lin0"], inference_mode=True)
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.lora_A.cpu()
+        model.lin0.lora_E.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.lora_A.default.device.type == "cpu"
+        assert model.lin0.lora_E.default.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.lora_A.default.device.type == "cpu"
+        assert model.lin0.lora_E.default.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.lora_A.other.device.type == "cuda"
+        assert model.lin0.lora_E.other.device.type == "cuda"
+
+    def test_boft_add_new_adapter_does_not_change_device(self, mlp):
+        # same as first test, but using BoFT
+        config = BOFTConfig(target_modules=["lin0"])
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.boft_R.cpu()
+        model.lin0.boft_s.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.boft_R.default.device.type == "cpu"
+        assert model.lin0.boft_s.default.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.boft_R.default.device.type == "cpu"
+        assert model.lin0.boft_s.default.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.boft_R.other.device.type == "cuda"
+        assert model.lin0.boft_s.other.device.type == "cuda"
+
+    def test_ia3_add_new_adapter_does_not_change_device(self, mlp):
+        # same as first test, but using IA3
+        config = IA3Config(target_modules=["lin0"], feedforward_modules=["lin0"])
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.ia3_l.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.ia3_l.default.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.ia3_l.default.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.ia3_l.other.device.type == "cuda"
+
+    @pytest.mark.xfail(reason="LN Tuning handling of multiple adapters may not be correct", strict=True)
+    def test_ln_tuning_add_new_adapter_does_not_change_device(self, mlp):
+        # same as first test, but using LN tuning
+        config = LNTuningConfig(target_modules=["lin0"])
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.ln_tuning_layers.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.ln_tuning_layers.default.weight.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.ln_tuning_layers.default.weight.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.ln_tuning_layers.other.weight.device.type == "cuda"
+
+    def test_loha_add_new_adapter_does_not_change_device(self, mlp):
+        # same as first test, but using LoHa
+        config = LoHaConfig(target_modules=["lin0"])
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.hada_w1_a.cpu()
+        model.lin0.hada_w2_b.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.hada_w1_a.default.device.type == "cpu"
+        assert model.lin0.hada_w2_b.default.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.hada_w1_a.default.device.type == "cpu"
+        assert model.lin0.hada_w2_b.default.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.hada_w1_a.other.device.type == "cuda"
+        assert model.lin0.hada_w2_b.other.device.type == "cuda"
+
+    def test_lokr_add_new_adapter_does_not_change_device(self, mlp):
+        # same as first test, but using LoKr
+        config = LoKrConfig(target_modules=["lin0"])
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.lokr_w1.cpu()
+        model.lin0.lokr_w2.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.lokr_w1.default.device.type == "cpu"
+        assert model.lin0.lokr_w2.default.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.lokr_w1.default.device.type == "cpu"
+        assert model.lin0.lokr_w2.default.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.lokr_w1.other.device.type == "cuda"
+        assert model.lin0.lokr_w2.other.device.type == "cuda"
+
+    def test_oft_add_new_adapter_does_not_change_device(self, mlp):
+        # same as first test, but using OFT
+        config = OFTConfig(target_modules=["lin0"])
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.oft_r.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.oft_r.default.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.oft_r.default.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.oft_r.other.device.type == "cuda"
+
+    def test_vera_add_new_adapter_does_not_change_device(self, mlp):
+        # same as first test, but using VERA
+        config = VeraConfig(target_modules=["lin0"])
+        model = get_peft_model(mlp, config)
+        model = model.cuda()
+        model.lin0.vera_A.cpu()
+        model.lin0.vera_lambda_d.cpu()
+
+        # check that the adapter is indeed on CPU and the base model on GPU
+        assert model.lin0.vera_A.default.device.type == "cpu"
+        assert model.lin0.vera_lambda_d.default.device.type == "cpu"
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+
+        model.add_adapter("other", config)
+        # check that after adding a new adapter, the old adapter is still on CPU
+        assert model.lin0.vera_A.default.device.type == "cpu"
+        assert model.lin0.vera_lambda_d.default.device.type == "cpu"
+        # the rest should be on GPU
+        assert model.lin0.base_layer.weight.device.type == "cuda"
+        assert model.lin0.vera_A.other.device.type == "cuda"
+        assert model.lin0.vera_lambda_d.other.device.type == "cuda"

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -1088,7 +1088,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         assert torch.allclose(out_dora, out_unloaded, atol=atol, rtol=rtol)
 
 
-@require_torch_gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires a CUDA GPU")
 class TestSameAdapterDifferentDevices:
     # 1639
     # The original issue comes down to the following problem: If the user has a base layer on CUDA, moves the adapter to

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -1088,6 +1088,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         assert torch.allclose(out_dora, out_unloaded, atol=atol, rtol=rtol)
 
 
+@require_torch_gpu
 class TestSameAdapterDifferentDevices:
     # 1639
     # The original issue comes down to the following problem: If the user has a base layer on CUDA, moves the adapter to


### PR DESCRIPTION
Resolves #1639

The issue is that so far, we made the assumption in PEFT that all adapter weights of a specific layer are on the same device. There can be cases where it is useful to have adapters on different devices. E.g. when a user loads a lot of LoRA adapters and wants to offload those not currently in use to CPU, they would not currently be able to do so.

With this PR, we add this possibility. To achieve this, when we update an adapter layer with a new adapter, we only move that specific adapter to the device of the base layer, will not touching the other loaded adapters.

While working on this, I discovered a small bug in VeRA when adding multiple adapters, which is now also fixed.

This PR has the potential to lead to unforeseen issues, so careful review is required. After merging this, let's keep it out of releases for a while to ensure it doesn't break anything.