### PR TITLE
FIX Type annoations in vera/bnb.py

### DIFF
--- a/src/peft/tuners/vera/bnb.py
+++ b/src/peft/tuners/vera/bnb.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import warnings
 from typing import Optional


### PR DESCRIPTION
The file was missing the `from __future__ import annotations` part. As this code is only running nightly with GPU, the normal CI missed this omission. With this PR, nightly CI should be green again.

When I tested it locally with GPU, I didn't check with Python 3.8, so this error did not occur. Once we stop supporting Python 3.8 very soon, this will also no longer be necessary, but we still need to fix it until then.