### PR TITLE
BUG🐛: Fixed scale related bugs in LoKr | Added rank_dropout_scale parameter

### DIFF
--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -41,7 +41,7 @@ class LoKrConfig(LycorisConfig):
         decompose_factor (`int`):
             Kronecker product decomposition factor.
         rank_dropout_scale ('bool)
-            Scale the rank dropout while training.
+            Whether to scale the rank dropout while training, defaults to `False`.
         target_modules (`Optional[Union[List[str], str]]`):
             The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
             names will be replaced. When passing a string, a regex match will be performed. When passing a list of

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -55,8 +55,8 @@ class LoKrConfig(LycorisConfig):
             When passing a list of strings, either an exact match will be performed or it is checked if the name of the
             module ends with any of the passed strings.
         init_weights (`bool`):
-            Whether to perform initialization of adapter weights. This defaults to `True`, passing `False` is
-            discouraged.
+            Whether to perform initialization of adapter weights. This defaults to `True`,Use "lycoris" to initialize
+            weights in the style of the LYCORIS repository. Passing `False` is discouraged.".
         layers_to_transform (`Union[List[int], int]`):
             The layer indices to transform. If a list of ints is passed, it will apply the adapter to the layer indices
             that are specified in this list. If a single integer is passed, it will apply the transformations on the
@@ -106,12 +106,12 @@ class LoKrConfig(LycorisConfig):
         default=None,
         metadata={"help": "List of module names or regex expression of the module names to exclude from LoKr."},
     )
