### PR TITLE
Fix usage of deprecated parameters/functions in X-LoRA

### DIFF
--- a/examples/causal_language_modeling/peft_lora_clm_with_additional_tokens.ipynb
+++ b/examples/causal_language_modeling/peft_lora_clm_with_additional_tokens.ipynb
@@ -168,7 +168,7 @@
     "model = AutoModelForCausalLM.from_pretrained(\n",
     "    model_name,\n",
     "    low_cpu_mem_usage=True\n",
-    "    # use_flash_attention_2=True, # leading to an error\n",
+    "    # _attn_implementation=\"flash_attention_2\", # leading to an error\n",
     ")\n",
     "model.resize_token_embeddings(len(tokenizer))"
    ]
@@ -956,7 +956,7 @@
     "inference_model = AutoModelForCausalLM.from_pretrained(\n",
     "    model_name,\n",
     "    low_cpu_mem_usage=True,\n",
-    "    # use_flash_attention_2=True,\n",
+    "    # _attn_implementation=\"flash_attention_2\",\n",
     ")\n",
     "inference_model.resize_token_embeddings(len(tokenizer))\n",
     "\n",

--- a/examples/causal_language_modeling/peft_lora_clm_with_additional_tokens.ipynb
+++ b/examples/causal_language_modeling/peft_lora_clm_with_additional_tokens.ipynb
@@ -168,7 +168,7 @@
     "model = AutoModelForCausalLM.from_pretrained(\n",
     "    model_name,\n",
     "    low_cpu_mem_usage=True\n",
-    "    # _attn_implementation=\"flash_attention_2\", # leading to an error\n",
+    "    # attn_implementation =\"flash_attention_2\", # leading to an error\n",
     ")\n",
     "model.resize_token_embeddings(len(tokenizer))"
    ]
@@ -956,7 +956,7 @@
     "inference_model = AutoModelForCausalLM.from_pretrained(\n",
     "    model_name,\n",
     "    low_cpu_mem_usage=True,\n",
-    "    # _attn_implementation=\"flash_attention_2\",\n",
+    "    # attn_implementation =\"flash_attention_2\",\n",
     ")\n",
     "inference_model.resize_token_embeddings(len(tokenizer))\n",
     "\n",

--- a/src/peft/tuners/xlora/model.py
+++ b/src/peft/tuners/xlora/model.py
@@ -188,7 +188,7 @@ class XLoraModel(BaseTuner):
         >>> model = AutoModelForCausalLM.from_pretrained(
         ...     "mistralai/Mistral-7B-Instruct-v0.1",
         ...     trust_remote_code=True,
-        ...     _attn_implementation="flash_attention_2",
+        ...     attn_implementation="flash_attention_2",
         ...     device_map="cuda:0",
         ...     torch_dtype=torch.bfloat16,
         ...     quantization_config=int8_config,

--- a/src/peft/tuners/xlora/model.py
+++ b/src/peft/tuners/xlora/model.py
@@ -171,7 +171,7 @@ class XLoraModel(BaseTuner):
     Example:
         ```py
         >>> from transformers import AutoModelForCausalLM, AutoConfig, BitsAndBytesConfig
-        >>> from peft import LoraConfig, PeftModel, get_peft_model
+        >>> from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
 
         >>> model_config = AutoConfig.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
         >>> config = XLoraConfig(
@@ -193,6 +193,7 @@ class XLoraModel(BaseTuner):
         ...     torch_dtype=torch.bfloat16,
         ...     quantization_config=int8_config,
         ... )
+        >>> model = prepare_model_for_kbit_training(4)
         >>> xlora_model = get_peft_model(model, config)
         ```
     """

--- a/src/peft/tuners/xlora/model.py
+++ b/src/peft/tuners/xlora/model.py
@@ -170,8 +170,8 @@ class XLoraModel(BaseTuner):
 
     Example:
         ```py
-        >>> from transformers import AutoModelForCausalLM, AutoConfig
-        >>> from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_int8_training
+        >>> from transformers import AutoModelForCausalLM, AutoConfig, BitsAndBytesConfig
+        >>> from peft import LoraConfig, PeftModel, get_peft_model
 
         >>> model_config = AutoConfig.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
         >>> config = XLoraConfig(
@@ -184,15 +184,17 @@ class XLoraModel(BaseTuner):
         ...         "adapter_n": "./path/to/the/checkpoint/",
         ...     },
         ... )
-
+        >>> int8_config = BitsAndBytesConfig(
+        ...     load_in_8bit=True
+        ... )
         >>> model = AutoModelForCausalLM.from_pretrained(
         ...     "mistralai/Mistral-7B-Instruct-v0.1",
         ...     trust_remote_code=True,
-        ...     use_flash_attention_2=False,
+        ...     _attn_implementation="flash_attention_2",
         ...     device_map="cuda:0",
         ...     torch_dtype=torch.bfloat16,
+        ...     quantization_config=int8_config,
         ... )
-        >>> model = prepare_model_for_int8_training(model)
         >>> xlora_model = get_peft_model(model, config)
         ```
     """

--- a/src/peft/tuners/xlora/model.py
+++ b/src/peft/tuners/xlora/model.py
@@ -184,9 +184,7 @@ class XLoraModel(BaseTuner):
         ...         "adapter_n": "./path/to/the/checkpoint/",
         ...     },
         ... )
-        >>> int8_config = BitsAndBytesConfig(
-        ...     load_in_8bit=True
-        ... )
+        >>> int8_config = BitsAndBytesConfig(load_in_8bit=True)
         >>> model = AutoModelForCausalLM.from_pretrained(
         ...     "mistralai/Mistral-7B-Instruct-v0.1",
         ...     trust_remote_code=True,


### PR DESCRIPTION
As pointed out by @benjamin-marie in #2002, we were calling `prepare_model_for_int8_training` and passing `use_flash_attention_2`. These are deprecated and this PR fixes any usages.