### PR TITLE
Prepare for PEFT release of v0.14.0

### DIFF
--- a/examples/pissa_finetuning/README.md
+++ b/examples/pissa_finetuning/README.md
@@ -71,7 +71,7 @@ The main advantage of PiSSA is concentrated during the training phase. For a tra
 peft_model.save_pretrained(output_dir) 
 # Given the matrices $A_0$ and $B_0$, initialized by PiSSA and untrained, and the trained matrices $A$ and $B$, 
 # we can convert these to LoRA by setting $\Delta W = A \times B - A_0 \times B_0 = [A \mid A_0] \times [B \mid -B_0]^T = A'B'$.
-peft_model.save_pretrained(output_dir, convert_pissa_to_lora="pissa_init")
+peft_model.save_pretrained(output_dir, path_initial_model_for_weight_conversion="pissa_init")
 
 ```
 This conversion enables the loading of LoRA on top of a standard base model:

--- a/examples/pissa_finetuning/pissa_finetuning.py
+++ b/examples/pissa_finetuning/pissa_finetuning.py
@@ -136,7 +136,7 @@ trainer.save_state()
 if script_args.convert_pissa_to_lora:
     peft_model.save_pretrained(
         os.path.join(script_args.output_dir, "pissa_lora"),
-        convert_pissa_to_lora=os.path.join(script_args.residual_model_name_or_path, "pissa_init"),
+        path_initial_model_for_weight_conversion=os.path.join(script_args.residual_model_name_or_path, "pissa_init"),
     )
 else:
     peft_model.save_pretrained(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.13.3.dev0"
+VERSION = "0.14.0"
 
 extras = {}
 extras["quality"] = [

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.13.3.dev0"
+__version__ = "0.14.0"
 
 from .auto import (
     AutoPeftModel,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -229,7 +229,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         selected_adapters: Optional[list[str]] = None,
         save_embedding_layers: Union[str, bool] = "auto",
         is_main_process: bool = True,
-        convert_pissa_to_lora: Optional[str] = None,
         path_initial_model_for_weight_conversion: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
@@ -253,8 +252,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             is_main_process (`bool`, *optional*):
                 Whether the process calling this is the main process or not. Will default to `True`. Will not save the
                 checkpoint if not on the main process, which is important for multi device setups (e.g. DDP).
-            convert_pissa_to_lora (`str, *optional*`):
-                Deprecated. Use `path_initial_model_for_weight_conversion` instead.
             path_initial_model_for_weight_conversion (`str, *optional*`):
                 The path to the initialized adapter, which is obtained after initializing the model with PiSSA or OLoRA
                 and before performing any training. When `path_initial_model_for_weight_conversion` is not None, the
@@ -281,13 +278,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     f"You passed an invalid `selected_adapters` arguments, current supported adapter names are"
                     f" {list(self.peft_config.keys())} - got {selected_adapters}."
                 )
-        # TODO: remove deprecated parameter in PEFT v0.14.0
-        if convert_pissa_to_lora is not None:
-            warnings.warn(
-                "`convert_pissa_to_lora` is deprecated and will be removed in a future version. "
-                "Use `path_initial_model_for_weight_conversion` instead."
-            )
-            path_initial_model_for_weight_conversion = convert_pissa_to_lora
 
         def save_mutated_as_lora(peft_config, path_initial_model_for_weight_conversion, output_state_dict, kwargs):
             if peft_config.use_rslora and (peft_config.rank_pattern or peft_config.alpha_pattern):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -912,7 +912,13 @@ class MockTransformerWrapper:
 
 
 class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
-    """TODO"""
+    """
+    Implements the tests for custom models.
+
+    Most tests should just call the parent class, e.g. test_save_pretrained calls self._test_save_pretrained. Override
+    this if custom models don't work with the parent test method.
+
+    """
 
     transformers_class = MockTransformerWrapper
 

--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -15,19 +15,14 @@
 import os
 
 import huggingface_hub
-import packaging
 import pytest
 import torch
-import transformers
 from safetensors.torch import load_file
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from peft import LoraConfig, PeftType, TaskType, XLoraConfig, get_peft_model
 from peft.peft_model import PeftModel
 from peft.utils import infer_device
-
-
-uses_transformers_4_45 = packaging.version.parse(transformers.__version__) >= packaging.version.parse("4.45.0")
 
 
 class TestXlora:
@@ -133,8 +128,7 @@ class TestXlora:
         )
         assert torch.isfinite(outputs[: inputs.shape[1] :]).all()
 
-    # TODO: remove the skip when 4.45 is released!
-    @pytest.mark.skipif(not uses_transformers_4_45, reason="Requires transformers >= 4.45")
+    # TODO: fix the xfailing test
     @pytest.mark.xfail
     def test_scalings_logging_methods(self, tokenizer, model):
         model.enable_scalings_logging()


### PR DESCRIPTION
This PR can be reviewed but should NOT BE MERGED yet. We'll do this close to the release, once we know that no further commits will make it into the release.

- Bump versions
- Remove deprecated convert_pissa_to_lora argument
- Remove a pytest skip for older transformers versions
- Adjust some comments, docstrings