### PR TITLE
FIX CI: Install pytest-reportlog package

### DIFF
--- a/.github/workflows/torch_compile_tests.yml
+++ b/.github/workflows/torch_compile_tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           source activate peft
           pip install -e . --no-deps
-          pip install pytest-cov parameterized datasets scipy einops
+          pip install pytest-cov pytest-reportlog parameterized datasets scipy einops
           pip install "pytest>=7.2.0,<8.0.0" # see: https://github.com/huggingface/transformers/blob/ce4fff0be7f6464d713f7ac3e0bbaafbc6959ae5/setup.py#L148C6-L148C26
           if [ "${{ github.event.inputs.pytorch_nightly }}" = "true" ]; then
             python -m pip install --upgrade --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu


### PR DESCRIPTION
To fix:

> `UsageError: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: unrecognized arguments: --report-log compile_tests.log`