### PR TITLE
MAINT: Default to loading weights only for torch.load

### DIFF
--- a/src/peft/tuners/multitask_prompt_tuning/model.py
+++ b/src/peft/tuners/multitask_prompt_tuning/model.py
@@ -16,6 +16,7 @@ import torch
 
 from peft.tuners.prompt_tuning import PromptEmbedding
 from peft.utils import TaskType
+from peft.utils.save_and_load import torch_load
 
 from .config import MultitaskPromptTuningConfig, MultitaskPromptTuningInit
 
@@ -71,7 +72,7 @@ class MultitaskPromptEmbedding(PromptEmbedding):
 
                 state_dict: dict = load_file(config.prompt_tuning_init_state_dict_path)
             else:
-                state_dict: dict = torch.load(
+                state_dict: dict = torch_load(
                     config.prompt_tuning_init_state_dict_path,
                     map_location=word_embeddings.weight.device,
                 )


### PR DESCRIPTION
The `torch.load` function allows to pass `weights_only=True`, which is more secure but may break some code that is more than just weights. For PEFT, this should not be the case, so the switch should just work.

By making the switch now, we can find out early if there are any problems, as `torch.load` will default to `True` in the future.