### PR TITLE
FIX: bugs of assign=True in load lora

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -442,7 +442,7 @@ def set_peft_model_state_dict(
         model, peft_model_state_dict, ignore_mismatched_sizes=ignore_mismatched_sizes
     )
     if low_cpu_mem_usage:
-        load_result = model.load_state_dict(peft_model_state_dict, strict=False, assign=True)
+        load_result = model.load_state_dict(peft_model_state_dict, strict=False)
         # ensure that the correct device is set
         for module in model.modules():
             if hasattr(module, "_move_adapter_to_device_of_base_layer"):


### PR DESCRIPTION
When I load Flux trained lora through:
```
from diffusers import AutoPipelineForText2Image, FluxPipeline
from safetensors.torch import load_file

pipe = FluxPipeline.from_pretrained("black-forest-labs/FLUX.1-dev", torch_dtype=torch.bfloat16).to('cuda')
pipe.load_lora_weights("model_qk_text.safetensors")
```

It raised this problem: 
```
    pipe.load_lora_weights("model_qk_text.safetensors")
  File "/output/diffusers/src/diffusers/loaders/lora_pipeline.py", line 1848, in load_lora_weights
    self.load_lora_into_transformer(
  File "/output/diffusers/src/diffusers/loaders/lora_pipeline.py", line 1951, in load_lora_into_transformer
    incompatible_keys = set_peft_model_state_dict(transformer, state_dict, adapter_name, **peft_kwargs)
  File "/usr/local/lib/python3.8/site-packages/peft/utils/save_and_load.py", line 458, in set_peft_model_state_dict
    load_result = model.load_state_dict(peft_model_state_dict, strict=False, assign=True)
```

After remove `assign=True`, it all works.