### PR TITLE
fix: lora+: include lr in optimizer kwargs

### DIFF
--- a/src/peft/optimizers/loraplus.py
+++ b/src/peft/optimizers/loraplus.py
@@ -42,7 +42,6 @@ def create_loraplus_optimizer(
     Args:
         model (`torch.nn.Module`): The model to be optimized.
         optimizer_cls (`torch.optim.Optimizer`): The optimizer class to be used.
-        lr (`float`): The learning rate to be used for the optimizer.
         loraplus_lr_ratio (`float`):
             The ratio of learning ηB/ηA where ηA (lr) is passed in as the optimizer learning rate. Should be ≥1. Should
             be set in tandem with the optimizer learning rate (lr); should be larger when the task is more difficult
@@ -82,7 +81,7 @@ def create_loraplus_optimizer(
         else:
             param_groups["groupA"][name] = param
 
-    lr = kwargs['lr']
+    lr = kwargs["lr"]
     loraplus_weight_decay = kwargs.pop("loraplus_weight_decay", 0.0)
     loraplus_lr_embedding = kwargs.pop("loraplus_lr_embedding", 1e-6)
 

--- a/src/peft/optimizers/loraplus.py
+++ b/src/peft/optimizers/loraplus.py
@@ -30,7 +30,7 @@ from ..tuners.lora.layer import Embedding
 
 
 def create_loraplus_optimizer(
-    model: PeftModel, optimizer_cls: type[Optimizer], *, lr: float, loraplus_lr_ratio: float, **kwargs
+    model: PeftModel, optimizer_cls: type[Optimizer], *, loraplus_lr_ratio: float, **kwargs
 ) -> Optimizer:
     """
     Creates a LoraPlus optimizer.
@@ -82,6 +82,7 @@ def create_loraplus_optimizer(
         else:
             param_groups["groupA"][name] = param
 
+    lr = kwargs['lr']
     loraplus_weight_decay = kwargs.pop("loraplus_weight_decay", 0.0)
     loraplus_lr_embedding = kwargs.pop("loraplus_lr_embedding", 1e-6)
 

--- a/src/peft/optimizers/loraplus.py
+++ b/src/peft/optimizers/loraplus.py
@@ -30,7 +30,7 @@ from ..tuners.lora.layer import Embedding
 
 
 def create_loraplus_optimizer(
-    model: PeftModel, optimizer_cls: type[Optimizer], *, loraplus_lr_ratio: float, **kwargs
+    model: PeftModel, optimizer_cls: type[Optimizer], *, lr: float, loraplus_lr_ratio: float, **kwargs
 ) -> Optimizer:
     """
     Creates a LoraPlus optimizer.
@@ -81,7 +81,7 @@ def create_loraplus_optimizer(
         else:
             param_groups["groupA"][name] = param
 
-    lr = kwargs["lr"]
+    kwargs["lr"] = lr
     loraplus_weight_decay = kwargs.pop("loraplus_weight_decay", 0.0)
     loraplus_lr_embedding = kwargs.pop("loraplus_lr_embedding", 1e-6)
 

--- a/src/peft/optimizers/loraplus.py
+++ b/src/peft/optimizers/loraplus.py
@@ -42,6 +42,7 @@ def create_loraplus_optimizer(
     Args:
         model (`torch.nn.Module`): The model to be optimized.
         optimizer_cls (`torch.optim.Optimizer`): The optimizer class to be used.
+        lr (`float`): The learning rate to be used for the optimizer.
         loraplus_lr_ratio (`float`):
             The ratio of learning ηB/ηA where ηA (lr) is passed in as the optimizer learning rate. Should be ≥1. Should
             be set in tandem with the optimizer learning rate (lr); should be larger when the task is more difficult


### PR DESCRIPTION
Playing with the LoRA+ optimizer, I realized that the underlying optimizer will complain about the required positional `lr` argument if it is not included in the optimizer kwargs.

In [the original implementation](https://github.com/nikhil-ghosh-berkeley/loraplus/blob/a0c44bfec0eff97b9574469366bc6b0ccc28838d/lora_plus.py#L106), this was actually already the case, but somehow this fell out along the way.
