### PR TITLE
Fix attribute check for print_trainable_parameters method

### DIFF
--- a/examples/sft/train.py
+++ b/examples/sft/train.py
@@ -137,7 +137,7 @@ def main(model_args, data_args, training_args):
         max_seq_length=data_args.max_seq_length,
     )
     trainer.accelerator.print(f"{trainer.model}")
-    if hasattr(trainer.model, "print_trainable_parameters()"):
+    if hasattr(trainer.model, "print_trainable_parameters"):
         trainer.model.print_trainable_parameters()
 
     # train


### PR DESCRIPTION
# Fix attribute check for print_trainable_parameters method

## Description
This PR fixes an incorrect attribute check in the main training script. The original code was checking for the existence of a method call instead of the method itself.

## Changes
- Changed `if hasattr(trainer.model, "print_trainable_parameters()")` to `if hasattr(trainer.model, "print_trainable_parameters")`
