### PR TITLE
ENH Layer/model status shows devices now

### DIFF
--- a/docs/source/developer_guides/troubleshooting.md
+++ b/docs/source/developer_guides/troubleshooting.md
@@ -214,6 +214,7 @@ It is possible to get this information for non-PEFT models if they are using PEF
 >>> pipe = StableDiffusionPipeline.from_pretrained(path, torch_dtype=torch.float16)
 >>> pipe.load_lora_weights(lora_id, adapter_name="adapter-1")
 >>> pipe.load_lora_weights(lora_id, adapter_name="adapter-2")
+>>> pipe.set_lora_device(["adapter-2"], "cuda")
 >>> get_layer_status(pipe.text_encoder)
 [TunerLayerStatus(name='text_model.encoder.layers.0.self_attn.k_proj',
                   module_type='lora.Linear',
@@ -221,14 +222,15 @@ It is possible to get this information for non-PEFT models if they are using PEF
                   active_adapters=['adapter-2'],
                   merged_adapters=[],
                   requires_grad={'adapter-1': False, 'adapter-2': True},
-                  available_adapters=['adapter-1', 'adapter-2']),
+                  available_adapters=['adapter-1', 'adapter-2'],
+                  devices={'adapter-1': ['cpu'], 'adapter-2': ['cuda]}),
  TunerLayerStatus(name='text_model.encoder.layers.0.self_attn.v_proj',
                   module_type='lora.Linear',
                   enabled=True,
                   active_adapters=['adapter-2'],
                   merged_adapters=[],
                   requires_grad={'adapter-1': False, 'adapter-2': True},
-                  available_adapters=['adapter-1', 'adapter-2']),
+                  devices={'adapter-1': ['cpu'], 'adapter-2': ['cuda]}),
 ...]
 
 >>> get_model_status(pipe.unet)
@@ -244,5 +246,6 @@ TunerModelStatus(
     merged_adapters=[],
     requires_grad={'adapter-1': False, 'adapter-2': True},
     available_adapters=['adapter-1', 'adapter-2'],
+    devices={'adapter-1': ['cpu'], 'adapter-2': ['cuda],
 )
 ```

--- a/docs/source/developer_guides/troubleshooting.md
+++ b/docs/source/developer_guides/troubleshooting.md
@@ -223,14 +223,14 @@ It is possible to get this information for non-PEFT models if they are using PEF
                   merged_adapters=[],
                   requires_grad={'adapter-1': False, 'adapter-2': True},
                   available_adapters=['adapter-1', 'adapter-2'],
-                  devices={'adapter-1': ['cpu'], 'adapter-2': ['cuda]}),
+                  devices={'adapter-1': ['cpu'], 'adapter-2': ['cuda']}),
  TunerLayerStatus(name='text_model.encoder.layers.0.self_attn.v_proj',
                   module_type='lora.Linear',
                   enabled=True,
                   active_adapters=['adapter-2'],
                   merged_adapters=[],
                   requires_grad={'adapter-1': False, 'adapter-2': True},
-                  devices={'adapter-1': ['cpu'], 'adapter-2': ['cuda]}),
+                  devices={'adapter-1': ['cpu'], 'adapter-2': ['cuda']}),
 ...]
 
 >>> get_model_status(pipe.unet)
@@ -246,6 +246,6 @@ TunerModelStatus(
     merged_adapters=[],
     requires_grad={'adapter-1': False, 'adapter-2': True},
     available_adapters=['adapter-1', 'adapter-2'],
-    devices={'adapter-1': ['cpu'], 'adapter-2': ['cuda],
+    devices={'adapter-1': ['cpu'], 'adapter-2': ['cuda']},
 )
 ```

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2437,6 +2437,7 @@ class TunerLayerStatus:
     merged_adapters: list[str]
     requires_grad: dict[str, bool | Literal["irregular"]]
     available_adapters: list[str]
+    devices: dict[str, list[str]]
 
 
 def get_layer_status(model: torch.nn.Module) -> list[TunerLayerStatus]:
@@ -2461,6 +2462,8 @@ def get_layer_status(model: torch.nn.Module) -> list[TunerLayerStatus]:
        `"irregular"`.
     - `available_adapters` (`list[str]`):
        The names of the available adapters, e.g. `["default"]`.
+    - `devices` (`dict[str, list[str]]`):
+       The devices where the parameters of the given adapter are stored, e.g. `["cuda"]`.
 
     Args:
         model ([Union[`~PeftModel`, `~transformers.PreTrainedModel`, `nn.Module`]]):
@@ -2510,6 +2513,20 @@ def get_layer_status(model: torch.nn.Module) -> list[TunerLayerStatus]:
 
         requires_grad = {key: check_irrgular(vals) for key, vals in mapping_requires_grad_list.items()}
 
+        devices_dd = collections.defaultdict(list)
+        for adapter_module_name in module.adapter_layer_names + module.other_param_names:
+            adapter_module = getattr(module, adapter_module_name)
+            if isinstance(adapter_module, torch.nn.ModuleDict):
+                for key, submodule in adapter_module.items():
+                    devices_dd[key].extend([param.device.type for param in submodule.parameters()])
+            elif (
+                isinstance(adapter_module, torch.nn.ParameterDict)
+                or (adapter_module.__class__.__name__ == "BufferDict")  # VeRA
+            ):
+                for key, param in adapter_module.items():
+                    devices_dd[key].append(param.device.type)
+        devices = {key: sorted(set(val)) for key, val in devices_dd.items()}
+
         status = TunerLayerStatus(
             name=name,
             module_type=repr(module).partition("(")[0],
@@ -2518,6 +2535,7 @@ def get_layer_status(model: torch.nn.Module) -> list[TunerLayerStatus]:
             merged_adapters=module.merged_adapters,
             requires_grad=requires_grad,
             available_adapters=sorted(module._get_available_adapters()),
+            devices=devices,
         )
         layer_status.append(status)
 
@@ -2543,6 +2561,7 @@ class TunerModelStatus:
     merged_adapters: list[str] | Literal["irregular"]
     requires_grad: dict[str, bool | Literal["irregular"]]
     available_adapters: list[str]
+    devices: dict[str, list[str]]
 
 
 def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
@@ -2577,6 +2596,8 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
        work as expected.
     - `available_adapters` (`list[str]`):
        The names of the available adapters, e.g. `["default"]`.
+    - `devices` (`dict[str, list[str]]`):
+       The devices where the parameters of the given adapter are stored, e.g. `["cuda"]`.
 
     Args:
         model ([Union[`~PeftModel`, `~transformers.PreTrainedModel`, `nn.Module`]]):
@@ -2668,6 +2689,12 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
 
     requires_grad = {key: check_irrgular(vals) for key, vals in requires_grad_all.items()}
 
+    devices_dd = collections.defaultdict(list)
+    for status in layer_status:
+        for key, val in status.devices.items():
+            devices_dd[key].extend(val)
+    devices = {key: sorted(set(val)) for key, val in devices_dd.items()}
+
     adapter_model_status = TunerModelStatus(
         base_model_type=base_model_type,
         adapter_model_type=adapter_model_type,
@@ -2680,5 +2707,6 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
         merged_adapters=merged_adapters,
         requires_grad=requires_grad,
         available_adapters=available_adapters,
+        devices=devices,
     )
     return adapter_model_status

--- a/src/peft/tuners/vera/layer.py
+++ b/src/peft/tuners/vera/layer.py
@@ -265,3 +265,7 @@ class Linear(nn.Linear, VeraLayer):
 
         result = result.to(previous_dtype)
         return result
+
+    def __repr__(self) -> str:
+        rep = super().__repr__()
+        return "vera." + rep

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -831,8 +831,8 @@ class TestModelAndLayerStatus:
         config = LoHaConfig(target_modules=["lin0", "lin1"], init_weights=False)
         model = get_peft_model(base_model, config)
 
-        model_status = get_model_status(model)
-        layer_status = get_layer_status(model)
+        model_status = model.get_model_status()
+        layer_status = model.get_layer_status()
 
         assert model_status.base_model_type == "SmallModel"
         assert model_status.adapter_model_type == "LoHaModel"
@@ -874,8 +874,8 @@ class TestModelAndLayerStatus:
         # move the buffer dict to CUDA
         model.lin0.vera_A["default"] = model.lin0.vera_A["default"].to("cuda")
 
-        model_status = get_model_status(model)
-        layer_status = get_layer_status(model)
+        model_status = model.get_model_status()
+        layer_status = model.get_layer_status()
 
         assert model_status.base_model_type == "SmallModel"
         assert model_status.adapter_model_type == "VeraModel"

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -31,6 +31,7 @@ from peft import (
     LoHaConfig,
     LoraConfig,
     PromptTuningConfig,
+    VeraConfig,
     get_layer_status,
     get_model_status,
     get_peft_model,
@@ -573,6 +574,50 @@ class TestModelAndLayerStatus:
         expected = [["default", "other"], ["default"], ["other"], ["default"]]
         assert result == expected
 
+    def test_devices_all_cpu_small(self, small_model):
+        layer_status = small_model.get_layer_status()
+        result = [status.devices for status in layer_status]
+        expected = [{"default": ["cpu"]}]
+        assert result == expected
+
+    def test_devices_all_cpu_large(self, large_model):
+        layer_status = large_model.get_layer_status()
+        result = [status.devices for status in layer_status]
+        expected = [
+            {"default": ["cpu"], "other": ["cpu"]},
+            {"default": ["cpu"]},
+            {"other": ["cpu"]},
+            {"default": ["cpu"]},
+        ]
+        assert result == expected
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    def test_devices_all_cuda_large(self, large_model):
+        large_model.to("cuda")
+        layer_status = large_model.get_layer_status()
+        result = [status.devices for status in layer_status]
+        expected = [
+            {"default": ["cuda"], "other": ["cuda"]},
+            {"default": ["cuda"]},
+            {"other": ["cuda"]},
+            {"default": ["cuda"]},
+        ]
+        assert result == expected
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    def test_devices_cpu_and_cuda_large(self, large_model):
+        # move the embedding layer to CUDA
+        large_model.model.lin0.lora_A["default"] = large_model.model.lin0.lora_A["default"].to("cuda")
+        layer_status = large_model.get_layer_status()
+        result = [status.devices for status in layer_status]
+        expected = [
+            {"default": ["cpu", "cuda"], "other": ["cpu"]},
+            {"default": ["cpu"]},
+            {"other": ["cpu"]},
+            {"default": ["cpu"]},
+        ]
+        assert result == expected
+
     ################
     # model status #
     ################
@@ -753,8 +798,29 @@ class TestModelAndLayerStatus:
         model_status = large_model.get_model_status()
         assert model_status.available_adapters == ["default", "other"]
 
+    def test_model_devices_all_cpu_small(self, small_model):
+        model_status = small_model.get_model_status()
+        assert model_status.devices == {"default": ["cpu"]}
+
+    def test_model_devices_all_cpu_large(self, large_model):
+        model_status = large_model.get_model_status()
+        assert model_status.devices == {"default": ["cpu"], "other": ["cpu"]}
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    def test_model_devices_all_cuda_large(self, large_model):
+        large_model.to("cuda")
+        model_status = large_model.get_model_status()
+        assert model_status.devices == {"default": ["cuda"], "other": ["cuda"]}
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    def test_model_devices_cpu_and_cuda_large(self, large_model):
+        # move the embedding layer to CUDA
+        large_model.model.lin0.lora_A["default"] = large_model.model.lin0.lora_A["default"].to("cuda")
+        model_status = large_model.get_model_status()
+        assert model_status.devices == {"default": ["cpu", "cuda"], "other": ["cpu"]}
+
     def test_loha_model(self):
-        # ensure that this also works with non-LoRA, it's enough to test one other tuner
+        # ensure that this also works with non-LoRA, it's not necessary to test all tuners
         class SmallModel(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -779,6 +845,7 @@ class TestModelAndLayerStatus:
         assert model_status.merged_adapters == []
         assert model_status.requires_grad == {"default": True}
         assert model_status.available_adapters == ["default"]
+        assert model_status.devices == {"default": ["cpu"]}
 
         layer_status0 = layer_status[0]
         assert len(layer_status) == 2
@@ -789,6 +856,50 @@ class TestModelAndLayerStatus:
         assert layer_status0.merged_adapters == []
         assert layer_status0.requires_grad == {"default": True}
         assert layer_status0.available_adapters == ["default"]
+        assert layer_status0.devices == {"default": ["cpu"]}
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    def test_vera_model(self):
+        # let's also test VeRA because it uses BufferDict
+        class SmallModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin0 = nn.Linear(10, 10)
+                self.lin1 = nn.Linear(10, 10)
+
+        base_model = SmallModel()
+        config = VeraConfig(target_modules=["lin0", "lin1"], init_weights=False)
+        model = get_peft_model(base_model, config)
+
+        # move the buffer dict to CUDA
+        model.lin0.vera_A["default"] = model.lin0.vera_A["default"].to("cuda")
+
+        model_status = get_model_status(model)
+        layer_status = get_layer_status(model)
+
+        assert model_status.base_model_type == "SmallModel"
+        assert model_status.adapter_model_type == "VeraModel"
+        assert model_status.peft_types == {"default": "VERA"}
+        assert model_status.trainable_params == 532
+        assert model_status.total_params == 752
+        assert model_status.num_adapter_layers == 2
+        assert model_status.enabled is True
+        assert model_status.active_adapters == ["default"]
+        assert model_status.merged_adapters == []
+        assert model_status.requires_grad == {"default": True}
+        assert model_status.available_adapters == ["default"]
+        assert model_status.devices == {"default": ["cpu", "cuda"]}
+
+        layer_status0 = layer_status[0]
+        assert len(layer_status) == 2
+        assert layer_status0.name == "model.lin0"
+        assert layer_status0.module_type == "vera.Linear"
+        assert layer_status0.enabled is True
+        assert layer_status0.active_adapters == ["default"]
+        assert layer_status0.merged_adapters == []
+        assert layer_status0.requires_grad == {"default": True}
+        assert layer_status0.available_adapters == ["default"]
+        assert layer_status0.devices == {"default": ["cpu", "cuda"]}
 
     ###################
     # non-PEFT models #
@@ -813,6 +924,7 @@ class TestModelAndLayerStatus:
         assert model_status.merged_adapters == []
         assert model_status.requires_grad == {"default": False}
         assert model_status.available_adapters == ["default"]
+        assert model_status.devices == {"default": ["cpu"]}
 
         layer_status0 = layer_status[0]
         assert len(layer_status) == 12
@@ -823,6 +935,7 @@ class TestModelAndLayerStatus:
         assert layer_status0.merged_adapters == []
         assert layer_status0.requires_grad == {"default": False}
         assert layer_status0.available_adapters == ["default"]
+        assert layer_status0.devices == {"default": ["cpu"]}
 
     def test_model_with_injected_layers(self, large_model):
         model = large_model.base_model.model
@@ -840,6 +953,7 @@ class TestModelAndLayerStatus:
         assert model_status.merged_adapters == []
         assert model_status.requires_grad == {"default": True, "other": False}
         assert model_status.available_adapters == ["default", "other"]
+        assert model_status.devices == {"default": ["cpu"], "other": ["cpu"]}
 
         layer_status1 = layer_status[1]
         assert len(layer_status) == 4
@@ -850,6 +964,7 @@ class TestModelAndLayerStatus:
         assert layer_status1.merged_adapters == []
         assert layer_status1.requires_grad == {"default": True}
         assert layer_status1.available_adapters == ["default"]
+        assert layer_status1.devices == {"default": ["cpu"]}
 
     ###############
     # error cases #


### PR DESCRIPTION
For each adapter, show all the devices of this adapter's parameters.

Also, while working on this, found a very minor bug in VeRA as its linear layer didn't implement its own `__repr__`.