### PR TITLE
TST: Potentially Skip 8bit bnb regression test if compute capability is too low

### DIFF
--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -584,6 +584,9 @@ class TestOpt8bitBnb(RegressionTester):
         )
         return model
 
+    @pytest.mark.skipif(
+        torch.cuda.get_device_properties(0).major < 8, reason="8bit bnb results vary with compute capability"
+    )
     def test_lora_8bit(self):
         base_model = self.load_base_model()
         config = LoraConfig(

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -585,11 +585,9 @@ class TestOpt8bitBnb(RegressionTester):
         return model
 
     def test_lora_8bit(self):
-        # note: we cannot use pytest.mark.skipif, because for the condition to be evaluated, cuda must be available, and
-        # since this runs on CI without CUDA, that would fail
-        if torch.cuda.get_device_properties(0).major < 8:
-            pytest.skip("8bit bnb results vary with compute capability")
-
+        # Warning: bnb results can vary significantly depending on the GPU. Therefore, if there is a change in GPU used
+        # in the CI, the test can fail without any code change. In that case, delete the regression artifact and create
+        # a new one using the new GPU.
         base_model = self.load_base_model()
         config = LoraConfig(
             r=8,
@@ -603,6 +601,9 @@ class TestOpt8bitBnb(RegressionTester):
         self.skipTest(
             "Skipping AdaLora for now, getting TypeError: unsupported operand type(s) for +=: 'dict' and 'Tensor'"
         )
+        # Warning: bnb results can vary significantly depending on the GPU. Therefore, if there is a change in GPU used
+        # in the CI, the test can fail without any code change. In that case, delete the regression artifact and create
+        # a new one using the new GPU.
         base_model = self.load_base_model()
         config = AdaLoraConfig(
             init_r=6,
@@ -646,6 +647,9 @@ class TestOpt4bitBnb(RegressionTester):
         return model
 
     def test_lora_4bit(self):
+        # Warning: bnb results can vary significantly depending on the GPU. Therefore, if there is a change in GPU used
+        # in the CI, the test can fail without any code change. In that case, delete the regression artifact and create
+        # a new one using the new GPU.
         base_model = self.load_base_model()
         config = LoraConfig(
             r=8,
@@ -657,6 +661,9 @@ class TestOpt4bitBnb(RegressionTester):
     def test_adalora(self):
         # TODO
         self.skipTest("Skipping AdaLora for now because of a bug, see #1113")
+        # Warning: bnb results can vary significantly depending on the GPU. Therefore, if there is a change in GPU used
+        # in the CI, the test can fail without any code change. In that case, delete the regression artifact and create
+        # a new one using the new GPU.
         base_model = self.load_base_model()
         config = AdaLoraConfig(
             init_r=6,

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -584,10 +584,12 @@ class TestOpt8bitBnb(RegressionTester):
         )
         return model
 
-    @pytest.mark.skipif(
-        torch.cuda.get_device_properties(0).major < 8, reason="8bit bnb results vary with compute capability"
-    )
     def test_lora_8bit(self):
+        # note: we cannot use pytest.mark.skipif, because for the condition to be evaluated, cuda must be available, and
+        # since this runs on CI without CUDA, that would fail
+        if torch.cuda.get_device_properties(0).major < 8:
+            pytest.skip("8bit bnb results vary with compute capability")
+
         base_model = self.load_base_model()
         config = LoraConfig(
             r=8,


### PR DESCRIPTION
The 8bit bnb LoRA regression test results are dependent on the underlying compute capability. The logits are slightly different depending on the version (up to 0.5 abs diff). Therefore, we now check the compute capability for this test and skip it if it's too low. This check may require updating if the hardware of the CI worker is updated.

Note that I have already [invalidated the old regression artifacts](https://huggingface.co/peft-internal-testing/regression-tests/commit/42a454d4d58ecb7938c14f5eab37007f4310099f) and created a new one.