### PR TITLE
Addeed information regarding freezing the base model in prepare_model_for_kbit_training docstring

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -99,7 +99,8 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
 
     This method wraps the entire protocol for preparing a model before running a training. This includes:
         1- Cast the layernorm in fp32 2- making output embedding layer require grads 3- Add the upcasting of the lm
-        head to fp32
+        head to fp32 4- Freezing the base model layers to ensure they are not updated during training
+
 
     Args:
         model (`transformers.PreTrainedModel`):


### PR DESCRIPTION
Related issue #2299
This PR updates the docstring of the prepare_model_for_kbit_training function to include the following improvements:

1. Added a step specifying that the base model layers are frozen during training preparation. #2299 