### PR TITLE
Bump version to 0.13.2.dev0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.13.2.dev0"
+VERSION = "0.13.3.dev0"
 
 extras = {}
 extras["quality"] = [

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.13.2.dev0"
+__version__ = "0.13.3.dev0"
 
 from .auto import (
     AutoPeftModel,


### PR DESCRIPTION
After the patch release of [PEFT v0.13.2](https://github.com/huggingface/peft/releases/tag/v0.13.2), let's bump the dev version of PEFT to `v0.13.3.dev0` so that it stays ahead (the bugfix from the patch release is already contained in the main branch).