### PR TITLE
FIX low_cpu_mem_usage consolidates devices

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -443,6 +443,10 @@ def set_peft_model_state_dict(
     )
     if low_cpu_mem_usage:
         load_result = model.load_state_dict(peft_model_state_dict, strict=False, assign=True)
+        # ensure that the correct device is set
+        for module in model.modules():
+            if hasattr(module, "_move_adapter_to_device_of_base_layer"):
+                module._move_adapter_to_device_of_base_layer(adapter_name)
     else:
         load_result = model.load_state_dict(peft_model_state_dict, strict=False)
 


### PR DESCRIPTION
See: https://github.com/huggingface/diffusers/pull/9510#issuecomment-2378316687

Right now, the `low_cpu_mem_usage=True` option does not consolidate the devices. E.g. when the model is on GPU and the `state_dict` on CPU, the adapter weight will be on CPU after loading, when it should be GPU. This fix ensures that the devices are consolidated.