### PR TITLE
Attempt to fix performance issue on CI runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           #make test
           # TODO: also test with --no-gc
-          python -m pytest --db monitor_db.sqlite -n 3 tests/
+          python -m pytest --db monitor_db.sqlite --dist loadscope -n 3 tests/
       - name: Upload monitor data
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           #make test
           # TODO: also test with --no-gc
-          python -m pytest --db monitor_db.sqlite --dist loadscope -n 3 --profile tests/
+          python -m pytest -n 3 --profile tests/
       - name: Pack profiles
         run: |
           tar -czf profiles.tar.gz prof

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,10 +48,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools pytest-monitor
+          pip install setuptools pytest-profiling
           # cpu version of pytorch
           pip install -e .[test]
-          pip uninstall -y pytest-cov
       - name: Downgrade numpy on MacOS and Windows
         # TODO: remove numpy downgrade on MacOS & Windows once torch fixes numpy 2.0 issue
         shell: bash
@@ -62,10 +61,13 @@ jobs:
         run: |
           #make test
           # TODO: also test with --no-gc
-          python -m pytest --db monitor_db.sqlite --dist loadscope -n 3 tests/
+          python -m pytest --db monitor_db.sqlite --dist loadscope -n 3 --profile tests/
+      - name: Pack profiles
+        run: |
+          tar -czf profiles.tar.gz prof
       - name: Upload monitor data
         uses: actions/upload-artifact@v4
         with:
-          name: monitor_db_${{ matrix.os }}_${{ matrix.python-version }}.sqlite
-          path: monitor_db.sqlite
+          name: profiles_${{ matrix.os }}_${{ matrix.python-version }}.tar.gz
+          path: profiles.tar.gz
           retention-days: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,12 +51,6 @@ jobs:
           pip install setuptools
           # cpu version of pytorch
           pip install -e .[test]
-      - name: Downgrade numpy on MacOS and Windows
-        # TODO: remove numpy downgrade on MacOS & Windows once torch fixes numpy 2.0 issue
-        shell: bash
-        if: matrix.os == 'windows-latest' || matrix.os == 'macos-13'
-        run: |
-          pip install --force-reinstall -U "numpy<2.0.0"
       - name: Test with pytest
         run: |
           make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           #make test
           # TODO: also test with --no-gc
-          python --db monitor_db.sqlite -m pytest -n 3 tests/
+          python -m pytest --db monitor_db.sqlite -n 3 tests/
       - name: Upload monitor data
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,9 +49,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools pytest-monitor
-          pip uninstall pytest-cov
           # cpu version of pytorch
           pip install -e .[test]
+          pip uninstall pytest-cov
       - name: Downgrade numpy on MacOS and Windows
         # TODO: remove numpy downgrade on MacOS & Windows once torch fixes numpy 2.0 issue
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools
+          pip install setuptools pytest-monitor
           # cpu version of pytorch
           pip install -e .[test]
       - name: Downgrade numpy on MacOS and Windows
@@ -59,4 +59,12 @@ jobs:
           pip install --force-reinstall -U "numpy<2.0.0"
       - name: Test with pytest
         run: |
-          make test
+          #make test
+          # TODO: also test with --no-gc
+          python --db monitor_db.sqlite -m pytest -n 3 tests/
+      - name: Upload monitor data
+        uses: actions/upload-artifact@v4
+        with:
+          name: monitor_db_${{ matrix.os }}_${{ matrix.python_version }}.sqlite
+          path: monitor_db.sqlite
+          retention-days: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,12 @@ jobs:
           pip install setuptools
           # cpu version of pytorch
           pip install -e .[test]
+      - name: Downgrade numpy on MacOS and Windows
+        # TODO: remove numpy downgrade on MacOS & Windows once torch fixes numpy 2.0 issue
+        shell: bash
+        if: matrix.os == 'windows-latest' || matrix.os == 'macos-13'
+        run: |
+          pip install --force-reinstall -U "numpy<2.0.0"
       - name: Test with pytest
         run: |
           make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools pytest-monitor
+          pip uninstall pytest-cov
           # cpu version of pytorch
           pip install -e .[test]
       - name: Downgrade numpy on MacOS and Windows
@@ -65,6 +66,6 @@ jobs:
       - name: Upload monitor data
         uses: actions/upload-artifact@v4
         with:
-          name: monitor_db_${{ matrix.os }}_${{ matrix.python_version }}.sqlite
+          name: monitor_db_${{ matrix.os }}_${{ matrix.python-version }}.sqlite
           path: monitor_db.sqlite
           retention-days: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
           pip install setuptools pytest-monitor
           # cpu version of pytorch
           pip install -e .[test]
-          pip uninstall pytest-cov
+          pip uninstall -y pytest-cov
       - name: Downgrade numpy on MacOS and Windows
         # TODO: remove numpy downgrade on MacOS & Windows once torch fixes numpy 2.0 issue
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,8 @@ jobs:
           pip install setuptools pytest-profiling
           # cpu version of pytorch
           pip install -e .[test]
+          pip install "transformers==4.46.3"
+          pip list
       - name: Downgrade numpy on MacOS and Windows
         # TODO: remove numpy downgrade on MacOS & Windows once torch fixes numpy 2.0 issue
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ doctest_optionflags = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/peft --cov-report=term-missing --durations=10"
 markers = [
     "single_gpu_tests: tests that run on a single GPU",
     "multi_gpu_tests: tests that run on multiple GPUs",


### PR DESCRIPTION
**DO NOT MERGE YET**

MacOS and Windows CI runners / tests are taking ~4x as long as the Linux tests do.

For MacOS there is already an issue that reflects the numbers we get (https://github.com/actions/runner-images/issues/1336) but to make sure that it is not us, removing the lines to install `numpy < 2` for Windows and MacOS helps to debug.