### PR TITLE
Workflow / FIX: Fix red status on our CI

### DIFF
--- a/.github/workflows/nightly-bnb.yml
+++ b/.github/workflows/nightly-bnb.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
           title: 🤗 Results of bitsandbytes import
-          status: ${{ steps.import.status }}
+          status: ${{ steps.import.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
           
       - name: Run examples on single GPU
@@ -77,7 +77,7 @@ jobs:
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
           title: 🤗 Results of bitsandbytes examples tests - single GPU
-          status: ${{ steps.examples_tests.status }}
+          status: ${{ steps.examples_tests.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
       
       - name: Run core tests on single GPU
@@ -93,7 +93,7 @@ jobs:
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
           title: 🤗 Results of bitsandbytes core tests - single GPU
-          status: ${{ steps.core_tests.status }}
+          status: ${{ steps.core_tests.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
       - name: Run BNB regression tests on single GPU
@@ -109,7 +109,7 @@ jobs:
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
           title: 🤗 Results of bitsandbytes regression tests - single GPU
-          status: ${{ steps.regression_tests.status }}
+          status: ${{ steps.regression_tests.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
       - name: Run transformers tests on single GPU
@@ -125,7 +125,7 @@ jobs:
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
           title: 🤗 Results of bitsandbytes transformers tests - single GPU
-          status: ${{ steps.transformers_tests.status }}
+          status: ${{ steps.transformers_tests.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
           
       - name: Generate Report
@@ -181,7 +181,7 @@ jobs:
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
           title: 🤗 Results of bitsandbytes import
-          status: ${{ steps.import.status }}
+          status: ${{ steps.import.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
       - name: Run core GPU tests on multi-gpu
@@ -202,7 +202,7 @@ jobs:
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
           title: 🤗 Results of bitsandbytes examples tests - multi GPU
-          status: ${{ steps.examples_tests.status }}
+          status: ${{ steps.examples_tests.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
       
       - name: Run core tests on multi GPU
@@ -218,7 +218,7 @@ jobs:
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
           title: 🤗 Results of bitsandbytes core tests - multi GPU
-          status: ${{ steps.core_tests.status }}
+          status: ${{ steps.core_tests.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
       - name: Run transformers tests on multi GPU
@@ -234,7 +234,7 @@ jobs:
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
           title: 🤗 Results of bitsandbytes transformers tests - multi GPU
-          status: ${{ steps.transformers_tests.status }}
+          status: ${{ steps.transformers_tests.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
           
       - name: Generate Report


### PR DESCRIPTION
# What does this PR do?

According to: https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context when manipulating steps statuses, one should always use `steps.<step_id>.outputs` to retrieve the status. See also: https://stackoverflow.com/a/58003436 

cc @BenjaminBossan 