### PR TITLE
CI testing BNB: remove single GPU tests

### DIFF
--- a/.github/workflows/nightly-bnb.yml
+++ b/.github/workflows/nightly-bnb.yml
@@ -47,40 +47,40 @@ jobs:
             cd .. 
           fi
 
-      # TODO: uncomment this block if error is solved or bnb multi backend branch is merged
-      # - name: Test bnb import
-      #   id: import
-      #   if: always()
-      #   run: |
-      #     source activate peft
-      #     python3 -m bitsandbytes
-      #     python3 -c "import bitsandbytes as bnb"
-
-      # - name: Post to Slack
-      #   if: always()
-      #   uses: huggingface/hf-workflows/.github/actions/post-slack@main
-      #   with:
-      #     slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
-      #     title: 🤗 Results of bitsandbytes import
-      #     status: ${{ steps.import.outputs.status }}
-      #     slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
-
-      - name: Run examples on single GPU
-        id: examples_tests
+      - name: Test bnb import
+        id: import
         if: always()
         run: |
           source activate peft
-          make tests_examples_single_gpu_bnb
+          python3 -m bitsandbytes
+          python3 -c "import bitsandbytes as bnb"
 
       - name: Post to Slack
         if: always()
         uses: huggingface/hf-workflows/.github/actions/post-slack@main
         with:
           slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
-          title: 🤗 Results of bitsandbytes examples tests - single GPU
-          status: ${{ steps.examples_tests.outputs.status }}
+          title: 🤗 Results of bitsandbytes import
+          status: ${{ steps.import.outputs.status }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
-      
+
+      # TODO: uncomment this block if error is solved or bnb multi backend branch is merged
+      # - name: Run examples on single GPU
+      #   id: examples_tests
+      #   if: always()
+      #   run: |
+      #     source activate peft
+      #     make tests_examples_single_gpu_bnb
+
+      # - name: Post to Slack
+      #   if: always()
+      #   uses: huggingface/hf-workflows/.github/actions/post-slack@main
+      #   with:
+      #     slack_channel: ${{ secrets.BNB_SLACK_CHANNEL_ID }}
+      #     title: 🤗 Results of bitsandbytes examples tests - single GPU
+      #     status: ${{ steps.examples_tests.outputs.status }}
+      #     slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
+
       - name: Run core tests on single GPU
         id: core_tests
         if: always()

--- a/.github/workflows/nightly-bnb.yml
+++ b/.github/workflows/nightly-bnb.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   run_all_tests_single_gpu:
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -136,6 +137,7 @@ jobs:
           python scripts/log_reports.py --slack_channel_name bnb-daily-ci-collab >> $GITHUB_STEP_SUMMARY
 
   run_all_tests_multi_gpu:
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In #1859, we checked removing the import checks, but the single-GPU BNB multi-backend branch is still
[stuck](https://github.com/huggingface/peft/actions/runs/9540932758/job/26293392525#logs). Therefore, check commenting the next step instead.

Note: I only uncommented one step and commented the next. For some reason, the GitHub diff view is confused about that.

**Edit**: Tests are failing but for unrelated reasons, most likely because of numpy 2.0.