### PR TITLE
bypass print_trainable_parameter() if model is not peft model

### DIFF
--- a/examples/sft/train.py
+++ b/examples/sft/train.py
@@ -137,7 +137,8 @@ def main(model_args, data_args, training_args):
         max_seq_length=data_args.max_seq_length,
     )
     trainer.accelerator.print(f"{trainer.model}")
-    trainer.model.print_trainable_parameters()
+    if hasattr(trainer.model, "print_trainable_parameters()"):
+        trainer.model.print_trainable_parameters()
 
     # train
     checkpoint = None


### PR DESCRIPTION
The function call `print_trainable_parameter()` in `examples/sft/train.py` didn't take account of `--use_peft_lora False` and finetune will fail in such case.   This PR bypass this print if this function cannot be found in the model.