### PR TITLE
[FEAT] EVA: ensure deterministic behavior of SVD on multi gpu setups

### DIFF
--- a/examples/eva_finetuning/eva_finetuning_multi_gpu.py
+++ b/examples/eva_finetuning/eva_finetuning_multi_gpu.py
@@ -87,7 +87,7 @@ sampler.set_epoch(0)
 
 # Wrap model in DDP
 model = model.to(local_rank)
-model = DDP(model, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=False)
+model = DDP(model, device_ids=[local_rank], output_device=local_rank)
 
 # setup peft config
 eva_config = EvaConfig(rho=rho)
@@ -96,7 +96,8 @@ peft_config = LoraConfig(
 )
 
 # EVA initialization
-eva_state_dict = get_eva_state_dict(model, dataloader, peft_config)
+# It is important to set `gather_distributed_inputs=True` here if you use a distributed data sampler.
+eva_state_dict = get_eva_state_dict(model, dataloader, peft_config, gather_distributed_inputs=True)
 eva_state_dict = {".".join(["base_model.model"] + k.split(".")[1:]): v for k, v in eva_state_dict.items()}
 
 # cleanup ddp

--- a/examples/eva_finetuning/eva_finetuning_multi_gpu.py
+++ b/examples/eva_finetuning/eva_finetuning_multi_gpu.py
@@ -96,8 +96,7 @@ peft_config = LoraConfig(
 )
 
 # EVA initialization
-# It is important to set `gather_distributed_inputs=True` here if you use a distributed data sampler.
-eva_state_dict = get_eva_state_dict(model, dataloader, peft_config, gather_distributed_inputs=True)
+eva_state_dict = get_eva_state_dict(model, dataloader, peft_config)
 eva_state_dict = {".".join(["base_model.model"] + k.split(".")[1:]): v for k, v in eva_state_dict.items()}
 
 # cleanup ddp

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -469,7 +469,7 @@ def _load_eva_state_dict(
             elif new_rank != r:
                 if peft_config.eva_config.adjust_scaling_factors:
                     alpha *= new_rank / r
-            if new_rank != r or module.lora_A[adapter_name].weight.device == "meta":
+            if new_rank != r or module.lora_A[adapter_name].weight.device.type == "meta":
                 module.update_layer(r=new_rank, lora_alpha=alpha, init_lora_weights="eva", **update_layer_kwargs)
             module.lora_A[adapter_name].weight.copy_(w)
             new_target_modules.append(name_in_base_model)

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -43,8 +43,14 @@ class _Hook:
     A base class for hooks that prepares layer inputs for EVA.
     """
 
-    def __init__(self, name: str, prepare_layer_inputs_fn: Optional[callable] = None):
+    def __init__(
+        self,
+        name: str,
+        prepare_layer_inputs_fn: Optional[callable] = None,
+        gather_distributed_inputs: bool = True,
+    ):
         self.name = name
+        self.gather_distributed_inputs = gather_distributed_inputs
         if prepare_layer_inputs_fn is None:
             self._prepare_layer_inputs_fn = self._prepare_layer_inputs_fn_default
         else:
@@ -71,9 +77,8 @@ class _Hook:
     def prepare_layer_inputs(self, layer_input):
         return self._prepare_layer_inputs_fn(layer_input, self.model_input, self.name)
 
-    @staticmethod
-    def gather_layer_inputs(layer_input):
-        if dist.is_initialized():
+    def gather_layer_inputs(self, layer_input):
+        if dist.is_initialized() and self.gather_distributed_inputs:
             world_size = dist.get_world_size()
 
             # First gather sizes from all processes more efficiently
@@ -116,12 +121,11 @@ class SVDHook(_Hook):
 
     def __init__(
         self,
-        name: str,
         n_components: int,
         sim_thresh: Union[float, torch.Tensor],
-        prepare_layer_inputs_fn: Optional[callable] = None,
+        **base_class_kwargs,
     ):
-        super().__init__(name, prepare_layer_inputs_fn)
+        super().__init__(**base_class_kwargs)
         self.n_components = n_components
         self.sim_thresh = sim_thresh
         if isinstance(sim_thresh, torch.Tensor) and len(sim_thresh.shape) > 0:
@@ -131,7 +135,12 @@ class SVDHook(_Hook):
                 raise ValueError(
                     "if sim_thresh is a tensor with more than 0 dimensions it must have shape (n_components,) or (1,)"
                 )
-        self.svd = IncrementalPCA(n_components=n_components, copy=True, lowrank=True)
+        self.svd = IncrementalPCA(
+            n_components=n_components,
+            copy=True,
+            lowrank=True,
+            lowrank_seed=42,
+        )
         self.model_input = None
         self.converged = torch.zeros((n_components,), dtype=torch.bool)
 
@@ -174,12 +183,8 @@ class HashHook(_Hook):
         prepare_layer_inputs_fn (Optional[callable]): Function to prepare layer inputs for hashing.
     """
 
-    def __init__(
-        self,
-        name: str,
-        prepare_layer_inputs_fn: Optional[callable] = None,
-    ):
-        super().__init__(name, prepare_layer_inputs_fn)
+    def __init__(self, **base_class_kwargs):
+        super().__init__(**base_class_kwargs)
         self.hashed_inputs = []
 
     @staticmethod
@@ -289,11 +294,9 @@ def _get_eva_state_dict(
     forward_fn: Optional[callable],
     prepare_model_inputs_fn: Optional[callable],
     prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None],
+    gather_distributed_inputs: bool,
     show_progress_bar: bool,
 ) -> dict:
