### PR TITLE
Fix: Ensure Device Compatibility for BOFT Forward/Merging with CUDA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.13.0"
+VERSION = "0.13.1"
 
 extras = {}
 extras["quality"] = [

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.13.1"
+VERSION = "0.13.2"
 
 extras = {}
 extras["quality"] = [

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 from .auto import (
     AutoPeftModel,

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.13.1"
+__version__ = "0.13.2"
 
 from .auto import (
     AutoPeftModel,

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -460,7 +460,9 @@ class BaseTuner(nn.Module, ABC):
             and len(peft_config.target_modules) >= MIN_TARGET_MODULES_FOR_OPTIMIZATION
         ):
             names_no_target = [
-                name for name in key_list if not any(name.endswith(suffix) for suffix in peft_config.target_modules)
+                name
+                for name in key_list
+                if not any((name == suffix) or name.endswith("." + suffix) for suffix in peft_config.target_modules)
             ]
             new_target_modules = _find_minimal_target_modules(peft_config.target_modules, names_no_target)
             if len(new_target_modules) < len(peft_config.target_modules):

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -456,6 +456,10 @@ def set_peft_model_state_dict(
     )
     if low_cpu_mem_usage:
         load_result = model.load_state_dict(peft_model_state_dict, strict=False, assign=True)
+        # ensure that the correct device is set
+        for module in model.modules():
+            if hasattr(module, "_move_adapter_to_device_of_base_layer"):
+                module._move_adapter_to_device_of_base_layer(adapter_name)
     else:
         load_result = model.load_state_dict(peft_model_state_dict, strict=False)
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1830,8 +1830,10 @@ class MultipleActiveAdaptersTester(unittest.TestCase):
     would be overkill.
     """
 
+    torch_device = infer_device()
+
     def prepare_inputs_for_testing(self):
-        X = torch.arange(90).view(9, 10)
+        X = torch.arange(90).view(9, 10).to(self.torch_device)
         return {"X": X}
 
     def set_multiple_active_adapters(self, model, adapter_names):
@@ -1844,8 +1846,7 @@ class MultipleActiveAdaptersTester(unittest.TestCase):
         self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2
     ):
         torch.manual_seed(0)
-        model = MLP(bias=tuner_method != "ia3")
-        model.eval()
+        model = MLP(bias=tuner_method != "ia3").to(self.torch_device).eval()
         X = self.prepare_inputs_for_testing()
 
         config_1 = config_cls(**config_kwargs_1)
@@ -1885,8 +1886,7 @@ class MultipleActiveAdaptersTester(unittest.TestCase):
         self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2
     ):
         torch.manual_seed(0)
-        model = MLP(bias=tuner_method != "ia3")
-        model.eval()
+        model = MLP(bias=tuner_method != "ia3").to(self.torch_device).eval()
         X = self.prepare_inputs_for_testing()
         base_output = model(**X)
 
@@ -1902,7 +1902,7 @@ class MultipleActiveAdaptersTester(unittest.TestCase):
 
         peft_model.merge_adapter()
         merged_combined_output = peft_model(**X)
-        assert torch.allclose(merged_combined_output, combined_output, atol=1e-5)
+        assert torch.allclose(merged_combined_output, combined_output, atol=1e-4)
 
         peft_model.unmerge_adapter()
 
@@ -1914,8 +1914,7 @@ class MultipleActiveAdaptersTester(unittest.TestCase):
     @parameterized.expand(MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES)
     def test_merge_layers_multi(self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2):
         torch.manual_seed(0)
-        model = MLP(bias=tuner_method != "ia3")
-        model.eval()
+        model = MLP(bias=tuner_method != "ia3").to(self.torch_device).eval()
 
         config_1 = config_cls(**config_kwargs_1)
         config_2 = config_cls(**config_kwargs_2)

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -1327,3 +1327,45 @@ class TestFindMinimalTargetModules:
         expected = {"time_emb_proj", "proj", "proj_out"}
         result = find_minimal_target_modules(target_modules, other_module_names)
         assert result == expected
+
+    def test_get_peft_modules_module_name_is_suffix_of_another_module(self):
+        # Solves the following bug:
+        # https://github.com/huggingface/diffusers/pull/9622#issuecomment-2404789721
+
+        # The cause for the bug is as follows: When we have, say, a module called "bar.0.query" that we want to target
+        # and another module called "foo_bar.0.query" that we don't want to target, there was potential for an error.
+        # This is not caused by _find_minimal_target_modules directly, but rather the bug was inside of
+        # BaseTuner.inject_adapter and how the names_no_target were chosen. Those used to be chosen based on suffix. In
+        # our example, however, "bar.0.query" is a suffix of "foo_bar.0.query", therefore "foo_bar.0.query" was *not*
+        # added to names_no_target when it should have. As a consequence, during the optimization, it looks like "query"
+        # is safe to use as target_modules because we don't see that it wrongly matches "foo_bar.0.query".
+
+        # ensure that we have sufficiently many modules to trigger the optimization
+        n_layers = MIN_TARGET_MODULES_FOR_OPTIMIZATION + 1
+
+        class InnerModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.query = nn.Linear(10, 10)
+
+        class OuterModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                # note that "transformer_blocks" is a suffix of "single_transformer_blocks"
+                self.transformer_blocks = nn.ModuleList([InnerModule() for _ in range(n_layers)])
+                self.single_transformer_blocks = nn.ModuleList([InnerModule() for _ in range(n_layers)])
+
+        # we want to match all "transformer_blocks" layers but not "single_transformer_blocks"
+        target_modules = [f"transformer_blocks.{i}.query" for i in range(n_layers)]
+        model = get_peft_model(OuterModule(), LoraConfig(target_modules=target_modules))
+
+        # sanity check: we should have n_layers PEFT layers in model.transformer_blocks
+        transformer_blocks = model.base_model.model.transformer_blocks
+        assert sum(isinstance(module, BaseTunerLayer) for module in transformer_blocks.modules()) == n_layers
+
+        # we should not have any PEFT layers in model.single_transformer_blocks
+        single_transformer_blocks = model.base_model.model.single_transformer_blocks
+        assert not any(isinstance(module, BaseTunerLayer) for module in single_transformer_blocks.modules())
+
+        # target modules should *not* be simplified to "query" as that would match "single_transformers_blocks" too
+        assert model.peft_config["default"].target_modules != {"query"}


### PR DESCRIPTION
Fixes #2219

### Description

This pull request resolves above issue regarding BOFT forward/merging with CUDA by ensuring that all relevant tensors and models are moved to the correct device. This change is necessary to prevent issues such as zero matrices and test failures when using CUDA.

### Changes

- Ensuring that all operations will be performed on the same device:
  - Added `torch_device = infer_device()` to infer and set the appropriate device (CPU or CUDA) at the beginning of the `MultipleActiveAdaptersTester` class.
  - Modified `prepare_inputs_for_testing()` to move input tensors to the inferred device using `.to(self.torch_device)`.
  - Updated model initialization in `test_merge_layers_multi` to move models to the inferred device with `.to(self.torch_device)`.
- Due to floating point precision on CUDA, for `test_multiple_active_adapters_merge_and_unmerge` the absolute tolerance had to be decreased from `atol=1e-5` to `atol=1e-4`

### Testing

- Verified that tests in `tests/test_custom_models.py` pass successfully with these changes, on both Linux (Ubuntu) and Windows
- Ensured compatibility across different environments, including CPU and CUDA-enabled setups.