### PR TITLE
DOC Small fixes for HQQ and section title

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -45,8 +45,6 @@
     title: Troubleshooting
   - local: developer_guides/checkpoint
     title: PEFT checkpoint format
-  - local: package_reference/helpers
-    title: Helpers
 
 - title: 🤗 Accelerate integrations
   sections:
@@ -114,11 +112,12 @@
       title: VeRA
     - local: package_reference/fourierft
       title: FourierFT
-      
+
     title: Adapters
   - sections:
     - local: package_reference/merge_utils
       title: Model merge
+    - local: package_reference/helpers
+      title: Helpers
     title: Utilities
   title: API reference
-

--- a/docs/source/developer_guides/quantization.md
+++ b/docs/source/developer_guides/quantization.md
@@ -168,13 +168,11 @@ model = get_peft_model(model, config)
 
 The models that is quantized using Half-Quadratic Quantization of Large Machine Learning Models ([HQQ](https://mobiusml.github.io/hqq_blog/)) support LoRA adapter tuning. To tune the quantized model, you'll need to install the `hqq` library with: `pip install hqq`.
 
-```py
+```python
 from hqq.engine.hf import HQQModelForCausalLM
 
 quantized_model = HQQModelForCausalLM.from_quantized(save_dir_or_hfhub, device='cuda')
-
 peft_config = LoraConfig(...)
-
 quantized_model = get_peft_model(quantized_model, peft_config)
 ```
 
@@ -184,11 +182,8 @@ Or using transformers version that is compatible with HQQ (e.g. by installing it
 from transformers import HqqConfig, AutoModelForCausalLM
 
 quant_config = HqqConfig(nbits=4, group_size=64)
-
-quantized_model = AutoModelForCausalLM.from_pretrained(save_dir_or_hfhub, device='cuda', quantization_config=quant_config)
-
+quantized_model = AutoModelForCausalLM.from_pretrained(save_dir_or_hfhub, device_map=device_map, quantization_config=quant_config)
 peft_config = LoraConfig(...)
-
 quantized_model = get_peft_model(quantized_model, peft_config)
 ```
 

--- a/docs/source/package_reference/helpers.md
+++ b/docs/source/package_reference/helpers.md
@@ -2,7 +2,7 @@
 rendered properly in your Markdown viewer.
 -->
 
-# Document Title
+# Helper methods
 
 A collection of helper functions for PEFT.
 


### PR DESCRIPTION
Changed:

- Helper section had placeholder title
- `device` is not a valid argument to `from_pretrained`
- Excess empty lines

Not sure if py vs python makes a difference in code blocks.