### PR TITLE
FIX Failing Llama tests due to new kv cache

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1566,7 +1566,7 @@ class PeftModelForCausalLM(PeftModel):
                 # In prompt learning methods, past key values are longer when compared to the `input_ids`.
                 # As such only consider the last input ids in the autogressive generation phase.
                 past_key_values = model_kwargs["past_key_values"]
-                if isinstance(past_key_values, tuple):
+                if isinstance(past_key_values, (tuple, list)):
                     seq_len = past_key_values[0][0].shape[-2]
                 else:  # using transformers kv cache
                     seq_len = past_key_values.get_seq_length()

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1565,7 +1565,12 @@ class PeftModelForCausalLM(PeftModel):
                 # change in the logic of `prepare_inputs_for_generation` makes the below code necessary
                 # In prompt learning methods, past key values are longer when compared to the `input_ids`.
                 # As such only consider the last input ids in the autogressive generation phase.
-                if model_kwargs["past_key_values"][0][0].shape[-2] >= model_kwargs["input_ids"].shape[1]:
+                past_key_values = model_kwargs["past_key_values"]
+                if isinstance(past_key_values, tuple):
+                    seq_len = past_key_values[0][0].shape[-2]
+                else:  # using transformers kv cache
+                    seq_len = past_key_values.get_seq_length()
+                if seq_len >= model_kwargs["input_ids"].shape[1]:
                     model_kwargs["input_ids"] = model_kwargs["input_ids"][:, -1:]
 
             if model_kwargs.get("attention_mask", None) is not None:


### PR DESCRIPTION
Requires to install transformers from source (so normal CI won't pick this up).

To replicate, run these tests:

```
pytest tests/test_multitask_prompt_tuning.py
pytest tests/test_decoder_models.py -k
"test_trl_internal_testing_tiny_random_LlamaForCausalLM and (prefix or prompt) and (generate or disable)"
```

This should result in 17 failing tests.

The issue is that `past_key_values` can now be an instance of `DynamicCache`. Therefore, just indexing into it won't work anymore. The solution is to check the type and if it's not a tuple, use the methods on the cache object instead.