### PR TITLE
FIX: Import location of HF hub errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "tqdm",
         "accelerate>=0.21.0",
         "safetensors",
-        "huggingface_hub>=0.17.0",
+        "huggingface_hub>=0.25.0",
     ],
     extras_require=extras,
     classifiers=[

--- a/src/peft/utils/loftq_utils.py
+++ b/src/peft/utils/loftq_utils.py
@@ -23,8 +23,7 @@ from typing import Callable, Optional, Union
 
 import torch
 from huggingface_hub import snapshot_download
-from huggingface_hub.errors import HFValidationError
-from huggingface_hub.utils import LocalEntryNotFoundError
+from huggingface_hub.utils import HFValidationError, LocalEntryNotFoundError
 from safetensors import SafetensorError, safe_open
 from transformers.utils import cached_file
 from transformers.utils.hub import get_checkpoint_shard_files

--- a/src/peft/utils/loftq_utils.py
+++ b/src/peft/utils/loftq_utils.py
@@ -23,7 +23,7 @@ from typing import Callable, Optional, Union
 
 import torch
 from huggingface_hub import snapshot_download
-from huggingface_hub.utils import HFValidationError, LocalEntryNotFoundError
+from huggingface_hub.errors import HFValidationError, LocalEntryNotFoundError
 from safetensors import SafetensorError, safe_open
 from transformers.utils import cached_file
 from transformers.utils.hub import get_checkpoint_shard_files

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -25,7 +25,7 @@ import torch
 from accelerate.hooks import add_hook_to_module, remove_hook_from_module
 from accelerate.utils import is_npu_available, is_xpu_available
 from huggingface_hub import file_exists
-from huggingface_hub.utils import EntryNotFoundError, HFValidationError
+from huggingface_hub.errors import EntryNotFoundError, HFValidationError
 from packaging import version
 from safetensors.torch import storage_ptr, storage_size
 

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -20,7 +20,7 @@ from typing import Optional
 import huggingface_hub
 import torch
 from huggingface_hub import file_exists, hf_hub_download
-from huggingface_hub.utils import EntryNotFoundError, LocalEntryNotFoundError
+from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
 from packaging import version
 from safetensors.torch import load_file as safe_load_file
 


### PR DESCRIPTION
Resolves #2097

This fix should make the import of the `huggingface_hub` error work with older versions of that package.