### PR TITLE
ENH: Improved attribute access for modules_to_save

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -243,8 +243,12 @@ class ModulesToSaveWrapper(torch.nn.Module):
         modules = self.__dict__["_modules"]
         if self.disable_adapters:
             module = modules["original_module"]
-        else:
+        elif self.active_adapter in modules["modules_to_save"]:
             module = modules["modules_to_save"][self.active_adapter]
+        else:
+            # For some reason, there is no module corresponding to the active adapter; this should normally not be
+            # reached and exists as a failsafe (otherwise, a KeyError would be raised)
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
         return getattr(module, name)
 
     def update(self, adapter_name):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -191,3 +191,11 @@ class TestModulesToSaveAttributeAccess:
         with pytest.raises(AttributeError, match="has no attribute 'foo'"):
             with model.disable_adapter():
                 model.lin1.foo
+
+    def test_transient_attribute_access_non_existing_adapter(self, mlp):
+        # This should normally never happen, as the active adapter should always exist, but it's a failsafe
+        config = LoraConfig(target_modules=["lin0"], modules_to_save=["lin1"])
+        model = get_peft_model(mlp, config)
+        model.base_model.model.lin1._active_adapter = "does-not-exist"
+        with pytest.raises(AttributeError, match="has no attribute 'weight'"):
+            model.lin1.weight


### PR DESCRIPTION
Resolves #2099

So far, if a module was wrapped due to `modules_to_save`, we handled access to the `weight` and `bias` attribute (albeit incorrectly in case of disabled adapters!). However, there could be more attributes than those that could be accessed, in which case we got an error so far.

Instead of special properties, we now implement a generic `__getattr__` method that can deal with any attribute. The implementation is a bit complex to take into account the way that `torch.nn.Module` handles `__getattr__`.