### PR TITLE
CI Activate env to prevent bnb import error

### DIFF
--- a/.github/workflows/nightly-bnb.yml
+++ b/.github/workflows/nightly-bnb.yml
@@ -51,6 +51,7 @@ jobs:
         id: import
         if: always()
         run: |
+          source activate peft
           python3 -m bitsandbytes
           python3 -c "import bitsandbytes as bnb"
 

--- a/.github/workflows/nightly-bnb.yml
+++ b/.github/workflows/nightly-bnb.yml
@@ -171,6 +171,8 @@ jobs:
         id: import
         if: always()
         run: |
+          source activate peft
+          python3 -m bitsandbytes
           python3 -c "import bitsandbytes as bnb"
 
       - name: Post to Slack


### PR DESCRIPTION
All bitsandbytes nightly CI runs are currently [failing](https://github.com/huggingface/peft/actions/runs/9458512932/job/26054124989) with:

> Run python3 -m bitsandbytes
> /opt/conda/bin/python3: No module named bitsandbytes

This fix should hopefully solve this, but it's untested.