### PR TITLE
Bug: set correct pre-commit-hooks version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
           - --fix
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v0.6.1
+    rev: v4.6.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml


### PR DESCRIPTION
### Context

Since the upgrade of pre-commit-hooks version #1965 , my pre-commit fails, and it looks like the version does not exists. 

### Fix

This PR fixes the version to [latest](https://pypi.org/project/pre-commit-hooks/).