### PR TITLE
[tests] enable `test_mixed_adapter_batches_lora_opt_timing` on XPU

### DIFF
--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -3276,7 +3276,6 @@ class TestMixedAdapterBatches:
         with pytest.raises(ValueError, match=msg):
             peft_model.forward(**inputs)
 
-    @require_torch_gpu
     def test_mixed_adapter_batches_lora_opt_timing(self):
         # Use a more realistic model (opt-125m) and do a simple runtime check to ensure that mixed adapter batches
         # don't add too much overhead. These types of tests are inherently flaky, so we try to add in some robustness.


### PR DESCRIPTION
After Fix:
```bash
====================================== short test summary info ======================================
PASSED tests/test_custom_models.py::TestMixedAdapterBatches::test_mixed_adapter_batches_lora_opt_timing
=================================== 1 passed, 1 warning in 7.59s ====================================
```

Just like other tests in this file, this function should not only apply to NV GPU. We can actually remove this test marker. 