### PR TITLE
FIX: Adalora ranknum loaded on wrong device

### DIFF
--- a/src/peft/tuners/adalora/layer.py
+++ b/src/peft/tuners/adalora/layer.py
@@ -35,7 +35,8 @@ class AdaLoraLayer(LoraLayer):
     # List all names of layers that may contain adapter weights
     # Note: ranknum doesn't need to be included as it is not an nn.Module
     adapter_layer_names = ("lora_A", "lora_B", "lora_E", "lora_embedding_A", "lora_embedding_B")
-    # other_param_names is defined in LoraLayer
+    # All names of other parameters that may contain adapter-related parameters
+    other_param_names = ("r", "lora_alpha", "scaling", "lora_dropout", "ranknum")
 
     def __init__(self, base_layer: nn.Module) -> None:
         super().__init__(base_layer)

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -669,7 +669,9 @@ class BaseTunerLayer(ABC):
                     )
                     self.set_adapter(remaining_adapters[0])
 
-    def _move_adapter_to_device_of_base_layer(self, adapter_name: str, device: Optional[torch.device] = None) -> None:
+    def _move_adapter_to_device_of_base_layer(
+        self, adapter_name: str, device: Optional[torch.device] = None
+    ) -> torch.device:
         """
         Move the adapter of the given name to the device of the base layer.
         """
@@ -700,6 +702,8 @@ class BaseTunerLayer(ABC):
                 adapter_layer[adapter_name] = adapter_layer[adapter_name].to(device, dtype=dtype)
             else:
                 adapter_layer[adapter_name] = adapter_layer[adapter_name].to(device)
+
+        return device
 
 
 def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -669,9 +669,7 @@ class BaseTunerLayer(ABC):
                     )
                     self.set_adapter(remaining_adapters[0])
 
-    def _move_adapter_to_device_of_base_layer(
-        self, adapter_name: str, device: Optional[torch.device] = None
-    ) -> torch.device:
+    def _move_adapter_to_device_of_base_layer(self, adapter_name: str, device: Optional[torch.device] = None) -> None:
         """
         Move the adapter of the given name to the device of the base layer.
         """
@@ -702,8 +700,6 @@ class BaseTunerLayer(ABC):
                 adapter_layer[adapter_name] = adapter_layer[adapter_name].to(device, dtype=dtype)
             else:
                 adapter_layer[adapter_name] = adapter_layer[adapter_name].to(device)
-
-        return device
 
 
 def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -1085,6 +1085,7 @@ class PeftGPUCommonTests(unittest.TestCase):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires a CUDA GPU")
+@pytest.mark.single_gpu_tests
 class TestSameAdapterDifferentDevices:
     # 1639
     # The original issue comes down to the following problem: If the user has a base layer on CUDA, moves the adapter to


### PR DESCRIPTION
Locally, multiple AdaLoRA-related tests are failing. We did not catch this in the nightly run because the tests were missing the necessary pytest marker.

The issue is related to the change in #1742, which made it possible to load different adapters on different devices. Although that PR itself was sound, the problem is that for AdaLoRA, one of its parameters, `ranknum`, was not listed in the `other_param_names` and was thus not moved to the correct device. This oversight is now fixed and the GPU tests are now passing locally for me.

Note that this bug only occurred in the tests when loading a 2nd AdaLoRA adapter. At first I was confused because I thought that this is not supported (there is a check for that), but actually it's supported as long as the additional adapters are not trainable, so the check is fine.

This PR also adds the missing pytest marker to the test class that was missing it, so that these errors should be caught by our nightly CI in the future.