### PR TITLE
[tests] enable regression tests on XPU

### DIFF
--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -187,7 +187,7 @@ def save_model(model, name, force=False):
 
 def load_output(name):
     filename = os.path.join(REGRESSION_DIR, name, "output.pt")
-    return torch.load(filename)
+    return torch.load(filename, map_location=infer_device())
 
 
 @pytest.mark.regression


### PR DESCRIPTION
Before fix:
```bash
============================================ short test summary info ============================================
FAILED tests/regression/test_regression.py::TestOpt::test_adalora - RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If y...
FAILED tests/regression/test_regression.py::TestOpt::test_ia3 - RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If y...
FAILED tests/regression/test_regression.py::TestOpt::test_lora - RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If y...
```

After fix:
```bash
============================================ short test summary info ============================================
PASSED tests/regression/test_regression.py::TestOpt::test_adalora
PASSED tests/regression/test_regression.py::TestOpt::test_ia3
PASSED tests/regression/test_regression.py::TestOpt::test_lora
======================================== 3 passed, 2 warnings in 18.80s =========================================
```