### PR TITLE
Warn if using tied target module with `tie_word_embeddings`

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -131,7 +131,6 @@ def get_peft_config(config_dict: dict[str, Any]) -> PeftConfig:
     return PEFT_TYPE_TO_CONFIG_MAPPING[config_dict["peft_type"]](**config_dict)
 
 def warn_if_tied_embeddings_in_target_modules(model_config, peft_config):
-    
     if model_config.get("tie_word_embeddings"):
         for target_module in peft_config.target_modules:
             if target_module in EMBEDDING_LAYER_NAMES:

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -65,7 +65,7 @@ from .tuners import (
     XLoraConfig,
 )
 from .tuners.tuners_utils import BaseTuner as _BaseTuner
-from .utils import _prepare_prompt_learning_config, EMBEDDING_LAYER_NAMES
+from .utils import _prepare_prompt_learning_config
 
 
 if TYPE_CHECKING:
@@ -130,13 +130,6 @@ def get_peft_config(config_dict: dict[str, Any]) -> PeftConfig:
 
     return PEFT_TYPE_TO_CONFIG_MAPPING[config_dict["peft_type"]](**config_dict)
 
-def warn_if_tied_embeddings_in_target_modules(model_config, peft_config):
-    if model_config.get("tie_word_embeddings"):
-        for target_module in peft_config.target_modules:
-            if target_module in EMBEDDING_LAYER_NAMES:
-                warnings.warn(
-                    f"{model_config['tie_word_embeddings']=} and a tied {target_module=} is passed to peft config. This can lead to complications, for example when merging the adapter. Are you sure you want to use the target module {target_module}?"
-                )
 
 def get_peft_model(
     model: PreTrainedModel,
@@ -173,8 +166,6 @@ def get_peft_model(
     old_name = peft_config.base_model_name_or_path
     new_name = model.__dict__.get("name_or_path", None)
     peft_config.base_model_name_or_path = new_name
-
-    warn_if_tied_embeddings_in_target_modules(model_config, peft_config)
 
     if (old_name is not None) and (old_name != new_name):
         warnings.warn(

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -132,7 +132,7 @@ def get_peft_config(config_dict: dict[str, Any]) -> PeftConfig:
 
 def warn_if_tied_embeddings_in_target_modules(model_config, peft_config):
     common_output_target_module = [
-        "lm_head",
+        "lm_head", "embed_tokens",
     ]
     
     if model_config.get("tie_word_embeddings"):

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -136,7 +136,7 @@ def warn_if_tied_embeddings_in_target_modules(model_config, peft_config):
         for target_module in peft_config.target_modules:
             if target_module in EMBEDDING_LAYER_NAMES:
                 warnings.warn(
-                    f"{model_config['tie_word_embeddings']=} and a tied {target_module=} is passed to peft config. This can lead to complications, for example when merging the adapter. Are you sure you want to infect and adapter to {target_module}?"
+                    f"{model_config['tie_word_embeddings']=} and a tied {target_module=} is passed to peft config. This can lead to complications, for example when merging the adapter. Are you sure you want to use the  target module {target_module}?"
                 )
 
 def get_peft_model(

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -135,7 +135,7 @@ def warn_if_tied_embeddings_in_target_modules(model_config, peft_config):
         for target_module in peft_config.target_modules:
             if target_module in EMBEDDING_LAYER_NAMES:
                 warnings.warn(
-                    f"{model_config['tie_word_embeddings']=} and a tied {target_module=} is passed to peft config. This can lead to complications, for example when merging the adapter. Are you sure you want to use the  target module {target_module}?"
+                    f"{model_config['tie_word_embeddings']=} and a tied {target_module=} is passed to peft config. This can lead to complications, for example when merging the adapter. Are you sure you want to use the target module {target_module}?"
                 )
 
 def get_peft_model(

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -64,7 +64,7 @@ from .tuners import (
     VeraModel,
     XLoraConfig,
 )
-from .tuners.tuners_utils import BaseTuner as _BaseTuner
+from .tuners.tuners_utils import BaseTuner
 from .utils import _prepare_prompt_learning_config
 
 
@@ -103,7 +103,7 @@ PEFT_TYPE_TO_CONFIG_MAPPING: dict[str, type[PeftConfig]] = {
     "HRA": HRAConfig,
 }
 
-PEFT_TYPE_TO_TUNER_MAPPING: dict[str, type[_BaseTuner]] = {
+PEFT_TYPE_TO_TUNER_MAPPING: dict[str, type[BaseTuner]] = {
     "LORA": LoraModel,
     "LOHA": LoHaModel,
     "LOKR": LoKrModel,
@@ -159,10 +159,7 @@ def get_peft_model(
             The revision of the base model. If this isn't set, the saved peft model will load the `main` revision for
             the base model
     """
-    model_config = getattr(model, "config", {"model_type": "custom"})
-    if hasattr(model_config, "to_dict"):
-        model_config = model_config.to_dict()
-
+    model_config = BaseTuner.get_model_config(model)
     old_name = peft_config.base_model_name_or_path
     new_name = model.__dict__.get("name_or_path", None)
     peft_config.base_model_name_or_path = new_name

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -65,7 +65,7 @@ from .tuners import (
     XLoraConfig,
 )
 from .tuners.tuners_utils import BaseTuner as _BaseTuner
-from .utils import _prepare_prompt_learning_config
+from .utils import _prepare_prompt_learning_config, EMBEDDING_LAYER_NAMES
 
 
 if TYPE_CHECKING:
@@ -131,13 +131,10 @@ def get_peft_config(config_dict: dict[str, Any]) -> PeftConfig:
     return PEFT_TYPE_TO_CONFIG_MAPPING[config_dict["peft_type"]](**config_dict)
 
 def warn_if_tied_embeddings_in_target_modules(model_config, peft_config):
-    common_output_target_module = [
-        "lm_head", "embed_tokens",
-    ]
     
     if model_config.get("tie_word_embeddings"):
         for target_module in peft_config.target_modules:
-            if target_module in common_output_target_module:
+            if target_module in EMBEDDING_LAYER_NAMES:
                 warnings.warn(
                     f"{model_config['tie_word_embeddings']=} and a tied {target_module=} is passed to peft config. This can lead to complications, for example when merging the adapter. Are you sure you want to infect and adapter to {target_module}?"
                 )

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -23,6 +23,8 @@ from accelerate.hooks import remove_hook_from_submodules
 from torch import nn
 from transformers.utils import PushToHubMixin
 
+from peft.utils.constants import DUMMY_MODEL_CONFIG
+
 from .config import PeftConfig
 from .peft_model import PeftModel
 from .tuners import (
@@ -120,7 +122,7 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
         self.base_model = MixedModel(model, {adapter_name: peft_config}, adapter_name)
         self.set_modules_to_save(peft_config, adapter_name)
 
-        self.config = getattr(model, "config", {"model_type": "custom"})
+        self.config = getattr(model, "config", DUMMY_MODEL_CONFIG)
 
         # the `pretraining_tp` is set for some models to simulate Tensor Parallelism during inference to avoid
         # numerical differences, https://github.com/pytorch/pytorch/issues/76232 - to avoid any unexpected

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -37,6 +37,8 @@ from transformers import PreTrainedModel
 from transformers.modeling_outputs import QuestionAnsweringModelOutput, SequenceClassifierOutput, TokenClassifierOutput
 from transformers.utils import PushToHubMixin
 
+from peft.utils.constants import DUMMY_MODEL_CONFIG
+
 from . import __version__
 from .config import PeftConfig
 from .tuners import (
@@ -1231,7 +1233,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         card.data["library_name"] = "peft"
 
-        model_config = BaseTuner.get_model_config(self, default=None)
+        model_config = BaseTuner.get_model_config(self)
+        model_config = None if model_config == DUMMY_MODEL_CONFIG else model_config
         if model_config is not None and "_name_or_path" in model_config:
             card.data["base_model"] = model_config["_name_or_path"]
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1231,9 +1231,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         card.data["library_name"] = "peft"
 
-        model_config = getattr(self, "config", None)
-        if hasattr(model_config, "to_dict"):
-            model_config = model_config.to_dict()
+        model_config = BaseTuner.get_model_config(self, default=None)
         if model_config is not None and "_name_or_path" in model_config:
             card.data["base_model"] = model_config["_name_or_path"]
 

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -447,6 +447,7 @@ class LoraModel(BaseTuner):
 
         Currently gptq quantization and replicated layers do not support merging.
         """
+        self._warn_if_tied_embeddings_in_target_modules(self.model)
         if getattr(self.model, "quantization_method", None) == "gptq":
             raise ValueError("Cannot merge LORA layers when the model is gptq quantized")
         if self.peft_config.get("layer_replication"):

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -447,7 +447,15 @@ class LoraModel(BaseTuner):
 
         Currently gptq quantization and replicated layers do not support merging.
         """
-        self._warn_if_tied_embeddings_in_target_modules(self.model)
+        tied_target_modeules = self._get_tied_target_modeules(self.model)
+        if tied_target_modeules:
+            warnings.warn(
+                f"Model with `tie_word_embeddings=True` and the {tied_target_modeules=} are part of the adapter. "
+                "This can lead to complications when merging the adapter. "
+                "You can opt to merge the adapter after cloning the weights (to untie the embeddings), "
+                "and then load the merged model `tie_word_embeddings=False`: "
+                "\n```python\nAutoModelForCausalLM.from_pretrained('path/to/merged/model', tie_word_embeddings=False)\n```\n"
+            )
         if getattr(self.model, "quantization_method", None) == "gptq":
             raise ValueError("Cannot merge LORA layers when the model is gptq quantized")
         if self.peft_config.get("layer_replication"):

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -447,15 +447,7 @@ class LoraModel(BaseTuner):
 
         Currently gptq quantization and replicated layers do not support merging.
         """
-        tied_target_modules = self._get_tied_target_modules(self.model)
-        if tied_target_modules:
-            warnings.warn(
-                f"Model with `tie_word_embeddings=True` and the {tied_target_modules=} are part of the adapter. "
-                "This can lead to complications when merging the adapter. "
-                "You can opt to merge the adapter after cloning the weights (to untie the embeddings), "
-                "and then load the merged model with `tie_word_embeddings=False`: "
-                "\n```python\nAutoModelForCausalLM.from_pretrained('path/to/merged/model', tie_word_embeddings=False)\n```\n"
-            )
+        super()._check_merge_allowed()
         if getattr(self.model, "quantization_method", None) == "gptq":
             raise ValueError("Cannot merge LORA layers when the model is gptq quantized")
         if self.peft_config.get("layer_replication"):

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -453,7 +453,7 @@ class LoraModel(BaseTuner):
                 f"Model with `tie_word_embeddings=True` and the {tied_target_modeules=} are part of the adapter. "
                 "This can lead to complications when merging the adapter. "
                 "You can opt to merge the adapter after cloning the weights (to untie the embeddings), "
-                "and then load the merged model `tie_word_embeddings=False`: "
+                "and then load the merged model with `tie_word_embeddings=False`: "
                 "\n```python\nAutoModelForCausalLM.from_pretrained('path/to/merged/model', tie_word_embeddings=False)\n```\n"
             )
         if getattr(self.model, "quantization_method", None) == "gptq":

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -447,10 +447,10 @@ class LoraModel(BaseTuner):
 
         Currently gptq quantization and replicated layers do not support merging.
         """
-        tied_target_modeules = self._get_tied_target_modeules(self.model)
-        if tied_target_modeules:
+        tied_target_modules = self._get_tied_target_modules(self.model)
+        if tied_target_modules:
             warnings.warn(
-                f"Model with `tie_word_embeddings=True` and the {tied_target_modeules=} are part of the adapter. "
+                f"Model with `tie_word_embeddings=True` and the {tied_target_modules=} are part of the adapter. "
                 "This can lead to complications when merging the adapter. "
                 "You can opt to merge the adapter after cloning the weights (to untie the embeddings), "
                 "and then load the merged model with `tie_word_embeddings=False`: "

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -530,8 +530,8 @@ model = AutoModelForCausalLM.from_pretrained(untied_model_dir)
     @staticmethod
     def get_model_config(model: nn.Module) -> dict:
         """
-        This method gets the config from a model in dictionary form.
-        If model has not attribute config, then this method returns a default config.
+        This method gets the config from a model in dictionary form. If model has not attribute config, then this
+        method returns a default config.
 
         Args:
             model (`nn.Module`):

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -500,7 +500,6 @@ class BaseTuner(nn.Module, ABC):
             model_config = model_config.to_dict()
         return model_config
 
-    
     def _warn_if_tied_embeddings_in_target_modules(self, model):
             model_config = self.get_model_config(model)
             if model_config.get("tie_word_embeddings"):

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -365,7 +365,7 @@ class BaseTuner(nn.Module, ABC):
         if tied_target_modules:
             warnings.warn(
                 f"Model with `tie_word_embeddings=True` and the {tied_target_modules=} are part of the adapter. "
-                "This can lead to complications when merging the adapter. "
+                "This can lead to complications. "
                 "You can opt to merge the adapter after cloning the weights (to untie the embeddings). "
                 "You can untie the embeddings by loading the model with `tie_word_embeddings=False`. For example:"
                 """
@@ -458,8 +458,9 @@ model = AutoModelForCausalLM.from_pretrained(untied_model_dir)
         if tied_target_modules:
             warnings.warn(
                 f"Model with `tie_word_embeddings=True` and the {tied_target_modules=} are part of the adapter. "
-                "This can lead to complications, for example when merging the adapter. "
-                f"See for example https://github.com/huggingface/peft/issues/2018."
+                "This can lead to complications, for example when merging the adapter "
+                "or converting your model to formats other than safetensors. "
+                "See for example https://github.com/huggingface/peft/issues/2018."
             )
 
         # Handle X-LoRA case.

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -367,8 +367,26 @@ class BaseTuner(nn.Module, ABC):
                 f"Model with `tie_word_embeddings=True` and the {tied_target_modules=} are part of the adapter. "
                 "This can lead to complications when merging the adapter. "
                 "You can opt to merge the adapter after cloning the weights (to untie the embeddings). "
-                "You can untie the embeddings by loading the model with `tie_word_embeddings=False`: "
-                "\n```python\nAutoModelForCausalLM.from_pretrained('path/to/model', tie_word_embeddings=False)\n```\n"
+                "You can untie the embeddings by loading the model with `tie_word_embeddings=False`. For example:"
+                """
+```python
+from transformers import AutoModelForCausalLM
+
+# Load original tied model
+model = AutoModelForCausalLM.from_pretrained("google/gemma-2-2b-it", tie_word_embeddings=False)
+
+# Set the randomly initialized lm_head to the previously tied embeddings
+model.lm_head.weight.data = model.model.embed_tokens.weight.data
+
+# Save the untied model
+untied_model_dir = "dir/for/untied/model"
+model.save_pretrained(untied_model_dir, safe_serialization=True)
+model.config.save_pretrained(untied_model_dir)
+
+# Now use the original model but in untied format
+model = AutoModelForCausalLM.from_pretrained(untied_model_dir)
+```
+"""
             )
 
     def inject_adapter(self, model: nn.Module, adapter_name: str, autocast_adapter_dtype: bool = True) -> None:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -30,7 +30,7 @@ from transformers import PreTrainedModel
 from transformers.pytorch_utils import Conv1D
 
 from peft.utils import INCLUDE_LINEAR_LAYERS_SHORTHAND
-from peft.utils.constants import DUMMY_MODEL_CONFIG, DUMMY_TARGET_MODULES, SEQ_CLS_HEAD_NAMES, EMBEDDING_LAYER_NAMES
+from peft.utils.constants import DUMMY_MODEL_CONFIG, DUMMY_TARGET_MODULES, EMBEDDING_LAYER_NAMES, SEQ_CLS_HEAD_NAMES
 from peft.utils.peft_types import PeftType, TaskType
 
 from ..config import PeftConfig
@@ -366,9 +366,9 @@ class BaseTuner(nn.Module, ABC):
             warnings.warn(
                 f"Model with `tie_word_embeddings=True` and the {tied_target_modules=} are part of the adapter. "
                 "This can lead to complications when merging the adapter. "
-                "You can opt to merge the adapter after cloning the weights (to untie the embeddings), "
-                "and then load the merged model with `tie_word_embeddings=False`: "
-                "\n```python\nAutoModelForCausalLM.from_pretrained('path/to/merged/model', tie_word_embeddings=False)\n```\n"
+                "You can opt to merge the adapter after cloning the weights (to untie the embeddings). "
+                "You can untie the embeddings by loading the model with `tie_word_embeddings=False`: "
+                "\n```python\nAutoModelForCausalLM.from_pretrained('path/to/model', tie_word_embeddings=False)\n```\n"
             )
 
     def inject_adapter(self, model: nn.Module, adapter_name: str, autocast_adapter_dtype: bool = True) -> None:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -506,8 +506,8 @@ class BaseTuner(nn.Module, ABC):
                 for target_module in self.targeted_module_names:
                     if target_module in EMBEDDING_LAYER_NAMES:
                         warnings.warn(
-                            f"{model_config.get('tie_word_embeddings')=} and the tied {target_module=} is part of the adapter.\n"
-                            "This can lead to complications, for example when merging the adapter.\n"
+                            f"{model_config.get('tie_word_embeddings')=} and the tied {target_module=} is part of the adapter. "
+                            "This can lead to complications, for example when merging the adapter. "
                             f"See for example https://github.com/huggingface/peft/issues/2018."
                         )
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -108,6 +108,7 @@ def onload_layer(layer):
             offload_state_dict(safetensors_filename, layer.base_layer._hf_hook.weights_map)
         layer.base_layer._hf_hook.post_forward(layer.base_layer, torch.tensor([]))
 
+
 class BaseTuner(nn.Module, ABC):
     r"""
     A base tuner model that provides the common methods and attributes for all tuners that are injectable into a
@@ -492,7 +493,7 @@ class BaseTuner(nn.Module, ABC):
         )
         if is_modules_to_save_available and len(adapters_to_consider) > 1:
             raise ValueError("Cannot unload multiple adapters that specify `modules_to_save`.")
-    
+
     @staticmethod
     def get_model_config(model, default={"model_type": "custom"}):
         model_config = getattr(model, "config", default)
@@ -501,15 +502,15 @@ class BaseTuner(nn.Module, ABC):
         return model_config
 
     def _warn_if_tied_embeddings_in_target_modules(self, model):
-            model_config = self.get_model_config(model)
-            if model_config.get("tie_word_embeddings"):
-                for target_module in self.targeted_module_names:
-                    if target_module in EMBEDDING_LAYER_NAMES:
-                        warnings.warn(
-                            f"{model_config.get('tie_word_embeddings')=} and the tied {target_module=} is part of the adapter. "
-                            "This can lead to complications, for example when merging the adapter. "
-                            f"See for example https://github.com/huggingface/peft/issues/2018."
-                        )
+        model_config = self.get_model_config(model)
+        if model_config.get("tie_word_embeddings"):
+            for target_module in self.targeted_module_names:
+                if target_module in EMBEDDING_LAYER_NAMES:
+                    warnings.warn(
+                        f"{model_config.get('tie_word_embeddings')=} and the tied {target_module=} is part of the adapter. "
+                        "This can lead to complications, for example when merging the adapter. "
+                        f"See for example https://github.com/huggingface/peft/issues/2018."
+                    )
 
 
 class BaseTunerLayer(ABC):

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -428,7 +428,7 @@ class BaseTuner(nn.Module, ABC):
             parent, target, target_name = _get_submodules(model, key)
             self._create_and_replace(peft_config, adapter_name, target, target_name, parent, current_key=key)
 
-        tied_target_modules = self._get_tied_target_modeules(model=model)
+        tied_target_modules = self._get_tied_target_modules(model=model)
         if tied_target_modules:
             warnings.warn(
                 f"Model with `tie_word_embeddings=True` and the {tied_target_modules=} are part of the adapter. "
@@ -516,7 +516,7 @@ class BaseTuner(nn.Module, ABC):
             model_config = model_config.to_dict()
         return model_config
 
-    def _get_tied_target_modeules(self, model):
+    def _get_tied_target_modules(self, model):
         tied_target_modules = []
         model_config = self.get_model_config(model)
         if model_config.get("tie_word_embeddings"):

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -506,9 +506,9 @@ class BaseTuner(nn.Module, ABC):
                 for target_module in self.targeted_module_names:
                     if target_module in EMBEDDING_LAYER_NAMES:
                         warnings.warn(
-                            f"{model_config.get('tie_word_embeddings')=} and a tied {target_module=} is passed to peft config.\n"
+                            f"{model_config.get('tie_word_embeddings')=} and the tied {target_module=} is part of the adapter.\n"
                             "This can lead to complications, for example when merging the adapter.\n"
-                            f"Are you sure you want to use the target module {target_module}?"
+                            f"See for example https://github.com/huggingface/peft/issues/2018."
                         )
 
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -376,11 +376,11 @@ from transformers import AutoModelForCausalLM
 model = AutoModelForCausalLM.from_pretrained("google/gemma-2-2b-it", tie_word_embeddings=False)
 
 # Set the randomly initialized lm_head to the previously tied embeddings
-model.lm_head.weight.data = model.model.embed_tokens.weight.data
+model.lm_head.weight.data = model.model.embed_tokens.weight.data.clone()
 
 # Save the untied model
 untied_model_dir = "dir/for/untied/model"
-model.save_pretrained(untied_model_dir, safe_serialization=True)
+model.save_pretrained(untied_model_dir)
 model.config.save_pretrained(untied_model_dir)
 
 # Now use the original model but in untied format

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -30,7 +30,7 @@ from transformers import PreTrainedModel
 from transformers.pytorch_utils import Conv1D
 
 from peft.utils import INCLUDE_LINEAR_LAYERS_SHORTHAND
-from peft.utils.constants import DUMMY_MODEL_CONFIG, DUMMY_TARGET_MODULES, SEQ_CLS_HEAD_NAMES
+from peft.utils.constants import DUMMY_MODEL_CONFIG, DUMMY_TARGET_MODULES, SEQ_CLS_HEAD_NAMES, EMBEDDING_LAYER_NAMES
 from peft.utils.peft_types import PeftType, TaskType
 
 from ..config import PeftConfig

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -107,9 +107,7 @@ class VeraModel(BaseTuner):
 
         This will be used for determining the size of the shared vera_A and vera_B matrices.
         """
-        model_config = getattr(self.model, "config", {"model_type": "custom"})
-        if hasattr(model_config, "to_dict"):
-            model_config = model_config.to_dict()
+        model_config = self.get_model_config(self.model)
 
         peft_config = self._prepare_adapter_config(config, model_config)
         peft_config = _maybe_include_all_linear_layers(peft_config, self.model)

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -52,3 +52,4 @@ from .other import (
     cast_mixed_precision_params,
 )
 from .save_and_load import get_peft_model_state_dict, set_peft_model_state_dict, load_peft_weights
+from .constants import EMBEDDING_LAYER_NAMES

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -52,4 +52,3 @@ from .other import (
     cast_mixed_precision_params,
 )
 from .save_and_load import get_peft_model_state_dict, set_peft_model_state_dict, load_peft_weights
-from .constants import EMBEDDING_LAYER_NAMES

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -261,3 +261,4 @@ SEQ_CLS_HEAD_NAMES = ["score", "classifier"]
 INCLUDE_LINEAR_LAYERS_SHORTHAND = "all-linear"
 TOKENIZER_CONFIG_NAME = "tokenizer_config.json"
 DUMMY_TARGET_MODULES = "dummy-target-modules"
+DUMMY_MODEL_CONFIG = {"model_type": "custom"}

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -43,12 +43,14 @@ from peft import (
     get_peft_model,
 )
 from peft.tuners.tuners_utils import (
+    BaseTuner,
     BaseTunerLayer,
     _maybe_include_all_linear_layers,
     check_target_module_exists,
     inspect_matched_modules,
 )
 from peft.utils import INCLUDE_LINEAR_LAYERS_SHORTHAND, ModulesToSaveWrapper, infer_device
+from peft.utils.constants import DUMMY_MODEL_CONFIG
 
 from .testing_utils import require_bitsandbytes, require_non_cpu, require_torch_gpu
 
@@ -1065,3 +1067,39 @@ class TestModelAndLayerStatus:
 
         with pytest.raises(TypeError, match="get_model_status is not supported for PeftMixedModel"):
             model.get_model_status()
+
+
+# Tests for BaseTuner
+class MockModelConfig:
+    config = {"mock_key": "mock_value"}
+
+    def to_dict(self):
+        return self.config
+
+
+class ModelWithConfig(nn.Module):
+    def __init__(self):
+        self.config = MockModelConfig()
+
+
+class ModelWithDictConfig(nn.Module):
+    def __init__(self):
+        self.config = MockModelConfig.config
+
+
+class ModelWithNoConfig(nn.Module):
+    pass
+
+
+class TestBaseTunerMethods(unittest.TestCase):
+    def test_get_model_config_use_to_dict(self):
+        config = BaseTuner.get_model_config(ModelWithConfig())
+        assert config == MockModelConfig.config
+
+    def test_get_model_config_as_dict(self):
+        config = BaseTuner.get_model_config(ModelWithDictConfig())
+        assert config == MockModelConfig.config
+
+    def test_get_model_config_with_no_config(self):
+        config = BaseTuner.get_model_config(ModelWithNoConfig())
+        assert config == DUMMY_MODEL_CONFIG

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -1120,32 +1120,32 @@ class TestBaseTunerWarnForTiedEmbeddings:
         )
         return model
 
-    def _is_warn_triggered(self, rrecwarn, endswith):
-        return any(str(warning.message).endswith(endswith) for warning in rrecwarn.list)
+    def _is_warn_triggered(self, warning_list, endswith):
+        return any(str(warning.message).endswith(endswith) for warning in warning_list)
 
     def test_warn_for_tied_embeddings_inject(self, recwarn):
         self._get_peft_model(tie_word_embeddings=True, target_module="lm_head")
-        assert self._is_warn_triggered(recwarn, self.warn_end_inject)
+        assert self._is_warn_triggered(recwarn.list, self.warn_end_inject)
 
     def test_warn_for_tied_embeddings_merge(self, recwarn):
         model = self._get_peft_model(tie_word_embeddings=True, target_module="lm_head")
         model.merge_and_unload()
-        assert self._is_warn_triggered(recwarn, self.warn_end_merge)
+        assert self._is_warn_triggered(recwarn.list, self.warn_end_merge)
 
     def test_no_warn_for_untied_embeddings_inject(self, recwarn):
         self._get_peft_model(tie_word_embeddings=False, target_module="lm_head")
-        assert not self._is_warn_triggered(recwarn, self.warn_end_inject)
+        assert not self._is_warn_triggered(recwarn.list, self.warn_end_inject)
 
     def test_no_warn_for_untied_embeddings_merge(self, recwarn):
         model_not_tied = self._get_peft_model(tie_word_embeddings=False, target_module="lm_head")
         model_not_tied.merge_and_unload()
-        assert not self._is_warn_triggered(recwarn, self.warn_end_merge)
+        assert not self._is_warn_triggered(recwarn.list, self.warn_end_merge)
 
     def test_no_warn_for_no_target_module_inject(self, recwarn):
         self._get_peft_model(tie_word_embeddings=True, target_module="q_proj")
-        assert not self._is_warn_triggered(recwarn, self.warn_end_inject)
+        assert not self._is_warn_triggered(recwarn.list, self.warn_end_inject)
 
     def test_no_warn_for_no_target_module_merge(self, recwarn):
         model_no_target_module = self._get_peft_model(tie_word_embeddings=True, target_module="q_proj")
         model_no_target_module.merge_and_unload()
-        assert not self._is_warn_triggered(recwarn, self.warn_end_merge)
+        assert not self._is_warn_triggered(recwarn.list, self.warn_end_merge)

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -1108,7 +1108,10 @@ class TestBaseTunerGetModelConfig(unittest.TestCase):
 class TestBaseTunerWarnForTiedEmbeddings:
     model_id = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
     warn_end_inject = "huggingface/peft/issues/2018."
-    warn_end_merge = "tie_word_embeddings=False)\n```\n"
+    warn_end_merge = (
+        "# Now use the original model but in untied format\n"
+        "model = AutoModelForCausalLM.from_pretrained(untied_model_dir)\n```\n"
+    )
 
     def _get_peft_model(self, tie_word_embeddings, target_module):
         model = get_peft_model(

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -1163,7 +1163,7 @@ class TestBaseTunerMethods(unittest.TestCase):
             triggered=False,
         )
 
-        # No warning when loading model with tie_word_embeddings although but not relevant target module
+        # No warning when loading model with tie_word_embeddings but not relevant target module
         with warnings.catch_warnings(record=True) as records_inject_tied_no_target:
             model_not_tied = get_peft_model(
                 AutoModelForCausalLM.from_pretrained(model_id, tie_word_embeddings=False),

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -1145,7 +1145,7 @@ class TestBaseTunerMethods(unittest.TestCase):
         with warnings.catch_warnings(record=True) as records_inject_not_tied:
             model_not_tied = get_peft_model(
                 AutoModelForCausalLM.from_pretrained(model_id, tie_word_embeddings=False),
-                LoraConfig(target_modules=["q_proj"]),
+                LoraConfig(target_modules=["lm_head"]),
             )
         with warnings.catch_warnings(record=True) as records_merge_not_tied:
             model_not_tied.merge_and_unload(safe_merge=True, adapter_names=["default"])

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -1162,3 +1162,25 @@ class TestBaseTunerMethods(unittest.TestCase):
             warn_end=warn_end_merge,
             triggered=False,
         )
+
+        # No warning when loading model with tie_word_embeddings although but not relevant target module
+        with warnings.catch_warnings(record=True) as records_inject_tied_no_target:
+            model_not_tied = get_peft_model(
+                AutoModelForCausalLM.from_pretrained(model_id, tie_word_embeddings=False),
+                LoraConfig(target_modules=["q_proj"]),
+            )
+        with warnings.catch_warnings(record=True) as records_merge_tied_no_target:
+            model_not_tied.merge_and_unload(safe_merge=True, adapter_names=["default"])
+
+        assert_warning_triggered(
+            records_inject_tied_no_target,
+            warn_start=warn_start,
+            warn_end=warn_end_inject,
+            triggered=False,
+        )
+        assert_warning_triggered(
+            records_merge_tied_no_target,
+            warn_start=warn_start,
+            warn_end=warn_end_merge,
+            triggered=False,
+        )


### PR DESCRIPTION
### Context

Solving issue #2018.

- Raise a warning if the user is requesting an output `target_module` when the embeddings are tied, because this could lead to errors, for example when merging the adapter.
- Also refactored the code to get the model config

#### Todo

- [x] ~~Try if load with `tie_word_embeddings=False` is an actual option. Load Gemma2 with finetuned different `lm_weights` and check that the lm_head is not replaced with the embedding (even if cloned). If it works, try to merge an adapter to lm_weight and then load it to check if embed and lm_head are kept separate. (the main concern is that the loading model's architecture might ignore any `lm_head` weight present in safetensors, as it happens in llama.cpp for example).~~
- [x] In the end I only checked how to save the base model as untied, then the user can work from there, although I DID NOT DO  A THOROUGH CHECK OF THIS APPROACH, only checked this:
```python
from transformers import AutoModelForCausalLM
import torch

# Load original tied model
model = AutoModelForCausalLM.from_pretrained("google/gemma-2-2b-it", tie_word_embeddings=False)
# Set the randomly initialized lm_head to the previously tied embeddings
model.lm_head.weight.data = model.model.embed_tokens.weight.data.clone()
assert torch.equal(model.lm_head.weight.data, model.model.embed_tokens.weight.data)

# Save the untied model
untied_model_dir = "tmp_model"
model.save_pretrained(untied_model_dir)
model.config.save_pretrained(untied_model_dir)
# Now use the original model but in untied format
model = AutoModelForCausalLM.from_pretrained(untied_model_dir)

assert torch.equal(model.lm_head.weight.data, model.model.embed_tokens.weight.data)
assert model.model.embed_tokens.weight.data.data_ptr() != model.lm_head.weight.data.data_ptr()
```

- [x] Add in warning about porting to other formats.
