### PR TITLE
FIX: Prefix tuning with model on multiple devices

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -735,6 +735,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 # Dont' apply this to encoder-decoder models and not to models requiring special processing.
                 # local import in case users use a very old transformers version
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+                map_cache_to_layer_device_map(self.get_base_model(), past_key_values)  # no-op if not a Cache instance
             elif peft_config.num_transformer_submodules == 2 and self.base_model._supports_cache_class:
                 # Dont' apply this to encoder-decoder models that don't support new Cachc format yet
                 # If we don't apply this, prefix-tuning fails to update cross-attn cache

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -79,6 +79,7 @@ from .utils import (
     id_tensor_storage,
     infer_device,
     load_peft_weights,
+    map_cache_to_layer_device_map,
     set_peft_model_state_dict,
     shift_tokens_right,
 )
@@ -742,6 +743,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 past_key_values.is_updated = {
                     layer_idx: False for layer_idx in range(len(past_key_values.cross_attention_cache.key_cache))
                 }
+            map_cache_to_layer_device_map(self.get_base_model(), past_key_values)  # no-op if not a Cache instance
             return past_key_values
         else:
             if peft_config.peft_type == PeftType.MULTITASK_PROMPT_TUNING:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -744,7 +744,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 past_key_values.is_updated = {
                     layer_idx: False for layer_idx in range(len(past_key_values.cross_attention_cache.key_cache))
                 }
-            map_cache_to_layer_device_map(self.get_base_model(), past_key_values)  # no-op if not a Cache instance
             return past_key_values
         else:
             if peft_config.peft_type == PeftType.MULTITASK_PROMPT_TUNING:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -735,7 +735,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 # Dont' apply this to encoder-decoder models and not to models requiring special processing.
                 # local import in case users use a very old transformers version
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
-                map_cache_to_layer_device_map(self.get_base_model(), past_key_values)  # no-op if not a Cache instance
             elif peft_config.num_transformer_submodules == 2 and self.base_model._supports_cache_class:
                 # Dont' apply this to encoder-decoder models that don't support new Cachc format yet
                 # If we don't apply this, prefix-tuning fails to update cross-attn cache
@@ -744,6 +743,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 past_key_values.is_updated = {
                     layer_idx: False for layer_idx in range(len(past_key_values.cross_attention_cache.key_cache))
                 }
+            map_cache_to_layer_device_map(self.get_base_model(), past_key_values)  # no-op if not a Cache instance
             return past_key_values
         else:
             if peft_config.peft_type == PeftType.MULTITASK_PROMPT_TUNING:

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 # from .config import PeftConfig, PeftType, PromptLearningConfig, TaskType
+from .integrations import map_cache_to_layer_device_map
 from .loftq_utils import replace_lora_weights_loftq
 from .peft_types import PeftType, TaskType
 from .other import (

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -120,3 +120,49 @@ def get_bnb_param_type(param: torch.nn.Parameter) -> Literal[False, "4bit", "8bi
     if param.__class__.__name__ == "Int8Params":
         return "8bit"
     return False
+
+
+# adapted from:
+# https://github.com/huggingface/transformers/blob/eab6c491d439e83d5e31c660df6f7e36592eb0a2/src/transformers/generation/utils.py#L1617-L1643
+def get_layer_device_map(model):
+    """
+    Derive the device map for the layers of the model.
+    """
+    main_device = [d for d in model.hf_device_map.values() if d not in ["cpu", "disk"]][0]
+
+    execution_device_map = {
+        name: main_device if device in ["cpu", "disk"] else device for name, device in model.hf_device_map.items()
+    }
+
+    if execution_device_map is None:
+        return None
+
+    if len(execution_device_map) == 1 and "" in execution_device_map:
+        return {idx: execution_device_map[""] for idx in range(model.config.num_hidden_layers)}
+
+    layer_device_map = {}
+    for layer in execution_device_map:
+        for idx in range(model.config.num_hidden_layers):
+            if f".{idx}." in f"{layer}.":
+                layer_device_map[idx] = execution_device_map[layer]
+                break
+    for idx in range(model.config.num_hidden_layers):
+        if idx not in layer_device_map:
+            raise RuntimeError(f"layer {idx} has not been mapped to a device.")
+    return layer_device_map
+
+
+# adapted from:
+# https://github.com/huggingface/transformers/blob/eab6c491d439e83d5e31c660df6f7e36592eb0a2/src/transformers/cache_utils.py#L1159-L1179
+def map_cache_to_layer_device_map(model, cache) -> None:
+    """
+    Ensure that the key and value cache of the model are on the same device as their corresponding layers.
+    """
+    if not (isinstance(cache, transformers.Cache) and hasattr(model, "hf_device_map")):
+        return
+
+    layer_device_map = get_layer_device_map(model)
+    for idx in range(model.config.num_hidden_layers):
+        layer_device = layer_device_map[idx]
+        cache.key_cache[idx] = cache.key_cache[idx].to(layer_device)
+        cache.value_cache[idx] = cache.value_cache[idx].to(layer_device)

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -161,6 +161,10 @@ def map_cache_to_layer_device_map(model, cache) -> None:
     if not (isinstance(cache, transformers.Cache) and hasattr(model, "hf_device_map")):
         return
 
+    if isinstance(cache, transformers.EncoderDecoderCache):
+        map_cache_to_layer_device_map(model, cache.self_attention_cache)
+        return
+
     layer_device_map = get_layer_device_map(model)
     for idx in range(model.config.num_hidden_layers):
         layer_device = layer_device_map[idx]

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -3892,7 +3892,7 @@ class TestLowCpuMemUsageDifferentDevices:
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires a GPU")
 @pytest.mark.multi_gpu_tests
 class TestPrefixTuning:
-    def test_prefix_tuning_multiple_devices(self):
+    def test_prefix_tuning_multiple_devices_decoder_model(self):
         # See issue 2134
         model_id = "hf-internal-testing/tiny-random-MistralForCausalLM"
         tokenizer = AutoTokenizer.from_pretrained(model_id, padding="left")


### PR DESCRIPTION
See #2134

After introducing the usage of `DynamicCache` for prefix tuning, a bug could now occur if the model is dispatched to different devices. This is because we need to move the key and value cache for each layer to that layer's respective device.

The new code mostly consists of code copied from transformers to be consistent with how transformers solves this.

Note that this only works if the `hf_device_map` attribute is set on the model.