### PR TITLE
ENH: Add default target layers for gemma2 architecture

### DIFF
--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -72,7 +72,13 @@ TRANSFORMERS_MODELS_TO_LNTUNING_TARGET_MODULES_MAPPING = {
     "mistral": ["input_layernorm", "post_attention_layernorm", "norm"],
     "phi": ["input_layernorm", "final_layernorm"],
     "gemma": ["input_layernorm", "post_attention_layernorm", "norm"],
-    "gemma2": ["input_layernorm", "norm"],
+    "gemma2": [
+        "input_layernorm",
+        "post_attention_layernorm",
+        "pre_feedforward_layernorm",
+        "post_feedforward_layernorm",
+        "norm",
+    ],
     "qwen2": ["post_attention_layernorm"],
 }
 

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -72,6 +72,7 @@ TRANSFORMERS_MODELS_TO_LNTUNING_TARGET_MODULES_MAPPING = {
     "mistral": ["input_layernorm", "post_attention_layernorm", "norm"],
     "phi": ["input_layernorm", "final_layernorm"],
     "gemma": ["input_layernorm", "post_attention_layernorm", "norm"],
+    "gemma2": ["input_layernorm", "norm"],
     "qwen2": ["post_attention_layernorm"],
 }
 
@@ -107,6 +108,7 @@ TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING = {
     "stablelm": ["q_proj", "v_proj"],
     "phi": ["q_proj", "v_proj", "fc1", "fc2"],
     "gemma": ["q_proj", "v_proj"],
+    "gemma2": ["q_proj", "v_proj"],
     "qwen2": ["q_proj", "v_proj"],
 }
 
@@ -133,6 +135,7 @@ TRANSFORMERS_MODELS_TO_IA3_TARGET_MODULES_MAPPING = {
     "falcon": ["query_key_value", "dense_4h_to_h"],
     "phi": ["q_proj", "v_proj", "fc2"],
     "gemma": ["q_proj", "v_proj", "down_proj"],
+    "gemma2": ["q_proj", "v_proj", "down_proj"],
     "qwen2": ["q_proj", "v_proj", "down_proj"],
 }
 
@@ -159,6 +162,7 @@ TRANSFORMERS_MODELS_TO_IA3_FEEDFORWARD_MODULES_MAPPING = {
     "falcon": ["dense_4h_to_h"],
     "phi": ["fc2"],
     "gemma": ["down_proj"],
+    "gemma2": ["down_proj"],
     "qwen2": ["down_proj"],
 }
 
@@ -216,6 +220,7 @@ TRANSFORMERS_MODELS_TO_VERA_TARGET_MODULES_MAPPING = {
     "stablelm": ["q_proj", "v_proj"],
     "phi": ["q_proj", "v_proj"],
     "gemma": ["q_proj", "v_proj"],
+    "gemma2": ["q_proj", "v_proj"],
     "qwen2": ["q_proj", "v_proj"],
 }
 
@@ -250,6 +255,7 @@ TRANSFORMERS_MODELS_TO_FOURIERFT_TARGET_MODULES_MAPPING = {
     "stablelm": ["q_proj", "v_proj"],
     "phi": ["q_proj", "v_proj", "fc1", "fc2"],
     "gemma": ["q_proj", "v_proj"],
+    "gemma2": ["q_proj", "v_proj"],
     "qwen2": ["q_proj", "v_proj"],
 }
 


### PR DESCRIPTION
Google's gemma 2 models have a slightly different architecture than gemma 1 and thus a different `model_type` attribute. This PR adds default `target_layer`s for gemma 2 that correspond to the default `target_layer`s of gemma 1.