### PR TITLE
FIX active_adapters for transformers models

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -179,6 +179,15 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
     def active_adapters(self) -> list[str]:
         try:
             adapters = self.base_model.active_adapters
+            if not isinstance(adapters, list):
+                # Base model is probably a transformers model, see:
+                # https://github.com/huggingface/transformers/pull/30790#issuecomment-2253808249
+                # Unfortunately, transformers models also have an active_adapters method but it's 1) not a property and
+                # 2) calling it fails because the base model (usually) has no loaded adapter. The base model can be a
+                # transformers model for prompt learning, where the base model is not wrapped in a LoraModel or similar.
+                adapters = self.active_adapter
+                if isinstance(adapters, str):
+                    adapters = [adapters]
         except AttributeError:
             adapters = self.active_adapter
             if isinstance(adapters, str):

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -18,7 +18,7 @@ import torch
 from parameterized import parameterized
 from transformers import AutoModelForSeq2SeqLM, AutoModelForTokenClassification
 
-from peft import LoraConfig, TaskType, get_peft_model
+from peft import LoraConfig, PromptEncoderConfig, TaskType, get_peft_model
 
 from .testing_common import PeftCommonTester, PeftTestConfigManager
 
@@ -215,6 +215,14 @@ class PeftEncoderDecoderModelTester(unittest.TestCase, PeftCommonTester):
     )
     def test_disable_adapter(self, test_name, model_id, config_cls, config_kwargs):
         self._test_disable_adapter(model_id, config_cls, config_kwargs)
+
+    def test_active_adapters_prompt_learning(self):
+        # see issue https://github.com/huggingface/transformers/pull/30790#issuecomment-2253808249
+        model = AutoModelForSeq2SeqLM.from_pretrained("hf-internal-testing/tiny-random-BartForConditionalGeneration")
+        # any prompt learning method would work here
+        config = PromptEncoderConfig(task_type=TaskType.SEQ_2_SEQ_LM, num_virtual_tokens=10)
+        model = get_peft_model(model, config)
+        assert model.active_adapters == ["default"]
 
 
 class PeftEncoderDecoderCustomModelTester(unittest.TestCase):


### PR DESCRIPTION
Fixes the error reported here:

https://github.com/huggingface/transformers/pull/30790#issuecomment-2253808249

Unfortunately, transformers models have an active_adapters method but it's 1) not a property and 2) calling it fails because the base model (usually) has no loaded adapter. The base model can be a transformers model for prompt learning, where the base model is not wrapped in a LoraModel or similar. Therefore, this special case needs to be handled separately.