### PR TITLE
Refactor: PEFT method registration function

### DIFF
--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -26,6 +26,7 @@ from .auto import (  # noqa: I001
 from .mapping import (
     MODEL_TYPE_TO_PEFT_MODEL_MAPPING,
     PEFT_TYPE_TO_CONFIG_MAPPING,
+    PEFT_TYPE_TO_TUNER_MAPPING,
     get_peft_config,
     get_peft_model,
     inject_adapter_in_model,
@@ -111,6 +112,7 @@ from .config import PeftConfig, PromptLearningConfig
 __all__ = [
     "MODEL_TYPE_TO_PEFT_MODEL_MAPPING",
     "PEFT_TYPE_TO_CONFIG_MAPPING",
+    "PEFT_TYPE_TO_TUNER_MAPPING",
     "TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING",
     "AdaLoraConfig",
     "AdaLoraModel",

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -24,7 +24,7 @@ from .auto import (  # noqa: I001
     AutoPeftModelForFeatureExtraction,
     MODEL_TYPE_TO_PEFT_MODEL_MAPPING,
 )
-from .foo import get_peft_model
+from .func import get_peft_model
 from .mapping import (
     PEFT_TYPE_TO_CONFIG_MAPPING,
     PEFT_TYPE_TO_MIXED_MODEL_MAPPING,

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -22,13 +22,14 @@ from .auto import (  # noqa: I001
     AutoPeftModelForTokenClassification,
     AutoPeftModelForQuestionAnswering,
     AutoPeftModelForFeatureExtraction,
-)
-from .mapping import (
     MODEL_TYPE_TO_PEFT_MODEL_MAPPING,
+)
+from .foo import get_peft_model
+from .mapping import (
     PEFT_TYPE_TO_CONFIG_MAPPING,
+    PEFT_TYPE_TO_MIXED_MODEL_MAPPING,
     PEFT_TYPE_TO_TUNER_MAPPING,
     get_peft_config,
-    get_peft_model,
     inject_adapter_in_model,
 )
 from .mixed_model import PeftMixedModel
@@ -112,6 +113,7 @@ from .config import PeftConfig, PromptLearningConfig
 __all__ = [
     "MODEL_TYPE_TO_PEFT_MODEL_MAPPING",
     "PEFT_TYPE_TO_CONFIG_MAPPING",
+    "PEFT_TYPE_TO_MIXED_MODEL_MAPPING",
     "PEFT_TYPE_TO_TUNER_MAPPING",
     "TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING",
     "AdaLoraConfig",

--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -29,7 +29,6 @@ from transformers import (
 )
 
 from .config import PeftConfig
-from .mapping import MODEL_TYPE_TO_PEFT_MODEL_MAPPING
 from .peft_model import (
     PeftModel,
     PeftModelForCausalLM,
@@ -41,6 +40,16 @@ from .peft_model import (
 )
 from .utils.constants import TOKENIZER_CONFIG_NAME
 from .utils.other import check_file_exists_on_hf_hub
+
+
+MODEL_TYPE_TO_PEFT_MODEL_MAPPING: dict[str, type[PeftModel]] = {
+    "SEQ_CLS": PeftModelForSequenceClassification,
+    "SEQ_2_SEQ_LM": PeftModelForSeq2SeqLM,
+    "CAUSAL_LM": PeftModelForCausalLM,
+    "TOKEN_CLS": PeftModelForTokenClassification,
+    "QUESTION_ANS": PeftModelForQuestionAnswering,
+    "FEATURE_EXTRACTION": PeftModelForFeatureExtraction,
+}
 
 
 class _BaseAutoPeftModel:

--- a/src/peft/func.py
+++ b/src/peft/func.py
@@ -1,0 +1,118 @@
+# Copyright 2024-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from typing import Optional
+
+from transformers import PreTrainedModel
+
+from .auto import MODEL_TYPE_TO_PEFT_MODEL_MAPPING
+from .config import PeftConfig
+from .mapping import PEFT_TYPE_TO_CONFIG_MAPPING, PEFT_TYPE_TO_PREFIX_MAPPING
+from .mixed_model import PeftMixedModel
+from .peft_model import PeftModel
+from .tuners.tuners_utils import BaseTuner
+from .utils import _prepare_prompt_learning_config
+
+
+def get_peft_model(
+    model: PreTrainedModel,
+    peft_config: PeftConfig,
+    adapter_name: str = "default",
+    mixed: bool = False,
+    autocast_adapter_dtype: bool = True,
+    revision: Optional[str] = None,
+    low_cpu_mem_usage: bool = False,
+) -> PeftModel | PeftMixedModel:
+    """
+    Returns a Peft model object from a model and a config.
+
+    Args:
+        model ([`transformers.PreTrainedModel`]):
+            Model to be wrapped.
+        peft_config ([`PeftConfig`]):
+            Configuration object containing the parameters of the Peft model.
+        adapter_name (`str`, `optional`, defaults to `"default"`):
+            The name of the adapter to be injected, if not provided, the default adapter name is used ("default").
+        mixed (`bool`, `optional`, defaults to `False`):
+            Whether to allow mixing different (compatible) adapter types.
+        autocast_adapter_dtype (`bool`, *optional*):
+            Whether to autocast the adapter dtype. Defaults to `True`. Right now, this will only cast adapter weights
+            using float16 or bfloat16 to float32, as this is typically required for stable training, and only affect
+            select PEFT tuners.
+        revision (`str`, `optional`, defaults to `main`):
+            The revision of the base model. If this isn't set, the saved peft model will load the `main` revision for
+            the base model
+        low_cpu_mem_usage (`bool`, `optional`, defaults to `False`):
+            Create empty adapter weights on meta device. Useful to speed up the loading process. Leave this setting as
+            False if you intend on training the model, unless the adapter weights will be replaced by different weights
+            before training starts.
+    """
+    model_config = BaseTuner.get_model_config(model)
+    old_name = peft_config.base_model_name_or_path
+    new_name = model.__dict__.get("name_or_path", None)
+    peft_config.base_model_name_or_path = new_name
+
+    if (old_name is not None) and (old_name != new_name):
+        warnings.warn(
+            f"The PEFT config's `base_model_name_or_path` was renamed from '{old_name}' to '{new_name}'. "
+            "Please ensure that the correct base model is loaded when loading this checkpoint."
+        )
+
+    if revision is not None:
+        if peft_config.revision is not None and peft_config.revision != revision:
+            warnings.warn(
+                f"peft config has already set base model revision to {peft_config.revision}, overwriting with revision {revision}"
+            )
+        peft_config.revision = revision
+
+    if (
+        (isinstance(peft_config, PEFT_TYPE_TO_CONFIG_MAPPING["LORA"]))
+        and (peft_config.init_lora_weights == "eva")
+        and not low_cpu_mem_usage
+    ):
+        warnings.warn(
+            "lora with eva initialization used with low_cpu_mem_usage=False. "
+            "Setting low_cpu_mem_usage=True can improve the maximum batch size possible for eva initialization."
+        )
+
+    prefix = PEFT_TYPE_TO_PREFIX_MAPPING.get(peft_config.peft_type)
+    if prefix and adapter_name in prefix:
+        warnings.warn(
+            f"Adapter name {adapter_name} should not be contained in the prefix {prefix}."
+            "This may lead to reinitialization of the adapter weights during loading."
+        )
+
+    if mixed:
+        # note: PeftMixedModel does not support autocast_adapter_dtype, so don't pass it
+        return PeftMixedModel(model, peft_config, adapter_name=adapter_name)
+
+    if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys() and not peft_config.is_prompt_learning:
+        return PeftModel(
+            model,
+            peft_config,
+            adapter_name=adapter_name,
+            autocast_adapter_dtype=autocast_adapter_dtype,
+            low_cpu_mem_usage=low_cpu_mem_usage,
+        )
+
+    if peft_config.is_prompt_learning:
+        peft_config = _prepare_prompt_learning_config(peft_config, model_config)
+    return MODEL_TYPE_TO_PEFT_MODEL_MAPPING[peft_config.task_type](
+        model,
+        peft_config,
+        adapter_name=adapter_name,
+        autocast_adapter_dtype=autocast_adapter_dtype,
+        low_cpu_mem_usage=low_cpu_mem_usage,
+    )

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -38,8 +38,6 @@ from .tuners import (
     AdaptionPromptConfig,
     BOFTConfig,
     BOFTModel,
-    BoneConfig,
-    BoneModel,
     CPTConfig,
     CPTEmbedding,
     FourierFTConfig,
@@ -110,7 +108,6 @@ PEFT_TYPE_TO_CONFIG_MAPPING: dict[str, type[PeftConfig]] = {
     "HRA": HRAConfig,
     "VBLORA": VBLoRAConfig,
     "CPT": CPTConfig,
-    "BONE": BoneConfig,
 }
 
 PEFT_TYPE_TO_TUNER_MAPPING: dict[str, type[BaseTuner]] = {
@@ -129,7 +126,6 @@ PEFT_TYPE_TO_TUNER_MAPPING: dict[str, type[BaseTuner]] = {
     "HRA": HRAModel,
     "VBLORA": VBLoRAModel,
     "CPT": CPTEmbedding,
-    "BONE": BoneModel,
 }
 
 

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -14,119 +14,23 @@
 
 from __future__ import annotations
 
-import warnings
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import torch
 
-from peft.tuners.xlora.model import XLoraModel
-
-from .config import PeftConfig
-from .mixed_model import PeftMixedModel
-from .peft_model import (
-    PeftModel,
-    PeftModelForCausalLM,
-    PeftModelForFeatureExtraction,
-    PeftModelForQuestionAnswering,
-    PeftModelForSeq2SeqLM,
-    PeftModelForSequenceClassification,
-    PeftModelForTokenClassification,
-)
-from .tuners import (
-    AdaLoraConfig,
-    AdaLoraModel,
-    AdaptionPromptConfig,
-    BOFTConfig,
-    BOFTModel,
-    CPTConfig,
-    CPTEmbedding,
-    FourierFTConfig,
-    FourierFTModel,
-    HRAConfig,
-    HRAModel,
-    IA3Config,
-    IA3Model,
-    LNTuningConfig,
-    LNTuningModel,
-    LoHaConfig,
-    LoHaModel,
-    LoKrConfig,
-    LoKrModel,
-    LoraConfig,
-    LoraModel,
-    MultitaskPromptTuningConfig,
-    OFTConfig,
-    OFTModel,
-    PolyConfig,
-    PolyModel,
-    PrefixTuningConfig,
-    PromptEncoderConfig,
-    PromptTuningConfig,
-    VBLoRAConfig,
-    VBLoRAModel,
-    VeraConfig,
-    VeraModel,
-    XLoraConfig,
-)
-from .tuners.tuners_utils import BaseTuner
-from .utils import _prepare_prompt_learning_config
-from .utils.constants import PEFT_TYPE_TO_PREFIX_MAPPING
+from .utils import PeftType
 
 
 if TYPE_CHECKING:
-    from transformers import PreTrainedModel
+    from .config import PeftConfig
+    from .tuners.tuners_utils import BaseTuner
 
 
-MODEL_TYPE_TO_PEFT_MODEL_MAPPING: dict[str, type[PeftModel]] = {
-    "SEQ_CLS": PeftModelForSequenceClassification,
-    "SEQ_2_SEQ_LM": PeftModelForSeq2SeqLM,
-    "CAUSAL_LM": PeftModelForCausalLM,
-    "TOKEN_CLS": PeftModelForTokenClassification,
-    "QUESTION_ANS": PeftModelForQuestionAnswering,
-    "FEATURE_EXTRACTION": PeftModelForFeatureExtraction,
-}
-
-PEFT_TYPE_TO_CONFIG_MAPPING: dict[str, type[PeftConfig]] = {
-    "ADAPTION_PROMPT": AdaptionPromptConfig,
-    "PROMPT_TUNING": PromptTuningConfig,
-    "PREFIX_TUNING": PrefixTuningConfig,
-    "P_TUNING": PromptEncoderConfig,
-    "LORA": LoraConfig,
-    "LOHA": LoHaConfig,
-    "LORAPLUS": LoraConfig,
-    "LOKR": LoKrConfig,
-    "ADALORA": AdaLoraConfig,
-    "BOFT": BOFTConfig,
-    "IA3": IA3Config,
-    "MULTITASK_PROMPT_TUNING": MultitaskPromptTuningConfig,
-    "OFT": OFTConfig,
-    "POLY": PolyConfig,
-    "LN_TUNING": LNTuningConfig,
-    "VERA": VeraConfig,
-    "FOURIERFT": FourierFTConfig,
-    "XLORA": XLoraConfig,
-    "HRA": HRAConfig,
-    "VBLORA": VBLoRAConfig,
-    "CPT": CPTConfig,
-}
-
-PEFT_TYPE_TO_TUNER_MAPPING: dict[str, type[BaseTuner]] = {
-    "LORA": LoraModel,
-    "LOHA": LoHaModel,
-    "LOKR": LoKrModel,
-    "ADALORA": AdaLoraModel,
-    "BOFT": BOFTModel,
-    "IA3": IA3Model,
-    "OFT": OFTModel,
-    "POLY": PolyModel,
-    "LN_TUNING": LNTuningModel,
-    "VERA": VeraModel,
-    "FOURIERFT": FourierFTModel,
-    "XLORA": XLoraModel,
-    "HRA": HRAModel,
-    "VBLORA": VBLoRAModel,
-    "CPT": CPTEmbedding,
-}
+# these will be filled by the register_peft_method function
+PEFT_TYPE_TO_CONFIG_MAPPING: dict[PeftType, type[PeftConfig]] = {}
+PEFT_TYPE_TO_TUNER_MAPPING: dict[PeftType, type[BaseTuner]] = {}
+PEFT_TYPE_TO_MIXED_MODEL_MAPPING: dict[PeftType, type[BaseTuner]] = {}
+PEFT_TYPE_TO_PREFIX_MAPPING: dict[PeftType, str] = {}
 
 
 def get_peft_config(config_dict: dict[str, Any]) -> PeftConfig:
@@ -138,98 +42,6 @@ def get_peft_config(config_dict: dict[str, Any]) -> PeftConfig:
     """
 
     return PEFT_TYPE_TO_CONFIG_MAPPING[config_dict["peft_type"]](**config_dict)
-
-
-def get_peft_model(
-    model: PreTrainedModel,
-    peft_config: PeftConfig,
-    adapter_name: str = "default",
-    mixed: bool = False,
-    autocast_adapter_dtype: bool = True,
-    revision: Optional[str] = None,
-    low_cpu_mem_usage: bool = False,
-) -> PeftModel | PeftMixedModel:
-    """
-    Returns a Peft model object from a model and a config.
-
-    Args:
-        model ([`transformers.PreTrainedModel`]):
-            Model to be wrapped.
-        peft_config ([`PeftConfig`]):
-            Configuration object containing the parameters of the Peft model.
-        adapter_name (`str`, `optional`, defaults to `"default"`):
-            The name of the adapter to be injected, if not provided, the default adapter name is used ("default").
-        mixed (`bool`, `optional`, defaults to `False`):
-            Whether to allow mixing different (compatible) adapter types.
-        autocast_adapter_dtype (`bool`, *optional*):
-            Whether to autocast the adapter dtype. Defaults to `True`. Right now, this will only cast adapter weights
-            using float16 or bfloat16 to float32, as this is typically required for stable training, and only affect
-            select PEFT tuners.
-        revision (`str`, `optional`, defaults to `main`):
-            The revision of the base model. If this isn't set, the saved peft model will load the `main` revision for
-            the base model
-        low_cpu_mem_usage (`bool`, `optional`, defaults to `False`):
-            Create empty adapter weights on meta device. Useful to speed up the loading process. Leave this setting as
-            False if you intend on training the model, unless the adapter weights will be replaced by different weights
-            before training starts.
-    """
-    model_config = BaseTuner.get_model_config(model)
-    old_name = peft_config.base_model_name_or_path
-    new_name = model.__dict__.get("name_or_path", None)
-    peft_config.base_model_name_or_path = new_name
-
-    if (old_name is not None) and (old_name != new_name):
-        warnings.warn(
-            f"The PEFT config's `base_model_name_or_path` was renamed from '{old_name}' to '{new_name}'. "
-            "Please ensure that the correct base model is loaded when loading this checkpoint."
-        )
-
-    if revision is not None:
-        if peft_config.revision is not None and peft_config.revision != revision:
-            warnings.warn(
-                f"peft config has already set base model revision to {peft_config.revision}, overwriting with revision {revision}"
-            )
-        peft_config.revision = revision
-
-    if (
-        (isinstance(peft_config, PEFT_TYPE_TO_CONFIG_MAPPING["LORA"]))
-        and (peft_config.init_lora_weights == "eva")
-        and not low_cpu_mem_usage
-    ):
-        warnings.warn(
-            "lora with eva initialization used with low_cpu_mem_usage=False. "
-            "Setting low_cpu_mem_usage=True can improve the maximum batch size possible for eva initialization."
-        )
-
-    prefix = PEFT_TYPE_TO_PREFIX_MAPPING.get(peft_config.peft_type)
-    if prefix and adapter_name in prefix:
-        warnings.warn(
-            f"Adapter name {adapter_name} should not be contained in the prefix {prefix}."
-            "This may lead to reinitialization of the adapter weights during loading."
-        )
-
-    if mixed:
-        # note: PeftMixedModel does not support autocast_adapter_dtype, so don't pass it
-        return PeftMixedModel(model, peft_config, adapter_name=adapter_name)
-
-    if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys() and not peft_config.is_prompt_learning:
-        return PeftModel(
-            model,
-            peft_config,
-            adapter_name=adapter_name,
-            autocast_adapter_dtype=autocast_adapter_dtype,
-            low_cpu_mem_usage=low_cpu_mem_usage,
-        )
-
-    if peft_config.is_prompt_learning:
-        peft_config = _prepare_prompt_learning_config(peft_config, model_config)
-    return MODEL_TYPE_TO_PEFT_MODEL_MAPPING[peft_config.task_type](
-        model,
-        peft_config,
-        adapter_name=adapter_name,
-        autocast_adapter_dtype=autocast_adapter_dtype,
-        low_cpu_mem_usage=low_cpu_mem_usage,
-    )
 
 
 def inject_adapter_in_model(

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -27,25 +27,7 @@ from peft.utils.constants import DUMMY_MODEL_CONFIG
 
 from .config import PeftConfig
 from .peft_model import PeftModel
-from .tuners import (
-    AdaLoraModel,
-    IA3Model,
-    LoHaModel,
-    LoKrModel,
-    LoraModel,
-    MixedModel,
-)
-from .tuners.mixed import COMPATIBLE_TUNER_TYPES
-from .utils import PeftType, _set_adapter, _set_trainable
-
-
-PEFT_TYPE_TO_MODEL_MAPPING = {
-    PeftType.LORA: LoraModel,
-    PeftType.LOHA: LoHaModel,
-    PeftType.LOKR: LoKrModel,
-    PeftType.ADALORA: AdaLoraModel,
-    PeftType.IA3: IA3Model,
-}
+from .utils import _set_adapter, _set_trainable
 
 
 def _prepare_model_for_gradient_checkpointing(model: nn.Module) -> None:
@@ -72,6 +54,8 @@ def _prepare_model_for_gradient_checkpointing(model: nn.Module) -> None:
 
 
 def _check_config_compatible(peft_config: PeftConfig) -> None:
+    from .tuners.mixed import COMPATIBLE_TUNER_TYPES
+
     if peft_config.peft_type not in COMPATIBLE_TUNER_TYPES:
         raise ValueError(
             f"The provided `peft_type` '{peft_config.peft_type.value}' is not compatible with the `PeftMixedModel`. "
@@ -440,7 +424,7 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
                 Additional keyword arguments passed along to the specific PEFT configuration class.
         """
         # note: adapted from PeftModel.from_pretrained
-        from .mapping import PEFT_TYPE_TO_CONFIG_MAPPING
+        from .mapping import PEFT_TYPE_TO_CONFIG_MAPPING, PEFT_TYPE_TO_MIXED_MODEL_MAPPING
 
         # load the config
         if config is None:
@@ -459,7 +443,7 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
             raise ValueError(f"The input config must be a PeftConfig, got {config.__class__}")
 
         # note: this is different from PeftModel.from_pretrained
-        if config.peft_type not in PEFT_TYPE_TO_MODEL_MAPPING:
+        if config.peft_type not in PEFT_TYPE_TO_MIXED_MODEL_MAPPING:
             raise ValueError(f"Adapter of type {config.peft_type} is not supported for mixed models.")
 
         if (getattr(model, "hf_device_map", None) is not None) and len(

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -27,6 +27,7 @@ from peft.utils.constants import DUMMY_MODEL_CONFIG
 
 from .config import PeftConfig
 from .peft_model import PeftModel
+from .tuners import MixedModel
 from .utils import _set_adapter, _set_trainable
 
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -43,26 +43,11 @@ from peft.utils.constants import DUMMY_MODEL_CONFIG, PEFT_TYPE_TO_PREFIX_MAPPING
 from . import __version__
 from .config import PeftConfig
 from .tuners import (
-    AdaLoraModel,
-    AdaptionPromptModel,
-    BOFTModel,
-    BoneModel,
     CPTEmbedding,
-    FourierFTModel,
-    HRAModel,
-    IA3Model,
-    LNTuningModel,
-    LoHaModel,
-    LoKrModel,
-    LoraModel,
     MultitaskPromptEmbedding,
-    OFTModel,
-    PolyModel,
     PrefixEncoder,
     PromptEmbedding,
     PromptEncoder,
-    VBLoRAModel,
-    VeraModel,
     XLoraConfig,
     XLoraModel,
 )
@@ -85,30 +70,6 @@ from .utils import (
     set_peft_model_state_dict,
     shift_tokens_right,
 )
-
-
-PEFT_TYPE_TO_MODEL_MAPPING = {
-    PeftType.LORA: LoraModel,
-    PeftType.LOHA: LoHaModel,
-    PeftType.LOKR: LoKrModel,
-    PeftType.PROMPT_TUNING: PromptEmbedding,
-    PeftType.P_TUNING: PromptEncoder,
-    PeftType.PREFIX_TUNING: PrefixEncoder,
-    PeftType.ADALORA: AdaLoraModel,
-    PeftType.BOFT: BOFTModel,
-    PeftType.ADAPTION_PROMPT: AdaptionPromptModel,
-    PeftType.IA3: IA3Model,
-    PeftType.OFT: OFTModel,
-    PeftType.POLY: PolyModel,
-    PeftType.LN_TUNING: LNTuningModel,
-    PeftType.VERA: VeraModel,
-    PeftType.FOURIERFT: FourierFTModel,
-    PeftType.XLORA: XLoraModel,
-    PeftType.HRA: HRAModel,
-    PeftType.VBLORA: VBLoRAModel,
-    PeftType.CPT: CPTEmbedding,
-    PeftType.BONE: BoneModel,
-}
 
 
 class PeftModel(PushToHubMixin, torch.nn.Module):
@@ -170,7 +131,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             self.add_adapter(adapter_name, peft_config, low_cpu_mem_usage=low_cpu_mem_usage)
         else:
             self._peft_config = None
-            cls = PEFT_TYPE_TO_MODEL_MAPPING[peft_config.peft_type]
+            cls = PEFT_TYPE_TO_TUNER_MAPPING[peft_config.peft_type]
             ctx = init_empty_weights if low_cpu_mem_usage else nullcontext
             with ctx():
                 self.base_model = cls(model, {adapter_name: peft_config}, adapter_name)

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -38,11 +38,12 @@ from transformers import Cache, DynamicCache, EncoderDecoderCache, PreTrainedMod
 from transformers.modeling_outputs import QuestionAnsweringModelOutput, SequenceClassifierOutput, TokenClassifierOutput
 from transformers.utils import PushToHubMixin
 
-from peft.utils.constants import DUMMY_MODEL_CONFIG
 from peft.tuners.tuners_utils import BaseTuner, BaseTunerLayer
+from peft.utils.constants import DUMMY_MODEL_CONFIG
+
 from . import __version__
 from .config import PeftConfig
-from .mapping import PEFT_TYPE_TO_CONFIG_MAPPING, PEFT_TYPE_TO_TUNER_MAPPING, PEFT_TYPE_TO_PREFIX_MAPPING
+from .mapping import PEFT_TYPE_TO_CONFIG_MAPPING, PEFT_TYPE_TO_PREFIX_MAPPING, PEFT_TYPE_TO_TUNER_MAPPING
 from .utils import (
     SAFETENSORS_WEIGHTS_NAME,
     TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING,
@@ -1736,9 +1737,7 @@ class PeftModelForCausalLM(PeftModel):
             inputs_embeds = torch.cat((prompts, inputs_embeds), dim=1)
             return self.base_model(inputs_embeds=inputs_embeds, **kwargs)
 
-    def _cpt_forward(
-        self, input_ids, inputs_embeds, peft_config, task_ids, batch_size, **kwargs
-    ):
+    def _cpt_forward(self, input_ids, inputs_embeds, peft_config, task_ids, batch_size, **kwargs):
         # Extract labels from kwargs
         labels = kwargs.pop("labels")
         device = [i.device for i in [input_ids, inputs_embeds, labels] if i is not None][0]

--- a/src/peft/tuners/adalora/__init__.py
+++ b/src/peft/tuners/adalora/__init__.py
@@ -24,7 +24,9 @@ from .model import AdaLoraModel
 __all__ = ["AdaLoraConfig", "AdaLoraLayer", "AdaLoraModel", "SVDLinear", "RankAllocator", "SVDQuantLinear"]
 
 
-register_peft_method(name="adalora", config_cls=AdaLoraConfig, model_cls=AdaLoraModel, prefix="lora_", is_mixed_compatible=True)
+register_peft_method(
+    name="adalora", config_cls=AdaLoraConfig, model_cls=AdaLoraModel, prefix="lora_", is_mixed_compatible=True
+)
 
 
 def __getattr__(name):

--- a/src/peft/tuners/adalora/__init__.py
+++ b/src/peft/tuners/adalora/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
+from peft.utils import register_peft_method
 
 from .config import AdaLoraConfig
 from .gptq import SVDQuantLinear
@@ -21,6 +22,9 @@ from .model import AdaLoraModel
 
 
 __all__ = ["AdaLoraConfig", "AdaLoraLayer", "AdaLoraModel", "SVDLinear", "RankAllocator", "SVDQuantLinear"]
+
+
+register_peft_method(name="adalora", config_cls=AdaLoraConfig, model_cls=AdaLoraModel, prefix="lora_", is_mixed_compatible=True)
 
 
 def __getattr__(name):

--- a/src/peft/tuners/adaption_prompt/__init__.py
+++ b/src/peft/tuners/adaption_prompt/__init__.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from peft.utils import register_peft_method
+
 from .config import AdaptionPromptConfig
 from .layer import AdaptedAttention
 from .model import AdaptionPromptModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["AdaptionPromptConfig", "AdaptedAttention", "AdaptionPromptModel"]

--- a/src/peft/tuners/adaption_prompt/__init__.py
+++ b/src/peft/tuners/adaption_prompt/__init__.py
@@ -15,5 +15,9 @@ from .config import AdaptionPromptConfig
 from .layer import AdaptedAttention
 from .model import AdaptionPromptModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["AdaptionPromptConfig", "AdaptedAttention", "AdaptionPromptModel"]
+
+register_peft_method(name="adaption_prompt", config_cls=AdaptionPromptConfig, model_cls=AdaptionPromptModel)

--- a/src/peft/tuners/boft/__init__.py
+++ b/src/peft/tuners/boft/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import BOFTConfig
 from .layer import BOFTLayer
 from .model import BOFTModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["BOFTConfig", "BOFTLayer", "BOFTModel"]

--- a/src/peft/tuners/boft/__init__.py
+++ b/src/peft/tuners/boft/__init__.py
@@ -16,5 +16,9 @@ from .config import BOFTConfig
 from .layer import BOFTLayer
 from .model import BOFTModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["BOFTConfig", "BOFTLayer", "BOFTModel"]
+
+register_peft_method(name="boft", config_cls=BOFTConfig, model_cls=BOFTModel)

--- a/src/peft/tuners/bone/__init__.py
+++ b/src/peft/tuners/bone/__init__.py
@@ -16,5 +16,9 @@ from .config import BoneConfig
 from .layer import BoneLayer, BoneLinear
 from .model import BoneModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["BoneConfig", "BoneModel", "BoneLinear", "BoneLayer"]
+
+register_peft_method(name="bone", config_cls=BoneConfig, model_cls=BoneModel)

--- a/src/peft/tuners/bone/__init__.py
+++ b/src/peft/tuners/bone/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import BoneConfig
 from .layer import BoneLayer, BoneLinear
 from .model import BoneModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["BoneConfig", "BoneModel", "BoneLinear", "BoneLayer"]

--- a/src/peft/tuners/cpt/__init__.py
+++ b/src/peft/tuners/cpt/__init__.py
@@ -16,5 +16,9 @@
 from .config import CPTConfig
 from .model import CPTEmbedding
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["CPTConfig", "CPTEmbedding"]
+
+register_peft_method(name="cpt", config_cls=CPTConfig, model_cls=CPTEmbedding)

--- a/src/peft/tuners/cpt/__init__.py
+++ b/src/peft/tuners/cpt/__init__.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 
+from peft.utils import register_peft_method
+
 from .config import CPTConfig
 from .model import CPTEmbedding
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["CPTConfig", "CPTEmbedding"]

--- a/src/peft/tuners/fourierft/__init__.py
+++ b/src/peft/tuners/fourierft/__init__.py
@@ -16,5 +16,9 @@ from .config import FourierFTConfig
 from .layer import FourierFTLayer, FourierFTLinear
 from .model import FourierFTModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["FourierFTConfig", "FourierFTLayer", "FourierFTLinear", "FourierFTModel"]
+
+register_peft_method(name="fourierft", model_cls=FourierFTModel, config_cls=FourierFTConfig)

--- a/src/peft/tuners/fourierft/__init__.py
+++ b/src/peft/tuners/fourierft/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import FourierFTConfig
 from .layer import FourierFTLayer, FourierFTLinear
 from .model import FourierFTModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["FourierFTConfig", "FourierFTLayer", "FourierFTLinear", "FourierFTModel"]

--- a/src/peft/tuners/hra/__init__.py
+++ b/src/peft/tuners/hra/__init__.py
@@ -16,5 +16,9 @@ from .config import HRAConfig
 from .layer import HRAConv2d, HRALayer, HRALinear
 from .model import HRAModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["HRAConfig", "HRAModel", "HRAConv2d", "HRALinear", "HRALayer"]
+
+register_peft_method(name="hra", config_cls=HRAConfig, model_cls=HRAModel)

--- a/src/peft/tuners/hra/__init__.py
+++ b/src/peft/tuners/hra/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import HRAConfig
 from .layer import HRAConv2d, HRALayer, HRALinear
 from .model import HRAModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["HRAConfig", "HRAModel", "HRAConv2d", "HRALinear", "HRALayer"]

--- a/src/peft/tuners/ia3/__init__.py
+++ b/src/peft/tuners/ia3/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
+from peft.utils import register_peft_method
 
 from .config import IA3Config
 from .layer import Conv2d, Conv3d, IA3Layer, Linear
@@ -20,6 +21,8 @@ from .model import IA3Model
 
 
 __all__ = ["Conv2d", "Conv3d", "IA3Config", "IA3Layer", "IA3Model", "Linear"]
+
+register_peft_method(name="ia3", config_cls=IA3Config, model_cls=IA3Model, is_mixed_compatible=True)
 
 
 def __getattr__(name):

--- a/src/peft/tuners/ln_tuning/__init__.py
+++ b/src/peft/tuners/ln_tuning/__init__.py
@@ -15,5 +15,8 @@
 from .config import LNTuningConfig
 from .model import LNTuningModel
 
+from peft.utils import register_peft_method
 
 __all__ = ["LNTuningConfig", "LNTuningModel"]
+
+register_peft_method(name="ln_tuning", config_cls=LNTuningConfig, model_cls=LNTuningModel)

--- a/src/peft/tuners/ln_tuning/__init__.py
+++ b/src/peft/tuners/ln_tuning/__init__.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import LNTuningConfig
 from .model import LNTuningModel
 
-from peft.utils import register_peft_method
 
 __all__ = ["LNTuningConfig", "LNTuningModel"]
 

--- a/src/peft/tuners/loha/__init__.py
+++ b/src/peft/tuners/loha/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import LoHaConfig
 from .layer import Conv2d, Linear, LoHaLayer
 from .model import LoHaModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["LoHaConfig", "LoHaModel", "Conv2d", "Linear", "LoHaLayer"]

--- a/src/peft/tuners/loha/__init__.py
+++ b/src/peft/tuners/loha/__init__.py
@@ -16,5 +16,9 @@ from .config import LoHaConfig
 from .layer import Conv2d, Linear, LoHaLayer
 from .model import LoHaModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["LoHaConfig", "LoHaModel", "Conv2d", "Linear", "LoHaLayer"]
+
+register_peft_method(name="loha", config_cls=LoHaConfig, model_cls=LoHaModel, prefix="hada_", is_mixed_compatible=True)

--- a/src/peft/tuners/lokr/__init__.py
+++ b/src/peft/tuners/lokr/__init__.py
@@ -16,5 +16,9 @@ from .config import LoKrConfig
 from .layer import Conv2d, Linear, LoKrLayer
 from .model import LoKrModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["LoKrConfig", "LoKrModel", "Conv2d", "Linear", "LoKrLayer"]
+
+register_peft_method(name="lokr", config_cls=LoKrConfig, model_cls=LoKrModel, is_mixed_compatible=True)

--- a/src/peft/tuners/lokr/__init__.py
+++ b/src/peft/tuners/lokr/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import LoKrConfig
 from .layer import Conv2d, Linear, LoKrLayer
 from .model import LoKrModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["LoKrConfig", "LoKrModel", "Conv2d", "Linear", "LoKrLayer"]

--- a/src/peft/tuners/lora/__init__.py
+++ b/src/peft/tuners/lora/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available, is_eetq_available
+from peft.utils import register_peft_method
 
 from .config import EvaConfig, LoftQConfig, LoraConfig, LoraRuntimeConfig
 from .eva import get_eva_state_dict, initialize_lora_eva_weights
@@ -36,6 +37,8 @@ __all__ = [
     "get_eva_state_dict",
     "initialize_lora_eva_weights",
 ]
+
+register_peft_method(name="lora", config_cls=LoraConfig, model_cls=LoraModel, is_mixed_compatible=True)
 
 
 def __getattr__(name):

--- a/src/peft/tuners/multitask_prompt_tuning/__init__.py
+++ b/src/peft/tuners/multitask_prompt_tuning/__init__.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import MultitaskPromptTuningConfig, MultitaskPromptTuningInit
 from .model import MultitaskPromptEmbedding
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["MultitaskPromptTuningConfig", "MultitaskPromptTuningInit", "MultitaskPromptEmbedding"]
 
-register_peft_method(name="multitask_prompt_tuning", config_cls=MultitaskPromptTuningConfig, model_cls=MultitaskPromptEmbedding)
+register_peft_method(
+    name="multitask_prompt_tuning", config_cls=MultitaskPromptTuningConfig, model_cls=MultitaskPromptEmbedding
+)

--- a/src/peft/tuners/multitask_prompt_tuning/__init__.py
+++ b/src/peft/tuners/multitask_prompt_tuning/__init__.py
@@ -15,5 +15,9 @@
 from .config import MultitaskPromptTuningConfig, MultitaskPromptTuningInit
 from .model import MultitaskPromptEmbedding
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["MultitaskPromptTuningConfig", "MultitaskPromptTuningInit", "MultitaskPromptEmbedding"]
+
+register_peft_method(name="multitask_prompt_tuning", config_cls=MultitaskPromptTuningConfig, model_cls=MultitaskPromptEmbedding)

--- a/src/peft/tuners/oft/__init__.py
+++ b/src/peft/tuners/oft/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import OFTConfig
 from .layer import Conv2d, Linear, OFTLayer
 from .model import OFTModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["OFTConfig", "OFTModel", "Conv2d", "Linear", "OFTLayer"]

--- a/src/peft/tuners/oft/__init__.py
+++ b/src/peft/tuners/oft/__init__.py
@@ -16,5 +16,9 @@ from .config import OFTConfig
 from .layer import Conv2d, Linear, OFTLayer
 from .model import OFTModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["OFTConfig", "OFTModel", "Conv2d", "Linear", "OFTLayer"]
+
+register_peft_method(name="oft", config_cls=OFTConfig, model_cls=OFTModel)

--- a/src/peft/tuners/p_tuning/__init__.py
+++ b/src/peft/tuners/p_tuning/__init__.py
@@ -15,5 +15,9 @@
 from .config import PromptEncoderConfig, PromptEncoderReparameterizationType
 from .model import PromptEncoder
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["PromptEncoder", "PromptEncoderConfig", "PromptEncoderReparameterizationType"]
+
+register_peft_method(name="p_tuning", config_cls=PromptEncoderConfig, model_cls=PromptEncoder)

--- a/src/peft/tuners/p_tuning/__init__.py
+++ b/src/peft/tuners/p_tuning/__init__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import PromptEncoderConfig, PromptEncoderReparameterizationType
 from .model import PromptEncoder
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["PromptEncoder", "PromptEncoderConfig", "PromptEncoderReparameterizationType"]

--- a/src/peft/tuners/poly/__init__.py
+++ b/src/peft/tuners/poly/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import PolyConfig
 from .layer import Linear, PolyLayer
 from .model import PolyModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["Linear", "PolyConfig", "PolyLayer", "PolyModel"]

--- a/src/peft/tuners/poly/__init__.py
+++ b/src/peft/tuners/poly/__init__.py
@@ -16,5 +16,9 @@ from .config import PolyConfig
 from .layer import Linear, PolyLayer
 from .model import PolyModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["Linear", "PolyConfig", "PolyLayer", "PolyModel"]
+
+register_peft_method(name="poly", config_cls=PolyConfig, model_cls=PolyModel)

--- a/src/peft/tuners/prefix_tuning/__init__.py
+++ b/src/peft/tuners/prefix_tuning/__init__.py
@@ -15,5 +15,9 @@
 from .config import PrefixTuningConfig
 from .model import PrefixEncoder
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["PrefixTuningConfig", "PrefixEncoder"]
+
+register_peft_method(name="prefix_tuning", config_cls=PrefixTuningConfig, model_cls=PrefixEncoder)

--- a/src/peft/tuners/prefix_tuning/__init__.py
+++ b/src/peft/tuners/prefix_tuning/__init__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import PrefixTuningConfig
 from .model import PrefixEncoder
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["PrefixTuningConfig", "PrefixEncoder"]

--- a/src/peft/tuners/prompt_tuning/__init__.py
+++ b/src/peft/tuners/prompt_tuning/__init__.py
@@ -15,5 +15,9 @@
 from .config import PromptTuningConfig, PromptTuningInit
 from .model import PromptEmbedding
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["PromptTuningConfig", "PromptEmbedding", "PromptTuningInit"]
+
+register_peft_method(name="prompt_tuning", config_cls=PromptTuningConfig, model_cls=PromptEmbedding)

--- a/src/peft/tuners/prompt_tuning/__init__.py
+++ b/src/peft/tuners/prompt_tuning/__init__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import PromptTuningConfig, PromptTuningInit
 from .model import PromptEmbedding
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["PromptTuningConfig", "PromptEmbedding", "PromptTuningInit"]

--- a/src/peft/tuners/vblora/__init__.py
+++ b/src/peft/tuners/vblora/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import VBLoRAConfig
 from .layer import Linear, VBLoRALayer
 from .model import VBLoRAModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["VBLoRAConfig", "VBLoRALayer", "Linear", "VBLoRAModel"]

--- a/src/peft/tuners/vblora/__init__.py
+++ b/src/peft/tuners/vblora/__init__.py
@@ -16,5 +16,9 @@ from .config import VBLoRAConfig
 from .layer import Linear, VBLoRALayer
 from .model import VBLoRAModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["VBLoRAConfig", "VBLoRALayer", "Linear", "VBLoRAModel"]
+
+register_peft_method(name="vblora", config_cls=VBLoRAConfig, model_cls=VBLoRAModel)

--- a/src/peft/tuners/vera/__init__.py
+++ b/src/peft/tuners/vera/__init__.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available
+from peft.utils import register_peft_method
 
 from .config import VeraConfig
 from .layer import Linear, VeraLayer
 from .model import VeraModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["VeraConfig", "VeraLayer", "Linear", "VeraModel"]

--- a/src/peft/tuners/vera/__init__.py
+++ b/src/peft/tuners/vera/__init__.py
@@ -18,8 +18,13 @@ from .config import VeraConfig
 from .layer import Linear, VeraLayer
 from .model import VeraModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["VeraConfig", "VeraLayer", "Linear", "VeraModel"]
+
+
+register_peft_method(name="vera", config_cls=VeraConfig, model_cls=VeraModel, prefix="vera_lambda_")
 
 
 def __getattr__(name):

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -99,7 +99,7 @@ class VeraModel(BaseTuner):
         - **peft_config** ([`VeraConfig`]): The configuration of the Vera model.
     """
 
-    prefix: str = "vera_lambda"
+    prefix: str = "vera_lambda_"
 
     def __init__(self, model, config, adapter_name, low_cpu_mem_usage: bool = False) -> None:
         super().__init__(model, config, adapter_name, low_cpu_mem_usage=low_cpu_mem_usage)

--- a/src/peft/tuners/xlora/__init__.py
+++ b/src/peft/tuners/xlora/__init__.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from peft.utils import register_peft_method
+
 from .config import XLoraConfig
 from .model import XLoraModel
-
-from peft.utils import register_peft_method
 
 
 __all__ = ["XLoraConfig", "XLoraModel"]

--- a/src/peft/tuners/xlora/__init__.py
+++ b/src/peft/tuners/xlora/__init__.py
@@ -15,5 +15,9 @@
 from .config import XLoraConfig
 from .model import XLoraModel
 
+from peft.utils import register_peft_method
+
 
 __all__ = ["XLoraConfig", "XLoraModel"]
+
+register_peft_method(name="xlora", config_cls=XLoraConfig, model_cls=XLoraModel)

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -14,7 +14,7 @@
 
 from .integrations import map_cache_to_layer_device_map  # noqa: I001
 from .loftq_utils import replace_lora_weights_loftq
-from .peft_types import PeftType, TaskType
+from .peft_types import PeftType, TaskType, register_peft_method
 from .other import (
     TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING,
     TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING,
@@ -83,6 +83,7 @@ __all__ = [
     "load_peft_weights",
     "map_cache_to_layer_device_map",
     "prepare_model_for_kbit_training",
+    "register_peft_method",
     "replace_lora_weights_loftq",
     "set_peft_model_state_dict",
     "shift_tokens_right",

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -15,8 +15,6 @@
 import torch
 from transformers import BloomPreTrainedModel
 
-from .peft_types import PeftType
-
 
 # needed for prefix-tuning of bloom model
 def bloom_model_postprocess_past_key_value(past_key_values):

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -300,7 +300,6 @@ PEFT_TYPE_TO_PREFIX_MAPPING = {
     PeftType.FOURIERFT: "fourierft_",
     PeftType.HRA: "hra_",
     PeftType.VBLORA: "vblora_",
-    PeftType.BONE: "bone_",
 }
 
 WEIGHTS_NAME = "adapter_model.bin"

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -286,22 +286,6 @@ TRANSFORMERS_MODELS_TO_VBLORA_TARGET_MODULES_MAPPING = {
     "qwen2": ["q_proj", "v_proj"],
 }
 
-PEFT_TYPE_TO_PREFIX_MAPPING = {
-    PeftType.IA3: "ia3_",
-    PeftType.LORA: "lora_",
-    PeftType.ADALORA: "lora_",
-    PeftType.LOHA: "hada_",
-    PeftType.LOKR: "lokr_",
-    PeftType.OFT: "oft_",
-    PeftType.POLY: "poly_",
-    PeftType.BOFT: "boft_",
-    PeftType.LN_TUNING: "ln_tuning_",
-    PeftType.VERA: "vera_lambda_",
-    PeftType.FOURIERFT: "fourierft_",
-    PeftType.HRA: "hra_",
-    PeftType.VBLORA: "vblora_",
-}
-
 WEIGHTS_NAME = "adapter_model.bin"
 SAFETENSORS_WEIGHTS_NAME = "adapter_model.safetensors"
 CONFIG_NAME = "adapter_config.json"

--- a/src/peft/utils/peft_types.py
+++ b/src/peft/utils/peft_types.py
@@ -116,7 +116,7 @@ def register_peft_method(*, name: str, config_cls, model_cls, prefix: Optional[s
     if (model_cls_prefix is not None) and (model_cls_prefix != prefix):
         raise ValueError(f"Inconsistent prefixes found: '{prefix}' and '{model_cls_prefix}' (they should be the same).")
 
-    PEFT_TYPE_TO_PREFIX_MAPPING[peft_type] = name
+    PEFT_TYPE_TO_PREFIX_MAPPING[peft_type] = prefix
     PEFT_TYPE_TO_CONFIG_MAPPING[peft_type] = config_cls
     PEFT_TYPE_TO_TUNER_MAPPING[peft_type] = model_cls
     if is_mixed_compatible:

--- a/src/peft/utils/peft_types.py
+++ b/src/peft/utils/peft_types.py
@@ -84,3 +84,34 @@ class TaskType(str, enum.Enum):
     TOKEN_CLS = "TOKEN_CLS"
     QUESTION_ANS = "QUESTION_ANS"
     FEATURE_EXTRACTION = "FEATURE_EXTRACTION"
+
+
+def register_peft_method(*, name, config_cls, model_cls=None) -> None:
+    """TODO"""
+    from peft.mapping import PEFT_TYPE_TO_CONFIG_MAPPING, PEFT_TYPE_TO_TUNER_MAPPING
+    from peft.utils.constants import PEFT_TYPE_TO_PREFIX_MAPPING
+
+    if name.endswith("_"):
+        raise ValueError(f"Please pass the name of the PEFT method without '_' suffix, got {name}.")
+
+    if not name.islower():
+        raise ValueError(f"The name of the PEFT method should be in lower case letters, got {name}.")
+
+    if name.upper() not in list(PeftType):
+        raise ValueError(f"Unknown PEFT type {name.upper()}, please add an entry to peft.utils.peft_types.PeftType.")
+
+    peft_type = getattr(PeftType, name.upper())
+
+    # model_cls can be None for prompt learning methods, which don't have dedicated model classes
+    if model_cls:
+
+        if model_cls.prefix != name + "_":
+            raise ValueError(
+                f"Inconsistent names: The method is called '{name}' but the prefix is called {model_cls.prefix} "
+                "(they should be the same, except that the prefix ends with an '_')"
+            )
+
+    PEFT_TYPE_TO_PREFIX_MAPPING[peft_type] = name
+    PEFT_TYPE_TO_CONFIG_MAPPING[peft_type] = config_cls
+    if model_cls:
+        PEFT_TYPE_TO_TUNER_MAPPING[peft_type] = model_cls

--- a/src/peft/utils/peft_types.py
+++ b/src/peft/utils/peft_types.py
@@ -87,9 +87,16 @@ class TaskType(str, enum.Enum):
     FEATURE_EXTRACTION = "FEATURE_EXTRACTION"
 
 
-def register_peft_method(*, name: str, config_cls, model_cls, prefix: Optional[str] = None, is_mixed_compatible=False) -> None:
+def register_peft_method(
+    *, name: str, config_cls, model_cls, prefix: Optional[str] = None, is_mixed_compatible=False
+) -> None:
     """TODO"""
-    from peft.mapping import PEFT_TYPE_TO_CONFIG_MAPPING, PEFT_TYPE_TO_MIXED_MODEL_MAPPING, PEFT_TYPE_TO_TUNER_MAPPING, PEFT_TYPE_TO_PREFIX_MAPPING
+    from peft.mapping import (
+        PEFT_TYPE_TO_CONFIG_MAPPING,
+        PEFT_TYPE_TO_MIXED_MODEL_MAPPING,
+        PEFT_TYPE_TO_PREFIX_MAPPING,
+        PEFT_TYPE_TO_TUNER_MAPPING,
+    )
 
     if name.endswith("_"):
         raise ValueError(f"Please pass the name of the PEFT method without '_' suffix, got {name}.")
@@ -106,7 +113,11 @@ def register_peft_method(*, name: str, config_cls, model_cls, prefix: Optional[s
     if prefix is None:
         prefix = name + "_"
 
-    if (peft_type in PEFT_TYPE_TO_CONFIG_MAPPING) or (peft_type in PEFT_TYPE_TO_TUNER_MAPPING) or (peft_type in PEFT_TYPE_TO_MIXED_MODEL_MAPPING):
+    if (
+        (peft_type in PEFT_TYPE_TO_CONFIG_MAPPING)
+        or (peft_type in PEFT_TYPE_TO_TUNER_MAPPING)
+        or (peft_type in PEFT_TYPE_TO_MIXED_MODEL_MAPPING)
+    ):
         raise KeyError(f"There is already PEFT method called '{name}', please choose a unique name.")
 
     if prefix in PEFT_TYPE_TO_PREFIX_MAPPING:
@@ -114,7 +125,9 @@ def register_peft_method(*, name: str, config_cls, model_cls, prefix: Optional[s
 
     model_cls_prefix = getattr(model_cls, "prefix", None)
     if (model_cls_prefix is not None) and (model_cls_prefix != prefix):
-        raise ValueError(f"Inconsistent prefixes found: '{prefix}' and '{model_cls_prefix}' (they should be the same).")
+        raise ValueError(
+            f"Inconsistent prefixes found: '{prefix}' and '{model_cls_prefix}' (they should be the same)."
+        )
 
     PEFT_TYPE_TO_PREFIX_MAPPING[peft_type] = prefix
     PEFT_TYPE_TO_CONFIG_MAPPING[peft_type] = config_cls

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -208,7 +208,7 @@ def get_peft_model_state_dict(
         to_return["base_model.vblora_vector_bank." + adapter_name] = state_dict[
             "base_model.vblora_vector_bank." + adapter_name
         ]
-    elif config.peft_type == PeftType.BONE:
+    elif config.peft_type in list(PeftType):
         to_return = {k: state_dict[k] for k in state_dict if "bone_" in k}
     else:
         raise ValueError(f"Unknown PEFT type passed: {config.peft_type}")

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -24,7 +24,8 @@ from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
 from packaging import version
 from safetensors.torch import load_file as safe_load_file
 
-from .constants import PEFT_TYPE_TO_PREFIX_MAPPING
+from peft.mapping import PEFT_TYPE_TO_PREFIX_MAPPING
+
 from .other import (
     EMBEDDING_LAYER_NAMES,
     SAFETENSORS_WEIGHTS_NAME,
@@ -133,12 +134,6 @@ def get_peft_model_state_dict(
         else:
             raise NotImplementedError
 
-    elif config.peft_type == PeftType.LOHA:
-        to_return = {k: state_dict[k] for k in state_dict if "hada_" in k}
-
-    elif config.peft_type == PeftType.LOKR:
-        to_return = {k: state_dict[k] for k in state_dict if "lokr_" in k}
-
     elif config.peft_type == PeftType.ADAPTION_PROMPT:
         to_return = {k: state_dict[k] for k in state_dict if k.split(".")[-1].startswith("adaption_")}
 
@@ -155,18 +150,6 @@ def get_peft_model_state_dict(
                 prompt_embeddings = model.get_prompt_embedding_to_save(adapter_name)
         to_return["prompt_embeddings"] = prompt_embeddings
 
-    elif config.peft_type == PeftType.IA3:
-        to_return = {k: state_dict[k] for k in state_dict if "ia3_" in k}
-
-    elif config.peft_type == PeftType.OFT:
-        to_return = {k: state_dict[k] for k in state_dict if "oft_" in k}
-
-    elif config.peft_type == PeftType.POLY:
-        to_return = {k: state_dict[k] for k in state_dict if "poly_" in k}
-
-    elif config.peft_type == PeftType.LN_TUNING:
-        to_return = {k: state_dict[k] for k in state_dict if "ln_tuning_" in k}
-
     elif config.peft_type == PeftType.VERA:
         to_return = {k: state_dict[k] for k in state_dict if "vera_lambda_" in k}
         if config.save_projection:
@@ -179,12 +162,8 @@ def get_peft_model_state_dict(
                 )
             to_return["base_model.vera_A." + adapter_name] = state_dict["base_model.vera_A." + adapter_name]
             to_return["base_model.vera_B." + adapter_name] = state_dict["base_model.vera_B." + adapter_name]
-    elif config.peft_type == PeftType.FOURIERFT:
-        to_return = {k: state_dict[k] for k in state_dict if "fourierft_" in k}
     elif config.peft_type == PeftType.XLORA:
         to_return = {k: state_dict[k] for k in state_dict if "internal_xlora_classifier" in k}
-    elif config.peft_type == PeftType.HRA:
-        to_return = {k: state_dict[k] for k in state_dict if "hra_" in k}
     elif config.peft_type == PeftType.VBLORA:
         to_return = {}
         # choose the most efficient dtype for indices
@@ -209,7 +188,7 @@ def get_peft_model_state_dict(
             "base_model.vblora_vector_bank." + adapter_name
         ]
     elif config.peft_type in list(PeftType):
-        to_return = {k: state_dict[k] for k in state_dict if "bone_" in k}
+        to_return = {k: state_dict[k] for k in state_dict if PEFT_TYPE_TO_PREFIX_MAPPING[config.peft_type] in k}
     else:
         raise ValueError(f"Unknown PEFT type passed: {config.peft_type}")
 


### PR DESCRIPTION
This is a refactor of how new PEFT methods are _registered_. It got bigger than I initially expected.

## Goal

The goal of this refactor is the following: Right now, when a new PEFT method is added, a new directory is created in `src/peft/tuners/<name>` with a config, model, etc. This is fine and self-contained.

However, in addition to that, a couple of other places in the PEFT code base need to be touched for this new PEFT method to become usable.

As an example, take the recently added Bone method (#2172). Ignoring tests, docs, and examples, we have the additions to `src/peft/tuners/bone`, but also need to:

1. Add an entry to `PEFT_TYPE_TO_CONFIG_MAPPING` in `mapping.py`.
2. Add an entry to `PEFT_TYPE_TO_TUNER_MAPPING` in `mapping.py`.
3. Add an entry to `PEFT_TYPE_TO_MODEL_MAPPING` in `peft_model.py`
4. Add an entry to `PEFT_TYPE_TO_PREFIX_MAPPING` in `utils/constants.py`
5. Add some code to `get_peft_model_state_dict`in `utils.save_and_load.py`

With the changes in this PR, all these steps can be omitted.

On top of that, we also have the re-imports to `peft/__init__.py` and `peft/tuners/__init__.py` but those are still required (I'm hesitant to mess with the import system). Furthermore, it's still required to add an entry to `PeftType` in `utils.peft_types.py`. Since this is an `enum`, it can't be easily generated automatically. Therefore, adding a new PEFT method is still not 100% self-contained.

## Changes in this PR

With this PR, less book-keeping is required. Instead of the 5 steps described above, contributors now only need to call

```python
# example for the Bone method
register_peft_method(name="bone", config_cls=BoneConfig, model_cls=BoneModel)
```

in the `__init__.py` of their PEFT method. In addition to registering the method, this also performs a couple of sanity checks (e.g. no duplicate names, method name and method prefix being identical).

Moreover, since so much book keeping is removed, this PR reduces the number of lines of code overall (at the moment +317, - 343).

## Implementation

The real difficulty of this task is that the module structure in PEFT is really messy, easily resulting in circular imports. This has been an issue in the past but has been especially painful here. For this reason, some stuff had to be moved around:

- `MODEL_TYPE_TO_PEFT_MODEL_MAPPING` is now in `auto.py` instead of `mapping.py`
- `PEFT_TYPE_TO_PREFIX_MAPPING` has been moved to `mapping.py` from `constants.py`
- `get_peft_model` had to be moved out of `mapping.py` and is now in its own module, `func.py` (better name suggestions welcome). This should be safe, as the function is re-imported to the main PEFT namespace, which all examples use.

The `PEFT_TYPE_TO_MODEL_MAPPING` dict could be completely removed, as it was basically redundant with `PEFT_TYPE_TO_TUNER_MAPPING`. The `get_peft_model_state_dict` could be simplified, as a lot of code was almost duplicated.

Overall, I think this is a cleaner module structure, but still not very clean overall.

## Open questions

I'm not 100% sure if this should be merged. AFAICT it should be a safe refactor that does not affect user code. There could be other packages out there that use some PEFT internals that could break with this refactor. If we decide to merge this, we should consider alerting potentially affected packages to test it.

I'm also open to the argument that the benefits are not outweighing the cost of the refactor.