### PR TITLE
CI Use latest MacOS in test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        os: ["ubuntu-latest", "macos-12", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We switched to MacOS 12 in #1680 because latest MacOS was moved to use the ARM Macs, which were not provided for [Python 3.8 and 3.9](https://github.com/actions/setup-python/issues/850#issuecomment-2097496030). This should have been fixed by now.

Of course, this means that CI no longer checks Intel Macs, but I think ARM Macs will be more relevant for most users.