### PR TITLE
Add MoSLoRA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,8 @@ dmypy.json
 
 # More test things
 wandb
+
+moslora_finetuning
+moslora_finetuning/
+log.out
+test.sh

--- a/docs/source/developer_guides/checkpoint.md
+++ b/docs/source/developer_guides/checkpoint.md
@@ -106,6 +106,8 @@ class LoraLayer(BaseTunerLayer):
         self.merged_adapters = []
         self.use_dora: dict[str, bool] = {}
         self.lora_magnitude_vector: Optional[torch.nn.ParameterDict] = None  # for DoRA
+        self.use_moslora: dict[str, bool] = {}
+        self.lora_mixer = nn.ModuleDict({}) # for MoSLoRA
         self._caches: dict[str, Any] = {}
         self.kwargs = kwargs
 ```
@@ -188,6 +190,7 @@ All the other information needed to load a PEFT model is contained in the `adapt
   ],
   "task_type": null,
   "use_dora": false,
+  "use_moslora": false,
   "use_rslora": false
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,5 +40,5 @@ markers = [
     "single_gpu_tests: tests that run on a single GPU",
     "multi_gpu_tests: tests that run on multiple GPUs",
     "regression: whether to run regression suite test",
-    "bitsandbytes: select bitsandbytes integration tests"
-]
+    "bitsandbytes: select bitsandbytes integration tests"]
+pythonpath = [".", "src"]

--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -53,6 +53,10 @@ class AdaLoraConfig(LoraConfig):
 
         if self.use_dora:
             raise ValueError(f"{self.peft_type} does not support DoRA.")
+        
+        if self.use_moslora:
+            raise ValueError(f"{self.peft_type} does not support MoSLoRA.")
+
 
         if self.loftq_config:
             raise ValueError(f"{self.peft_type} does not support LOFTQ.")

--- a/src/peft/tuners/lora/aqlm.py
+++ b/src/peft/tuners/lora/aqlm.py
@@ -35,13 +35,14 @@ class AqlmLoraLinear(torch.nn.Module, LoraLayer):
         lora_dropout: float = 0.0,
         init_lora_weights: bool = True,
         use_rslora: bool = False,
+        use_moslora: bool = False,
         **kwargs,
     ):
         super().__init__()
         LoraLayer.__init__(self, base_layer)
 
         self._active_adapter = adapter_name
-        self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
+        self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora, use_moslora=use_moslora)
 
     def forward(self, x: torch.Tensor):
         # note: logic differs from default Linear because merging is not supported
@@ -58,12 +59,18 @@ class AqlmLoraLinear(torch.nn.Module, LoraLayer):
             dropout = self.lora_dropout[active_adapter]
             scaling = self.scaling[active_adapter]
 
+            if self.use_moslora[active_adapter]:
+                lora_mixer = self.lora_mixer[active_adapter]
+
             requires_conversion = not torch.is_autocast_enabled()
             if requires_conversion:
                 expected_dtype = result.dtype
                 x = x.to(lora_A.weight.dtype)
 
-            output = lora_B(lora_A(dropout(x)))
+            if not self.use_moslora[active_adapter]:
+                output = lora_B(lora_A(dropout(x)))
+            else:
+                output = lora_B(lora_mixer(lora_A(dropout(x))))
             if requires_conversion:
                 output = output.to(expected_dtype)
             output = output * scaling

--- a/src/peft/tuners/lora/awq.py
+++ b/src/peft/tuners/lora/awq.py
@@ -36,6 +36,7 @@ class AwqLoraLinear(torch.nn.Module, LoraLayer):
         lora_dropout: float = 0.0,
         init_lora_weights: bool = True,
         use_rslora: bool = False,
+        use_moslora: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -46,7 +47,7 @@ class AwqLoraLinear(torch.nn.Module, LoraLayer):
         self.quant_linear_module = base_layer
 
         self._active_adapter = adapter_name
-        self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora)
+        self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora, use_moslora=use_moslora)
 
     def forward(self, x: torch.Tensor):
         result = self.quant_linear_module(x)
@@ -62,12 +63,18 @@ class AwqLoraLinear(torch.nn.Module, LoraLayer):
             dropout = self.lora_dropout[active_adapter]
             scaling = self.scaling[active_adapter]
 
+            if self.use_moslora[active_adapter]:
+                lora_mixer = self.lora_mixer[active_adapter]
+
             requires_conversion = not torch.is_autocast_enabled()
             if requires_conversion:
                 expected_dtype = result.dtype
                 x = x.to(lora_A.weight.dtype)
 
