### PR TITLE
TST: Skip test on multi-GPU as DataParallel fails

### DIFF
--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -538,6 +538,11 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
         # Test prompt learning methods with gradient checkpointing in a semi realistic setting.
         # Prefix tuning does not work if the model uses the new caching implementation. In that case, a helpful error
         # should be raised.
+
+        # skip if multi GPU, since this results in DataParallel usage by Trainer, which fails
+        if torch.cuda.device_count() > 1:
+            pytest.skip("Skip prompt_learning_with_gradient_checkpointing test on multi-GPU setups")
+
         peft_config = config_cls(
             base_model_name_or_path=model_id,
             **config_kwargs,


### PR DESCRIPTION
This test fails in multi-GPU setting because `transformers.Trainer` switches to `DataParallel`. As this is not a commonly used parallelization strategy, it should be okay to just skip this. The test will still be run on single GPU and CPU.

https://github.com/huggingface/peft/actions/runs/12002085686/job/33453519249#step:6:45046

Unfortunately, once this test fails, all subsequent tests also fail with

> RuntimeError: CUDA error: device-side assert triggered

so it's important to fix this test fast, as it may mask other failures on multi-GPU.