### PR TITLE
fix fsdp_auto_wrap_policy

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -525,6 +525,8 @@ def fsdp_auto_wrap_policy(model):
     ).split(",")
     transformer_cls_to_wrap = {PrefixEncoder, PromptEncoder, PromptEmbedding}
     for layer_class in transformer_cls_names_to_wrap:
+        if len(layer_class)==0:
+            continue
         transformer_cls = get_module_class_from_name(model, layer_class)
         if transformer_cls is None:
             raise Exception("Could not find the transformer layer class to wrap in the model.")

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -525,7 +525,7 @@ def fsdp_auto_wrap_policy(model):
     ).split(",")
     transformer_cls_to_wrap = {PrefixEncoder, PromptEncoder, PromptEmbedding}
     for layer_class in transformer_cls_names_to_wrap:
-        if len(layer_class)==0:
+        if len(layer_class) == 0:
             continue
         transformer_cls = get_module_class_from_name(model, layer_class)
         if transformer_cls is None:

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -3774,6 +3774,11 @@ class TestFSDPWrap:
         # check that this does not raise:
         FSDP(model, auto_wrap_policy=fsdp_auto_wrap_policy(model), use_orig_params=False, sync_module_states=True)
 
+    def test_fsdp_auto_wrap_policy_does_not_raise_on_custom_model(self):
+        # See #2167
+        # Avoid raising on custom models since Trainer uses fsdp_auto_wrap_policy automatically for PEFT + FSDP
+        fsdp_auto_wrap_policy(SimpleModel())  # does not raise
+
 
 class TestBOFT:
     """


### PR DESCRIPTION
fix the issue that fsdp_auto_wrap_policy is not working when FSDP_TRANSFORMER_CLS_TO_WRAP and the model's _no_split_modules are None
@BenjaminBossan @sayakpaul 

Fixes #2166 