### PR TITLE
FIX Correctly set device of input data in bnb test

### DIFF
--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -639,7 +639,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         )
         model = get_peft_model(model, config)
 
-        random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(0)
+        random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
         _ = model(random_input)
 
     @require_torch_multi_gpu
@@ -662,7 +662,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         )
         model = get_peft_model(model, config)
 
-        random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(0)
+        random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
         _ = model(random_input)
 
     @require_torch_gpu

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -734,7 +734,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         original_module = lm_head.original_module
         modules_to_save = lm_head.modules_to_save.default
 
-        inputs = torch.randn(1024)
+        inputs = torch.randn(1024).to(model.device)
         o1 = lm_head(inputs)
         o1.mean().backward()
 


### PR DESCRIPTION
Fixes a failing CI bitsandbytes CI tests [here](https://github.com/huggingface/peft/actions/runs/11925572071/job/33237877071#step:9:267) and [here](https://github.com/huggingface/peft/actions/runs/11925572071/job/33237876848#step:10:548).

The input data was on CPU but the model is on GPU, resulting in an error. Note that this mismatch was not an issue previously because accelerate added an `AlignDevicesHook` that took care of this. With the latest accelerate, this is no longer the case, whereas the hook is present for v1.1.1.

In any case, it's better that we set the device of the data explicitly, so I think this is a safe change. But it would be good to know what happened that caused this change.

Note: CI won't catch these errors, as the tests require GPU. However, I reproduced and confirmed locally.