### PR TITLE
FIX: Don't target the classification head when using target_modules="all-linear"

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -31,7 +31,7 @@ from transformers.pytorch_utils import Conv1D
 
 from peft.utils import INCLUDE_LINEAR_LAYERS_SHORTHAND
 from peft.utils.constants import DUMMY_TARGET_MODULES
-from peft.utils.peft_types import PeftType
+from peft.utils.peft_types import PeftType, TaskType
 
 from ..config import PeftConfig
 from ..utils import ModulesToSaveWrapper, _get_submodules
@@ -814,11 +814,23 @@ def _maybe_include_all_linear_layers(peft_config: PeftConfig, model: nn.Module) 
             names = name.rsplit(".", 1)[-1]  # get the base name
             linear_module_names.add(names)
 
-    # ignore the last classification head for text generation models
+    # Try to remove linear layers that should not be targeted as best as possible. We have to rely on convention as
+    # there are no hard rules to detect these modules.
+    module_names_to_exclude = set()
     output_emb = model.get_output_embeddings()
     if output_emb is not None:
+        # ignore the last classification head for text generation models
         last_module_name = [name for name, module in model.named_modules() if module is output_emb][0]
-        linear_module_names -= {last_module_name}
+        module_names_to_exclude.add(last_module_name)
+    elif peft_config.task_type == TaskType.SEQ_CLS:
+        # ignore classifier head for classification models (issue 2027)
+        # there is no fix name for the classifier head, "score" and "classifier" are most common
+        cls_head = getattr(model, "score", None) or getattr(model, "classifier", None)
+        if cls_head is not None:
+            last_module_name = [name for name, module in model.named_modules() if module is cls_head][0]
+            module_names_to_exclude.add(last_module_name)
+
+    linear_module_names -= module_names_to_exclude
     peft_config.target_modules = linear_module_names
     return peft_config
 

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -257,6 +257,7 @@ WEIGHTS_NAME = "adapter_model.bin"
 SAFETENSORS_WEIGHTS_NAME = "adapter_model.safetensors"
 CONFIG_NAME = "adapter_config.json"
 EMBEDDING_LAYER_NAMES = ["embed_tokens", "lm_head"]
+SEQ_CLS_HEAD_NAMES = ["score", "classifier"]
 INCLUDE_LINEAR_LAYERS_SHORTHAND = "all-linear"
 TOKENIZER_CONFIG_NAME = "tokenizer_config.json"
 DUMMY_TARGET_MODULES = "dummy-target-modules"


### PR DESCRIPTION
Fixes #2027

When using a transformers sequence classification model, `target_modules="all-linear"` should not wrap the classification head with LoRA. This is because it is already wrapped with `ModulesToSave`, i.e. it will be fully fine-tuned, which is the generally desired behavior.

Before this bug fix, the classification head would be double-wrapped. With #2028, this now raises an error. With this PR, it is avoided completely. Still, keeping #2028 is good because it helps prevent other situations where double-wrapping might occur due to mis-configuration.

Note that there is no fool-proof method to detect the classification head, we have to rely on transformers convention.