### PR TITLE
FIX: Bug in find_minimal_target_modules

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -871,14 +871,16 @@ def _find_minimal_target_modules(
     # Initialize a set for required suffixes
     required_suffixes = set()
 
-    for item, suffixes in target_modules_suffix_map.items():
+    # We sort the target_modules_suffix_map simple to get deterministic behavior, since sets have no order. In theory
+    # the order should not matter but in case there is a bug, it's better for the bug to be deterministic.
+    for item, suffixes in sorted(target_modules_suffix_map.items(), key=lambda tup: tup[1]):
         # Go through target_modules items, shortest suffixes first
         for suffix in suffixes:
             # If the suffix is already in required_suffixes or matches other_module_names, skip it
             if suffix in required_suffixes or suffix in other_module_suffixes:
                 continue
             # Check if adding this suffix covers the item
-            if not any(item.endswith(req_suffix) for req_suffix in required_suffixes):
+            if not any(item.endswith("." + req_suffix) for req_suffix in required_suffixes):
                 required_suffixes.add(suffix)
                 break
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -871,7 +871,7 @@ def _find_minimal_target_modules(
     # Initialize a set for required suffixes
     required_suffixes = set()
 
-    # We sort the target_modules_suffix_map simple to get deterministic behavior, since sets have no order. In theory
+    # We sort the target_modules_suffix_map simply to get deterministic behavior, since sets have no order. In theory
     # the order should not matter but in case there is a bug, it's better for the bug to be deterministic.
     for item, suffixes in sorted(target_modules_suffix_map.items(), key=lambda tup: tup[1]):
         # Go through target_modules items, shortest suffixes first


### PR DESCRIPTION
See #2045 for context.

This bug was reported by Sayak and would occur in `find_minimal_target_modules` if a required suffix had itself as suffix a string that was already determined to be required, in which case this required suffix would not be added.

The fix consists of prepending a `"."` to the suffix before checking if it is required or not.

On top of this, the algorithm has been changed to be deterministic. Previously, it was not deterministic because a dictionary that was looped over was built from a set, and sets don't guarantee order. This would result in the loop being in arbitrary order.

As long as the algorithm is 100% correct, the order should not matter. But in case we find bugs like this, the order does matter. We don't want bugs to be flaky, therefore it is best to sort the dict and remove randomness from the function.