-            output = lora_B(lora_A(dropout(x)))
+            if not self.use_moslora[active_adapter]:
+                output = lora_B(lora_A(dropout(x)))
+            else:
+                output = lora_B(lora_mixer(lora_A(dropout(x))))
             if requires_conversion:
                 output = output.to(expected_dtype)
             output = output * scaling

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -144,6 +144,10 @@ class LoraConfig(PeftConfig):
             ranks. Right now, DoRA only supports linear and Conv2D layers. DoRA introduces a bigger overhead than pure
             LoRA, so it is recommended to merge weights for inference. For more information, see
             https://arxiv.org/abs/2402.09353.
+        use_moslora (`bool`):
+            Enable 'Mixture-of-Subspaces in Low-Rank Adaptation' (MoSLoRA). This technique employs a learnable mixer to fuse
+            more subspaces in vanilla LoRA and more flexibly. In code implement, MoSLoRA inserts a mixer of r*r size between 
+            lora_A and lora_B. For more information, see https://arxiv.org/pdf/2406.11909.
         layer_replication (`List[Tuple[int, int]]`):
             Build a new stack of layers by stacking the original model layers according to the ranges specified. This
             allows expanding (or shrinking) the model without duplicating the base model weights. The new layers will
@@ -287,6 +291,16 @@ class LoraConfig(PeftConfig):
                 "especially at low ranks. Right now, DoRA only supports linear and Conv2D layers. DoRA introduces a bigger"
                 "overhead than pure LoRA, so it is recommended to merge weights for inference. For more information, "
                 "see  https://arxiv.org/abs/2402.09353."
+            )
+        },
+    )
+    use_moslora: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Enable 'Mixture-of-Subspaces in Low-Rank Adaptation' (MoSLoRA). This technique employs a learnable mixer to fuse"
+                "more subspaces in vanilla LoRA and more flexibly. In code implement, MoSLoRA inserts a mixer of r*r size between"
+                "lora_A and lora_B. For more information, see https://arxiv.org/pdf/2406.11909."
             )
         },
     )

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -196,6 +196,7 @@ class LoraModel(BaseTuner):
             "init_lora_weights": lora_config.init_lora_weights,
             "use_rslora": lora_config.use_rslora,
             "use_dora": lora_config.use_dora,
+            "use_moslora": lora_config.use_moslora,
             "ephemeral_gpu_offload": lora_config.runtime_config.ephemeral_gpu_offload,
             "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
             "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
@@ -219,6 +220,7 @@ class LoraModel(BaseTuner):
                 init_lora_weights=lora_config.init_lora_weights,
                 use_rslora=lora_config.use_rslora,
                 use_dora=lora_config.use_dora,
+                use_moslora=lora_config.use_moslora
             )
         else:
             new_module = self._create_new_module(lora_config, adapter_name, target, **kwargs)

--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -45,6 +45,7 @@ class LoraParallelLinear(nn.Module, LoraLayer):
         init_lora_weights: bool = True,
         use_rslora: bool = False,
         use_dora: bool = False,
+        use_moslora: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -52,6 +53,9 @@ class LoraParallelLinear(nn.Module, LoraLayer):
 
         if use_dora:
             raise ValueError(f"{self.__class__.__name__} does not support DoRA yet, please set it to False")
+        
+        if use_moslora:
+            raise ValueError(f"{self.__class__.__name__} does not support MoSLoRA yet, please set it to False")
 
         self.backend = backend
         self.is_parallel_a = isinstance(base_layer, backend.RowParallelLinear)
@@ -77,6 +81,7 @@ class LoraParallelLinear(nn.Module, LoraLayer):
             init_lora_weights=init_lora_weights,
             use_rslora=use_rslora,
             use_dora=use_dora,
+            use_moslora=use_moslora,
             init_method=init_method,
             input_is_parallel=input_is_parallel,
             gather_output=gather_output,

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -320,6 +320,17 @@ class TestMlp(RegressionTester):
         )
         model = get_peft_model(base_model, config)
         self.assert_results_equal_or_store(model, "lora_dora_mlp")
