### PR TITLE
ENH: Warn when loading PiSSA/OLoRA together with other adapters

### DIFF
--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -52,7 +52,7 @@ Alternatively, execute fast SVD, which takes only a few seconds. The number of i
 ```python
 lora_config = LoraConfig(init_lora_weights="pissa_niter_[number of iters]", ...) 
 ```
-For detailed instruction on using PiSSA, please follow [these instructions](https://github.com/fxmeng/peft/tree/main/examples/pissa_finetuning).
+For detailed instruction on using PiSSA, please follow [these instructions](https://github.com/huggingface/peft/tree/main/examples/pissa_finetuning).
 
 ### OLoRA
 [OLoRA](https://arxiv.org/abs/2406.01775) utilizes QR decomposition to initialize the LoRA adapters. OLoRA translates the base weights of the model by a factor of their QR decompositions, i.e., it mutates the weights before performing any training on them. This approach significantly improves stability, accelerates convergence speed, and ultimately achieves superior performance.

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -348,6 +348,9 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
     def _split_kwargs(cls, kwargs: dict[str, Any]):
         return PeftModel._split_kwargs(kwargs)
 
+    def _check_new_adapter_config(self, peft_config: PeftConfig, is_trainable: bool) -> None:
+        return PeftModel._check_new_adapter_config(self, peft_config, is_trainable=is_trainable)
+
     def load_adapter(self, model_id: str, adapter_name: str, *args: Any, **kwargs: Any):
         """
         Load a trained adapter into the model.

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1133,8 +1133,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         if peft_config.is_prompt_learning and is_trainable:
             raise ValueError("Cannot set a prompt learning adapter to trainable when loading pretrained adapter.")
 
-        # Since PiSSA/OLoRA modifies the base weights, it should not be combined with other adapters. Check for a
-        # warning.
+        # Since PiSSA/OLoRA modifies the base weights, it should not be combined with other adapters.
         all_configs = [peft_config] + list(self.peft_config.values())
         if (len(all_configs) > 1) and any(getattr(config, "init_lora_weights") == "pissa" for config in all_configs):
             msg = (

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1128,6 +1128,29 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                         os.makedirs(base_name)
                     safe_save_file(safe_dict, new_fname, metadata=metadata)
 
+    def _check_new_adapter_config(self, peft_config: PeftConfig, is_trainable: bool) -> None:
+        """Perform checks on newly added PEFT configs to ensure integrity."""
+        if peft_config.is_prompt_learning and is_trainable:
+            raise ValueError("Cannot set a prompt learning adapter to trainable when loading pretrained adapter.")
+
+        # Since PiSSA/OLoRA modifies the base weights, it should not be combined with other adapters. Check for a
+        # warning.
+        all_configs = [peft_config] + list(self.peft_config.values())
+        if (len(all_configs) > 1) and any(getattr(config, "init_lora_weights") == "pissa" for config in all_configs):
+            msg = (
+                "PiSSA changes the base weights of the model and should thus not be used with other adapters. "
+                "Consider converting the PiSSA adapter into a normal LoRA adapter: "
+                "https://github.com/huggingface/peft/tree/main/examples/pissa_finetuning#convert-pissa-to-lora"
+            )
+            warnings.warn(msg)
+        elif (len(all_configs) > 1) and any(getattr(config, "init_lora_weights") == "olora" for config in all_configs):
+            msg = (
+                "OLoRA changes the base weights of the model and should thus not be used with other adapters. "
+                "Consider converting the OLoRA adapter into a normal LoRA adapter: "
+                "https://github.com/huggingface/peft/tree/main/examples/olora_finetuning#olora-and-lora"
+            )
+            warnings.warn(msg)
+
     def load_adapter(
         self,
         model_id: Union[str, os.PathLike],
@@ -1191,10 +1214,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 ephemeral_gpu_offload=ephemeral_gpu_offload,
                 **hf_hub_download_kwargs,
             )
-            if peft_config.is_prompt_learning and is_trainable:
-                raise ValueError("Cannot set a prompt learning adapter to trainable when loading pretrained adapter.")
-            else:
-                peft_config.inference_mode = not is_trainable
+            self._check_new_adapter_config(peft_config, is_trainable=is_trainable)
+            peft_config.inference_mode = not is_trainable
             self.add_adapter(adapter_name, peft_config, low_cpu_mem_usage=low_cpu_mem_usage)
 
         adapters_weights = load_peft_weights(model_id, device=torch_device, **hf_hub_download_kwargs)

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1135,20 +1135,21 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         # Since PiSSA/OLoRA modifies the base weights, it should not be combined with other adapters.
         all_configs = [peft_config] + list(self.peft_config.values())
-        if (len(all_configs) > 1) and any(getattr(config, "init_lora_weights") == "pissa" for config in all_configs):
-            msg = (
-                "PiSSA changes the base weights of the model and should thus not be used with other adapters. "
-                "Consider converting the PiSSA adapter into a normal LoRA adapter: "
-                "https://github.com/huggingface/peft/tree/main/examples/pissa_finetuning#convert-pissa-to-lora"
-            )
-            warnings.warn(msg)
-        elif (len(all_configs) > 1) and any(getattr(config, "init_lora_weights") == "olora" for config in all_configs):
-            msg = (
-                "OLoRA changes the base weights of the model and should thus not be used with other adapters. "
-                "Consider converting the OLoRA adapter into a normal LoRA adapter: "
-                "https://github.com/huggingface/peft/tree/main/examples/olora_finetuning#olora-and-lora"
-            )
-            warnings.warn(msg)
+        if len(all_configs) > 1:
+            if any(getattr(config, "init_lora_weights", None) == "pissa" for config in all_configs):
+                msg = (
+                    "PiSSA changes the base weights of the model and should thus not be used with other adapters. "
+                    "Consider converting the PiSSA adapter into a normal LoRA adapter: "
+                    "https://github.com/huggingface/peft/tree/main/examples/pissa_finetuning#convert-pissa-to-lora"
+                )
+                warnings.warn(msg)
+            elif any(getattr(config, "init_lora_weights", None) == "olora" for config in all_configs):
+                msg = (
+                    "OLoRA changes the base weights of the model and should thus not be used with other adapters. "
+                    "Consider converting the OLoRA adapter into a normal LoRA adapter: "
+                    "https://github.com/huggingface/peft/tree/main/examples/olora_finetuning#olora-and-lora"
+                )
+                warnings.warn(msg)
 
     def load_adapter(
         self,


### PR DESCRIPTION
Resolves #2184

Since PiSSA/OLoRA modifies the base weights, it should not be combined with other adapters. We now warn users about that and tell them how to mitigate this.