### PR TITLE
FIX Don't assume past_key_valus for encoder models

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2062,7 +2062,7 @@ class PeftModelForSeq2SeqLM(PeftModel):
         model_kwargs = self.base_model_prepare_inputs_for_generation(*args, **kwargs)
         if peft_config.peft_type == PeftType.POLY:
             model_kwargs["task_ids"] = task_ids
-        if model_kwargs["past_key_values"] is None and peft_config.peft_type == PeftType.PREFIX_TUNING:
+        if model_kwargs.get("past_key_values", None) is None and peft_config.peft_type == PeftType.PREFIX_TUNING:
             batch_size = model_kwargs["decoder_input_ids"].shape[0]
             past_key_values = self.get_prompt(batch_size)
             model_kwargs["past_key_values"] = past_key_values


### PR DESCRIPTION
Don't assume that `past_key_values` is part of the `model_kwargs`.

This fix is similar to #2140 but for encoder-decoder models. It became necessary after https://github.com/huggingface/transformers/pull/34048 was merged into transformers.

Fixes the [currently failing CI](https://github.com/huggingface/peft/actions/runs/11319951259/job/31476746284).