### PR TITLE
Add missed requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ transformers
 tqdm
 packaging
 pytest
+pytest-coverage
+pytest-xdist
 numpy
 pyyaml
 datasets


### PR DESCRIPTION
A clean environment needs `pytest-coverage` and `pytest-xdist` to execute `make test`.