### PR TITLE
[FIX] EVA `meta` device check bug + add multi-gpu functionality

### DIFF
--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -65,7 +65,7 @@ config = LoraConfig(init_lora_weights="olora", ...)
 For more advanced usage, please refer to our [documentation](https://github.com/huggingface/peft/tree/main/examples/olora_finetuning).
 
 ### EVA
-[EVA](https://arxiv.org/pdf/2410.07170) performs SVD on the input activations of each layer and uses the right-singular vectors to initialize LoRA weights. It therefore is a data-driven initialization scheme. Furthermore EVA adaptively allocates ranks across layers based on their "explained variance ratio" - a metric derived from the SVD analysis.
+[EVA](https://arxiv.org/pdf/2410.07170) performs SVD on the input activations of each layer and uses the right-singular vectors to initialize LoRA weights. It is therefore a data-driven initialization scheme. Furthermore EVA adaptively allocates ranks across layers based on their "explained variance ratio" - a metric derived from the SVD analysis.
 
 You can use EVA by setting `init_lora_weights="eva"` and defining [`EvaConfig`] in [`LoraConfig`]:
 ```python
@@ -76,7 +76,7 @@ peft_config = LoraConfig(
     ...
 )
 ```
-The parameter `rho` (≥ 1.0) determines how much redistribution is allowed. When `rho=1.0` and `r=16`, the system is limited to exactly 16 ranks, preventing any redistribution from occurring. A recommended value for eva with redistribution is 2.0, meaning the maximum rank allowed for a layer is 2r.
+The parameter `rho` (≥ 1.0) determines how much redistribution is allowed. When `rho=1.0` and `r=16`, LoRA adapters are limited to exactly 16 ranks, preventing any redistribution from occurring. A recommended value for EVA with redistribution is 2.0, meaning the maximum rank allowed for a layer is 2r.
 
 It is recommended to perform EVA initialization on a GPU as it is much faster. To optimize the amount of available memory for EVA, you can use the `low_cpu_mem_usage` flag in [`get_peft_model`]:
 ```python

--- a/examples/eva_finetuning/README.md
+++ b/examples/eva_finetuning/README.md
@@ -90,6 +90,7 @@ In some cases you might just want to get the state_dict after EVA initialization
 - you want to precompute and store the state_dict for different downstream tasks.
 - you need to quantize the model for finetuning but want to perform EVA initialization with model weights in full/half precision.
 - you do not intend to use a peft model for LoRA finetuning.
+- you would like to leverage multiple GPUs for EVA initialization. (At the moment this is not directly supported by `initialize_lora_eva_weights`)
 
 You can do this by calling `get_eva_state_dict` directly (you only need to pass `peft_config` if `model` is not a PeftModel):
 ```python
@@ -97,10 +98,14 @@ from peft import get_eva_state_dict
 
 eva_state_dict = get_eva_state_dict(model, dataloader, peft_config)
 ```
-Later you can load the state_dict into a model without adapter weights by using the `eva_state_dict` argument in `initialize_lora_eva_weights`:
+Later you can load the state_dict into a `PeftModel` by using the `eva_state_dict` argument in `initialize_lora_eva_weights`:
 ```python
 initialize_lora_eva_weights(peft_model, eva_state_dict=eva_state_dict)
 ```
+
+## Leveraging multiple GPUs
+
+EVA initialization can be parallelized across multiple GPUs. In this case inputs from multiple GPUs are gathered before computing the SVD for the batch. This requires that the model is wrapped in a `torch.nn.DataParallel` or `torch.nn.DistributedDataParallel` class. An example of how to use this can be found in [eva_finetuning_multi_gpu.py](https://github.com/huggingface/peft/blob/main/examples/eva_finetuning/eva_finetuning_multi_gpu.py).
 
 ## Customizing EVA
 

--- a/examples/eva_finetuning/eva_finetuning_multi_gpu.py
+++ b/examples/eva_finetuning/eva_finetuning_multi_gpu.py
@@ -25,6 +25,7 @@ from utils import DataCollator, TokenizerMetaMath
 
 from peft import EvaConfig, LoraConfig, get_eva_state_dict, get_peft_model, initialize_lora_eva_weights
 
+
 # run this script e.g. with: torchrun --nproc_per_node=4 eva_finetuning_multi_gpu.py
 
 # config

--- a/examples/eva_finetuning/eva_finetuning_multi_gpu.py
+++ b/examples/eva_finetuning/eva_finetuning_multi_gpu.py
@@ -25,6 +25,7 @@ from utils import DataCollator, TokenizerMetaMath
 
 from peft import EvaConfig, LoraConfig, get_eva_state_dict, get_peft_model, initialize_lora_eva_weights
 
+# run this script e.g. with: torchrun --nproc_per_node=4 eva_finetuning_multi_gpu.py
 
 # config
 model_name = "meta-llama/Llama-2-7b-hf"

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -196,7 +196,7 @@ def get_peft_model(
         and not low_cpu_mem_usage
     ):
         warnings.warn(
-            "lora with eva initialization used with low_cpu_mem_usage=False"
+            "lora with eva initialization used with low_cpu_mem_usage=False. "
             "Setting low_cpu_mem_usage=True can improve the maximum batch size possible for eva initialization."
         )
 

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -321,10 +321,7 @@ def _get_eva_state_dict(
         rho = min(rho, rho_ceil)
 
     training = model.training
-    if dist.is_initialized():
-        device = model.device
-    else:
-        device = get_device_with_meta_params(model)
+    device = get_device_with_meta_params(model)
     model.eval()
 
     # get model inputs

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -44,7 +44,6 @@ class _Hook:
     """
 
     def __init__(self, name: str, prepare_layer_inputs_fn: Optional[callable] = None):
-        torch.manual_seed(0)
         self.name = name
         if prepare_layer_inputs_fn is None:
             self._prepare_layer_inputs_fn = self._prepare_layer_inputs_fn_default
@@ -292,6 +291,9 @@ def _get_eva_state_dict(
     prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None],
     show_progress_bar: bool,
 ) -> dict:
+    # Set seeds for reproducibility at the start of EVA computation
+    torch.manual_seed(0)
+
     # Computes the rank distribution for each layer based on the explained variance ratio.
     # when rank_pattern flag is False, all values in max_components are the same
     def _get_rank_distribution(hooks, layer_hook_map, equal_inputs_map, rank_budget, max_components):

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -22,6 +22,7 @@ from itertools import cycle
 from typing import Dict, Iterable, Optional, Union
 
 import torch
+import torch.distributed as dist
 from tqdm import tqdm
 from transformers.pytorch_utils import Conv1D
 
@@ -43,6 +44,7 @@ class _Hook:
     """
 
     def __init__(self, name: str, prepare_layer_inputs_fn: Optional[callable] = None):
+        torch.manual_seed(0)
         self.name = name
         if prepare_layer_inputs_fn is None:
             self._prepare_layer_inputs_fn = self._prepare_layer_inputs_fn_default
@@ -67,8 +69,34 @@ class _Hook:
         return layer_input
 
     @torch.no_grad()
-    def prepare_layer_inputs(self, input):
-        return self._prepare_layer_inputs_fn(input, self.model_input, self.name)
+    def prepare_layer_inputs(self, layer_input):
+        return self._prepare_layer_inputs_fn(layer_input, self.model_input, self.name)
+
+    @staticmethod
+    def gather_layer_inputs(layer_input):
+        if dist.is_initialized():
+            world_size = dist.get_world_size()
+
+            # First gather sizes from all processes more efficiently
+            local_size = torch.tensor([layer_input.shape[0]], device=layer_input.device)
+            all_sizes = torch.empty(world_size, dtype=local_size.dtype, device=layer_input.device)
+            dist.all_gather_into_tensor(all_sizes, local_size)
+            all_sizes = all_sizes.tolist()
+
+            # Find maximum size and pad tensors
+            padded_input = layer_input.new_zeros((max(all_sizes), *layer_input.shape[1:]))
+            padded_input[: layer_input.shape[0]] = layer_input
+
+            # Gather padded tensors
+            gathered_inputs = [torch.zeros_like(padded_input) for _ in range(world_size)]
+            dist.all_gather(gathered_inputs, padded_input.contiguous())
+
+            # Remove padding for each gathered tensor
+            gathered_inputs = [tensor[:size] for tensor, size in zip(gathered_inputs, all_sizes)]
+
+            # Concatenate along batch dimension
+            return torch.cat(gathered_inputs, dim=0)
+        return layer_input
 
 
 class SVDHook(_Hook):
@@ -114,6 +142,7 @@ class SVDHook(_Hook):
         if hasattr(self.svd, "components_"):
             previous_components = self.svd.components_.clone().detach()
         states = self.prepare_layer_inputs(input)
+        states = self.gather_layer_inputs(states)
         # check if batch sizes is more than the number of components
         if states.size(0) < self.n_components:
             print(f"skipping SVD for {self.name} because there are less than {self.n_components} examples")
@@ -160,8 +189,9 @@ class HashHook(_Hook):
 
     @torch.no_grad()
     def __call__(self, model, input, output):
-        x = self.prepare_layer_inputs(input).cpu()
-        self.hashed_inputs.append(self.hash_fn(x))
+        x = self.prepare_layer_inputs(input)
+        x = self.gather_layer_inputs(x)
+        self.hashed_inputs.append(self.hash_fn(x.cpu()))
 
 
 def find_equal_values(dictionary: dict) -> dict:
@@ -291,7 +321,10 @@ def _get_eva_state_dict(
         rho = min(rho, rho_ceil)
 
     training = model.training
-    device = get_device_with_meta_params(model)
+    if dist.is_initialized():
+        device = model.device
+    else:
+        device = get_device_with_meta_params(model)
     model.eval()
 
     # get model inputs
@@ -352,10 +385,12 @@ def _get_eva_state_dict(
     layer_hook_map = {**dict(zip(hooks.keys(), hooks.keys())), **equal_inputs_map}
 
     # start svd calculation
-    if show_progress_bar:
+    if show_progress_bar and (not dist.is_initialized() or dist.get_rank() == 0):
         pbar = tqdm(iter(cycle(dataloader)), position=0, leave=False)
+        use_tqdm = True
     else:
         pbar = iter(cycle(dataloader))
+        use_tqdm = False
     convergence_dict = {k: False for k in hooks.keys()}
     rank_dist = max_components.copy()
     for inputs in pbar:
@@ -384,7 +419,7 @@ def _get_eva_state_dict(
             hook.model_input = model_inputs_for_hooks
             hooks[name] = (hook, handle)
 
-        if show_progress_bar:
+        if use_tqdm:
             layer_converged = list(convergence_dict.values()) + [
                 convergence_dict[v] for v in equal_inputs_map.values()
             ]
@@ -469,7 +504,7 @@ def _load_eva_state_dict(
             elif new_rank != r:
                 if peft_config.eva_config.adjust_scaling_factors:
                     alpha *= new_rank / r
-            if new_rank != r or module.lora_A[adapter_name].weight.device == "meta":
+            if new_rank != r or module.lora_A[adapter_name].weight.device.type == "meta":
                 module.update_layer(r=new_rank, lora_alpha=alpha, init_lora_weights="eva", **update_layer_kwargs)
             module.lora_A[adapter_name].weight.copy_(w)
             new_target_modules.append(name_in_base_model)


### PR DESCRIPTION
This PR contains 
- an important bugfix for a faulty device check in [eva.py](https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora/eva.py). 
- torch `all_gather` operations for all SVD Hooks to be able to leverage a higher batch size for EVA in multi-gpu setups.
- An example in the docs for using EVA with multiple GPUs