### PR TITLE
ENH: Warn when from_pretrained misses PEFT keys

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -592,11 +592,16 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             **kwargs,
         )
 
-        if load_result.missing_keys:
+        # 1. Remove VB-LoRA vector bank, since it's a shared parameter set via the VBLoRAModel
+        # 2. Remove the prompt encoder, as it does not need to be part of the checkpoint
+        missing_keys = [
+            k for k in load_result.missing_keys if "vblora_vector_bank" not in k and "prompt_encoder" not in k
+        ]
+        if missing_keys:
             # Let's warn here since (in contrast to load_adapter) we don't return the load result, so it could be quite
             # difficult for users to even notice that something might have gone wrong here. As we filter out non PEFT
             # keys from the missing keys, this gives no false positives.
-            warnings.warn(f"Found missing adapter keys while loading the checkpoint: {load_result.missing_keys}")
+            warnings.warn(f"Found missing adapter keys while loading the checkpoint: {missing_keys}")
 
         return model
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -583,7 +583,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 low_cpu_mem_usage=low_cpu_mem_usage,
             )
 
-        model.load_adapter(
+        load_result = model.load_adapter(
             model_id,
             adapter_name,
             is_trainable=is_trainable,
@@ -591,6 +591,12 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             low_cpu_mem_usage=low_cpu_mem_usage,
             **kwargs,
         )
+
+        if load_result.missing_keys:
+            # Let's warn here since (in contrast to load_adapter) we don't return the load result, so it could be quite
+            # difficult for users to even notice that something might have gone wrong here. As we filter out non PEFT
+            # keys from the missing keys, this gives no false positives.
+            warnings.warn(f"Found missing adapter keys while loading the checkpoint: {load_result.missing_keys}")
 
         return model
 

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -18,6 +18,7 @@ import pickle
 import re
 import shutil
 import tempfile
+import warnings
 from collections import OrderedDict
 from dataclasses import replace
 
@@ -372,7 +373,10 @@ class PeftCommonTester:
                 model.save_pretrained(tmp_dirname, safe_serialization=False)
 
             model_from_pretrained = self.transformers_class.from_pretrained(model_id)
-            model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
+            with warnings.catch_warnings(record=True) as recs:
+                model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
+                # ensure that there is no warning
+                assert not any("found missing adapter keys" in str(rec.message) for rec in recs)
 
             # check if the state dicts are equal
             if issubclass(config_cls, PromptEncoderConfig):

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -376,7 +376,7 @@ class PeftCommonTester:
             with warnings.catch_warnings(record=True) as recs:
                 model_from_pretrained = PeftModel.from_pretrained(model_from_pretrained, tmp_dirname)
                 # ensure that there is no warning
-                assert not any("found missing adapter keys" in str(rec.message) for rec in recs)
+                assert not any("Found missing adapter keys" in str(rec.message) for rec in recs)
 
             # check if the state dicts are equal
             if issubclass(config_cls, PromptEncoderConfig):


### PR DESCRIPTION
After merging #2084, we now clean up the `missing_keys` when loading a PEFT adapter to remove all but the relevant keys (the fact that base model keys are missing is expected when loading a PEFT adapter).

Since the presence of `missing_keys` now really means that something might have gone wrong during loading, we can now warn the user if they call `PeftModel.from_pretrained`.

Note that load_adapter still does not warn, as here we return the `load_result` and users can already check, but for `from_pretrained`, they don't have that possibility.