### PR TITLE
TST: Fewer inference steps for stable diffusion tests

### DIFF
--- a/tests/test_stablediffusion.py
+++ b/tests/test_stablediffusion.py
@@ -145,7 +145,7 @@ class StableDiffusionModelTester(TestCase, PeftCommonTester):
     def prepare_inputs_for_testing(self):
         return {
             "prompt": "a high quality digital photo of a cute corgi",
-            "num_inference_steps": 20,
+            "num_inference_steps": 3,
         }
 
     @parameterized.expand(


### PR DESCRIPTION
Reduce the number of inference steps for stable diffusion tests. These tests are the slowest ones on CI, this should hopefully help.