### PR TITLE
DOC: fix broken link in the README of loftq

### DIFF
--- a/examples/loftq_finetuning/README.md
+++ b/examples/loftq_finetuning/README.md
@@ -10,7 +10,7 @@ Steps:
 1. Apply LoftQ to a full-precision pre-trained weight and save.
 2. Load LoftQ initialization and train.
 
-For step 1, we have provided off-the-shelf LoftQ initializations (see [supported model list](#appendix-off-the-shelf-model-table)) 
+For step 1, we have provided off-the-shelf LoftQ initializations (see [supported model list](#appendix-off-the-shelf-model-list)) 
 in [Huggingface Hub LoftQ](https://huggingface.co/LoftQ).
 If you want to do it yourself, jump to [LoftQ DIY](#loftq-diy).
 


### PR DESCRIPTION
# Why This PR?

The README file in loftq contains broken link, which might confuse the reader.

# How to fix?

Simply update the link name to the correct section.