### PR TITLE
FIX TEST Even higher tolerance for AdaLoRA in test

### DIFF
--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -569,7 +569,7 @@ class PeftCommonTester:
             atol, rtol = 1e-3, 1e-3  # MLU
         if config.peft_type == "ADALORA":
             # AdaLoRA is a bit flaky on CI, but this cannot be reproduced locally
-            atol, rtol = 1e-3, 1e-3
+            atol, rtol = 1e-2, 1e-2
         if (config.peft_type == "IA3") and (model_id == "Conv2d"):
             # for some reason, the IA³ Conv2d introduces a larger error
             atol, rtol = 0.3, 0.01


### PR DESCRIPTION
See #1897 for more context. The test is still flaky, increasing tolerance further.

Example of a failed run:

https://github.com/huggingface/peft/actions/runs/9745363462/job/26893196728

No matter how often I run this locally, I can't reproduce :-/