### PR TITLE
FIX Loading adapter honors offline mode

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -459,7 +459,7 @@ def load_peft_weights(model_id: str, device: Optional[str] = None, **hf_hub_down
             filename = hf_hub_download(model_id, hub_filename, local_files_only=True)
             use_safetensors = True
         except LocalEntryNotFoundError:
-            # Could not find safetensors, try pickle; if this also fails. It's fine to let the error be raised here, as
+            # Could not find safetensors, try pickle. If this also fails, it's fine to let the error be raised here, as
             # it means that the user tried to load a non-cached model in offline mode.
             hub_filename = get_hub_filename(use_safetensors=False)
             filename = hf_hub_download(model_id, hub_filename, local_files_only=True)

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -17,6 +17,7 @@ import os
 import warnings
 from typing import Optional
 
+import huggingface_hub
 import torch
 from huggingface_hub import file_exists, hf_hub_download
 from huggingface_hub.utils import EntryNotFoundError, LocalEntryNotFoundError
@@ -452,7 +453,7 @@ def load_peft_weights(model_id: str, device: Optional[str] = None, **hf_hub_down
     elif os.path.exists(os.path.join(path, WEIGHTS_NAME)):
         filename = os.path.join(path, WEIGHTS_NAME)
         use_safetensors = False
-    elif os.environ.get("HF_HUB_OFFLINE", 0) in {"1", "ON", "YES", "TRUE"}:  # same check as in hfh
+    elif huggingface_hub.constants.HF_HUB_OFFLINE:
         # if in offline mode, check if we can find the adapter file locally
         hub_filename = get_hub_filename(use_safetensors=True)
         try:

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 import torch
 from huggingface_hub import file_exists, hf_hub_download
-from huggingface_hub.utils import EntryNotFoundError
+from huggingface_hub.utils import EntryNotFoundError, LocalEntryNotFoundError
 from safetensors.torch import load_file as safe_load_file
 
 from .other import (
@@ -438,22 +438,38 @@ def load_peft_weights(model_id: str, device: Optional[str] = None, **hf_hub_down
     if device is None:
         device = infer_device()
 
+    def get_hub_filename(use_safetensors=True):
+        weights_name = SAFETENSORS_WEIGHTS_NAME if use_safetensors else WEIGHTS_NAME
+        return (
+            os.path.join(hf_hub_download_kwargs["subfolder"], weights_name)
+            if hf_hub_download_kwargs.get("subfolder", None) is not None
+            else weights_name
+        )
+
     if os.path.exists(os.path.join(path, SAFETENSORS_WEIGHTS_NAME)):
         filename = os.path.join(path, SAFETENSORS_WEIGHTS_NAME)
         use_safetensors = True
     elif os.path.exists(os.path.join(path, WEIGHTS_NAME)):
         filename = os.path.join(path, WEIGHTS_NAME)
         use_safetensors = False
+    elif os.environ.get("HF_HUB_OFFLINE", 0) in {"1", "ON", "YES", "TRUE"}:  # same check as in hfh
+        # if in offline mode, check if we can find the adapter file locally
+        hub_filename = get_hub_filename(use_safetensors=True)
+        try:
+            filename = hf_hub_download(model_id, hub_filename, local_files_only=True)
+            use_safetensors = True
+        except LocalEntryNotFoundError:
+            # Could not find safetensors, try pickle; if this also fails. It's fine to let the error be raised here, as
+            # it means that the user tried to load a non-cached model in offline mode.
+            hub_filename = get_hub_filename(use_safetensors=False)
+            filename = hf_hub_download(model_id, hub_filename, local_files_only=True)
+            use_safetensors = False
     else:
         token = hf_hub_download_kwargs.get("token", None)
         if token is None:
             token = hf_hub_download_kwargs.get("use_auth_token", None)
 
-        hub_filename = (
-            os.path.join(hf_hub_download_kwargs["subfolder"], SAFETENSORS_WEIGHTS_NAME)
-            if hf_hub_download_kwargs.get("subfolder", None) is not None
-            else SAFETENSORS_WEIGHTS_NAME
-        )
+        hub_filename = get_hub_filename(use_safetensors=True)
         has_remote_safetensors_file = file_exists(
             repo_id=model_id,
             filename=hub_filename,

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1223,6 +1223,8 @@ class TestNoInfiniteRecursionDeepspeed:
 
 
 class TestLoadAdapterOfflineMode:
+    # make sure that PEFT honors offline mode
+
     @contextmanager
     def hub_offline_ctx(self):
         # this is required to simulate offline mode, setting the env var dynamically inside the test does not work
@@ -1232,7 +1234,6 @@ class TestLoadAdapterOfflineMode:
             yield
         reset_sessions()
 
-    # make sure that PEFT honors offline mode
     def test_load_from_hub_then_offline_model(self):
         # this uses LoRA but it's the same mechanism for other methods
         peft_model_id = "peft-internal-testing/gpt2-lora-random"

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -13,12 +13,16 @@
 # limitations under the License.
 
 import re
+from contextlib import contextmanager
 from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
 import torch
+from huggingface_hub.utils import reset_sessions
 from scipy import stats
 from torch import nn
+from transformers import AutoModelForCausalLM
 
 from peft import (
     AdaLoraConfig,
@@ -1216,3 +1220,30 @@ class TestNoInfiniteRecursionDeepspeed:
         finally:
             # ensure there are no side effects of this test
             cls.__init__ = original_init
+
+
+class TestLoadAdapterOfflineMode:
+    @contextmanager
+    def hub_offline_ctx(self):
+        # this is required to simulate offline mode, setting the env var dynamically inside the test does not work
+        # because the value is checked only once at the start of the session
+        with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
+            reset_sessions()
+            yield
+        reset_sessions()
+
+    # make sure that PEFT honors offline mode
+    def test_load_from_hub_then_offline_model(self):
+        # this uses LoRA but it's the same mechanism for other methods
+        peft_model_id = "peft-internal-testing/gpt2-lora-random"
+        base_model = AutoModelForCausalLM.from_pretrained("gpt2")
+
+        # first ensure that the adapter model has been downloaded
+        PeftModel.from_pretrained(base_model, peft_model_id)
+
+        del base_model
+
+        base_model = AutoModelForCausalLM.from_pretrained("gpt2")
+        with self.hub_offline_ctx():
+            # does not raise
+            PeftModel.from_pretrained(base_model, peft_model_id)


### PR DESCRIPTION
`HF_HUB_OFFLINE=1` was not honored when trying to load an adapter. This is now fixed.

Resolves https://github.com/huggingface/transformers/issues/31700.