### PR TITLE
Fix func docstring

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1069,7 +1069,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
     def load_adapter(
         self,
         model_id: str,
-        adapter_name: str,
+        adapter_name: Union[str, os.PathLike],
         is_trainable: bool = False,
         torch_device: Optional[str] = None,
         autocast_adapter_dtype: bool = True,
@@ -1085,10 +1085,14 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         adapter.
 
         Args:
+            model_id (`str` or `os.PathLike`):
+                The name of the PEFT configuration to use. Can be either:
+                    - A string, the `model id` of a PEFT configuration hosted inside a model repo on the Hugging Face
+                      Hub.
+                    - A path to a directory containing a PEFT configuration file saved using the `save_pretrained`
+                      method (`./my_peft_config_directory/`).
             adapter_name (`str`):
                 The name of the adapter to be added.
-            peft_config ([`PeftConfig`]):
-                The configuration of the adapter to be added.
             is_trainable (`bool`, *optional*, defaults to `False`):
                 Whether the adapter should be trainable or not. If `False`, the adapter will be frozen and can only be
                 used for inference.

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1068,8 +1068,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
     def load_adapter(
         self,
-        model_id: str,
-        adapter_name: Union[str, os.PathLike],
+        model_id: Union[str, os.PathLike],
+        adapter_name: str,
         is_trainable: bool = False,
         torch_device: Optional[str] = None,
         autocast_adapter_dtype: bool = True,


### PR DESCRIPTION
Fix docstring of function `load_adapter`.

1. `model_id` type hint
add Pathlike to keep consistency with other functions that call `load_adapter`.

2. add missing `model_id` docstring
3. remove `peft_config` docstring as `peft_config` argument doesn't exist.