### PR TITLE
MNT: Remove version pin of diffusers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras["test"] = extras["dev"] + [
     "pytest-xdist",
     "parameterized",
     "datasets",
-    "diffusers<0.21.0",
+    "diffusers",
     "scipy",
 ]
 


### PR DESCRIPTION
The `diffusers<0.21.0` pin was added way back in #936 and then we forget to ever remove it.

This is now causing trouble, as the old diffusers version still uses `cached_download`, which was removed from `huggingface_hub`:

> ImportError: cannot import name 'cached_download' from 'huggingface_hub'