### PR TITLE
FIX TEST: Higher tolerance for AdaLoRA in test

### DIFF
--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -567,6 +567,9 @@ class PeftCommonTester:
         atol, rtol = 1e-4, 1e-4
         if self.torch_device in ["mlu"]:
             atol, rtol = 1e-3, 1e-3  # MLU
+        if config.peft_type == "ADALORA":
+            # AdaLoRA is a bit flaky on CI, but this cannot be reproduced locally
+            atol, rtol = 1e-3, 1e-3
         if (config.peft_type == "IA3") and (model_id == "Conv2d"):
             # for some reason, the IA³ Conv2d introduces a larger error
             atol, rtol = 0.3, 0.01


### PR DESCRIPTION
The test is flaky on CI, so this PR increases the tolerance to hopefully fix the flakines. I cannot reproduce the error locally (neither on GPU nor CPU), so I'm not 100% sure if this tolerance is enough to make the test reliable.