### PR TITLE
FIX Use correct attribute name for HQQ in merge

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -236,7 +236,10 @@ class LoraModel(BaseTuner):
             child = child.base_layer
 
         if not hasattr(new_module, "base_layer"):
-            new_module.weight = child.weight
+            if hasattr(new_module, "W_q"):  # HQQ
+                new_module.W_q = child.W_q
+            else:
+                new_module.weight = child.weight
             if hasattr(child, "bias"):
                 new_module.bias = child.bias
 


### PR DESCRIPTION
Without this fix, [test_hqq_lora_model_outputs](https://github.com/huggingface/peft/actions/runs/9184294503/job/25256361781) currently fails.