### PR TITLE
TST Speed up vision model tests

### DIFF
--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -76,7 +76,7 @@ class TestPastKV:
 
 
 class TestResnet:
-    model_id = "microsoft/resnet-18"
+    model_id = "hf-internal-testing/tiny-random-ResNetForImageClassification"
 
     @pytest.fixture(autouse=True)
     def teardown(self):
@@ -117,8 +117,8 @@ class TestResnet:
         optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
         batch_size = 4
         max_steps = 5 * batch_size
-        labels = torch.zeros(1, 1000)
-        labels[0, 283] = 1
+        labels = torch.zeros(1, 3)
+        labels[0, 1] = 1
         for i in range(0, max_steps, batch_size):
             optimizer.zero_grad()
             outputs = model(**data, labels=labels)


### PR DESCRIPTION
The HRA vision model test is extremely slow on CI (> 600 sec, ~50% of total time). This change speeds up the test by using a smaller ResNet model to run the tests.

It's still not clear why HRA was so slow specifically -- LoRA is 40x faster -- but that can be fixed separately.

HRA author has been [notified](https://github.com/huggingface/peft/pull/1864#issuecomment-2332035181) 5 days ago but no response so far.