### PR TITLE
AdaLora: Trigger warning when user uses 'r' inplace of 'init_r'

### DIFF
--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Optional
 
 from peft.tuners.lora import LoraConfig
 from peft.utils import PeftType
 
-import warnings
 
 @dataclass
 class AdaLoraConfig(LoraConfig):
@@ -68,9 +68,10 @@ class AdaLoraConfig(LoraConfig):
         # if target_modules is a regex expression, then layers_pattern should be None
         if isinstance(self.target_modules, str) and self.layers_pattern is not None:
             raise ValueError("`layers_pattern` cannot be used when `target_modules` is a str.")
-            
+
         # Check if 'r' has been set to a non-default value
         if self.r != 8:  # 8 is the default value for 'r' in LoraConfig
             warnings.warn(
-                "Note that `r` is not used in AdaLora and will be ignored. If you intended to set the initial rank, use `init_r` instead."
+                "Note that `r` is not used in AdaLora and will be ignored."
+                "If you intended to set the initial rank, use `init_r` instead."
             )

--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -18,6 +18,7 @@ from typing import Optional
 from peft.tuners.lora import LoraConfig
 from peft.utils import PeftType
 
+import warnings
 
 @dataclass
 class AdaLoraConfig(LoraConfig):
@@ -67,3 +68,9 @@ class AdaLoraConfig(LoraConfig):
         # if target_modules is a regex expression, then layers_pattern should be None
         if isinstance(self.target_modules, str) and self.layers_pattern is not None:
             raise ValueError("`layers_pattern` cannot be used when `target_modules` is a str.")
+            
+        # Check if 'r' has been set to a non-default value
+        if self.r != 8:  # 8 is the default value for 'r' in LoraConfig
+            warnings.warn(
+                "Note that `r` is not used in AdaLora and will be ignored. If you intended to set the initial rank, use `init_r` instead."
+            )

--- a/src/peft/tuners/adalora/model.py
+++ b/src/peft/tuners/adalora/model.py
@@ -48,14 +48,12 @@ class AdaLoraModel(LoraModel):
 
     Example::
 
-        >>> from transformers import AutoModelForSeq2SeqLM
-        >>> from peft import LoraConfig, AdaLoraModel, AdaLoraConfig
+        >>> from transformers import AutoModelForSeq2SeqLM >>> from peft import LoraConfig, AdaLoraModel, AdaLoraConfig
         >>> config = AdaLoraConfig(
                 peft_type="ADALORA", task_type="SEQ_2_SEQ_LM", init_r=12, lora_alpha=32, target_modules=["q", "v"],
                 lora_dropout=0.01,
             )
-        >>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-base")
-        >>> model = AdaLoraModel(model, config, "default")
+        >>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-base") >>> model = AdaLoraModel(model, config, "default")
 
     **Attributes**:
         - **model** ([`transformers.PreTrainedModel`]) -- The model to be adapted.

--- a/src/peft/tuners/adalora/model.py
+++ b/src/peft/tuners/adalora/model.py
@@ -48,12 +48,14 @@ class AdaLoraModel(LoraModel):
 
     Example::
 
-        >>> from transformers import AutoModelForSeq2SeqLM >>> from peft import LoraConfig, AdaLoraModel, AdaLoraConfig
+        >>> from transformers import AutoModelForSeq2SeqLM
+        >>> from peft import LoraConfig, AdaLoraModel, AdaLoraConfig
         >>> config = AdaLoraConfig(
                 peft_type="ADALORA", task_type="SEQ_2_SEQ_LM", init_r=12, lora_alpha=32, target_modules=["q", "v"],
                 lora_dropout=0.01,
             )
-        >>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-base") >>> model = AdaLoraModel(model, config, "default")
+        >>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-base")
+        >>> model = AdaLoraModel(model, config, "default")
 
     **Attributes**:
         - **model** ([`transformers.PreTrainedModel`]) -- The model to be adapted.

