### PR TITLE
TST: Update Llava model id in test

### DIFF
--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -56,7 +56,7 @@ CONFIGS = {
 # Ensure that models like Llava that pass past_key_values automatically do not fail, see #1938
 class TestPastKV:
     def test_past_kv(self):
-        model_id = "trl-internal-testing/tiny-random-LlavaForConditionalGeneration"
+        model_id = "peft-internal-testing/tiny-LlavaForConditionalGeneration"
         prompt = "USER: <image>\nWhat are these?\nASSISTANT:"
 
         # prepare model and inputs


### PR DESCRIPTION
Currently PEFT tests are [failing](https://github.com/huggingface/peft/actions/runs/12015138902/job/33529040221?pr=2234#step:6:1762) because 2 trl internal models that we relied on for testing were moved (one has also been changed). The new models have now been copied to `peft-internal-testing` to avoid this in the future.

I have updated `peft-internal-testing/tiny_T5ForSeq2SeqLM-lora` to use the new copied model in `peft-internal-testing` as the base model (no change in PEFT code necessary). This model also required the LoRA adapter to be updated, as the shapes of the base model were changed.

This PR updates the used Llava model id to now use the copy of that model that is inside of `peft-internal-testing`.