-    # Set seeds for reproducibility at the start of EVA computation
-    torch.manual_seed(0)
-
     # Computes the rank distribution for each layer based on the explained variance ratio.
     # when rank_pattern flag is False, all values in max_components are the same
     def _get_rank_distribution(hooks, layer_hook_map, equal_inputs_map, rank_budget, max_components):
@@ -313,6 +316,14 @@ def _get_eva_state_dict(
     # dataloader is not empty
     if len(dataloader) == 0:
         raise ValueError("dataloader is empty")
+
+    # check if dist is initialized
+    if dist.is_initialized() and gather_distributed_inputs:
+        warnings.warn(
+            "torch.distributed is initialized and `gather_distributed_inputs` is True, "
+            "therefore EVA initialization will gather tensors from all ranks. "
+            "Ensure the model does not recieve the same inputs on different ranks."
+        )
 
     # for unusually high rho values, define an upper limit
     rho_threshold = 1000
@@ -345,7 +356,7 @@ def _get_eva_state_dict(
             fn = prepare_layer_inputs_fn.pop(name, None)
         else:
             fn = prepare_layer_inputs_fn
-        hook = HashHook(name, fn)
+        hook = HashHook(name=name, prepare_layer_inputs_fn=fn, gather_distributed_inputs=gather_distributed_inputs)
         hook.model_input = model_inputs_for_hooks
         handle = module.register_forward_hook(hook)
         hooks[name] = (hook, handle)
@@ -377,7 +388,13 @@ def _get_eva_state_dict(
         handle.remove()
         if name in equal_inputs_map:
             continue
-        hook = SVDHook(name, max_components[name], peft_config.eva_config.tau, hook._prepare_layer_inputs_fn)
+        hook = SVDHook(
+            n_components=max_components[name],
+            sim_thresh=peft_config.eva_config.tau,
+            name=name,
+            prepare_layer_inputs_fn=hook._prepare_layer_inputs_fn,
+            gather_distributed_inputs=gather_distributed_inputs,
+        )
         module = model.get_submodule(name)
         handle = module.register_forward_hook(hook)
         hooks[name] = (hook, handle)  # adding the old handle here so we dont get errors in the first forward pass
@@ -546,6 +563,7 @@ def get_eva_state_dict(
     prepare_model_inputs_fn: Optional[callable] = prepare_model_inputs_fn_language_modeling,
     prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
     adapter_name: str = "default",
+    gather_distributed_inputs: bool = True,
     show_progress_bar: bool = True,
 ) -> dict:
     """
@@ -579,6 +597,7 @@ def get_eva_state_dict(
             case model_inputs is the mask used to determine which indices should be used for SVD (created by
             `prepare_model_inputs_fn_language_modeling`).
         adapter_name (str): The name of the adapter to compute the SVD for.
+        gather_distributed_inputs (bool): Whether to gather the layer inputs from all ranks. Default is True.
         show_progress_bar (bool): Whether to show a progress bar. Default is True.
 
     Returns:
@@ -624,6 +643,7 @@ def get_eva_state_dict(
             forward_fn=forward_fn,
             prepare_model_inputs_fn=prepare_model_inputs_fn,
             prepare_layer_inputs_fn=prepare_layer_inputs_fn,
+            gather_distributed_inputs=gather_distributed_inputs,
             show_progress_bar=show_progress_bar,
         )
     return eva_state_dict

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -47,7 +47,7 @@ class _Hook:
         self,
         name: str,
         prepare_layer_inputs_fn: Optional[callable] = None,
-        gather_distributed_inputs: bool = True,
+        gather_distributed_inputs: bool = False,
     ):
         self.name = name
         self.gather_distributed_inputs = gather_distributed_inputs
@@ -563,7 +563,7 @@ def get_eva_state_dict(
     prepare_model_inputs_fn: Optional[callable] = prepare_model_inputs_fn_language_modeling,
     prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
     adapter_name: str = "default",
-    gather_distributed_inputs: bool = True,
+    gather_distributed_inputs: bool = False,
     show_progress_bar: bool = True,
 ) -> dict:
     """
@@ -597,7 +597,7 @@ def get_eva_state_dict(
             case model_inputs is the mask used to determine which indices should be used for SVD (created by
             `prepare_model_inputs_fn_language_modeling`).
         adapter_name (str): The name of the adapter to compute the SVD for.
-        gather_distributed_inputs (bool): Whether to gather the layer inputs from all ranks. Default is True.
+        gather_distributed_inputs (bool): Whether to gather the layer inputs from all ranks. Default is False.
         show_progress_bar (bool): Whether to show a progress bar. Default is True.
 
     Returns:
@@ -658,7 +658,7 @@ def initialize_lora_eva_weights(
     prepare_model_inputs_fn: Optional[callable] = prepare_model_inputs_fn_language_modeling,
     prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
     adapter_name: str = "default",
-    gather_distributed_inputs: bool = True,
+    gather_distributed_inputs: bool = False,
     show_progress_bar: bool = True,
 ):
     """
@@ -693,7 +693,7 @@ def initialize_lora_eva_weights(
             case model_inputs is the mask used to determine which indices should be used for SVD (created by
             `prepare_model_inputs_fn_language_modeling`).
         adapter_name (str): The name of the adapter to initialize the weights for.
-        gather_distributed_inputs (bool): Whether to gather the layer inputs from all ranks. Default is True.
+        gather_distributed_inputs (bool): Whether to gather the layer inputs from all ranks. Default is False.
         show_progress_bar (bool): Whether to show a progress bar. Default is True.
 
     Returns:

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -322,7 +322,7 @@ def _get_eva_state_dict(
         warnings.warn(
             "torch.distributed is initialized and `gather_distributed_inputs` is True, "
             "therefore EVA initialization will gather tensors from all ranks. "
-            "Ensure the model does not recieve the same inputs on different ranks."
+            "Ensure the model does not receive the same inputs on different ranks."
         )
 
     # for unusually high rho values, define an upper limit

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -658,6 +658,7 @@ def initialize_lora_eva_weights(
     prepare_model_inputs_fn: Optional[callable] = prepare_model_inputs_fn_language_modeling,
     prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
     adapter_name: str = "default",
+    gather_distributed_inputs: bool = True,
     show_progress_bar: bool = True,
 ):
     """
@@ -692,6 +693,7 @@ def initialize_lora_eva_weights(
             case model_inputs is the mask used to determine which indices should be used for SVD (created by
             `prepare_model_inputs_fn_language_modeling`).
         adapter_name (str): The name of the adapter to initialize the weights for.
+        gather_distributed_inputs (bool): Whether to gather the layer inputs from all ranks. Default is True.
         show_progress_bar (bool): Whether to show a progress bar. Default is True.
 
     Returns:
@@ -720,6 +722,7 @@ def initialize_lora_eva_weights(
             prepare_model_inputs_fn=prepare_model_inputs_fn,
             prepare_layer_inputs_fn=prepare_layer_inputs_fn,
             adapter_name=adapter_name,
+            gather_distributed_inputs=gather_distributed_inputs,
             show_progress_bar=show_progress_bar,
         )
 

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -563,7 +563,7 @@ def get_eva_state_dict(
     prepare_model_inputs_fn: Optional[callable] = prepare_model_inputs_fn_language_modeling,
     prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
     adapter_name: str = "default",
-    gather_distributed_inputs: bool = False,
+    gather_distributed_inputs: bool = True,
     show_progress_bar: bool = True,
 ) -> dict:
     """
@@ -597,7 +597,10 @@ def get_eva_state_dict(
             case model_inputs is the mask used to determine which indices should be used for SVD (created by
             `prepare_model_inputs_fn_language_modeling`).
         adapter_name (str): The name of the adapter to compute the SVD for.
-        gather_distributed_inputs (bool): Whether to gather the layer inputs from all ranks. Default is False.
+        gather_distributed_inputs (bool):
+            Whether to gather the layer inputs from all ranks. Default is True meaning in a distributed setting the
+            layer inputs will be gathered from all ranks for the SVD computation. For non-distributed settings this
+            argument is ignored. Set to False if you are using a non-distributed dataloader in a distributed setting.
         show_progress_bar (bool): Whether to show a progress bar. Default is True.
 
     Returns:
@@ -658,7 +661,7 @@ def initialize_lora_eva_weights(
     prepare_model_inputs_fn: Optional[callable] = prepare_model_inputs_fn_language_modeling,
     prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
     adapter_name: str = "default",
-    gather_distributed_inputs: bool = False,
+    gather_distributed_inputs: bool = True,
     show_progress_bar: bool = True,
 ):
     """
@@ -693,7 +696,10 @@ def initialize_lora_eva_weights(
             case model_inputs is the mask used to determine which indices should be used for SVD (created by
             `prepare_model_inputs_fn_language_modeling`).
         adapter_name (str): The name of the adapter to initialize the weights for.
-        gather_distributed_inputs (bool): Whether to gather the layer inputs from all ranks. Default is False.
+        gather_distributed_inputs (bool):
+            Whether to gather the layer inputs from all ranks. Default is True meaning in a distributed setting the
+            layer inputs will be gathered from all ranks for the SVD computation. For non-distributed settings this
+            argument is ignored. Set to False if you are using a non-distributed dataloader in a distributed setting.
         show_progress_bar (bool): Whether to show a progress bar. Default is True.
 
     Returns:

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -47,7 +47,7 @@ class _Hook:
         self,
         name: str,
         prepare_layer_inputs_fn: Optional[callable] = None,
-        gather_distributed_inputs: bool = False,
+        gather_distributed_inputs: bool = True,
     ):
         self.name = name
         self.gather_distributed_inputs = gather_distributed_inputs

--- a/tests/test_incremental_pca.py
+++ b/tests/test_incremental_pca.py
@@ -107,7 +107,7 @@ def test_n_components_none():
         # First partial_fit call, ipca.n_components_ is inferred from
         # min(X.shape)
         ipca.partial_fit(X)
-        assert ipca.n_components_ == min(X.shape)
+        assert ipca.n_components == min(X.shape)
 
 
 def test_incremental_pca_num_features_change():


### PR DESCRIPTION
Deterministic behavior of SVD computations on layer inputs is important on multi gpu setups to ensure resulting EVA state dicts are identical. Currently deterministic behaviour of SVD is ensured by just setting torch.manual_seed() inside `_get_eva_state_dict` which is not ideal because it can interfere with the seed set by the user. I therefore moved this functionality inside the `IncrementalPCA` class.

I also added a new argument for `get_eva_state_dict`: `gather_distributed_inputs` which is `False` by default and defines if inputs should be concatenated for the SVD computation for distributed runs.