### PR TITLE
TST: Move slow compile tests to nightly CI

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -15,6 +15,8 @@ import importlib
 import itertools
 import os
 import re
+import subprocess
+import sys
 import tempfile
 import unittest
 from collections import Counter, defaultdict
@@ -4069,3 +4071,78 @@ class TestPrefixTuning:
         peft_config = PrefixTuningConfig(num_virtual_tokens=10, task_type="SEQ_2_SEQ_LM")
         model = get_peft_model(model, peft_config)
         model.generate(**inputs)  # does not raise
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires a GPU")
+@pytest.mark.single_gpu_tests
+class TestHotSwapping:
+    def test_hotswapping_compiled_model_does_not_trigger_recompilation(self):
+        env = os.environ.copy()
+        env["TORCH_LOGS"] = "guards,recompiles"
+        here = os.path.dirname(__file__)
+        file_name = os.path.join(here, "run_compiled_model_hotswap.py")
+
+        process = subprocess.Popen(
+            [sys.executable, file_name, "1"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        # Communicate will read the output and error streams, preventing deadlock
+        stdout, stderr = process.communicate()
+        exit_code = process.returncode
+
+        # sanity check:
+        assert exit_code == 0
+
+        # check that the recompilation message is not present
+        assert "__recompiles" not in stderr.decode()
+
+        # contingency check: without hotswapping, we *do* get recompilation
+        process = subprocess.Popen(
+            [sys.executable, file_name, "0"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        # Communicate will read the output and error streams, preventing deadlock
+        stdout, stderr = process.communicate()
+        exit_code = process.returncode
+
+        # sanity check:
+        assert exit_code == 0
+
+        # check that the recompilation message is not present
+        assert "__recompiles" in stderr.decode()
+
+    @pytest.mark.xfail(strict=True, reason="Requires hotswap to be implemented in diffusers")
+    def test_hotswapping_compiled_diffusion_model_does_not_trigger_recompilation(self):
+        env = os.environ.copy()
+        env["TORCH_LOGS"] = "guards,recompiles"
+        here = os.path.dirname(__file__)
+        file_name = os.path.join(here, "run_compiled_diffusion_model_hotswap.py")
+
+        process = subprocess.Popen(
+            [sys.executable, file_name, "1"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        # Communicate will read the output and error streams, preventing deadlock
+        stdout, stderr = process.communicate()
+        exit_code = process.returncode
+
+        # sanity check:
+        assert exit_code == 0
+
+        # check that the recompilation message is not present
+        assert "__recompiles" not in stderr.decode()
+
+        # contingency check: without hotswapping, we *do* get recompilation
+        process = subprocess.Popen(
+            [sys.executable, file_name, "0"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        # Communicate will read the output and error streams, preventing deadlock
+        stdout, stderr = process.communicate()
+        exit_code = process.returncode
+
+        # sanity check:
+        assert exit_code == 0
+
+        # check that the recompilation message is not present
+        assert "__recompiles" in stderr.decode()

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -14,11 +14,8 @@
 
 
 import itertools
-import os
 import platform
 import re
-import subprocess
-import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from copy import deepcopy
@@ -2219,74 +2216,3 @@ class TestHotSwapping:
         msg = f"Hot swapping the adapter did not succeed. Unexpected keys: {new_key}"
         with pytest.raises(RuntimeError, match=msg):
             hotswap_adapter(model, tmp_path / "adapter1", adapter_name="default")
-
-    def test_hotswapping_compiled_model_does_not_trigger_recompilation(self):
-        env = os.environ.copy()
-        env["TORCH_LOGS"] = "guards,recompiles"
-        here = os.path.dirname(__file__)
-        file_name = os.path.join(here, "run_compiled_model_hotswap.py")
-
-        process = subprocess.Popen(
-            [sys.executable, file_name, "1"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-
-        # Communicate will read the output and error streams, preventing deadlock
-        stdout, stderr = process.communicate()
-        exit_code = process.returncode
-
-        # sanity check:
-        assert exit_code == 0
-
-        # check that the recompilation message is not present
-        assert "__recompiles" not in stderr.decode()
-
-        # contingency check: without hotswapping, we *do* get recompilation
-        process = subprocess.Popen(
-            [sys.executable, file_name, "0"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-
-        # Communicate will read the output and error streams, preventing deadlock
-        stdout, stderr = process.communicate()
-        exit_code = process.returncode
-
-        # sanity check:
-        assert exit_code == 0
-
-        # check that the recompilation message is not present
-        assert "__recompiles" in stderr.decode()
-
-    @pytest.mark.xfail(strict=True, reason="Requires hotswap to be implemented in diffusers")
-    def test_hotswapping_compiled_diffusion_model_does_not_trigger_recompilation(self):
-        env = os.environ.copy()
-        env["TORCH_LOGS"] = "guards,recompiles"
-        here = os.path.dirname(__file__)
-        file_name = os.path.join(here, "run_compiled_diffusion_model_hotswap.py")
-
-        process = subprocess.Popen(
-            [sys.executable, file_name, "1"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-
-        # Communicate will read the output and error streams, preventing deadlock
-        stdout, stderr = process.communicate()
-        exit_code = process.returncode
-
-        # sanity check:
-        assert exit_code == 0
-
-        # check that the recompilation message is not present
-        assert "__recompiles" not in stderr.decode()
-
-        # contingency check: without hotswapping, we *do* get recompilation
-        process = subprocess.Popen(
-            [sys.executable, file_name, "0"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-
-        # Communicate will read the output and error streams, preventing deadlock
-        stdout, stderr = process.communicate()
-        exit_code = process.returncode
-
-        # sanity check:
-        assert exit_code == 0
-
-        # check that the recompilation message is not present
-        assert "__recompiles" in stderr.decode()


### PR DESCRIPTION
These tests use `torch.compile` on semi-realistic models and are thus slow to execute. In sum, they take ~3 min to finish, with an overall CI runtime of ~15 min, so it's significant.

As these tests are very unlikely to be affected by most code changes, it should be fine to move them to nightly CI instead of running them on each PR. Also, presence of GPUs might speed the tests up.

Note that apart from moving the tests around, they are completely unchanged. They pass locally.