### PR TITLE
Bump version of MacOS runners from 12 to 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: ["ubuntu-latest", "macos-12", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
       - name: Downgrade numpy on MacOS and Windows
         # TODO: remove numpy downgrade on MacOS & Windows once torch fixes numpy 2.0 issue
         shell: bash
-        if: matrix.os == 'windows-latest' || matrix.os == 'macos-12'
+        if: matrix.os == 'windows-latest' || matrix.os == 'macos-13'
         run: |
           pip install --force-reinstall -U "numpy<2.0.0"
       - name: Test with pytest


### PR DESCRIPTION
Version 12 will be deprecated in the coming month and there are already some problems with it so we might just as well upgrade.

This might fix errors where the runner does not run anything at all as seen [here](https://github.com/huggingface/peft/actions/runs/12015138902/job/33492659879?pr=2234).