+    
+    def test_lora_moslora(self):
+        base_model = self.load_base_model()
+        config = LoraConfig(
+            r=8,
+            init_lora_weights=False,
+            target_modules=["lin0"],
+            use_moslora=True,
+        )
+        model = get_peft_model(base_model, config)
+        self.assert_results_equal_or_store(model, "lora_moslora_mlp")
 
     def test_adalora(self):
         base_model = self.load_base_model()

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -83,6 +83,14 @@ TEST_CASES = [
         LoraConfig,
         {"target_modules": "lin1", "use_dora": True, "lora_alpha": 32},
     ),
+    ("Vanilla MLP 10 LoRA with MoSLoRA", "MLP", LoraConfig, {"target_modules": ["lin0"], "use_moslora": True}),
+    ("Vanilla MLP 11 LoRA with MoSLoRA", "MLP", LoraConfig, {"target_modules": ["lin0", "lin1"], "use_moslora": True}),
+    (
+        "Vanilla MLP 12 LoRA with MoSLoRA",
+        "MLP",
+        LoraConfig,
+        {"target_modules": "lin1", "use_moslora": True, "lora_alpha": 32},
+    ),
     ("Embedding + transformers Conv1D 1 LoRA", "EmbConv1D", LoraConfig, {"target_modules": ["conv1d"]}),
     ("Embedding + transformers Conv1D 2 LoRA", "EmbConv1D", LoraConfig, {"target_modules": ["emb"]}),
     ("Embedding + transformers Conv1D 3 LoRA", "EmbConv1D", LoraConfig, {"target_modules": ["emb", "conv1d"]}),
@@ -1512,6 +1520,21 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         for k in state_dict:
             assert torch.allclose(state_dict[k], state_dict_loaded[k])
 
+    def test_gpt2_moslora_merge_and_unload(self):
+        # see https://github.com/huggingface/peft/pull/1588#discussion_r1537914207
+        model = AutoModelForCausalLM.from_pretrained("gpt2")
+        config = LoraConfig(task_type="CAUSAL_LM", use_moslora=True)
+        model = get_peft_model(model, config)
+        # should not raise an error
+        model.merge_and_unload()
+
+    def test_gpt2_moslora_merge_and_unload_safe_merge(self):
+        # see https://github.com/huggingface/peft/pull/1588#discussion_r1537914207
+        model = AutoModelForCausalLM.from_pretrained("gpt2")
+        config = LoraConfig(task_type="CAUSAL_LM", use_moslora=True)
+        model = get_peft_model(model, config)
+        # should not raise an error
+        model.merge_and_unload(safe_merge=True)
 
 class TestMultiRankAdapter(unittest.TestCase):
     """Tests related to multirank LoRA adapters"""

--- a/tests/test_torch_compile.py
+++ b/tests/test_torch_compile.py
@@ -62,6 +62,7 @@ SETTINGS = {
     "adalora": (AdaLoraConfig(task_type=TaskType.CAUSAL_LM), {}),
     "boft": (BOFTConfig(task_type=TaskType.CAUSAL_LM), {}),
     "dora": (LoraConfig(task_type=TaskType.CAUSAL_LM, use_dora=True), {}),
+    "moslora": (LoraConfig(task_type=TaskType.CAUSAL_LM, use_moslora=True), {}),
     "ia3": (IA3Config(task_type=TaskType.CAUSAL_LM), {}),
     "ln_tuning": (LNTuningConfig(task_type=TaskType.CAUSAL_LM, target_modules=["final_layer_norm"]), {}),
     "loha": (LoHaConfig(task_type=TaskType.CAUSAL_LM, target_modules=["q_proj", "v_proj"]), {}),


### PR DESCRIPTION
Link: https://arxiv.org/pdf/2406.11909v1

Hello, I am one of the authors of this paper.

In this PR, I try to add MoSLoRA, a subspace-inspired Low-Rank Adaptation (LoRA) method. MoSLoRA employs a learnable mixer to fuse more subspaces and more flexibly, while vanilla LoRA can be considered a special case with a fixed identity matrix being the mixer. Please read the paper for more details. 

Related Issue: https://github.com/huggingface/peft/issues/1878 

Also, the Implement is similar to DoRA, you can just set "use_moslora=True" to enable MoSLoRA.

For the test, I follow the test items of DoRA and added test functions in the following files:

> tests/regression/test_regression.py
tests/regression/test_regression.py
tests/test_common_gpu.py 
tests/test_custom_models.py
tests/test_gpu_examples.py
tests/test_initialization.py
tests/test_torch_compile.py 

And I try the "pytest xxx.py -k moslora" and all the tests pass.

Thanks for reviewing! @BenjaminBossan 