### PR TITLE
FIX: Error with OLoRA init when using bnb

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -192,12 +192,20 @@ class LoraLayer(BaseTunerLayer):
 
         weight_tensor.data -= scale_factor * self.lora_B[adapter_name].weight @ self.lora_A[adapter_name].weight
         if bnb_param_type == "4bit":
-            weight_tensor = orig_weight.__class__(weight_tensor, quant_type=orig_weight.quant_type).to(
-                orig_weight.device
-            )
+            weight_tensor = orig_weight.__class__(
+                weight_tensor,
+                quant_type=orig_weight.quant_type,
+                quant_storage=orig_weight.quant_storage,
+                compress_statistics=orig_weight.compress_statistics,
+                module=orig_weight.module,
+            ).to(orig_weight.device)
             base_layer.weight = weight_tensor
         elif bnb_param_type == "8bit":
-            weight_tensor = orig_weight.__class__(weight_tensor, requires_grad=False).to(orig_weight.device)
+            weight_tensor = orig_weight.__class__(
+                weight_tensor,
+                requires_grad=orig_weight.requires_grad,
+                has_fp16_weights=orig_weight.has_fp16_weights,
+            ).to(orig_weight.device)
             base_layer.weight = weight_tensor
         else:
             weight_tensor = weight_tensor.to(dtype)

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -24,7 +24,7 @@ from torch import svd_lowrank
 from transformers.pytorch_utils import Conv1D
 
 from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
-from peft.utils.integrations import dequantize_module_weight, gather_params_ctx
+from peft.utils.integrations import dequantize_module_weight, gather_params_ctx, is_bnb_param
 from peft.utils.other import transpose
 
 from .config import LoraConfig
@@ -166,11 +166,16 @@ class LoraLayer(BaseTunerLayer):
             nn.init.normal_(self.lora_embedding_B[adapter_name])
 
     def olora_init(self, adapter_name):
-        dtype = self.get_base_layer().weight.dtype
-        if dtype in [torch.int8, torch.uint8]:
-            weight_tensor = dequantize_module_weight(self.get_base_layer())
+        base_layer = self.get_base_layer()
+        orig_weight = base_layer.weight
+        orig_weight_is_bnb = is_bnb_param(orig_weight)
+        dtype = orig_weight.dtype
+
+        if orig_weight_is_bnb:
+            # check without importing bitsandbytes and robust to bnb_4bit_quant_storage=float*
+            weight_tensor = dequantize_module_weight(base_layer)
         elif dtype in [torch.float32, torch.float16, torch.bfloat16]:
-            weight_tensor = self.get_base_layer().weight
+            weight_tensor = orig_weight
         else:
             raise TypeError(f"Unsupported data type for the base layer. Got {dtype}.")
 
@@ -185,8 +190,14 @@ class LoraLayer(BaseTunerLayer):
         self.lora_B[adapter_name].weight.data = Qr.contiguous()
 
         weight_tensor.data -= scale_factor * self.lora_B[adapter_name].weight @ self.lora_A[adapter_name].weight
-        weight_tensor = weight_tensor.to(dtype)
-        self.get_base_layer().weight.data = weight_tensor
+        if orig_weight_is_bnb:
+            import bitsandbytes as bnb
+
+            weight_tensor = bnb.nn.Params4bit(weight_tensor, quant_type=orig_weight.quant_type).to(orig_weight.device)
+            base_layer.weight = weight_tensor
+        else:
+            weight_tensor = weight_tensor.to(dtype)
+            base_layer.weight.data = weight_tensor
 
     def pissa_init(self, adapter_name, init_lora_weights):
         weight = self.get_base_layer().weight

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -192,7 +192,9 @@ class LoraLayer(BaseTunerLayer):
 
         weight_tensor.data -= scale_factor * self.lora_B[adapter_name].weight @ self.lora_A[adapter_name].weight
         if bnb_param_type == "4bit":
-            weight_tensor = orig_weight.__class__(weight_tensor, quant_type=orig_weight.quant_type).to(orig_weight.device)
+            weight_tensor = orig_weight.__class__(weight_tensor, quant_type=orig_weight.quant_type).to(
+                orig_weight.device
+            )
             base_layer.weight = weight_tensor
         elif bnb_param_type == "8bit":
             weight_tensor = orig_weight.__class__(weight_tensor, requires_grad=False).to(orig_weight.device)

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -191,14 +191,10 @@ class LoraLayer(BaseTunerLayer):
 
         weight_tensor.data -= scale_factor * self.lora_B[adapter_name].weight @ self.lora_A[adapter_name].weight
         if bnb_param_type == "4bit":
-            import bitsandbytes as bnb
-
-            weight_tensor = bnb.nn.Params4bit(weight_tensor, quant_type=orig_weight.quant_type).to(orig_weight.device)
+            weight_tensor = orig_weight.__class__(weight_tensor, quant_type=orig_weight.quant_type).to(orig_weight.device)
             base_layer.weight = weight_tensor
         elif bnb_param_type == "8bit":
-            import bitsandbytes as bnb
-
-            weight_tensor = bnb.nn.Int8Params(weight_tensor, requires_grad=False).to(orig_weight.device)
+            weight_tensor = orig_weight.__class__(weight_tensor, requires_grad=False).to(orig_weight.device)
             base_layer.weight = weight_tensor
         else:
             weight_tensor = weight_tensor.to(dtype)

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -104,3 +104,7 @@ def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
     if is_cpu:
         dequantized = dequantized.to(device)
     return dequantized
+
+
+def is_bnb_param(param):
+    return param.__class__.__name__ in ("Params4bit", "Int8Params")

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from contextlib import contextmanager
+from typing import Literal
 
 import packaging.version
 import torch
@@ -106,5 +109,10 @@ def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
     return dequantized
 
 
-def is_bnb_param(param):
-    return param.__class__.__name__ in ("Params4bit", "Int8Params")
+def get_bnb_param_type(param: torch.nn.Parameter) -> Literal[False, "4bit", "8bit"]:
+    """Returns '4bit' or '8bit' if bitsandbytes parameter, else False"""
+    if param.__class__.__name__ == "Params4bit":
+        return "4bit"
+    if param.__class__.__name__ == "Int8Params":
+        return "8bit"
+    return False


### PR DESCRIPTION
Resolves #1999

- dtype check for bnb quantized weights can be misleading when using `bnb_4bit_quant_storage`
- updated base weights must be re-quantized if original weight is bnb quantized