### PR TITLE
ENH: Warn when a user provided model name in the config renamed

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -163,7 +163,14 @@ def get_peft_model(
     if hasattr(model_config, "to_dict"):
         model_config = model_config.to_dict()
 
-    peft_config.base_model_name_or_path = model.__dict__.get("name_or_path", None)
+    old_name = peft_config.base_model_name_or_path
+    new_name = model.__dict__.get("name_or_path", None)
+    peft_config.base_model_name_or_path = new_name
+    if (old_name is not None) and (old_name != new_name):
+        warnings.warn(
+            f"The PEFT config's `base_model_name_or_path` was renamed from '{old_name}' to '{new_name}'. "
+            "Please ensure that the correct base model is loaded when loading this checkpoint."
+        )
 
     if revision is not None:
         if peft_config.revision is not None and peft_config.revision != revision:

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1264,7 +1264,7 @@ class TestCustomModelConfigWarning:
 
     def test_no_warning_by_default_transformers_model(self, recwarn):
         # first a sanity test that there is no warning by default when using a model from transformers
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-OPTForCausalLM")
         get_peft_model(model, LoraConfig())
         for warning in recwarn.list:
             assert "renamed" not in str(warning.message)
@@ -1277,18 +1277,21 @@ class TestCustomModelConfigWarning:
 
     def test_warning_name_transformers_model(self, recwarn):
         # The base_model_name_or_path provided by the user is overridden.
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
-        get_peft_model(model, LoraConfig(base_model_name_or_path="custom_name"))
-        msg = "was renamed from 'custom_name' to 'facebook/opt-125m'"
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-OPTForCausalLM")
+        custom_name = "custom_name"
+        get_peft_model(model, LoraConfig(base_model_name_or_path=custom_name))
+        msg = f"was renamed from '{custom_name}' to 'hf-internal-testing/tiny-random-OPTForCausalLM'"
         assert any(msg in str(warning.message) for warning in recwarn.list)
 
     def test_warning_name_custom_model(self, custom_module, recwarn):
-        get_peft_model(custom_module, LoraConfig(target_modules=["lin"], base_model_name_or_path="custom_name"))
-        msg = "was renamed from 'custom_name' to 'None'"
+        custom_name = "custom_name"
+        get_peft_model(custom_module, LoraConfig(target_modules=["lin"], base_model_name_or_path=custom_name))
+        msg = f"was renamed from '{custom_name}' to 'None'"
         assert any(msg in str(warning.message) for warning in recwarn.list)
 
     def test_warning_name_custom_model_with_custom_name(self, custom_module, recwarn):
+        custom_name = "custom_name"
         custom_module.name_or_path = "foobar"
-        get_peft_model(custom_module, LoraConfig(target_modules=["lin"], base_model_name_or_path="custom_name"))
-        msg = "was renamed from 'custom_name' to 'foobar'"
+        get_peft_model(custom_module, LoraConfig(target_modules=["lin"], base_model_name_or_path=custom_name))
+        msg = f"was renamed from '{custom_name}' to 'foobar'"
         assert any(msg in str(warning.message) for warning in recwarn.list)


### PR DESCRIPTION
Resolves #2001

In PEFT, users can provide a custom `base_model_name_or_path` argument to the PEFT config. However, this value is overridden by the model's `name_or_path` attribute. This can be surprising for users. Therefore, there is now a warning about this.

To see why that can be relevant, check the original issue.

It eludes me why this argument can be passed by users only to be overridden by PEFT. This was implemented by Younes before I joined the project.