### PR TITLE
[tests] enable cuda-only tests in `test_common_gpu.py` to work on XPU

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -20,6 +20,7 @@ from typing import Any, Optional, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from accelerate.utils.imports import is_xpu_available
 from torch import svd_lowrank
 from transformers.pytorch_utils import Conv1D
 
@@ -254,11 +255,14 @@ class LoraLayer(BaseTunerLayer):
         lora_B = self.lora_B[adapter_name].weight
         place_on_cpu = self.ephemeral_gpu_offload and (lora_A.device.type == "cpu" or lora_B.device.type == "cpu")
         if self.ephemeral_gpu_offload:
-            if lora_A.device.type == "cuda":
+            if lora_A.device.type in ["cuda", "xpu"]:
                 lora_B = lora_B.to(lora_A.device)
             else:
-                if lora_B.device.type != "cuda":
-                    lora_B = lora_B.to("cuda")
+                if lora_B.device.type not in ["cuda", "xpu"]:
+                    if is_xpu_available():
+                        lora_B = lora_B.to("xpu")
+                    else:
+                        lora_B = lora_B.to("cuda")
                 lora_A = lora_A.to(lora_B.device)
         scaling = self.scaling[adapter_name]
         dora_layer.update_layer(

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -60,6 +60,16 @@ def require_torch_multi_gpu(test_case):
         return test_case
 
 
+def require_multi_accelerator(test_case):
+    """
+    Decorator marking a test that requires multiple hardware accelerators. These tests are skipped on a machine without
+    multiple accelerators.
+    """
+    return unittest.skipUnless(
+        torch_device != "cpu" and device_count > 1, "test requires multiple hardware accelerators"
+    )(test_case)
+
+
 def require_bitsandbytes(test_case):
     """
     Decorator marking a test that requires the bitsandbytes library. Will be skipped when the library is not installed.


### PR DESCRIPTION
Below are the UT Results after the fix: 
```bash
PASSED tests/test_common_gpu.py::PeftGPUCommonTests::test_adalora_bnb_quantization_from_pretrained_safetensors
PASSED tests/test_common_gpu.py::PeftGPUCommonTests::test_apply_GS_hra_inference
PASSED tests/test_common_gpu.py::PeftGPUCommonTests::test_dora_ephemeral_gpu_offload
PASSED tests/test_common_gpu.py::PeftGPUCommonTests::test_dora_ephemeral_gpu_offload_multigpu
PASSED tests/test_common_gpu.py::PeftGPUCommonTests::test_ia3_bnb_quantization_from_pretrained_safetensors
PASSED tests/test_common_gpu.py::PeftGPUCommonTests::test_lora_bnb_quantization_from_pretrained_safetensors
PASSED tests/test_common_gpu.py::PeftGPUCommonTests::test_r_odd_hra_inference
PASSED tests/test_common_gpu.py::PeftGPUCommonTests::test_serialization_shared_tensors
```