### PR TITLE
CI: Fix failing torchao test

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -3295,6 +3295,8 @@ class PeftTorchaoGPUTests(unittest.TestCase):
         self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
         # torchao breaks with fp16 and if a previous test uses fp16, transformers will set this env var, which affects
         # subsequent tests, therefore the env var needs to be cleared explicitly
+        #
+        # TODO: remove this once https://github.com/huggingface/transformers/pull/34886 is merged
         os.environ.pop("ACCELERATE_MIXED_PRECISION", None)
 
     def tearDown(self):

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -3293,6 +3293,9 @@ class PeftTorchaoGPUTests(unittest.TestCase):
     def setUp(self):
         self.causal_lm_model_id = "facebook/opt-125m"
         self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
+        # torchao breaks with fp16 and if a previous test uses fp16, transformers will set this env var, which affects
+        # subsequent tests, therefore the env var needs to be cleared explicitly
+        os.environ.pop("ACCELERATE_MIXED_PRECISION", None)
 
     def tearDown(self):
         r"""


### PR DESCRIPTION
The test failure is caused by a dangling accelerate environment variable indirectly set by previous tests through `TrainingArguments`, which results in torchao using fp16, which breaks.

The current fix is to delete the env var for torchao. In the future, we may use an accelerate function to clean up these env vars (https://github.com/huggingface/accelerate/pull/3252).