--- a/src/peft/tuners/adalora/model.py
+++ b/src/peft/tuners/adalora/model.py
@@ -48,9 +48,9 @@ class AdaLoraModel(LoraModel):
 
     Example::
 
-        >>> from transformers import AutoModelForSeq2SeqLM, LoraConfig >>> from peft import AdaLoraModel, AdaLoraConfig
+        >>> from transformers import AutoModelForSeq2SeqLM >>> from peft import LoraConfig, AdaLoraModel, AdaLoraConfig
         >>> config = AdaLoraConfig(
-                peft_type="ADALORA", task_type="SEQ_2_SEQ_LM", r=8, lora_alpha=32, target_modules=["q", "v"],
+                peft_type="ADALORA", task_type="SEQ_2_SEQ_LM", init_r=12, lora_alpha=32, target_modules=["q", "v"],
                 lora_dropout=0.01,
             )
         >>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-base") >>> model = AdaLoraModel(model, config, "default")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -295,12 +295,7 @@ class PeftConfigTester(unittest.TestCase):
     def test_adalora_config_r_warning(self):
         # This test checks that a warning is raised when r is set other than default in AdaLoraConfig
         # No warning should be raised when initializing AdaLoraConfig with default values.
-        kwargs = {
-            "peft_type":"ADALORA",
-            "task_type":"SEQ_2_SEQ_LM",
-            "init_r":12,
-            "lora_alpha":32
-            }
+        kwargs = {"peft_type": "ADALORA", "task_type": "SEQ_2_SEQ_LM", "init_r": 12, "lora_alpha": 32}
         # Test that no warning is raised with default initialization
         with warnings.catch_warnings():
             warnings.simplefilter("error")
@@ -309,7 +304,5 @@ class PeftConfigTester(unittest.TestCase):
             except Warning:
                 pytest.fail("AdaLoraConfig raised a warning with default initialization.")
         # Test that a warning is raised when r != 8 in AdaLoraConfig
-        with pytest.warns(UserWarning, match= "Note that `r` is not used in AdaLora and will be ignored."):
+        with pytest.warns(UserWarning, match="Note that `r` is not used in AdaLora and will be ignored."):
             AdaLoraConfig(r=10)
-
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -291,3 +291,25 @@ class PeftConfigTester(unittest.TestCase):
         # should run without errors
         IA3Config(**valid_config_regex_exp)
         IA3Config(**valid_config_list)
+
+    def test_adalora_config_r_warning(self):
+        # This test checks that a warning is raised when r is set other than default in AdaLoraConfig
+        # No warning should be raised when initializing AdaLoraConfig with default values.
+        kwargs = {
+            "peft_type":"ADALORA",
+            "task_type":"SEQ_2_SEQ_LM",
+            "init_r":12,
+            "lora_alpha":32
+            }
+        # Test that no warning is raised with default initialization
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            try:
+                AdaLoraConfig(**kwargs)
+            except Warning:
+                pytest.fail("AdaLoraConfig raised a warning with default initialization.")
+        # Test that a warning is raised when r != 8 in AdaLoraConfig
+        with pytest.warns(UserWarning, match= "Note that `r` is not used in AdaLora and will be ignored."):
+            AdaLoraConfig(r=10)
+
+


### PR DESCRIPTION
**Description:**
This PR addresses Issue #1971 by adding a warning in `__post_init__` of `AdaLoraConfig` when `r` is set to any non-default value. The changes aim to clarify the usage of `init_r` instead of `r` in `AdaLoraConfig`, resolving confusion around parameter naming.
Updated the docstring example in AdaLoraModel to reflect the same.

Testing:
 

- ✅ Verified that the warning is correctly triggered when 'r' is set in AdaLoraConfig
- ✅ Ensured that existing functionality is not affected by these changes
- ✅ Checked that the updated docstring example works as expected

**Related Issues**
✅ Closes #1971


