### PR TITLE
add resize_token_embeddings

### DIFF
--- a/docs/source/developer_guides/model_merging.md
+++ b/docs/source/developer_guides/model_merging.md
@@ -50,6 +50,9 @@ config = PeftConfig.from_pretrained("smangrul/tinyllama_lora_norobots")
 model = AutoModelForCausalLM.from_pretrained(config.base_model_name_or_path, load_in_4bit=True, device_map="auto").eval()
 tokenizer = AutoTokenizer.from_pretrained("smangrul/tinyllama_lora_norobots")
 
+model.config.vocab_size = 32005
+model.resize_token_embeddings(32005)
+
 model = PeftModel.from_pretrained(model, "smangrul/tinyllama_lora_norobots", adapter_name="norobots")
 _ = model.load_adapter("smangrul/tinyllama_lora_sql", adapter_name="sql")
 _ = model.load_adapter("smangrul/tinyllama_lora_adcopy", adapter_name="adcopy")


### PR DESCRIPTION
This may not be the best modification, but the previous code couldn't run directly. The following code needs to be added for it to work, otherwise, the following error would occur:

`
Traceback (most recent call last):
  File "/workspace/wubing/titan/scripts/leaderboard/lora/merge_loras_peft_example.py", line 13, in <module>
    model = PeftModel.from_pretrained(model, "smangrul/tinyllama_lora_norobots", adapter_name="norobots")
  File "/workspace/wubing/anaconda3/envs/titan/lib/python3.10/site-packages/peft/peft_model.py", line 581, in from_pretrained
    load_result = model.load_adapter(
  File "/workspace/wubing/anaconda3/envs/titan/lib/python3.10/site-packages/peft/peft_model.py", line 1239, in load_adapter
    load_result = set_peft_model_state_dict(
  File "/workspace/wubing/anaconda3/envs/titan/lib/python3.10/site-packages/peft/utils/save_and_load.py", line 451, in set_peft_model_state_dict
    load_result = model.load_state_dict(peft_model_state_dict, strict=False)
  File "/workspace/wubing/anaconda3/envs/titan/lib/python3.10/site-packages/torch/nn/modules/module.py", line 2584, in load_state_dict
    raise RuntimeError(
RuntimeError: Error(s) in loading state_dict for PeftModelForCausalLM:
        size mismatch for base_model.model.model.embed_tokens.base_layer.weight: copying a param with shape torch.Size([32005, 2048]) from checkpoint, the shape in current model is torch.Size([32000, 2048]).
        size mismatch for base_model.model.model.embed_tokens.lora_embedding_A.norobots: copying a param with shape torch.Size([8, 32005]) from checkpoint, the shape in current model is torch.Size([8, 32000]).
        size mismatch for base_model.model.lm_head.base_layer.weight: copying a param with shape torch.Size([32005, 2048]) from checkpoint, the shape in current model is torch.Size([32000, 2048]).
        size mismatch for base_model.model.lm_head.lora_B.norobots.weight: copying a param with shape torch.Size([32005, 8]) from checkpoint, the shape in current model is torch.Size([32000, 8]).

`