### PR TITLE
DOC Move helpers section to dev developer guide

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -45,6 +45,8 @@
     title: Troubleshooting
   - local: developer_guides/checkpoint
     title: PEFT checkpoint format
+  - local: package_reference/helpers
+    title: Helpers
 
 - title: 🤗 Accelerate integrations
   sections:
@@ -110,8 +112,6 @@
       title: Layernorm tuning
     - local: package_reference/vera
       title: VeRA
-    - local: package_reference/helpers
-      title: Helpers
     title: Adapters
   - sections:
     - local: package_reference/merge_utils


### PR DESCRIPTION
It was in the "Adapters" section, which doesn't really fit.