### PR TITLE
Add Validation for Invalid `task_type` in PEFT Configurations

### DIFF
--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -54,6 +54,7 @@ class PeftConfigMixin(PushToHubMixin):
     Args:
         peft_type (Union[[`~peft.utils.config.PeftType`], `str`]): The type of Peft method to use.
     """
+
     task_type: Optional[TaskType] = field(default=None, metadata={"help": "The type of task."})
     peft_type: Optional[PeftType] = field(default=None, metadata={"help": "The type of PEFT model."})
     auto_mapping: Optional[dict] = field(

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -54,11 +54,16 @@ class PeftConfigMixin(PushToHubMixin):
     Args:
         peft_type (Union[[`~peft.utils.config.PeftType`], `str`]): The type of Peft method to use.
     """
-
+    task_type: Optional[TaskType] = field(default=None, metadata={"help": "The type of task."})
     peft_type: Optional[PeftType] = field(default=None, metadata={"help": "The type of PEFT model."})
     auto_mapping: Optional[dict] = field(
         default=None, metadata={"help": "An auto mapping dict to help retrieve the base model class if needed."}
     )
+
+    def __post_init__(self):
+        # check for invalid task type
+        if (self.task_type is not None) and (self.task_type not in list(TaskType)):
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {', '.join(TaskType)}.")
 
     def to_dict(self) -> Dict:
         r"""

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -63,7 +63,9 @@ class PeftConfigMixin(PushToHubMixin):
     def __post_init__(self):
         # check for invalid task type
         if (self.task_type is not None) and (self.task_type not in list(TaskType)):
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {', '.join(TaskType)}.")
+            raise ValueError(
+                f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {', '.join(TaskType)}."
+            )
 
     def to_dict(self) -> Dict:
         r"""

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -190,7 +190,7 @@ def get_peft_model(
         return PeftMixedModel(model, peft_config, adapter_name=adapter_name)
 
     if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys() and not peft_config.is_prompt_learning:
-            return PeftModel(model, peft_config, adapter_name=adapter_name, autocast_adapter_dtype=autocast_adapter_dtype)
+        return PeftModel(model, peft_config, adapter_name=adapter_name, autocast_adapter_dtype=autocast_adapter_dtype)
 
     if peft_config.is_prompt_learning:
         peft_config = _prepare_prompt_learning_config(peft_config, model_config)

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -189,11 +189,8 @@ def get_peft_model(
         # note: PeftMixedModel does not support autocast_adapter_dtype, so don't pass it
         return PeftMixedModel(model, peft_config, adapter_name=adapter_name)
 
-    if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys():
-        if not peft_config.is_prompt_learning:
+    if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys() and not peft_config.is_prompt_learning:
             return PeftModel(model, peft_config, adapter_name=adapter_name, autocast_adapter_dtype=autocast_adapter_dtype)
-        else:
-            raise ValueError(f"Invalid task type: '{peft_config.task_type}'. Must be one of the following task types: {list(MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys())}.")
 
     if peft_config.is_prompt_learning:
         peft_config = _prepare_prompt_learning_config(peft_config, model_config)

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -189,8 +189,11 @@ def get_peft_model(
         # note: PeftMixedModel does not support autocast_adapter_dtype, so don't pass it
         return PeftMixedModel(model, peft_config, adapter_name=adapter_name)
 
-    if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys() and not peft_config.is_prompt_learning:
-        return PeftModel(model, peft_config, adapter_name=adapter_name, autocast_adapter_dtype=autocast_adapter_dtype)
+    if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys():
+        if not peft_config.is_prompt_learning:
+            return PeftModel(model, peft_config, adapter_name=adapter_name, autocast_adapter_dtype=autocast_adapter_dtype)
+        else:
+            raise ValueError(f"Invalid task type: '{peft_config.task_type}'. Must be one of the following task types: {list(MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys())}.")
 
     if peft_config.is_prompt_learning:
         peft_config = _prepare_prompt_learning_config(peft_config, model_config)

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -174,6 +174,10 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 self.base_model = cls(model, {adapter_name: peft_config}, adapter_name)
             self.set_additional_trainable_modules(peft_config, adapter_name)
 
+        if hasattr(peft_config, 'task_type'):
+            if peft_config.task_type not in TaskType.__members__:
+                raise ValueError(f"Invalid task type: '{peft_config.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+
         if hasattr(self.base_model, "_cast_adapter_dtype"):
             self.base_model._cast_adapter_dtype(
                 adapter_name=adapter_name, autocast_adapter_dtype=autocast_adapter_dtype

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -174,10 +174,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 self.base_model = cls(model, {adapter_name: peft_config}, adapter_name)
             self.set_additional_trainable_modules(peft_config, adapter_name)
 
-        if hasattr(peft_config, 'task_type'):
-            if peft_config.task_type not in TaskType.__members__:
-                raise ValueError(f"Invalid task type: '{peft_config.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-
         if hasattr(self.base_model, "_cast_adapter_dtype"):
             self.base_model._cast_adapter_dtype(
                 adapter_name=adapter_name, autocast_adapter_dtype=autocast_adapter_dtype

--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from peft.tuners.lora import LoraConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -50,6 +50,7 @@ class AdaLoraConfig(LoraConfig):
     rank_pattern: Optional[dict] = field(default=None, metadata={"help": "The saved rank pattern."})
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.ADALORA
 
         if self.use_dora:
@@ -57,10 +58,6 @@ class AdaLoraConfig(LoraConfig):
 
         if self.loftq_config:
             raise ValueError(f"{self.peft_type} does not support LOFTQ.")
-        
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
 
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules

--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from peft.tuners.lora import LoraConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -57,6 +57,10 @@ class AdaLoraConfig(LoraConfig):
 
         if self.loftq_config:
             raise ValueError(f"{self.peft_type} does not support LOFTQ.")
+        
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
 
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules

--- a/src/peft/tuners/adaption_prompt/config.py
+++ b/src/peft/tuners/adaption_prompt/config.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 from .utils import llama_compute_query_states
 
@@ -33,6 +33,10 @@ class AdaptionPromptConfig(PeftConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.ADAPTION_PROMPT
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
 
     @property
     def is_adaption_prompt(self) -> bool:

--- a/src/peft/tuners/adaption_prompt/config.py
+++ b/src/peft/tuners/adaption_prompt/config.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 from dataclasses import dataclass, field
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 from .utils import llama_compute_query_states
 
@@ -32,11 +32,8 @@ class AdaptionPromptConfig(PeftConfig):
     adapter_layers: int = field(default=None, metadata={"help": "Number of adapter layers (from the top)"})
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.ADAPTION_PROMPT
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
 
     @property
     def is_adaption_prompt(self) -> bool:

--- a/src/peft/tuners/boft/config.py
+++ b/src/peft/tuners/boft/config.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -139,6 +139,7 @@ class BOFTConfig(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.BOFT
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -146,11 +147,6 @@ class BOFTConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/boft/config.py
+++ b/src/peft/tuners/boft/config.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -146,6 +146,11 @@ class BOFTConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/bone/config.py
+++ b/src/peft/tuners/bone/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -108,6 +108,7 @@ class BoneConfig(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.BONE
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -115,11 +116,6 @@ class BoneConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-
         # if target_modules is a regex expression, then layers_to_transform should be None
         if isinstance(self.target_modules, str) and self.layers_to_transform is not None:
             raise ValueError("`layers_to_transform` cannot be used when `target_modules` is a str.")

--- a/src/peft/tuners/bone/config.py
+++ b/src/peft/tuners/bone/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -115,6 +115,11 @@ class BoneConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+
         # if target_modules is a regex expression, then layers_to_transform should be None
         if isinstance(self.target_modules, str) and self.layers_to_transform is not None:
             raise ValueError("`layers_to_transform` cannot be used when `target_modules` is a str.")

--- a/src/peft/tuners/fourierft/config.py
+++ b/src/peft/tuners/fourierft/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -185,6 +185,7 @@ class FourierFTConfig(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.FOURIERFT
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -192,11 +193,6 @@ class FourierFTConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-        
         # if target_modules is a regex expression, then layers_to_transform should be None
         if isinstance(self.target_modules, str) and self.layers_to_transform is not None:
             raise ValueError("`layers_to_transform` cannot be used when `target_modules` is a str.")

--- a/src/peft/tuners/fourierft/config.py
+++ b/src/peft/tuners/fourierft/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -192,6 +192,11 @@ class FourierFTConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+        
         # if target_modules is a regex expression, then layers_to_transform should be None
         if isinstance(self.target_modules, str) and self.layers_to_transform is not None:
             raise ValueError("`layers_to_transform` cannot be used when `target_modules` is a str.")

--- a/src/peft/tuners/hra/config.py
+++ b/src/peft/tuners/hra/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -122,6 +122,11 @@ class HRAConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+
         # if target_modules is a regex expression, then layers_to_transform should be None
         if isinstance(self.target_modules, str) and self.layers_to_transform is not None:
             raise ValueError("`layers_to_transform` cannot be used when `target_modules` is a str.")

--- a/src/peft/tuners/hra/config.py
+++ b/src/peft/tuners/hra/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -115,6 +115,7 @@ class HRAConfig(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.HRA
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -122,11 +123,6 @@ class HRAConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-
         # if target_modules is a regex expression, then layers_to_transform should be None
         if isinstance(self.target_modules, str) and self.layers_to_transform is not None:
             raise ValueError("`layers_to_transform` cannot be used when `target_modules` is a str.")

--- a/src/peft/tuners/ia3/config.py
+++ b/src/peft/tuners/ia3/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -104,6 +104,10 @@ class IA3Config(PeftConfig):
         self.feedforward_modules = (
             set(self.feedforward_modules) if isinstance(self.feedforward_modules, list) else self.feedforward_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
 
         # check if feedforward_modules is a subset of target_modules. run the check only if both are sets
         if isinstance(self.feedforward_modules, set) and isinstance(self.target_modules, set):

--- a/src/peft/tuners/ia3/config.py
+++ b/src/peft/tuners/ia3/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -94,6 +94,7 @@ class IA3Config(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.IA3
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -104,10 +105,6 @@ class IA3Config(PeftConfig):
         self.feedforward_modules = (
             set(self.feedforward_modules) if isinstance(self.feedforward_modules, list) else self.feedforward_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
 
         # check if feedforward_modules is a subset of target_modules. run the check only if both are sets
         if isinstance(self.feedforward_modules, set) and isinstance(self.target_modules, set):

--- a/src/peft/tuners/ln_tuning/config.py
+++ b/src/peft/tuners/ln_tuning/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -66,8 +66,5 @@ class LNTuningConfig(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.LN_TUNING
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/ln_tuning/config.py
+++ b/src/peft/tuners/ln_tuning/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -67,3 +67,7 @@ class LNTuningConfig(PeftConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.LN_TUNING
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/loha/config.py
+++ b/src/peft/tuners/loha/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.tuners.lycoris_utils import LycorisConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -133,6 +133,11 @@ class LoHaConfig(LycorisConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+                
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/loha/config.py
+++ b/src/peft/tuners/loha/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.tuners.lycoris_utils import LycorisConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -126,6 +126,7 @@ class LoHaConfig(LycorisConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.LOHA
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -133,11 +134,6 @@ class LoHaConfig(LycorisConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-                
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Literal, Optional, Union
 
 from peft.tuners.lycoris_utils import LycorisConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -145,6 +145,11 @@ class LoKrConfig(LycorisConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+                
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Literal, Optional, Union
 
 from peft.tuners.lycoris_utils import LycorisConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -138,6 +138,7 @@ class LoKrConfig(LycorisConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.LOKR
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -145,11 +146,6 @@ class LoKrConfig(LycorisConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-                
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -21,7 +21,7 @@ from typing import Literal, Optional, Union
 from torch import nn
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -333,6 +333,7 @@ class LoraConfig(PeftConfig):
         return rv
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.LORA
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -340,10 +341,6 @@ class LoraConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")        
 
         # if target_modules is a regex expression, then layers_to_transform should be None
         if isinstance(self.target_modules, str) and self.layers_to_transform is not None:

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -21,7 +21,7 @@ from typing import Literal, Optional, Union
 from torch import nn
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -340,6 +340,10 @@ class LoraConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")        
 
         # if target_modules is a regex expression, then layers_to_transform should be None
         if isinstance(self.target_modules, str) and self.layers_to_transform is not None:

--- a/src/peft/tuners/multitask_prompt_tuning/config.py
+++ b/src/peft/tuners/multitask_prompt_tuning/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.tuners.prompt_tuning import PromptTuningConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 class MultitaskPromptTuningInit(str, enum.Enum):
@@ -59,3 +59,7 @@ class MultitaskPromptTuningConfig(PromptTuningConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.MULTITASK_PROMPT_TUNING
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/multitask_prompt_tuning/config.py
+++ b/src/peft/tuners/multitask_prompt_tuning/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.tuners.prompt_tuning import PromptTuningConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 class MultitaskPromptTuningInit(str, enum.Enum):
@@ -58,8 +58,5 @@ class MultitaskPromptTuningConfig(PromptTuningConfig):
     num_tasks: Optional[int] = field(default=1, metadata={"help": "number of tasks"})
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.MULTITASK_PROMPT_TUNING
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/oft/config.py
+++ b/src/peft/tuners/oft/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Literal, Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -176,6 +176,11 @@ class OFTConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/oft/config.py
+++ b/src/peft/tuners/oft/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Literal, Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -169,6 +169,7 @@ class OFTConfig(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.OFT
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -176,11 +177,6 @@ class OFTConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/p_tuning/config.py
+++ b/src/peft/tuners/p_tuning/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Union
 
 from peft.config import PromptLearningConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 class PromptEncoderReparameterizationType(str, enum.Enum):
@@ -56,8 +56,5 @@ class PromptEncoderConfig(PromptLearningConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.P_TUNING
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/p_tuning/config.py
+++ b/src/peft/tuners/p_tuning/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Union
 
 from peft.config import PromptLearningConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 class PromptEncoderReparameterizationType(str, enum.Enum):
@@ -57,3 +57,7 @@ class PromptEncoderConfig(PromptLearningConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.P_TUNING
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/poly/config.py
+++ b/src/peft/tuners/poly/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Literal, Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -100,3 +100,7 @@ class PolyConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/poly/config.py
+++ b/src/peft/tuners/poly/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Literal, Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -93,6 +93,7 @@ class PolyConfig(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.POLY
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -100,7 +101,3 @@ class PolyConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/prefix_tuning/config.py
+++ b/src/peft/tuners/prefix_tuning/config.py
@@ -15,7 +15,7 @@
 from dataclasses import dataclass, field
 
 from peft.config import PromptLearningConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -39,3 +39,7 @@ class PrefixTuningConfig(PromptLearningConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.PREFIX_TUNING
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/prefix_tuning/config.py
+++ b/src/peft/tuners/prefix_tuning/config.py
@@ -15,7 +15,7 @@
 from dataclasses import dataclass, field
 
 from peft.config import PromptLearningConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -38,8 +38,5 @@ class PrefixTuningConfig(PromptLearningConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.PREFIX_TUNING
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")

--- a/src/peft/tuners/prompt_tuning/config.py
+++ b/src/peft/tuners/prompt_tuning/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PromptLearningConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 class PromptTuningInit(str, enum.Enum):
@@ -70,6 +70,11 @@ class PromptTuningConfig(PromptLearningConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.PROMPT_TUNING
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+
         if (self.prompt_tuning_init == PromptTuningInit.TEXT) and not self.tokenizer_name_or_path:
             raise ValueError(
                 f"When prompt_tuning_init='{PromptTuningInit.TEXT.value}', "

--- a/src/peft/tuners/prompt_tuning/config.py
+++ b/src/peft/tuners/prompt_tuning/config.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PromptLearningConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 class PromptTuningInit(str, enum.Enum):
@@ -69,12 +69,8 @@ class PromptTuningConfig(PromptLearningConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.PROMPT_TUNING
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-
         if (self.prompt_tuning_init == PromptTuningInit.TEXT) and not self.tokenizer_name_or_path:
             raise ValueError(
                 f"When prompt_tuning_init='{PromptTuningInit.TEXT.value}', "

--- a/src/peft/tuners/vblora/config.py
+++ b/src/peft/tuners/vblora/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -190,6 +190,11 @@ class VBLoRAConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+        
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/vblora/config.py
+++ b/src/peft/tuners/vblora/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -183,6 +183,7 @@ class VBLoRAConfig(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.VBLORA
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
@@ -190,11 +191,6 @@ class VBLoRAConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-        
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/vera/config.py
+++ b/src/peft/tuners/vera/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -150,6 +150,11 @@ class VeraConfig(PeftConfig):
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
         )
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
+
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/vera/config.py
+++ b/src/peft/tuners/vera/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from peft.config import PeftConfig
-from peft.utils import PeftType, TaskType
+from peft.utils import PeftType
 
 
 @dataclass
@@ -146,15 +146,11 @@ class VeraConfig(PeftConfig):
     )
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.VERA
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
         )
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
-
         # check for layers_to_transform and layers_pattern
         if self.layers_pattern and not self.layers_to_transform:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/xlora/config.py
+++ b/src/peft/tuners/xlora/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from peft.config import PeftConfig
-from peft.utils.peft_types import PeftType, TaskType
+from peft.utils.peft_types import PeftType
 
 
 @dataclass
@@ -76,11 +76,8 @@ class XLoraConfig(PeftConfig):
     global_scaling_weight: float = 1.0
 
     def __post_init__(self):
+        super().__post_init__()
         self.peft_type = PeftType.XLORA
-
-        # check for invalid task type
-        if self.task_type is None or self.task_type not in TaskType.__members__:
-            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
 
         if self.hidden_size is None:
             warnings.warn(

--- a/src/peft/tuners/xlora/config.py
+++ b/src/peft/tuners/xlora/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from peft.config import PeftConfig
-from peft.utils.peft_types import PeftType
+from peft.utils.peft_types import PeftType, TaskType
 
 
 @dataclass
@@ -77,6 +77,10 @@ class XLoraConfig(PeftConfig):
 
     def __post_init__(self):
         self.peft_type = PeftType.XLORA
+
+        # check for invalid task type
+        if self.task_type is None or self.task_type not in TaskType.__members__:
+            raise ValueError(f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {list(TaskType.__members__.keys())}.")
 
         if self.hidden_size is None:
             warnings.warn(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -95,11 +95,11 @@ class TestPeftConfig:
         config_class(task_type=valid_task_type)
 
     @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
-    @pytest.mark.parametrize("invalid_task_type", ["test"])
-    def test_invalid_task_type(self, config_class, invalid_task_type):
+    def test_invalid_task_type(self, config_class):
         r"""
         Test if all configs correctly raise the defined error message for invalid task types.
         """
+        invalid_task_type = "invalid-task-type"
         with pytest.raises(
             ValueError,
             match=f"Invalid task type: '{invalid_task_type}'. Must be one of the following task types: {', '.join(TaskType)}.",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,7 +87,7 @@ class TestPeftConfig:
         assert hasattr(config, "from_json_file")
 
     @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
-    @pytest.mark.parametrize("valid_task_type", list(TaskType))
+    @pytest.mark.parametrize("valid_task_type", list(TaskType) + [None])
     def test_valid_task_type(self, config_class, valid_task_type):
         r"""
         Test if all configs work correctly for all valid task types

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,7 @@ from peft import (
     PromptEncoder,
     PromptEncoderConfig,
     PromptTuningConfig,
+    TaskType,
     VBLoRAConfig,
     VeraConfig,
 )
@@ -86,8 +87,24 @@ class TestPeftConfig:
         assert hasattr(config, "from_json_file")
 
     @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
-    def test_task_type(self, config_class):
-        config_class(task_type="test")
+    @pytest.mark.parametrize("valid_task_type", list(TaskType))
+    def test_valid_task_type(self, config_class, valid_task_type):
+        r"""
+        Test if all configs work correctly for all valid task types
+        """
+        config_class(task_type=valid_task_type)
+
+    @pytest.mark.parametrize("config_class", ALL_CONFIG_CLASSES)
+    @pytest.mark.parametrize("invalid_task_type", ["test"])
+    def test_invalid_task_type(self, config_class, invalid_task_type):
+        r"""
+        Test if all configs correctly raise the defined error message for invalid task types.
+        """
+        with pytest.raises(
+            ValueError,
+            match=f"Invalid task type: '{invalid_task_type}'. Must be one of the following task types: {', '.join(TaskType)}.",
+        ):
+            config_class(task_type=invalid_task_type)
 
     def test_from_peft_type(self):
         r"""

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1222,7 +1222,7 @@ class TestAdaLoraInitialization:
 
     def test_adalora_loftq_config_raises(self):
         with pytest.raises(ValueError, match="ADALORA does not support LOFTQ"):
-            AdaLoraConfig(loftq_config={"loftq": "config"})
+            AdaLoraConfig(init_lora_weights="loftq", loftq_config={"loftq": "config"})
 
     def get_model(self):
         class MyModule(nn.Module):


### PR DESCRIPTION
Fixes #2203 

This PR adds validation for the `task_type` parameter across all PEFT types (e.g., LoRA, Prefix Tuning, etc.) to ensure that only valid task types, as defined in the `TaskType` enum, are used. This resolves the issue where invalid or non-sense task types (e.g., `"BLABLA"`) or typos (e.g., `"CUASAL_LM"` instead of `"CAUSAL_LM"`) could be passed without raising an error, potentially causing unexpected behavior.

#### Why This Change Is Necessary:
- **Prevents Silent Failures**: Without this validation, users could pass incorrect or unsupported task types without receiving any feedback. This could lead to silent failures or unexpected behavior during training or inference.
- **Consistency**: Ensures that all PEFT types adhere to the same validation rules for `task_type`, maintaining consistency across different PEFT configurations.

#### Tests:
- Ensured that invalid task types raise appropriate errors.
- Verified that valid task types continue to work as expected.

#### Example Scenario:
Before this PR, the following code would not raise an error despite using an invalid task type:

```python
from transformers import AutoModelForCausalLM, AutoTokenizer
from peft import LoraConfig, get_peft_model

# Step 1: Load the base model and tokenizer
model_name_or_path = "meta-llama/Llama-3.2-1B"
tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
tokenizer.pad_token = tokenizer.eos_token
tokenizer.padding_side = "right"

# Step 2: Define the LoRA configuration
lora_config = LoraConfig(
    r=16,  
    lora_alpha=32, 
    lora_dropout=0.1,  
    target_modules=["q_proj", "v_proj"],  
    bias="none",  
    task_type="BLABLA"  # Invalid task type 
)

# Step 3: Wrap the base model with LoRA using the configuration
peft_model = get_peft_model(model, lora_config)
```

With this PR, attempting to use an invalid task type like `"BLABLA"` will now raise a `ValueError`, ensuring that only valid task types are accepted:

```
ValueError: Invalid task type: 'BLABLA'. Must be one of the following task types: ['SEQ_CLS', 'SEQ_2_SEQ_LM', 'CAUSAL_LM', 'TOKEN_CLS', 'QUESTION_ANS', 'FEATURE_EXTRACTION'].
```

# For multiple PEFT methods:

## **INVALID** `task_type`

```python
from transformers import AutoModelForCausalLM, AutoTokenizer
from peft import (
    LoraConfig, 
    PromptTuningConfig, 
    PrefixTuningConfig,
    get_peft_model
)

# Step 1: Load the base model and tokenizer
model_name_or_path = "meta-llama/Llama-3.2-1B"
tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
tokenizer.pad_token = tokenizer.eos_token
tokenizer.padding_side = "right"

# Step 2: Define configurations for each PEFT method with an invalid task type
configs = [
    LoraConfig(
        r=16,
        lora_alpha=32,
        lora_dropout=0.1,
        target_modules=["q_proj", "v_proj"],
        bias="none",
        task_type="BLABLA"  # Invalid task type
    ),
    PromptTuningConfig(
        num_virtual_tokens=20,
        task_type="BLABLA"  # Invalid task type
    ),
    PrefixTuningConfig(
        num_virtual_tokens=30,
        task_type="BLABLA"  # Invalid task type
    ),
    # Add more configurations for other PeftTypes if necessary...
]

# Step 3: Test each configuration and check if it raises a ValueError for invalid task type
for config in configs:
    try:
        print(f"Testing {config.__class__.__name__}...")
        peft_model = get_peft_model(model, config)
        print("OK")
    except ValueError as e:
        print(f"Error: {e}")
```

```
Testing LoraConfig...
Error: Invalid task type: 'BLABLA'. Must be one of the following task types: ['SEQ_CLS', 'SEQ_2_SEQ_LM', 'CAUSAL_LM', 'TOKEN_CLS', 'QUESTION_ANS', 'FEATURE_EXTRACTION'].
Testing PromptTuningConfig...
Error: Invalid task type: 'BLABLA'. Must be one of the following task types: ['SEQ_CLS', 'SEQ_2_SEQ_LM', 'CAUSAL_LM', 'TOKEN_CLS', 'QUESTION_ANS', 'FEATURE_EXTRACTION'].
Testing PrefixTuningConfig...
Error: Invalid task type: 'BLABLA'. Must be one of the following task types: ['SEQ_CLS', 'SEQ_2_SEQ_LM', 'CAUSAL_LM', 'TOKEN_CLS', 'QUESTION_ANS', 'FEATURE_EXTRACTION'].
```

## **VALID** `task_type`

```python
from transformers import AutoModelForCausalLM, AutoTokenizer
from peft import (
    LoraConfig, 
    PromptTuningConfig, 
    PrefixTuningConfig,
    get_peft_model
)

# Step 1: Load the base model and tokenizer
model_name_or_path = "meta-llama/Llama-3.2-1B"
tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
tokenizer.pad_token = tokenizer.eos_token
tokenizer.padding_side = "right"

# Step 2: Define configurations for each PEFT method with an valid task type
configs = [
    LoraConfig(
        r=16,
        lora_alpha=32,
        lora_dropout=0.1,
        target_modules=["q_proj", "v_proj"],
        bias="none",
        task_type="CAUSAL_LM"  # Valid task type
    ),
    PromptTuningConfig(
        num_virtual_tokens=20,
        task_type="CAUSAL_LM"  # Valid task type
    ),
    PrefixTuningConfig(
        num_virtual_tokens=30,
        task_type="CAUSAL_LM"  # Valid task type
    ),
]

# Step 3: Test each configuration and check if it raises a ValueError for invalid task type
for config in configs:
    try:
        print(f"Testing {config.__class__.__name__}...")
        peft_model = get_peft_model(model, config)
        print("OK")
    except ValueError as e:
        print(f"Error: {e}")
```

```
Testing LoraConfig...
OK
Testing PromptTuningConfig...
OK
Testing PrefixTuningConfig...
OK
```