### PR TITLE
FIX: Prevent CUDA context initialization due to AWQ

### DIFF
--- a/src/peft/tuners/lora/awq.py
+++ b/src/peft/tuners/lora/awq.py
@@ -22,10 +22,6 @@ from peft.tuners.lora.layer import LoraLayer
 from peft.tuners.tuners_utils import BaseTunerLayer
 
 
-if is_auto_awq_available():
-    from awq.modules.linear import WQLinear_GEMM
-
-
 class AwqLoraLinear(torch.nn.Module, LoraLayer):
     def __init__(
         self,
@@ -91,18 +87,21 @@ def dispatch_awq(
     else:
         target_base_layer = target
 
-    if is_auto_awq_available() and isinstance(target_base_layer, WQLinear_GEMM):
-        # Raise the error only at the dispatch level
-        AUTOAWQ_MINIMUM_VERSION = packaging.version.parse("0.2.0")
-        version_autoawq = packaging.version.parse(importlib_metadata.version("autoawq"))
+    if is_auto_awq_available():
+        from awq.modules.linear import WQLinear_GEMM
 
-        if AUTOAWQ_MINIMUM_VERSION > version_autoawq:
-            raise ImportError(
-                f"Found an incompatible version of auto-awq. Found version {version_autoawq}, "
-                f"but only versions above {AUTOAWQ_MINIMUM_VERSION} are supported for PEFT."
-            )
+        if isinstance(target_base_layer, WQLinear_GEMM):
+            # Raise the error only at the dispatch level
+            AUTOAWQ_MINIMUM_VERSION = packaging.version.parse("0.2.0")
+            version_autoawq = packaging.version.parse(importlib_metadata.version("autoawq"))
 
-        new_module = AwqLoraLinear(target, adapter_name, **kwargs)
-        target.qweight = target_base_layer.qweight
+            if AUTOAWQ_MINIMUM_VERSION > version_autoawq:
+                raise ImportError(
+                    f"Found an incompatible version of auto-awq. Found version {version_autoawq}, "
+                    f"but only versions above {AUTOAWQ_MINIMUM_VERSION} are supported for PEFT."
+                )
+
+            new_module = AwqLoraLinear(target, adapter_name, **kwargs)
+            target.qweight = target_base_layer.qweight
 
     return new_module


### PR DESCRIPTION
Importing from AWQ triggers CUDA context initialization, which can be problematic in some circumstances (see #1877). This PR moves the import so that it's local, preventing this issue.

To test this, run this script:

```python
import multiprocessing

from torch import nn
import peft  # noqa F401

def func():
    nn.Linear(2, 3).cuda(0)

if __name__ == "__main__":
    proc = multiprocessing.Process(target=func)
    proc.start()
    proc.join()
```

Ideally, we can add this to our nightly GPU tests, but running this from the pytest runner does not work (IIRC) so some extra steps are required.