### PR TITLE
test: bump absolute tolerance level in test

### DIFF
--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -801,7 +801,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         with torch.inference_mode():
             out_adapter1 = model(**inputs).logits
 
-        atol, rtol = 1e-5, 1e-5
+        atol, rtol = 3e-5, 1e-5
         # sanity check, outputs have the right shape and are not the same
         assert len(out_base) >= 3
         assert len(out_base) == len(out_adapter0) == len(out_adapter1)


### PR DESCRIPTION
Addresses test_4bit_lora_mixed_adapter_batches_lora allclose checks which are beyond current tolerance levels on certain configurations.

Fixes #1889.

Note: I would like to verify that this test succeeds on CI checks **prior to this change,** preferably with logs or something. Right now I'm not even sure if this test is executing in CI or not. If it is, I would like to investigate what causes this discrepancy between environments.