### PR TITLE
FIX: Correctly pass low_cpu_mem_usage argument when initializing a PEFT model with task_type

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -220,7 +220,11 @@ def get_peft_model(
     if peft_config.is_prompt_learning:
         peft_config = _prepare_prompt_learning_config(peft_config, model_config)
     return MODEL_TYPE_TO_PEFT_MODEL_MAPPING[peft_config.task_type](
-        model, peft_config, adapter_name=adapter_name, autocast_adapter_dtype=autocast_adapter_dtype
+        model,
+        peft_config,
+        adapter_name=adapter_name,
+        autocast_adapter_dtype=autocast_adapter_dtype,
+        low_cpu_mem_usage=low_cpu_mem_usage,
     )
 
 


### PR DESCRIPTION
There was a bug that when creating a PEFT model with the `task_type` argument, the `low_cpu_mem_usage` argument was not passed along. This is now fixed and unit tests for this were added.

This is a very niche bug because there is typically no need to pass `low_cpu_mem_usage=True` when calling `get_peft_model`. Moreover, as the option for this was only added recently (#2142) and is unreleased, few if any users should be affected by the bug.

https://github.com/huggingface/peft/pull/2142/files#diff-b3b90f453dea37bf90203fd395e9dedc21b21c9a38464c6b1572368c049ef8b2