### PR TITLE
ENH Raise error when applying modules_to_save on tuner layer

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -202,7 +202,15 @@ class ModulesToSaveWrapper(torch.nn.Module):
         # ModuleList, even though their forward methods cannot be called
         forbidden_classes = (torch.nn.ModuleDict, torch.nn.ModuleList, torch.nn.ParameterDict, torch.nn.ParameterList)
         if isinstance(self.original_module, forbidden_classes):
-            cls_name = self.original_module.__class__.__name__
+            cls_name = self.original_module.__class__
+            raise TypeError(f"modules_to_save cannot be applied to modules of type {cls_name}")
+
+        # local import to avoid circular import
+        from peft.tuners.tuners_utils import BaseTunerLayer
+
+        if isinstance(self.original_module, BaseTunerLayer):
+            # e.g. applying modules_to_save to a lora layer makes no sense
+            cls_name = self.original_module.__class__
             raise TypeError(f"modules_to_save cannot be applied to modules of type {cls_name}")
 
     @property

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -49,7 +49,7 @@ from peft import (
     get_peft_model,
 )
 from peft.tuners.tuners_utils import BaseTunerLayer
-from peft.utils import ModulesToSaveWrapper, infer_device
+from peft.utils import infer_device
 
 from .testing_common import PeftCommonTester
 from .testing_utils import get_state_dict, require_torch_gpu


### PR DESCRIPTION
Relates to #2027

Normally, when selecting the layers for fine-tuning, PEFT already ensures that the same layer is not targeted for both parameter-efficient fine-tuning (e.g. LoRA layer) and full fine-tuning (via `modules_to_save`), as that makes no sense.

However, there is a loophole when the `modules_to_save` is applied ex post. This happens for instance when having a task type like sequence classification, where PEFT will automatically add the classification head to `modules_to_save` for the user. This loophole is now closed by adding a check to `ModulesToSaveWrapper` that validates that the targeted layer is not a tuner layer.

This does not fully resolve #2027 but will raise an early error in the future to avoid confusion. **Edit**: #2028 should fully resolve it, but having this PR would still be useful.

On top of this, the error message inside of
`ModulesToSaveWrapper.check_module` has been slightly adjusted. Previously, the class name would be used, which can be confusing. E.g. for LoRA, the class name of the linear LoRA layer is just `"Linear"`, which looks the same as `nn.Linear`. Therefore, the full name is now shown.

Moreover, a now obsolete test was removed.