### PR TITLE
ENH: Updates for upcoming BNB Int8 release

### DIFF
--- a/src/peft/tuners/adalora/model.py
+++ b/src/peft/tuners/adalora/model.py
@@ -174,7 +174,6 @@ class AdaLoraModel(LoraModel):
             kwargs.update(
                 {
                     "has_fp16_weights": target_base_layer.state.has_fp16_weights,
-                    "memory_efficient_backward": target_base_layer.state.memory_efficient_backward,
                     "threshold": target_base_layer.state.threshold,
                     "index": target_base_layer.index,
                 }

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -103,7 +103,6 @@ class IA3Model(BaseTuner):
             eightbit_kwargs.update(
                 {
                     "has_fp16_weights": target_base_layer.state.has_fp16_weights,
-                    "memory_efficient_backward": target_base_layer.state.memory_efficient_backward,
                     "threshold": target_base_layer.state.threshold,
                     "index": target_base_layer.index,
                 }

--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -214,8 +214,7 @@ if is_bnb_available():
                 output = lora_B(lora_A(dropout(sub_batch))) * scaling
                 if requires_conversion:
                     output = output.to(expected_dtype)
-                #result[sub_batch_indices_list[i]] += output
-                result[sub_batch_indices_list[i]] = result[sub_batch_indices_list[i]] + output
+                result[sub_batch_indices_list[i]] += output
 
             return result
 

--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -214,7 +214,8 @@ if is_bnb_available():
                 output = lora_B(lora_A(dropout(sub_batch))) * scaling
                 if requires_conversion:
                     output = output.to(expected_dtype)
-                result[sub_batch_indices_list[i]] += output
+                #result[sub_batch_indices_list[i]] += output
+                result[sub_batch_indices_list[i]] = result[sub_batch_indices_list[i]] + output
 
             return result
 
@@ -288,7 +289,6 @@ if is_bnb_available():
             eightbit_kwargs.update(
                 {
                     "has_fp16_weights": target.state.has_fp16_weights,
-                    "memory_efficient_backward": target.state.memory_efficient_backward,
                     "threshold": target.state.threshold,
                     "index": target.index,
                 }

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -314,7 +314,6 @@ class VeraModel(BaseTuner):
             eightbit_kwargs.update(
                 {
                     "has_fp16_weights": target_base_layer.state.has_fp16_weights,
-                    "memory_efficient_backward": target_base_layer.state.memory_efficient_backward,
                     "threshold": target_base_layer.state.threshold,
                     "index": target_base_layer.index,
                 }

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -101,13 +101,13 @@ def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
     if state.SCB is None:
         state.SCB = weight.SCB
 
-    im = torch.eye(weight.data.shape[-1]).contiguous().half().to(weight.device)
-    im, imt, SCim, SCimt, coo_tensorim = bnb.functional.double_quant(im)
-    im, Sim = bnb.functional.transform(im, "col32")
-    if state.CxB is None:
-        state.CxB, state.SB = bnb.functional.transform(weight.data, to_order=state.formatB)
-    out32, Sout32 = bnb.functional.igemmlt(im, state.CxB, Sim, state.SB)
-    dequantized = bnb.functional.mm_dequant(out32, Sout32, SCim, state.SCB, bias=None).t()
+    if hasattr(bnb.functional, "int8_vectorwise_dequant"):
+        # Use bitsandbytes API if available (requires v0.45.0+)
+        dequantized = bnb.functional.int8_vectorwise_dequant(weight.data, state.SCB)
+    else:
+        # Multiply by (scale/127) to dequantize.
+        dequantized = weight.data * state.SCB.view(-1, 1) * 7.874015718698502e-3
+
     if is_cpu:
         dequantized = dequantized.to(device)
     return dequantized

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -767,8 +767,8 @@ class PeftGPUCommonTests(unittest.TestCase):
         with torch.inference_mode():
             out_after_merge = F.softmax(model(random_input).logits, dim=-1)
 
-        atol = 0.01
-        rtol = 10
+        atol = 1e-3
+        rtol = 1
         assert not torch.allclose(out_base, out_before_merge, atol=atol, rtol=rtol)
         assert torch.allclose(out_before_merge, out_after_merge, atol=atol, rtol=rtol)
         assert isinstance(model, PeftModel)
@@ -803,8 +803,8 @@ class PeftGPUCommonTests(unittest.TestCase):
             with torch.inference_mode():
                 out_after = F.softmax(model(random_input).logits, dim=-1)
 
-        atol = 0.01
-        rtol = 10
+        atol = 1e-3
+        rtol = 1
         assert not torch.allclose(out_base, out_before, atol=atol, rtol=rtol)
         assert torch.allclose(out_base, out_after, atol=atol, rtol=rtol)
         assert isinstance(model, PeftModel)
@@ -838,8 +838,8 @@ class PeftGPUCommonTests(unittest.TestCase):
         with torch.inference_mode():
             out_after_merge = F.softmax(model(random_input).logits, dim=-1)
 
-        atol = 0.01
-        rtol = 10
+        atol = 1e-3
+        rtol = 1
         assert not torch.allclose(out_base, out_before_merge, atol=atol, rtol=rtol)
         assert torch.allclose(out_before_merge, out_after_merge, atol=atol, rtol=rtol)
 
@@ -1294,9 +1294,8 @@ class PeftGPUCommonTests(unittest.TestCase):
             model = model.merge_and_unload()
             out_unloaded = F.softmax(model(random_input).logits, dim=-1)
 
-        # 8bit merging less precise than 4bit
-        atol = 0.01
-        rtol = 10
+        atol = 1e-3
+        rtol = 1
         # sanity check that using DoRA changes the results
         assert not torch.allclose(out_base, out_dora, atol=atol, rtol=rtol)
         assert torch.allclose(out_dora, out_merged, atol=atol, rtol=rtol)


### PR DESCRIPTION
This PR contains changes to PEFT that relate to an upcoming 0.45.0 release that we are planning for bitsandbytes. Primarily the changes are related to [bitsandbytes#1401](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1401).

1. Bitsandbytes will introduce a public API function for LLM.int8() weight dequantization. We use this API when available, and otherwise use a functionally equivalent implementation. Apart from its relative simplicity, this will also resolve issues such as #2065.
2. The `memory_efficient_backward` kwarg for `Linear8bitLt` will be removed in the upcoming release, as per a longstanding [deprecation notice](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/7dca70049566b5b1c55cbd67e1cb191729a98152/bitsandbytes/nn/modules.py#L908). This PR removes usage of the kwarg for compatibility.

