### PR TITLE
Fix early import of torch extension in BOFT

### DIFF
--- a/src/peft/tuners/boft/layer.py
+++ b/src/peft/tuners/boft/layer.py
@@ -77,6 +77,7 @@ def get_fbd_cuda():
     if _FBD_CUDA is not None:
         return _FBD_CUDA
 
+    # This import initializes cuda context and should thus be local, see issue 1877
     from torch.utils.cpp_extension import load
 
     curr_dir = os.path.dirname(__file__)

--- a/src/peft/tuners/boft/layer.py
+++ b/src/peft/tuners/boft/layer.py
@@ -27,7 +27,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Function
-from torch.utils.cpp_extension import load
 
 from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
 
@@ -77,6 +76,8 @@ def get_fbd_cuda():
 
     if _FBD_CUDA is not None:
         return _FBD_CUDA
+
+    from torch.utils.cpp_extension import load
 
     curr_dir = os.path.dirname(__file__)
     # need ninja to build the extension


### PR DESCRIPTION
# Description

This PR resolves #1877.  

The proposed change simply moves the import  of ``torch.utils.cpp_extension`` into the function ``get_fbd_cuda``.