### PR TITLE
FIX Prompt learning with latest transformers error

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1756,7 +1756,7 @@ class PeftModelForCausalLM(PeftModel):
         if peft_config.peft_type == PeftType.POLY:
             model_kwargs["task_ids"] = task_ids
         if peft_config.is_prompt_learning:
-            if uses_cache and (model_kwargs["past_key_values"] is not None):
+            if uses_cache and (model_kwargs.get("past_key_values", None) is not None):
                 # change in the logic of `prepare_inputs_for_generation` makes the below code necessary
                 # In prompt learning methods, past key values are longer when compared to the `input_ids`.
                 # As such only consider the last input ids in the autogressive generation phase.
@@ -1786,7 +1786,7 @@ class PeftModelForCausalLM(PeftModel):
                 kwargs["token_type_ids"] = None
 
             # no past_key_values or past_key_values empty cache
-            requires_prompt_injection = (model_kwargs["past_key_values"] is None) or (
+            requires_prompt_injection = (model_kwargs.get("past_key_values", None) is None) or (
                 isinstance(model_kwargs["past_key_values"], transformers.Cache)
                 and not model_kwargs["past_key_values"].get_seq_length()
             )


### PR DESCRIPTION
The error in PEFT is occurring after this transformers change:

https://github.com/huggingface/transformers/pull/33870

Now, in our tests, some model_kwargs no longer necessarily contain past_key_values, resulting in a KeyError. We now account for this possibility. Affected models were opt and gpt2.

Example of failing CI: https://github.com/huggingface/peft/actions/runs/11256453704/job/31298371856

Note that CI won't detect this issue as it requires the latest transformers install. I ran this locally using `pytest tests/test_decoder_models.py -k "(prefix or prompt) and (opt or gpt2)" -v`.