### PR TITLE
Fix: Add warning for adapter_name conflict with tuner 

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -72,6 +72,7 @@ from .tuners import (
 )
 from .tuners.tuners_utils import BaseTuner
 from .utils import _prepare_prompt_learning_config
+from .utils.constants import PEFT_TYPE_TO_PREFIX_MAPPING
 
 
 if TYPE_CHECKING:
@@ -202,6 +203,13 @@ def get_peft_model(
         warnings.warn(
             "lora with eva initialization used with low_cpu_mem_usage=False. "
             "Setting low_cpu_mem_usage=True can improve the maximum batch size possible for eva initialization."
+        )
+
+    prefix = PEFT_TYPE_TO_PREFIX_MAPPING.get(peft_config.peft_type)
+    if prefix and adapter_name in prefix:
+        warnings.warn(
+            f"Adapter name {adapter_name} should not be contained in the prefix {prefix}."
+            "This may lead to reinitialization of the adapter weights during loading."
         )
 
     if mixed:


### PR DESCRIPTION
This pull request addresses an [issue ](https://github.com/huggingface/peft/issues/2252) where adapter weights are incorrectly initialized when the adapter_name conflicts with the tuner_prefix during model loading. Specifically, it introduces a warning message to notify users when this conflict occurs, as this could lead to confusion or unintentional weight reinitialization.

**Changes:**

- Added a warning message when adapter_name matches the tuner_prefix, indicating a potential issue with missing adapter keys during model loading.
- The warning clarifies that this conflict is likely caused by the adapter_name being contained in the tuner_prefix, helping users identify and resolve the issue more easily.

**Impact:**

- Improves user experience by providing clearer feedback when model loading doesn't match expectations, preventing silent failures and making debugging easier.