### PR TITLE
PiSSA, OLoRA: Delete initial adapter after conversion instead of the active adapter

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -264,22 +264,24 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 warnings.warn(
                     "`path_initial_model_for_weight_conversion` only works for converting a PiSSA or OLoRA adapter to a LoRA adapter"
                 )
-            initial_adapter = os.path.basename(path_initial_model_for_weight_conversion)
-            self.load_adapter(
-                os.path.dirname(path_initial_model_for_weight_conversion),
-                subfolder=initial_adapter,
-                adapter_name=initial_adapter,
-            )
-            if any(
-                str(self.peft_config[initial_adapter].init_lora_weights).lower().startswith(prefix)
-                for prefix in ["pissa", "olora"]
-            ):
-                raise ValueError(
-                    "The `init_lora_weights` parameter of the initial adapter should be set to `True`. "
-                    "Otherwise, `self.load_adapter` will subtract the decomposed values again based on the residual model."
+            initial_adapter_name = os.path.basename(path_initial_model_for_weight_conversion)
+            try:
+                self.load_adapter(
+                    os.path.dirname(path_initial_model_for_weight_conversion),
+                    subfolder=initial_adapter_name,
+                    adapter_name=initial_adapter_name,
                 )
-            output_state_dict = self.base_model.subtract_mutated_init(output_state_dict, initial_adapter, kwargs)
-            self.delete_adapter(adapter_name)
+                if any(
+                    str(self.peft_config[initial_adapter_name].init_lora_weights).lower().startswith(prefix)
+                    for prefix in ["pissa", "olora"]
+                ):
+                    raise ValueError(
+                        "The `init_lora_weights` parameter of the initial adapter should be set to `True`. "
+                        "Otherwise, `self.load_adapter` will subtract the decomposed values again based on the residual model."
+                    )
+                output_state_dict = self.base_model.subtract_mutated_init(output_state_dict, initial_adapter_name, kwargs)
+            finally:
+                self.delete_adapter(initial_adapter_name)
             return output_state_dict
 
         if is_main_process:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -262,7 +262,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 str(peft_config.init_lora_weights).lower().startswith(prefix) for prefix in ["pissa", "olora", "true"]
             ):
                 warnings.warn(
-                    "`path_initial_model_for_weight_conversion` only works for converting a PiSSA or OLoRA adapter to a LoRA adapter"
+                    "`path_initial_model_for_weight_conversion` only works for converting a PiSSA or OLoRA adapter to "
+                    "a LoRA adapter"
                 )
             initial_adapter_name = os.path.basename(path_initial_model_for_weight_conversion)
             try:
@@ -277,7 +278,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 ):
                     raise ValueError(
                         "The `init_lora_weights` parameter of the initial adapter should be set to `True`. "
-                        "Otherwise, `self.load_adapter` will subtract the decomposed values again based on the residual model."
+                        "Otherwise, `self.load_adapter` will subtract the decomposed values again based on the "
+                        "residual model."
                     )
                 output_state_dict = self.base_model.subtract_mutated_init(
                     output_state_dict, initial_adapter_name, kwargs

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -272,10 +272,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     subfolder=initial_adapter_name,
                     adapter_name=initial_adapter_name,
                 )
-                if any(
-                    str(self.peft_config[initial_adapter_name].init_lora_weights).lower().startswith(prefix)
-                    for prefix in ["pissa", "olora"]
-                ):
+                is_pissa = str(self.peft_config[initial_adapter_name].init_lora_weights).lower().startswith("pissa")
+                is_olora = str(self.peft_config[initial_adapter_name].init_lora_weights).lower() == "olora"
+                if is_pissa or is_olora:
                     raise ValueError(
                         "The `init_lora_weights` parameter of the initial adapter should be set to `True`. "
                         "Otherwise, `self.load_adapter` will subtract the decomposed values again based on the "

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -279,7 +279,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                         "The `init_lora_weights` parameter of the initial adapter should be set to `True`. "
                         "Otherwise, `self.load_adapter` will subtract the decomposed values again based on the residual model."
                     )
-                output_state_dict = self.base_model.subtract_mutated_init(output_state_dict, initial_adapter_name, kwargs)
+                output_state_dict = self.base_model.subtract_mutated_init(
+                    output_state_dict, initial_adapter_name, kwargs
+                )
             finally:
                 self.delete_adapter(initial_adapter_name)
             return output_state_dict

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -323,9 +323,13 @@ class TestLoraInitialization:
         )
 
         # save the model with conversion
+        peft_config_keys_before = list(peft_model.peft_config.keys())
         peft_model.save_pretrained(
             tmp_path / "pissa-model-converted", path_initial_model_for_weight_conversion=tmp_path / "init-model"
         )
+        peft_config_keys_after = list(peft_model.peft_config.keys())
+        assert peft_config_keys_before == peft_config_keys_after
+
         model_converted = PeftModel.from_pretrained(deepcopy(model), tmp_path / "pissa-model-converted")
         output_converted = model_converted(data)[0]
 
@@ -408,9 +412,13 @@ class TestLoraInitialization:
         )
 
         # save the model with conversion
+        peft_config_keys_before = list(peft_model.peft_config.keys())
         peft_model.save_pretrained(
             tmp_path / "olora-model-converted", path_initial_model_for_weight_conversion=tmp_path / "init-model"
         )
+        peft_config_keys_after = list(peft_model.peft_config.keys())
+        assert peft_config_keys_before == peft_config_keys_after
+
         model_converted = PeftModel.from_pretrained(deepcopy(model), tmp_path / "olora-model-converted")
         output_converted = model_converted(data)[0]
 


### PR DESCRIPTION
Resolves #1860

As discussed in that issue, it's not user friendly to delete the active adapter of a PiSSA/OLoRA model after calling `save_pretrained` with weight conversion. Instead, it is much more intuitive to delete the initial adapter instead, since it is loaded inside the method and not by the user, so it's really an implementation detail.

Apart from this, I made the following related changes:

- Put everything in a `try ... finally` to ensure that the initial adapter does not hang around if there is an error (thus not hogging memory).
- Renamed `initial_adapter` to `initial_adapter_name`, to make it clear that this is the name and not the adapter itself.
- Fix lines that are too long not fixed automatically by ruff (as they're strings).

For this reason, the diff looks much bigger than it actually is, most lines are actually identical.