### PR TITLE
[tests] make cuda-only cases in `TestModelAndLayerStatus` device-agnostic

### DIFF
--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -42,9 +42,9 @@ from peft.tuners.tuners_utils import (
     check_target_module_exists,
     inspect_matched_modules,
 )
-from peft.utils import infer_device, INCLUDE_LINEAR_LAYERS_SHORTHAND
+from peft.utils import INCLUDE_LINEAR_LAYERS_SHORTHAND, infer_device
 
-from .testing_utils import require_bitsandbytes, require_torch_gpu, require_non_cpu
+from .testing_utils import require_bitsandbytes, require_non_cpu, require_torch_gpu
 
 
 # Implements tests for regex matching logic common for all BaseTuner subclasses, and
@@ -394,6 +394,7 @@ class TestModelAndLayerStatus:
     corresponding features like merging).
 
     """
+
     torch_device = infer_device()
 
     @pytest.fixture

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -594,7 +594,7 @@ class TestModelAndLayerStatus:
         assert result == expected
 
     @require_non_cpu
-    def test_devices_all_cuda_large(self, large_model):
+    def test_devices_all_gpu_large(self, large_model):
         large_model.to(self.torch_device)
         layer_status = large_model.get_layer_status()
         result = [status.devices for status in layer_status]
@@ -607,8 +607,8 @@ class TestModelAndLayerStatus:
         assert result == expected
 
     @require_non_cpu
-    def test_devices_cpu_and_cuda_large(self, large_model):
-        # move the embedding layer to CUDA
+    def test_devices_cpu_and_gpu_large(self, large_model):
+        # move the embedding layer to GPU
         large_model.model.lin0.lora_A["default"] = large_model.model.lin0.lora_A["default"].to(self.torch_device)
         layer_status = large_model.get_layer_status()
         result = [status.devices for status in layer_status]
@@ -809,14 +809,14 @@ class TestModelAndLayerStatus:
         assert model_status.devices == {"default": ["cpu"], "other": ["cpu"]}
 
     @require_non_cpu
-    def test_model_devices_all_cuda_large(self, large_model):
+    def test_model_devices_all_gpu_large(self, large_model):
         large_model.to(self.torch_device)
         model_status = large_model.get_model_status()
         assert model_status.devices == {"default": [self.torch_device], "other": [self.torch_device]}
 
     @require_non_cpu
-    def test_model_devices_cpu_and_cuda_large(self, large_model):
-        # move the embedding layer to CUDA
+    def test_model_devices_cpu_and_gpu_large(self, large_model):
+        # move the embedding layer to GPU
         large_model.model.lin0.lora_A["default"] = large_model.model.lin0.lora_A["default"].to(self.torch_device)
         model_status = large_model.get_model_status()
         assert model_status.devices == {"default": ["cpu", self.torch_device], "other": ["cpu"]}
@@ -873,7 +873,7 @@ class TestModelAndLayerStatus:
         config = VeraConfig(target_modules=["lin0", "lin1"], init_weights=False)
         model = get_peft_model(base_model, config)
 
-        # move the buffer dict to CUDA
+        # move the buffer dict to GPU
         model.lin0.vera_A["default"] = model.lin0.vera_A["default"].to(self.torch_device)
 
         model_status = model.get_model_status()

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -42,9 +42,9 @@ from peft.tuners.tuners_utils import (
     check_target_module_exists,
     inspect_matched_modules,
 )
-from peft.utils import INCLUDE_LINEAR_LAYERS_SHORTHAND
+from peft.utils import infer_device, INCLUDE_LINEAR_LAYERS_SHORTHAND
 
-from .testing_utils import require_bitsandbytes, require_torch_gpu
+from .testing_utils import require_bitsandbytes, require_torch_gpu, require_non_cpu
 
 
 # Implements tests for regex matching logic common for all BaseTuner subclasses, and
@@ -394,6 +394,7 @@ class TestModelAndLayerStatus:
     corresponding features like merging).
 
     """
+    torch_device = infer_device()
 
     @pytest.fixture
     def small_model(self):
@@ -591,27 +592,27 @@ class TestModelAndLayerStatus:
         ]
         assert result == expected
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    @require_non_cpu
     def test_devices_all_cuda_large(self, large_model):
-        large_model.to("cuda")
+        large_model.to(self.torch_device)
         layer_status = large_model.get_layer_status()
         result = [status.devices for status in layer_status]
         expected = [
-            {"default": ["cuda"], "other": ["cuda"]},
-            {"default": ["cuda"]},
-            {"other": ["cuda"]},
-            {"default": ["cuda"]},
+            {"default": [self.torch_device], "other": [self.torch_device]},
+            {"default": [self.torch_device]},
+            {"other": [self.torch_device]},
+            {"default": [self.torch_device]},
         ]
         assert result == expected
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    @require_non_cpu
     def test_devices_cpu_and_cuda_large(self, large_model):
         # move the embedding layer to CUDA
