### PR TITLE
FIX VeRA failure on multiple GPUs

### DIFF
--- a/src/peft/tuners/vera/bnb.py
+++ b/src/peft/tuners/vera/bnb.py
@@ -161,8 +161,8 @@ if is_bnb_available():
                 lambda_d = lambda_d.float()
                 lambda_b = lambda_b.float()
 
-            sliced_A = vera_A[:, : self.in_features]
-            sliced_B = vera_B[: self.out_features, :]
+            sliced_A = vera_A[:, : self.in_features].to(lambda_d.device)
+            sliced_B = vera_B[: self.out_features, :].to(lambda_d.device)
             lambda_b = lambda_b.unsqueeze(-1)
             lambda_d = lambda_d.unsqueeze(-1)
 
@@ -219,8 +219,8 @@ if is_bnb_available():
                         if x.dtype != compute_dtype:
                             x = x.to(compute_dtype)
 
-                    sliced_A = vera_A[:, : self.in_features]
-                    sliced_B = vera_B[: self.out_features, :]
+                    sliced_A = vera_A[:, : self.in_features].to(x.device)
+                    sliced_B = vera_B[: self.out_features, :].to(x.device)
 
                     x_temp = dropout(x.to(lambda_d.dtype))
 
@@ -346,8 +346,8 @@ if is_bnb_4bit_available():
                 lambda_d = lambda_d.float()
                 lambda_b = lambda_b.float()
 
-            sliced_A = vera_A[:, : self.in_features]
-            sliced_B = vera_B[: self.out_features, :]
+            sliced_A = vera_A[:, : self.in_features].to(lambda_d.device)
+            sliced_B = vera_B[: self.out_features, :].to(lambda_d.device)
             lambda_b = lambda_b.unsqueeze(-1)
             lambda_d = lambda_d.unsqueeze(-1)
 
@@ -387,8 +387,8 @@ if is_bnb_4bit_available():
                         if x.dtype != compute_dtype:
                             x = x.to(compute_dtype)
 
-                    sliced_A = vera_A[:, : self.in_features]
-                    sliced_B = vera_B[: self.out_features, :]
+                    sliced_A = vera_A[:, : self.in_features].to(x.device)
+                    sliced_B = vera_B[: self.out_features, :].to(x.device)
 
                     x_temp = dropout(x.to(lambda_d.dtype))
 

--- a/src/peft/tuners/vera/layer.py
+++ b/src/peft/tuners/vera/layer.py
@@ -239,8 +239,8 @@ class Linear(nn.Linear, VeraLayer):
             lambda_d = lambda_d.float()
             lambda_b = lambda_b.float()
 
-        sliced_A = vera_A[:, : self.in_features]
-        sliced_B = vera_B[: self.out_features, :]
+        sliced_A = vera_A[:, : self.in_features].to(lambda_d.device)
+        sliced_B = vera_B[: self.out_features, :].to(lambda_d.device)
         lambda_b = lambda_b.unsqueeze(-1)
         lambda_d = lambda_d.unsqueeze(-1)
         output_tensor = transpose((lambda_b * sliced_B) @ (lambda_d * sliced_A), self.fan_in_fan_out)
@@ -279,8 +279,8 @@ class Linear(nn.Linear, VeraLayer):
                 # As adapted layers may have different shapes and VeRA contains a single shared pair of A and B matrices,
                 # we initialize these matrices with the largest required size for each dimension.
                 # During the forward pass, required submatrices are sliced out from the shared vera_A and vera_B.
-                sliced_A = vera_A[:, : self.in_features]
-                sliced_B = vera_B[: self.out_features, :]
+                sliced_A = vera_A[:, : self.in_features].to(x.device)
+                sliced_B = vera_B[: self.out_features, :].to(x.device)
 
                 dropout = self.vera_dropout[active_adapter]
                 x = x.to(lambda_d.dtype)


### PR DESCRIPTION
The shared buffers `vera_A` and `vera_B` could be on the wrong device when using multiple GPUs, resulting in an error. This PR moves the them to the correct device to fix the error.

Example of a failing run: https://github.com/huggingface/peft/actions/runs/11396317278/job/31709933958

Since these buffers are shared, I chose *not* to move the whole buffer to the device. Instead, when we create the slices from those buffers during `forward`, I move the devices only there. This could be inefficient in terms of runtime, but IIUC, the alternative would be to create new copies of these buffers per device, using more memory.

The failing tests were introduced in #2076 but the error was already there beforehand.

I did not discover these failing tests earlier because we had a concurrent error caused by a transformers issue which looked very similar and I wrongly assumed that the VeRA error was caused by the same issue. But now that the issue has been fixed, the error still persists, prompting me to investigate.