### PR TITLE
CI Downgrade numpy to <2.0 for Mac and Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
           # cpu version of pytorch
           pip install -e .[test]
       - name: Downgrade numpy on MacOS and Windows
-        # TODO: remove numpy downgrade on MacOS once torch fixes numpy 2.0 issue
+        # TODO: remove numpy downgrade on MacOS & Windows once torch fixes numpy 2.0 issue
         shell: bash
         if: matrix.os == 'windows-latest' || matrix.os == 'macos-12'
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,16 +44,16 @@ jobs:
           cache: "pip"
           cache-dependency-path: "setup.py"
       - name: Install dependencies
-        # TODO: remove numpy downgrade on Windows/MacOS once torch fixes numpy 2.0 issue
         run: |
           python -m pip install --upgrade pip
           # cpu version of pytorch
           pip install -e .[test]
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
-            pip install --force-reinstall -U "numpy<2.0.0"
-          elif [ "${{ matrix.os }}" == "macos-12" ]; then
-            pip install --force-reinstall -U "numpy<2.0.0"
-          fi
+      - name: Downgrade numpy on MacOS and Windows
+        # TODO: remove numpy downgrade on MacOS once torch fixes numpy 2.0 issue
+        shell: bash
+        if: matrix.os == 'windows-latest' || matrix.os == 'macos-12'
+        run: |
+          pip install --force-reinstall -U "numpy<2.0.0"
       - name: Test with pytest
         run: |
           make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,9 @@ jobs:
           python -m pip install --upgrade pip
           # cpu version of pytorch
           pip install -e .[test]
-          if [ "${{ matrix.os }}" == "windows-latest" ] || [ "${{ matrix.os }}" == "macos-12" ]; then
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            pip install --force-reinstall -U "numpy<2.0.0"
+          elif [ "${{ matrix.os }}" == "macos-12" ]; then
             pip install --force-reinstall -U "numpy<2.0.0"
           fi
       - name: Test with pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,10 +44,14 @@ jobs:
           cache: "pip"
           cache-dependency-path: "setup.py"
       - name: Install dependencies
+        # TODO: remove numpy downgrade on Windows/MacOS once torch fixes numpy 2.0 issue
         run: |
           python -m pip install --upgrade pip
           # cpu version of pytorch
           pip install -e .[test]
+          if [ "${{ matrix.os }}" == "windows-latest" ] || [ "${{ matrix.os }}" == "macos-12" ]; then
+            pip install --force-reinstall -U "numpy<2.0.0"
+          fi
       - name: Test with pytest
         run: |
           make test


### PR DESCRIPTION
As a temporary workaround to numpy 2.0 breaking CI, downgrade it for `macos-12` and `windows-latest`.