### PR TITLE
[BUG] Issue with using `rank_pattern` and `alpha_pattern` together in `LoraConfig`

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -45,6 +45,7 @@ from peft.utils import (
     get_quantization_config,
 )
 from peft.utils.merge_utils import dare_linear, dare_ties, magnitude_prune, task_arithmetic, ties
+from peft.utils.other import get_pattern_key
 
 from .aqlm import dispatch_aqlm
 from .awq import dispatch_awq
@@ -186,10 +187,10 @@ class LoraModel(BaseTuner):
             raise ValueError("Current Key shouldn't be `None`")
 
         # Regexp matching - Find key which matches current target_name in patterns provided
-        pattern_keys = list(chain(lora_config.rank_pattern.keys(), lora_config.alpha_pattern.keys()))
-        target_name_key = next(filter(lambda key: re.match(rf".*\.{key}$", current_key), pattern_keys), current_key)
-        r = lora_config.rank_pattern.get(target_name_key, lora_config.r)
-        alpha = lora_config.alpha_pattern.get(target_name_key, lora_config.lora_alpha)
+        r_key = get_pattern_key(lora_config.rank_pattern.keys(), current_key)
+        alpha_key = get_pattern_key(lora_config.alpha_pattern.keys(), current_key)
+        r = lora_config.rank_pattern.get(r_key, lora_config.r)
+        alpha = lora_config.alpha_pattern.get(alpha_key, lora_config.lora_alpha)
 
         kwargs = {
             "r": r,

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -15,13 +15,11 @@ from __future__ import annotations
 
 import math
 import operator
-import re
 import warnings
 from contextlib import contextmanager
 from dataclasses import asdict, replace
 from enum import Enum
 from functools import partial, reduce
-from itertools import chain
 from typing import Literal, Optional
 
 import torch

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -17,6 +17,7 @@ import copy
 import inspect
 import os
 import warnings
+import re
 from contextlib import nullcontext
 from typing import Any, Optional
 
@@ -716,3 +717,8 @@ def check_file_exists_on_hf_hub(repo_id: str, filename: str, **kwargs) -> Option
         )
 
     return exists
+
+
+def get_pattern_key(pattern_keys, current_key):
+    """Match a substring of the current key in pattern keys"""
+    return next(filter(lambda key: re.match(rf".*\.{key}$", current_key), pattern_keys), current_key)

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 import copy
 import inspect
 import os
-import warnings
 import re
+import warnings
 from contextlib import nullcontext
 from typing import Any, Optional
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -719,6 +719,6 @@ def check_file_exists_on_hf_hub(repo_id: str, filename: str, **kwargs) -> Option
     return exists
 
 
-def get_pattern_key(pattern_keys, current_key):
-    """Match a substring of the current key in pattern keys"""
-    return next(filter(lambda key: re.match(rf".*\.{key}$", current_key), pattern_keys), current_key)
+def get_pattern_key(pattern_keys, key_to_match):
+    """Match a substring of key_to_match in pattern keys"""
+    return next(filter(lambda key: re.match(rf".*\.{key}$", key_to_match), pattern_keys), key_to_match)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -276,7 +276,7 @@ class TestLoraInitialization:
         assert model.embed.scaling["default"] == expected_scaling
         assert model.conv2d.scaling["default"] == expected_scaling
 
-    # bugfix for issue 2194
+    # testcase for bugfix for issue 2194
     def test_pattern_override(self):
         torch.manual_seed(0)
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -288,23 +288,19 @@ class TestLoraInitialization:
             r=8,
             use_rslora=False,
             rank_pattern={"linear": 8},
-            alpha_pattern={"0.linear": 2}
+            alpha_pattern={"0.linear": 2},
         )
         model = get_peft_model(model, config)
         scaling_with_rank_pattern = model.model[0].linear.scaling
-        
+
         layer = self.get_model()
         model = nn.Sequential(layer, layer)
         config = LoraConfig(
-            target_modules=["linear"],
-            lora_alpha=1,
-            r=8,
-            use_rslora=False,
-            alpha_pattern={"0.linear": 2}
+            target_modules=["linear"], lora_alpha=1, r=8, use_rslora=False, alpha_pattern={"0.linear": 2}
         )
         model = get_peft_model(model, config)
         scaling_without_rank_pattern = model.model[0].linear.scaling
-        
+
         assert scaling_with_rank_pattern == scaling_without_rank_pattern
 
     def test_lora_pissa_linear_init_default(self, data):


### PR DESCRIPTION
This is a bugfix for issue [2194](https://github.com/huggingface/peft/issues/2194)

Since the line matching module name to a substring pattern is called twice, I created a function and moved it to `peft.utils.other`. I think its a utility function that could be useful multiple times.

Also added a test case closely resembling the example in issue 2194 which passes now.