### PR TITLE
TST Mark flaky X-LoRA test as xfail

### DIFF
--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -188,6 +188,8 @@ class TestXlora:
 
         assert str(model) is not None
 
+    # TODO: On CI (but not locally), this test seems to have become flaky with the latest transformers changes (v4.45).
+    @pytest.mark.xfail
     def test_save_load_functional(self, tokenizer, model, tmp_path):
         inputs = tokenizer.encode("Python is a", add_special_tokens=False, return_tensors="pt")
         outputs = model.generate(


### PR DESCRIPTION
Currently, CI is failing constantly because one of the X-LoRA tests has become flaky lately, most likely caused by the transformers 4.45.0 release. Therefore, this test is now marked to non-strictly xfail.

One example of the time of writing:

https://github.com/huggingface/peft/actions/runs/11104075939/job/30847479626?pr=2113

I cannot reproduce this error locally, neither on CPU nor GPU. It is thus unclear how to fix this test.