### PR TITLE
Expose bias to to ModulesToSaveWrapper

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -233,6 +233,12 @@ class ModulesToSaveWrapper(torch.nn.Module):
             return self.original_module.weight
         return self.modules_to_save[self.active_adapter].weight
 
+    @property
+    def bias(self):
+        if self.active_adapter not in self.modules_to_save:
+            return self.original_module.bias
+        return self.modules_to_save[self.active_adapter].bias
+
     def update(self, adapter_name):
         context_manager = nullcontext()
         for _, param in self.original_module.named_parameters():


### PR DESCRIPTION
Similar to https://github.com/huggingface/peft/pull/1238 and https://github.com/huggingface/peft/pull/1530

This PR aims at solving an issue similar to https://github.com/huggingface/peft/issues/1524 and https://github.com/huggingface/peft/issues/1225, where one would like to add `self.dt_proj` module to `modules_to_save` instead of `target_modules` for the following operation
```
            contextualized_states = mamba_inner_fn(
                projected_states,
                self.conv1d.weight,
                self.conv1d.bias if self.use_conv_bias else None,
                self.x_proj.weight,
                self.dt_proj.weight,
                self.out_proj.weight,
                self.out_proj.bias.float() if self.use_bias else None,
                -torch.exp(self.A_log.float()),
                None,  # input-dependent B
                None,  # input-dependent C
                self.D.float(),
                delta_bias=self.dt_proj.bias.float(),
                delta_softplus=True,
            )
```