### PR TITLE
FIX Recursion while accessing attribute before initialization

### DIFF
--- a/examples/feature_extraction/peft_lora_embedding_semantic_search.py
+++ b/examples/feature_extraction/peft_lora_embedding_semantic_search.py
@@ -194,7 +194,7 @@ class AutoModelForSentenceEmbedding(nn.Module):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/examples/feature_extraction/peft_lora_embedding_semantic_search.py
+++ b/examples/feature_extraction/peft_lora_embedding_semantic_search.py
@@ -194,6 +194,8 @@ class AutoModelForSentenceEmbedding(nn.Module):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
 

--- a/examples/feature_extraction/peft_lora_embedding_semantic_search.py
+++ b/examples/feature_extraction/peft_lora_embedding_semantic_search.py
@@ -194,7 +194,7 @@ class AutoModelForSentenceEmbedding(nn.Module):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -191,7 +191,7 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'base_model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "base_model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.base_model, name)
 

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -191,6 +191,8 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'base_model':
+                raise
             return getattr(self.base_model, name)
 
     def forward(self, *args: Any, **kwargs: Any):

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -191,7 +191,7 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'base_model':
+            if name == 'base_model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.base_model, name)
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -666,7 +666,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'base_model':
+            if name == 'base_model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.base_model, name)
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -666,7 +666,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'base_model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "base_model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.base_model, name)
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -666,6 +666,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'base_model':
+                raise
             return getattr(self.base_model, name)
 
     @contextmanager

--- a/src/peft/tuners/adalora/model.py
+++ b/src/peft/tuners/adalora/model.py
@@ -229,6 +229,8 @@ class AdaLoraModel(LoraModel):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
     def forward(self, *args, **kwargs):

--- a/src/peft/tuners/adalora/model.py
+++ b/src/peft/tuners/adalora/model.py
@@ -229,7 +229,7 @@ class AdaLoraModel(LoraModel):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/adalora/model.py
+++ b/src/peft/tuners/adalora/model.py
@@ -229,7 +229,7 @@ class AdaLoraModel(LoraModel):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/adaption_prompt/model.py
+++ b/src/peft/tuners/adaption_prompt/model.py
@@ -158,6 +158,6 @@ class AdaptionPromptModel(nn.Module):
         except AttributeError:
             # This is necessary as e.g. causal models have various methods that we
             # don't want to re-implement here.
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)

--- a/src/peft/tuners/adaption_prompt/model.py
+++ b/src/peft/tuners/adaption_prompt/model.py
@@ -158,6 +158,6 @@ class AdaptionPromptModel(nn.Module):
         except AttributeError:
             # This is necessary as e.g. causal models have various methods that we
             # don't want to re-implement here.
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)

--- a/src/peft/tuners/adaption_prompt/model.py
+++ b/src/peft/tuners/adaption_prompt/model.py
@@ -158,4 +158,6 @@ class AdaptionPromptModel(nn.Module):
         except AttributeError:
             # This is necessary as e.g. causal models have various methods that we
             # don't want to re-implement here.
+            if name == 'model':
+                raise
             return getattr(self.model, name)

--- a/src/peft/tuners/boft/model.py
+++ b/src/peft/tuners/boft/model.py
@@ -207,6 +207,8 @@ class BOFTModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
     def get_peft_config_as_dict(self, inference: bool = False):

