### PR TITLE
CI: Don't fail fast in test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,8 @@ jobs:
   tests:
     needs: check_code_quality
     strategy:
+      # TODO: remove 'fail-fast' line once timeout issue from the Hub is solved
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-latest", "macos-12", "windows-latest"]


### PR DESCRIPTION
Currently, we have fail-fast enabled (the default). Although this is generally reasonable -- if a test fails in one setting, we probably get the same failure in other settings -- it is currently an impediment. This is because we get occasional timeouts when loading models from the Hub. With fail-fast enabled, if a single setting fails because of timeouts, all other runs are cancelled, even if they would have passed. Then we need to retrigger all of them again, creating even more pressure on the Hub. With fail-fast disabled, we give those other runs a chance to pass successfully.