### PR TITLE
ENH: PiSSA/OLoRA: Preserve original config on save

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import collections
+import copy
 import inspect
 import os
 import warnings
@@ -348,6 +349,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     for shared_tensor_name in names[1:]:
                         output_state_dict[shared_tensor_name] = output_state_dict[shared_tensor_name].clone()
                 if path_initial_model_for_weight_conversion is not None:
+                    peft_config = copy.deepcopy(peft_config)
                     peft_config.init_lora_weights = True
                     peft_config.save_pretrained(path_initial_model_for_weight_conversion)
                     output_state_dict = save_mutated_as_lora(
@@ -360,6 +362,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 )
             elif is_main_process:
                 if path_initial_model_for_weight_conversion is not None:
+                    peft_config = copy.deepcopy(peft_config)
                     peft_config.init_lora_weights = True
                     peft_config.save_pretrained(path_initial_model_for_weight_conversion)
                     output_state_dict = save_mutated_as_lora(

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -329,11 +329,14 @@ class TestLoraInitialization:
 
         # save the model with conversion
         peft_config_keys_before = list(peft_model.peft_config.keys())
+        peft_config_dict_before = peft_model.peft_config["default"].to_dict()
         peft_model.save_pretrained(
             tmp_path / "pissa-model-converted", path_initial_model_for_weight_conversion=tmp_path / "init-model"
         )
         peft_config_keys_after = list(peft_model.peft_config.keys())
+        peft_config_dict_after = peft_model.peft_config["default"].to_dict()
         assert peft_config_keys_before == peft_config_keys_after
+        assert peft_config_dict_before == peft_config_dict_after
 
         model_converted = PeftModel.from_pretrained(deepcopy(model), tmp_path / "pissa-model-converted")
         output_converted = model_converted(data)[0]
@@ -607,11 +610,14 @@ class TestLoraInitialization:
 
         # save the model with conversion
         peft_config_keys_before = list(peft_model.peft_config.keys())
+        peft_config_dict_before = peft_model.peft_config["default"].to_dict()
         peft_model.save_pretrained(
             tmp_path / "olora-model-converted", path_initial_model_for_weight_conversion=tmp_path / "init-model"
         )
         peft_config_keys_after = list(peft_model.peft_config.keys())
+        peft_config_dict_after = peft_model.peft_config["default"].to_dict()
         assert peft_config_keys_before == peft_config_keys_after
+        assert peft_config_dict_before == peft_config_dict_after
 
         model_converted = PeftModel.from_pretrained(deepcopy(model), tmp_path / "olora-model-converted")
         output_converted = model_converted(data)[0]


### PR DESCRIPTION
Resolves #2075

When saving PiSSA or OLoRA with the option to convert to normal LoRA, the LoRA weight shapes change, which means that some values like `r` and `lora_alpha` need to be adjusted in the saved PEFT config. However, these modifications should be limited to the saved config, while the loaded config should stay the same.

This PR implements this change by creating a copy of the config before modifying it.