### PR TITLE
FIX: Bug in target module optimization if child module name is suffix of parent module name

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -461,7 +461,9 @@ class BaseTuner(nn.Module, ABC):
             and len(peft_config.target_modules) >= MIN_TARGET_MODULES_FOR_OPTIMIZATION
         ):
             names_no_target = [
-                name for name in key_list if not any(name.endswith(suffix) for suffix in peft_config.target_modules)
+                name
+                for name in key_list
+                if not any((name == suffix) or name.endswith("." + suffix) for suffix in peft_config.target_modules)
             ]
             new_target_modules = _find_minimal_target_modules(peft_config.target_modules, names_no_target)
             if len(new_target_modules) < len(peft_config.target_modules):


### PR DESCRIPTION
Solves the following bug:

https://github.com/huggingface/diffusers/pull/9622#issuecomment-2404789721

The cause for the bug is as follows: When we have, say, a module called `"bar.0.query"` that we want to target and another module called `"foo_bar.0.query"` that we don't want to target, there was potential for an error. 

This is not caused by `_find_minimal_target_modules` directly, but rather the bug was inside of `BaseTuner.inject_adapter` and how the `names_no_target` were chosen. Those used to be chosen based on suffix. In our example, however, `"bar.0.query"` is a suffix of `"foo_bar.0.query"`, therefore `"foo_bar.0.query"` was *not* added to `names_no_target` when it should have. As a consequence, during the optimization, it looks like `"query"` is safe to use as `target_modules` because we don't see that it wrongly matches `"foo_bar.0.query"`.