### PR TITLE
FIX: Small regression in BNB LoRA output

### DIFF
--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -235,7 +235,7 @@ if is_bnb_available():
                             x = x.to(compute_dtype)
 
                     if not self.use_dora[active_adapter]:
-                        result = result + lora_B(lora_A(dropout(x))) * scaling
+                        output = lora_B(lora_A(dropout(x))) * scaling
                     else:
                         if isinstance(dropout, torch.nn.Identity) or not self.training:
                             base_result = result
@@ -243,7 +243,7 @@ if is_bnb_available():
                             x = dropout(x)
                             base_result = None
 
-                        result = result + self.lora_magnitude_vector[active_adapter](
+                        output = self.lora_magnitude_vector[active_adapter](
                             x,
                             lora_A=lora_A,
                             lora_B=lora_B,
@@ -252,7 +252,8 @@ if is_bnb_available():
                             base_result=base_result,
                         )
                     if requires_conversion:
-                        result = result.to(expected_dtype)
+                        output = output.to(expected_dtype)
+                    result = result + output
 
             return result
 
@@ -490,7 +491,7 @@ if is_bnb_4bit_available():
                         x = x.to(lora_A.weight.dtype)
 
                     if not self.use_dora[active_adapter]:
-                        result = result + lora_B(lora_A(dropout(x))) * scaling
+                        output = lora_B(lora_A(dropout(x))) * scaling
                     else:
                         if isinstance(dropout, torch.nn.Identity) or not self.training:
                             base_result = result
@@ -498,7 +499,7 @@ if is_bnb_4bit_available():
                             x = dropout(x)
                             base_result = None
 
-                        result = result + self.lora_magnitude_vector[active_adapter](
+                        output = self.lora_magnitude_vector[active_adapter](
                             x,
                             lora_A=lora_A,
                             lora_B=lora_B,
@@ -507,7 +508,8 @@ if is_bnb_4bit_available():
                             base_result=base_result,
                         )
                     if requires_conversion:
-                        result = result.to(expected_dtype)
+                        output = output.to(expected_dtype)
+                    result = result + output
 
             return result
 


### PR DESCRIPTION
Our regression tests reveal that the 8bit LoRA BNB regression test is [failing](https://github.com/huggingface/peft/actions/runs/12042604161/job/33576548074#step:8:254). To reproduce, run:

`pytest tests/regression/test_regression.py -s --regression -k test_lora_8bit`

The regression was introduced in #2122. We didn't notice this earlier because of other failing tests in the nightly CI.

The cause of the error is subtle. In the original code, we would calculate the LoRA output, convert the `dtype` if necessary, then add it to the base output. After the mentioned PR, we calculate the LoRA output, add it to the base output, then convert the `dtype` if necessary ([code](https://github.com/huggingface/peft/pull/2122/files#diff-d6321d6b9970ada644811f3992899f3ef7df4581fced2a7584e0a51b03cc3355)). The difference is very small on a per layer basis, but it can accumulate over the layers, leading to a significant difference in outputs, as witnessed by the regression test.

This PR rolls back this specific part of the PR (both for 8bit and 4bit) while leaving the main change of that PR intact.