### PR TITLE
FIX Make special LoRA inits DeepSpeed compatible

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -114,6 +114,7 @@ class LoraLayer(BaseTunerLayer):
         else:
             self.scaling[adapter_name] = lora_alpha / r
 
+        # for inits that require access to the base weight, use gather_param_ctx so that the weight is gathered when using DeepSpeed
         if isinstance(init_lora_weights, str) and init_lora_weights.startswith("pissa"):
             with gather_params_ctx(self.get_base_layer().weight):
                 self.pissa_init(adapter_name, init_lora_weights)


### PR DESCRIPTION
Resolves https://github.com/huggingface/accelerate/issues/2886

Possibly resolves
https://github.com/huggingface/peft/issues/896#issuecomment-2172455458

Some LoRA init methods need to access the base layer weight. Getting this access can fail or stall in distributed settings. For DeepSpeed, the weight is now gathered before trying to access it.

Note: Without DeepSpeed, this is a no-op and should thus not have any disadvantage. We don't have DS in our CI, so this is not tested.

I also made some small changes to OLoRA init to use `self.get_base_layer()` instead of `self.base_layer`.