-        large_model.model.lin0.lora_A["default"] = large_model.model.lin0.lora_A["default"].to("cuda")
+        large_model.model.lin0.lora_A["default"] = large_model.model.lin0.lora_A["default"].to(self.torch_device)
         layer_status = large_model.get_layer_status()
         result = [status.devices for status in layer_status]
         expected = [
-            {"default": ["cpu", "cuda"], "other": ["cpu"]},
+            {"default": ["cpu", self.torch_device], "other": ["cpu"]},
             {"default": ["cpu"]},
             {"other": ["cpu"]},
             {"default": ["cpu"]},
@@ -806,18 +807,18 @@ class TestModelAndLayerStatus:
         model_status = large_model.get_model_status()
         assert model_status.devices == {"default": ["cpu"], "other": ["cpu"]}
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    @require_non_cpu
     def test_model_devices_all_cuda_large(self, large_model):
-        large_model.to("cuda")
+        large_model.to(self.torch_device)
         model_status = large_model.get_model_status()
-        assert model_status.devices == {"default": ["cuda"], "other": ["cuda"]}
+        assert model_status.devices == {"default": [self.torch_device], "other": [self.torch_device]}
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    @require_non_cpu
     def test_model_devices_cpu_and_cuda_large(self, large_model):
         # move the embedding layer to CUDA
-        large_model.model.lin0.lora_A["default"] = large_model.model.lin0.lora_A["default"].to("cuda")
+        large_model.model.lin0.lora_A["default"] = large_model.model.lin0.lora_A["default"].to(self.torch_device)
         model_status = large_model.get_model_status()
-        assert model_status.devices == {"default": ["cpu", "cuda"], "other": ["cpu"]}
+        assert model_status.devices == {"default": ["cpu", self.torch_device], "other": ["cpu"]}
 
     def test_loha_model(self):
         # ensure that this also works with non-LoRA, it's not necessary to test all tuners
@@ -858,7 +859,7 @@ class TestModelAndLayerStatus:
         assert layer_status0.available_adapters == ["default"]
         assert layer_status0.devices == {"default": ["cpu"]}
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device available.")
+    @require_non_cpu
     def test_vera_model(self):
         # let's also test VeRA because it uses BufferDict
         class SmallModel(nn.Module):
@@ -872,7 +873,7 @@ class TestModelAndLayerStatus:
         model = get_peft_model(base_model, config)
 
         # move the buffer dict to CUDA
-        model.lin0.vera_A["default"] = model.lin0.vera_A["default"].to("cuda")
+        model.lin0.vera_A["default"] = model.lin0.vera_A["default"].to(self.torch_device)
 
         model_status = model.get_model_status()
         layer_status = model.get_layer_status()
@@ -888,7 +889,7 @@ class TestModelAndLayerStatus:
         assert model_status.merged_adapters == []
         assert model_status.requires_grad == {"default": True}
         assert model_status.available_adapters == ["default"]
-        assert model_status.devices == {"default": ["cpu", "cuda"]}
+        assert model_status.devices == {"default": ["cpu", self.torch_device]}
 
         layer_status0 = layer_status[0]
         assert len(layer_status) == 2
@@ -899,7 +900,7 @@ class TestModelAndLayerStatus:
         assert layer_status0.merged_adapters == []
         assert layer_status0.requires_grad == {"default": True}
         assert layer_status0.available_adapters == ["default"]
-        assert layer_status0.devices == {"default": ["cpu", "cuda"]}
+        assert layer_status0.devices == {"default": ["cpu", self.torch_device]}
 
     ###################
     # non-PEFT models #

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 import numpy as np
 import pytest
 import torch
+from accelerate.test_utils.testing import get_backend
 
 from peft.import_utils import (
     is_aqlm_available,
@@ -27,7 +28,6 @@ from peft.import_utils import (
     is_optimum_available,
 )
 
-from accelerate.test_utils.testing import get_backend
 
 torch_device, device_count, memory_allocated_func = get_backend()
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -27,6 +27,18 @@ from peft.import_utils import (
     is_optimum_available,
 )
 
+from accelerate.test_utils.testing import get_backend
+
+torch_device, device_count, memory_allocated_func = get_backend()
+
+
+def require_non_cpu(test_case):
+    """
+    Decorator marking a test that requires a hardware accelerator backend. These tests are skipped when there are no
+    hardware accelerator available.
+    """
+    return unittest.skipUnless(torch_device != "cpu", "test requires a hardware accelerator")(test_case)
+
 
 def require_torch_gpu(test_case):
     """


### PR DESCRIPTION
After the fix, all tests in `TestModelAndLayerStatus` pass on XPU:
```bash
================================================ short test summary info ================================================
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_layer_names_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_layer_names_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_module_type_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_module_type_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_enabled_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_enabled_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_enabled_irregular
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_active_adapters_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_active_adapters_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_merge_adapters_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_merge_adapters_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_requires_grad_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_requires_grad_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_requires_grad_irregular
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_available_adapters_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_available_adapters_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_devices_all_cpu_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_devices_all_cpu_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_devices_all_cuda_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_devices_cpu_and_cuda_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_base_model_type_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_base_model_type_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_base_model_type_transformers_automodel
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_adapter_model_type_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_adapter_model_type_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_peft_types_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_peft_types_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_nb_params_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_nb_params_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_num_adapter_layers_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_num_adapter_layers_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_enabled_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_enabled_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_disabled_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_disabled_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_enabled_irregular
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_active_adapters_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_active_adapters_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_active_adapters_irregular
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_merged_adapters_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_merged_adapters_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_merged_adapters_irregular
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_requires_grad_model_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_requires_grad_model_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_requires_grad_model_irregular
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_available_adapters_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_available_adapters_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_devices_all_cpu_small
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_devices_all_cpu_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_devices_all_cuda_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_devices_cpu_and_cuda_large
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_loha_model
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_vera_model
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_transformers_model
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_model_with_injected_layers
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_vanilla_model_raises
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_transformer_model_without_adapter_raises
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_prefix_tuning
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_adaption_prompt
PASSED tests/test_tuners_utils.py::TestModelAndLayerStatus::test_mixed_model_raises
============================================ 60 passed, 7 warnings in 10.21s ============================================
```