-    init_weights: bool = field(
+    init_weights: Union[bool, str] = field(
         default=True,
         metadata={
             "help": (
-                "Whether to initialize the weights of the LoKr layers with their default initialization. Don't change "
-                "this setting, except if you know exactly what you're doing."
+                "Whether to initialize the weights of the LoKr layers with their default initialization. Can be True, False or 'lycoris'. Default is True"
+                "Don't change this setting, except if you know exactly what you're doing."
             ),
         },
     )

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -55,7 +55,7 @@ class LoKrConfig(LycorisConfig):
             When passing a list of strings, either an exact match will be performed or it is checked if the name of the
             module ends with any of the passed strings.
         init_weights (`bool`):
-            Whether to perform initialization of adapter weights. This defaults to `True`,Use "lycoris" to initialize
+            Whether to perform initialization of adapter weights. This defaults to `True`.Use "lycoris" to initialize
             weights in the style of the LYCORIS repository. Passing `False` is discouraged.".
         layers_to_transform (`Union[List[int], int]`):
             The layer indices to transform. If a list of ints is passed, it will apply the adapter to the layer indices

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -40,6 +40,8 @@ class LoKrConfig(LycorisConfig):
             Perform rank decomposition of left kronecker product matrix.
         decompose_factor (`int`):
             Kronecker product decomposition factor.
+        rank_dropout_scale ('bool)
+            Scale the rank dropout while training.
         target_modules (`Optional[Union[List[str], str]]`):
             The names of the modules to apply the adapter to. If this is specified, only the modules with the specified
             names will be replaced. When passing a string, a regex match will be performed. When passing a list of
@@ -91,6 +93,7 @@ class LoKrConfig(LycorisConfig):
         metadata={"help": "Perform rank decomposition of left kronecker product matrix."},
     )
     decompose_factor: int = field(default=-1, metadata={"help": "Kronecker product decomposition factor."})
+    rank_dropout_scale: bool = field(default=False, metadata={"help": "Rank dropout scale"})
     target_modules: Optional[Union[list[str], str]] = field(
         default=None,
         metadata={

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from peft.tuners.lycoris_utils import LycorisConfig
 from peft.utils import PeftType
@@ -55,8 +55,8 @@ class LoKrConfig(LycorisConfig):
             When passing a list of strings, either an exact match will be performed or it is checked if the name of the
             module ends with any of the passed strings.
         init_weights (`bool`):
-            Whether to perform initialization of adapter weights. This defaults to `True`.Use "lycoris" to initialize
-            weights in the style of the LYCORIS repository. Passing `False` is discouraged.".
+            Whether to perform initialization of adapter weights. This defaults to `True`. Use "lycoris" to initialize
+            weights in the style of the LYCORIS repository. Passing `False` is discouraged.
         layers_to_transform (`Union[List[int], int]`):
             The layer indices to transform. If a list of ints is passed, it will apply the adapter to the layer indices
             that are specified in this list. If a single integer is passed, it will apply the transformations on the
@@ -106,12 +106,12 @@ class LoKrConfig(LycorisConfig):
         default=None,
         metadata={"help": "List of module names or regex expression of the module names to exclude from LoKr."},
     )
-    init_weights: Union[bool, str] = field(
+    init_weights: Union[bool, Literal["lycoris"]] = field(
         default=True,
         metadata={
             "help": (
-                "Whether to initialize the weights of the LoKr layers with their default initialization. Can be True, False or 'lycoris'. Default is True"
-                "Don't change this setting, except if you know exactly what you're doing."
+                "Whether to initialize the weights of the LoKr layers with their default initialization. Can be True, False or 'lycoris'."
+                "Default is True. Don't change this setting to False, except if you know exactly what you're doing."
             ),
         },
     )

--- a/src/peft/tuners/lokr/layer.py
+++ b/src/peft/tuners/lokr/layer.py
@@ -126,6 +126,7 @@ class LoKrLayer(nn.Module, LycorisLayer):
         if adapter_name in self.lokr_t2:
             nn.init.kaiming_uniform_(self.lokr_t2[adapter_name], a=math.sqrt(5))
 
+    # Initializes weight matrices similar to the way initialized in the LyCORIS repository.
     def reset_adapter_parameters_lycoris_way(self, adapter_name):
         if adapter_name in self.lokr_w1:
             nn.init.kaiming_uniform_(self.lokr_w1[adapter_name], a=math.sqrt(5))

--- a/src/peft/tuners/lokr/model.py
+++ b/src/peft/tuners/lokr/model.py
@@ -21,7 +21,6 @@ from torch import nn
 
 from peft.tuners.lycoris_utils import LycorisConfig, LycorisTuner
 
-from .config import LoKrConfig
 from .layer import Conv2d, Linear, LoKrLayer
 
 

--- a/src/peft/tuners/lokr/model.py
+++ b/src/peft/tuners/lokr/model.py
@@ -92,7 +92,7 @@ class LoKrModel(LycorisTuner):
 
     def _create_and_replace(
         self,
-        config: LycorisConfig | LoKrConfig,
+        config: LycorisConfig,
         adapter_name: str,
         target: Union[LoKrLayer, nn.Module],
         target_name: str,

--- a/src/peft/tuners/lokr/model.py
+++ b/src/peft/tuners/lokr/model.py
@@ -21,6 +21,7 @@ from torch import nn
 
 from peft.tuners.lycoris_utils import LycorisConfig, LycorisTuner
 
+from .config import LoKrConfig
 from .layer import Conv2d, Linear, LoKrLayer
 
 
@@ -91,7 +92,7 @@ class LoKrModel(LycorisTuner):
 
     def _create_and_replace(
         self,
-        config: LycorisConfig,
+        config: LycorisConfig | LoKrConfig,
         adapter_name: str,
         target: Union[LoKrLayer, nn.Module],
         target_name: str,
@@ -109,6 +110,7 @@ class LoKrModel(LycorisTuner):
         kwargs = config.to_dict()
         kwargs["r"] = config.rank_pattern.get(target_name_key, config.r)
         kwargs["alpha"] = config.alpha_pattern.get(target_name_key, config.alpha)
+        kwargs["rank_dropout_scale"] = config.rank_dropout_scale
 
         if isinstance(target, LoKrLayer):
             target.update_layer(adapter_name, **kwargs)

--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -71,6 +71,7 @@ class LycorisLayer(BaseTunerLayer):
         self.alpha = {}
         self.scaling = {}
         self.rank_dropout = {}
+        self.rank_dropout_scale = {}
         self.module_dropout = {}
 
         # Tuner info

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -236,7 +236,6 @@ TEST_CASES = [
     ),
     ("Vanilla MLP 7 LOKR", "MLP", LoKrConfig, {"target_modules": "lin0", "rank_dropout": 0.5}),
     ("Vanilla MLP 8 LOKR", "MLP", LoKrConfig, {"target_modules": "lin0", "decompose_both": True, "r": 1, "alpha": 1}),
-    ("Vanilla MLP 9 LOKR", "MLP", LoKrConfig, {"target_modules": "lin0", "init_weights": "lycoris"}),
     ("Conv2d 1 LOKR", "Conv2d", LoKrConfig, {"target_modules": ["conv2d"]}),
     ("Conv2d 2 LOKR", "Conv2d", LoKrConfig, {"target_modules": ["conv2d", "lin0"]}),
     ("Conv2d 3 LOKR", "Conv2d", LoKrConfig, {"target_modules": ["conv2d"], "use_effective_conv2d": True}),
@@ -264,7 +263,6 @@ TEST_CASES = [
             "decompose_factor": 4,
         },
     ),
-    ("Conv2d 8 LOKR", "Conv2d", LoKrConfig, {"target_modules": ["conv2d"], "init_weights": "lycoris"}),
     ########
     # OFT #
     ########

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -236,6 +236,7 @@ TEST_CASES = [
     ),
     ("Vanilla MLP 7 LOKR", "MLP", LoKrConfig, {"target_modules": "lin0", "rank_dropout": 0.5}),
     ("Vanilla MLP 8 LOKR", "MLP", LoKrConfig, {"target_modules": "lin0", "decompose_both": True, "r": 1, "alpha": 1}),
+    ("Vanilla MLP 9 LOKR", "MLP", LoKrConfig, {"target_modules": "lin0", "init_weights": "lycoris"}),
     ("Conv2d 1 LOKR", "Conv2d", LoKrConfig, {"target_modules": ["conv2d"]}),
     ("Conv2d 2 LOKR", "Conv2d", LoKrConfig, {"target_modules": ["conv2d", "lin0"]}),
     ("Conv2d 3 LOKR", "Conv2d", LoKrConfig, {"target_modules": ["conv2d"], "use_effective_conv2d": True}),
@@ -263,6 +264,7 @@ TEST_CASES = [
             "decompose_factor": 4,
         },
     ),
+    ("Conv2d 8 LOKR", "Conv2d", LoKrConfig, {"target_modules": ["conv2d"], "init_weights": "lycoris"}),
     ########
     # OFT #
     ########

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -32,6 +32,7 @@ from transformers import AutoModelForCausalLM
 from peft import (
     AdaLoraConfig,
     IA3Config,
+    LoKrConfig,
     LoraConfig,
     PeftMixedModel,
     PeftModel,
@@ -1091,6 +1092,94 @@ class TestLoraInitialization:
         megatron_config = {"does-not": "matter-here"}
         with pytest.raises(ValueError, match="DoRA does not support megatron_core"):
             LoraConfig(target_modules=["linear"], use_dora=True, megatron_config=megatron_config)
+
+
+class TestLokrInitialization:
+    torch_device = infer_device()
+
+    def get_model(self):
+        class MyModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                # Choose a large weight so that averages are close to expected values.
+                self.linear = nn.Linear(1000, 1000)
+                self.conv2d = nn.Conv2d(100, 100, 3)
+
+            def forward(self, x):
+                x_4d = x.flatten().reshape(1, 100, 10, 10)
+                return self.linear(x), self.conv2d(x_4d)
+
+        return MyModule().eval().to(self.torch_device)
+
+    @pytest.fixture
+    def data(self):
+        return torch.rand(10, 1000).to(self.torch_device)
+
+    def test_lokr_linear_init_default(self, data):
+        torch.manual_seed(0)
+
+        model = self.get_model()
+        output_before = model(data)[0]
+        config = LoKrConfig(target_modules=["linear"])
+        model = get_peft_model(model, config)
+        output_after = model(data)[0]
+
+        assert torch.allclose(output_before, output_after)
+
+    def test_lokr_linear_init_false(self, data):
+        torch.manual_seed(0)
+
+        model = self.get_model()
+        output_before = model(data)[0]
+        config = LoKrConfig(target_modules=["linear"], init_weights=False)
+        model = get_peft_model(model, config)
+        output_after = model(data)[0]
+
+        assert not torch.allclose(output_before, output_after)
+
+    def test_lokr_linear_init_lycoris(self, data):
+        torch.manual_seed(0)
+
+        model = self.get_model()
+        output_before = model(data)[0]
+        config = LoKrConfig(target_modules=["linear"], init_weights="lycoris")
+        model = get_peft_model(model, config)
+        output_after = model(data)[0]
+
+        assert torch.allclose(output_before, output_after)
+
+    def test_lokr_conv2d_init_default(self, data):
+        torch.manual_seed(0)
+
+        model = self.get_model()
+        output_before = model(data)[1]
+        config = LoKrConfig(target_modules=["conv2d"])
+        model = get_peft_model(model, config)
+        output_after = model(data)[1]
+
+        assert torch.allclose(output_before, output_after)
+
+    def test_lokr_conv2d_init_false(self, data):
+        torch.manual_seed(0)
+
+        model = self.get_model()
+        output_before = model(data)[1]
+        config = LoKrConfig(target_modules=["conv2d"], init_weights=False)
+        model = get_peft_model(model, config)
+        output_after = model(data)[1]
+
+        assert not torch.allclose(output_before, output_after)
+
+    def test_lokr_conv2d_init_lycoris(self, data):
+        torch.manual_seed(0)
+
+        model = self.get_model()
+        output_before = model(data)[1]
+        config = LoKrConfig(target_modules=["conv2d"], init_weights="lycoris")
+        model = get_peft_model(model, config)
+        output_after = model(data)[1]
+
+        assert torch.allclose(output_before, output_after)
 
 
 class TestAdaLoraInitialization:


### PR DESCRIPTION
This PR adds a new parameter `rank_dropout_scale` and fixes scale related bugs in the LoKr. Please refer to the following function in Lycoris:
https://github.com/KohakuBlueleaf/LyCORIS/blob/258387f586beabfca71646a9671027f75ed34597/lycoris/modules/lokr.py#L347
