### PR TITLE
[bug fix] ensure `base_model` is correctly set in model card

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1316,7 +1316,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         model_config = BaseTuner.get_model_config(self)
         model_config = None if model_config == DUMMY_MODEL_CONFIG else model_config
-        if model_config is not None and "_name_or_path" in model_config:
+        if card.data.get("base_model") is None and model_config is not None and "_name_or_path" in model_config:
             card.data["base_model"] = model_config["_name_or_path"]
 
         lines = card.text.splitlines()


### PR DESCRIPTION
TLDR: 

When we train LoRA's on top of a **model loaded from disk**, `SFTTrainer.push_to_hub` fails because of the model card created by `Trainer.create_model_card`. The `Trainer.create_model_card` calls the peft library's `create_or_update_model_card` which overrides the `base_model` to the path of the model on disk even if the model card created by `Trainer.create_model_card` might have contained the value of the `base_model`. 

Long Form Context : 

The model card's parsing is [an essential when pushing the model to hub](https://github.com/huggingface/huggingface_hub/blob/ce38f468ae83e4a1e8813e9e72f6906ce614f9bd/src/huggingface_hub/hf_api.py#L9499-L9504). If the model card doesn't contain information that HF finds valid, then HF hub raises a ValueError. One of the fields in the model_card injected by the `peft` library is the `base_model` field. This field is set earlier using the `model_config["_name_or_path"]`. A problem occurs when the `model_config["_name_or_path"]` is not a model name on HuggingfaceHub but rather just a path on local file system. At this point the hf_hub's `folder_upload` method crashes. Now if the card already contained a `base_model`set then uploading the model from disk is still possible. One way to set the `base_model`'s value is to pass the `SFTTrainer.push_to_hub`/`Trainer.push_to_hub` `kwargs` which are passed down to the `create_model_card` function.  These `kwargs` can contain a field called `finetuned_from` which allow the model card creation properly. 