### PR TITLE
CI Update AutoAWQ version to fix CI

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -41,8 +41,8 @@ SHELL ["/bin/bash", "-c"]
 RUN source activate peft && \ 
     python3 -m pip install --no-cache-dir bitsandbytes optimum auto-gptq && \
     # Add autoawq for quantization testing
-    python3 -m pip install --no-cache-dir https://github.com/casper-hansen/AutoAWQ/releases/download/v0.2.6/autoawq-0.2.6-cp311-cp311-linux_x86_64.whl && \
-    python3 -m pip install --no-cache-dir https://github.com/casper-hansen/AutoAWQ_kernels/releases/download/v0.0.8/autoawq_kernels-0.0.8-cp311-cp311-linux_x86_64.whl && \
+    python3 -m pip install --no-cache-dir https://github.com/casper-hansen/AutoAWQ/releases/download/v0.2.7.post2/autoawq-0.2.7.post2-py3-none-any.whl && \
+    python3 -m pip install --no-cache-dir https://github.com/casper-hansen/AutoAWQ_kernels/releases/download/v0.0.9/autoawq_kernels-0.0.9-cp311-cp311-linux_x86_64.whl && \
     # Add eetq for quantization testing
     python3 -m pip install git+https://github.com/NetEase-FuXi/EETQ.git
 


### PR DESCRIPTION
Currently, the [CI fails](https://github.com/huggingface/peft/actions/runs/11905036144/job/33174835723#step:5:62) because awq tries to import a non-existing function from transformers (presumably it was there at one point but no longer is):

>     from transformers.modeling_utils import shard_checkpoint
> E   ImportError: cannot import name 'shard_checkpoint' from 'transformers.modeling_utils' (/opt/conda/envs/peft/lib/python3.11/site-packages/transformers/modeling_utils.py)

This has been [fixed](https://github.com/casper-hansen/AutoAWQ/commit/a28c747903bd917aaf43700e9ca8db65e74de19b) in awq v0.2.7. Therefore, this newer version is now used in CI.