### PR TITLE
TST: Skip AQLM test that is incompatible with torch 2.5

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -2731,6 +2731,8 @@ class PeftAqlmGPUTests(unittest.TestCase):
         model.train(training)
 
     @pytest.mark.single_gpu_tests
+    # see https://github.com/Vahe1994/AQLM/pull/139
+    @pytest.mark.xfail("AQLM does not work with PyTorch 2.5 (yet)", strict=True, raises=AttributeError)
     def test_causal_lm_training_aqlm(self):
         r"""
         Test the CausalLM training on a single GPU device. The test would simply fail if the adapters are not set

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -2732,7 +2732,7 @@ class PeftAqlmGPUTests(unittest.TestCase):
 
     @pytest.mark.single_gpu_tests
     # see https://github.com/Vahe1994/AQLM/pull/139
-    @pytest.mark.xfail("AQLM does not work with PyTorch 2.5 (yet)", strict=True, raises=AttributeError)
+    @pytest.mark.xfail(reason="AQLM does not work with PyTorch 2.5 (yet)", strict=True, raises=AttributeError)
     def test_causal_lm_training_aqlm(self):
         r"""
         Test the CausalLM training on a single GPU device. The test would simply fail if the adapters are not set


### PR DESCRIPTION
See: https://github.com/Vahe1994/AQLM/pull/139

It is unclear if/when AQLM will fix this and if there might not be other issues with torch 2.5.

Currently, the test [raises](https://github.com/huggingface/peft/actions/runs/11585832425/job/32255394229#step:6:171):

> E       AttributeError: module 'torch' has no attribute 'Any'