### PR TITLE
Update lora_based_methods.md

### DIFF
--- a/docs/source/task_guides/lora_based_methods.md
+++ b/docs/source/task_guides/lora_based_methods.md
@@ -307,7 +307,7 @@ Let's load the model from the Hub and test it out on a food image.
 
 ```py
 from peft import PeftConfig, PeftModel
-from transfomers import AutoImageProcessor
+from transformers import AutoImageProcessor
 from PIL import Image
 import requests
 


### PR DESCRIPTION
fixed typo in instructions for peft inference, i.e. transfomers to transformers.