--- a/src/peft/tuners/boft/model.py
+++ b/src/peft/tuners/boft/model.py
@@ -207,7 +207,7 @@ class BOFTModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/boft/model.py
+++ b/src/peft/tuners/boft/model.py
@@ -207,7 +207,7 @@ class BOFTModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -227,6 +227,8 @@ class IA3Model(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
     def get_peft_config_as_dict(self, inference: bool = False):

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -227,7 +227,7 @@ class IA3Model(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -227,7 +227,7 @@ class IA3Model(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/ln_tuning/model.py
+++ b/src/peft/tuners/ln_tuning/model.py
@@ -72,7 +72,7 @@ class LNTuningModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/ln_tuning/model.py
+++ b/src/peft/tuners/ln_tuning/model.py
@@ -72,7 +72,7 @@ class LNTuningModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/ln_tuning/model.py
+++ b/src/peft/tuners/ln_tuning/model.py
@@ -72,6 +72,8 @@ class LNTuningModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
     # TODO: here need to handle the modules_to_save rather than the target_modules

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -354,6 +354,8 @@ class LoraModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
     def get_peft_config_as_dict(self, inference: bool = False):

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -354,7 +354,7 @@ class LoraModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -354,7 +354,7 @@ class LoraModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -200,6 +200,8 @@ class LycorisTuner(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
     @staticmethod

--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -200,7 +200,7 @@ class LycorisTuner(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -200,7 +200,7 @@ class LycorisTuner(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -183,7 +183,7 @@ class MixedModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -183,6 +183,8 @@ class MixedModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
     def _set_adapter_layers(self, enabled=True):

--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -183,7 +183,7 @@ class MixedModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/poly/model.py
+++ b/src/peft/tuners/poly/model.py
@@ -114,7 +114,7 @@ class PolyModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/poly/model.py
+++ b/src/peft/tuners/poly/model.py
@@ -114,6 +114,8 @@ class PolyModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
     def get_peft_config_as_dict(self, inference: bool = False):

--- a/src/peft/tuners/poly/model.py
+++ b/src/peft/tuners/poly/model.py
@@ -114,7 +114,7 @@ class PolyModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -329,6 +329,8 @@ class VeraModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
+            if name == 'model':
+                raise
             return getattr(self.model, name)
 
     def get_peft_config_as_dict(self, inference: bool = False):

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -329,7 +329,7 @@ class VeraModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
+            if name == "model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -329,7 +329,7 @@ class VeraModel(BaseTuner):
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic
         except AttributeError:
-            if name == 'model':
+            if name == 'model':  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.model, name)
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -21,6 +21,9 @@ from scipy import stats
 from torch import nn
 
 from peft import AdaLoraConfig, LoraConfig, PeftModel, PromptTuningConfig, VeraConfig, get_peft_model
+from peft import AdaLoraModel, AdaptionPromptModel, BOFTModel, IA3Model, LNTuningModel, LoraModel, PeftMixedModel, PolyModel, VeraModel
+from peft.tuners import MixedModel
+from peft.tuners.lycoris_utils import LycorisTuner
 from peft.utils import infer_device
 
 
@@ -601,3 +604,54 @@ class TestPromptTuningInitialization:
         )
         with pytest.raises(ValueError, match=msg):
             model.add_adapter("other", config1)
+
+class TestNoInfiniteRecursionDeepspeed:
+    # see #1892 for details
+    classes = [
+        PeftModel,
+        AdaLoraModel,
+        AdaptionPromptModel,
+        BOFTModel,
+        IA3Model,
+        LNTuningModel,
+        LoraModel,
+        PeftMixedModel,
+        PolyModel,
+        VeraModel,
+        MixedModel, 
+        LycorisTuner
+    ]
+
+    @pytest.fixture
+    def wrap_init(self):
+        # emulates the wrapper from DeepSpeed
+        import functools
+
+        def decorator(f):
+            @functools.wraps(f)
+            def wrapper(self, *args, **kwargs):
+                hasattr(self, "abc")  # any hasattr will do
+                f(self, *args, **kwargs)
+            return wrapper
+
+        return decorator
+
+    @pytest.fixture
+    def model(self):
+        class MyModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(10, 10)
+
+        return MyModule()
+
+    @pytest.mark.parametrize("cls", classes)
+    def test_no_infinite_recursion(self, cls, model, wrap_init):
+        original_init = cls.__init__
+        try:
+            cls.__init__ = wrap_init(cls.__init__)
+            # this would trigger an infinite loop before the fix in 1892
+            cls(model, LoraConfig(target_modules=["linear"]))
+        finally:
+            # ensure there are no side effects of this test
+            cls.__init__ = original_init

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -616,6 +616,7 @@ class TestPromptTuningInitialization:
         with pytest.raises(ValueError, match=msg):
             model.add_adapter("other", config1)
 
+
 class TestNoInfiniteRecursionDeepspeed:
     # see #1892 for details
     classes = [
@@ -639,6 +640,7 @@ class TestNoInfiniteRecursionDeepspeed:
             def wrapper(self, *args, **kwargs):
                 hasattr(self, "abc")  # any hasattr will do
                 f(self, *args, **kwargs)
+
             return wrapper
 
         return decorator

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -20,10 +20,21 @@ import torch
 from scipy import stats
 from torch import nn
 
-from peft import AdaLoraConfig, LoraConfig, PeftModel, PromptTuningConfig, VeraConfig, get_peft_model
-from peft import AdaLoraModel, AdaptionPromptModel, BOFTModel, IA3Model, LNTuningModel, LoraModel, PeftMixedModel, PolyModel, VeraModel
-from peft.tuners import MixedModel
-from peft.tuners.lycoris_utils import LycorisTuner
+from peft import (
+    AdaLoraConfig,
+    LoraConfig,
+    PeftMixedModel,
+    PeftModel,
+    PeftModelForCausalLM,
+    PeftModelForFeatureExtraction,
+    PeftModelForQuestionAnswering,
+    PeftModelForSeq2SeqLM,
+    PeftModelForSequenceClassification,
+    PeftModelForTokenClassification,
+    PromptTuningConfig,
+    VeraConfig,
+    get_peft_model,
+)
 from peft.utils import infer_device
 
 
@@ -609,17 +620,13 @@ class TestNoInfiniteRecursionDeepspeed:
     # see #1892 for details
     classes = [
         PeftModel,
-        AdaLoraModel,
-        AdaptionPromptModel,
-        BOFTModel,
-        IA3Model,
-        LNTuningModel,
-        LoraModel,
         PeftMixedModel,
-        PolyModel,
-        VeraModel,
-        MixedModel, 
-        LycorisTuner
+        PeftModelForSequenceClassification,
+        PeftModelForQuestionAnswering,
+        PeftModelForTokenClassification,
+        PeftModelForCausalLM,
+        PeftModelForSeq2SeqLM,
+        PeftModelForFeatureExtraction,
     ]
 
     @pytest.fixture
@@ -642,6 +649,9 @@ class TestNoInfiniteRecursionDeepspeed:
             def __init__(self):
                 super().__init__()
                 self.linear = nn.Linear(10, 10)
+                # to emulate LMs:
+                self.prepare_inputs_for_generation = None
+                self._prepare_encoder_decoder_kwargs_for_generation = None
 
         return MyModule()
 


### PR DESCRIPTION
Resolves #1349
While using deepspeed, it will try to access attribute before the `__init__` method (which is wrapped by the following wrapper):

https://github.com/microsoft/DeepSpeed/blob/f0e3f01d7c7a3d8748212e61eaf487fab41168a7/deepspeed/runtime/zero/partition_parameters.py#L481-L522

However, at this time there is no `base_model` (or `model`) attribute, which would cause recursion in `__getattr__` method. So I make some modifications to the `__getattr__` method to fix this problem.