### PR TITLE
CI Test removing multiple tested models

### DIFF
--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -51,10 +51,6 @@ PEFT_DECODER_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-GPT2LMHeadModel",
     "hf-internal-testing/tiny-random-BloomForCausalLM",
     "hf-internal-testing/tiny-random-gpt_neo",
-    "hf-internal-testing/tiny-random-GPTJForCausalLM",
-    "hf-internal-testing/tiny-random-GPTBigCodeForCausalLM",
-    "trl-internal-testing/tiny-random-LlamaForCausalLM",
-    "peft-internal-testing/tiny-dummy-qwen2",
 ]
 
 FULL_GRID = {

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -25,7 +25,6 @@ from .testing_common import PeftCommonTester, PeftTestConfigManager
 
 PEFT_ENCODER_DECODER_MODELS_TO_TEST = [
     "ybelkada/tiny-random-T5ForConditionalGeneration-calibrated",
-    "hf-internal-testing/tiny-random-BartForConditionalGeneration",
 ]
 
 FULL_GRID = {"model_ids": PEFT_ENCODER_DECODER_MODELS_TO_TEST, "task_type": "SEQ_2_SEQ_LM"}

--- a/tests/test_feature_extraction_models.py
+++ b/tests/test_feature_extraction_models.py
@@ -24,8 +24,6 @@ from .testing_common import PeftCommonTester, PeftTestConfigManager
 
 PEFT_FEATURE_EXTRACTION_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-BertModel",
-    "hf-internal-testing/tiny-random-RobertaModel",
-    "hf-internal-testing/tiny-random-DebertaModel",
     "hf-internal-testing/tiny-random-DebertaV2Model",
 ]
 

--- a/tests/test_stablediffusion.py
+++ b/tests/test_stablediffusion.py
@@ -82,30 +82,6 @@ CONFIG_TESTING_KWARGS = (
             "module_dropout": 0.0,
         },
     },
-    {
-        "text_encoder": {
-            "boft_block_num": 1,
-            "boft_block_size": 0,
-            "target_modules": ["k_proj", "q_proj", "v_proj", "out_proj", "fc1", "fc2"],
-            "boft_dropout": 0.0,
-        },
-        "unet": {
-            "boft_block_num": 1,
-            "boft_block_size": 0,
-            "target_modules": ["proj_in", "proj_out", "to_k", "to_q", "to_v", "to_out.0", "ff.net.0.proj", "ff.net.2"],
-            "boft_dropout": 0.0,
-        },
-    },
-    {
-        "text_encoder": {
-            "r": 8,
-            "target_modules": ["k_proj", "q_proj", "v_proj", "out_proj", "fc1", "fc2"],
-        },
-        "unet": {
-            "r": 8,
-            "target_modules": ["proj_in", "proj_out", "to_k", "to_q", "to_v", "to_out.0", "ff.net.0.proj", "ff.net.2"],
-        },
-    },
 )
 CLASSES_MAPPING = {
     "lora": (LoraConfig, CONFIG_TESTING_KWARGS[0]),


### PR DESCRIPTION
**DO NOT MERGE**

Remove roughly half of the tested models. This is for debugging the slow Windows and MacOS runners.