### PR TITLE
FIX #2295: Warn when user reloads modified model

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -31,6 +31,7 @@ from .peft_model import (
     PeftModelForSeq2SeqLM,
     PeftModelForSequenceClassification,
     PeftModelForTokenClassification,
+    get_layer_status,
 )
 from .tuners import (
     AdaLoraConfig,
@@ -180,6 +181,21 @@ def get_peft_model(
     old_name = peft_config.base_model_name_or_path
     new_name = model.__dict__.get("name_or_path", None)
     peft_config.base_model_name_or_path = new_name
+
+    # Especially in notebook environments there could be a case that a user
+    # wants to experiment with different configuration values. However, it
+    # is likely that there won't be any changes for new configs on an already
+    # initialized PEFT model. The best we can do is warn the user about it.
+    try:
+        if len(get_layer_status(model)) > 0:
+            warnings.warn(
+                "You are trying to modify a model with PEFT for a "
+                "second time. If you want to reload the model with a "
+                "different config, make sure to call `.unload()` before."
+            )
+    except ValueError:
+        # not a PEFT model or no adapters in use
+        pass
 
     if (old_name is not None) and (old_name != new_name):
         warnings.warn(

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+
+class TestGetPeftModel:
+    RELOAD_WARNING_EXPECTED_MATCH = r"You are trying to modify a model .*"
+
+    @pytest.fixture
+    def get_peft_model(self):
+        from peft import get_peft_model
+
+        return get_peft_model
+
+    @pytest.fixture
+    def lora_config(self):
+        from peft import LoraConfig
+
+        return LoraConfig(target_modules="0")
+
+    @pytest.fixture
+    def base_model(self):
+        return torch.nn.Sequential(torch.nn.Linear(10, 2))
+
+    def test_get_peft_model_warns_when_reloading_model(self, get_peft_model, lora_config, base_model):
+        get_peft_model(base_model, lora_config)
+
+        with pytest.warns(UserWarning, match=self.RELOAD_WARNING_EXPECTED_MATCH):
+            get_peft_model(base_model, lora_config)
+
+    def test_get_peft_model_proposed_fix_in_warning_help(self, get_peft_model, lora_config, base_model, recwarn):
+        peft_model = get_peft_model(base_model, lora_config)
+        peft_model.unload()
+        get_peft_model(base_model, lora_config)
+
+        warning_checker = pytest.warns(UserWarning, match=self.RELOAD_WARNING_EXPECTED_MATCH)
+
+        for warning in recwarn:
+            if warning_checker.matches(warning):
+                pytest.fail("Warning raised even though model was unloaded.")

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -27,7 +27,7 @@ class TestGetPeftModel:
         with pytest.warns(UserWarning, match=self.RELOAD_WARNING_EXPECTED_MATCH):
             get_peft_model(base_model, lora_config)
 
-    def test_get_peft_model_proposed_fix_in_warning_help(self, get_peft_model, lora_config, base_model, recwarn):
+    def test_get_peft_model_proposed_fix_in_warning_helps(self, get_peft_model, lora_config, base_model, recwarn):
         peft_model = get_peft_model(base_model, lora_config)
         peft_model.unload()
         get_peft_model(base_model, lora_config)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,15 +1,24 @@
+# Copyright 2025-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import pytest
 import torch
+
+from peft import get_peft_model
 
 
 class TestGetPeftModel:
     RELOAD_WARNING_EXPECTED_MATCH = r"You are trying to modify a model .*"
-
-    @pytest.fixture
-    def get_peft_model(self):
-        from peft import get_peft_model
-
-        return get_peft_model
 
     @pytest.fixture
     def lora_config(self):
@@ -21,13 +30,13 @@ class TestGetPeftModel:
     def base_model(self):
         return torch.nn.Sequential(torch.nn.Linear(10, 2))
 
-    def test_get_peft_model_warns_when_reloading_model(self, get_peft_model, lora_config, base_model):
+    def test_get_peft_model_warns_when_reloading_model(self, lora_config, base_model):
         get_peft_model(base_model, lora_config)
 
         with pytest.warns(UserWarning, match=self.RELOAD_WARNING_EXPECTED_MATCH):
             get_peft_model(base_model, lora_config)
 
-    def test_get_peft_model_proposed_fix_in_warning_helps(self, get_peft_model, lora_config, base_model, recwarn):
+    def test_get_peft_model_proposed_fix_in_warning_helps(self, lora_config, base_model, recwarn):
         peft_model = get_peft_model(base_model, lora_config)
         peft_model.unload()
         get_peft_model(base_model, lora_config)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -47,6 +47,7 @@ class TestGetPeftModel:
     def test_get_peft_model_repeated_invocation(self, lora_config_0, base_model):
         peft_model = get_peft_model(base_model, lora_config_0)
 
+        # use direct-addressing of the other layer to accomodate for the nested model
         lora_config_1 = LoraConfig(target_modules="base_model.model.1")
 
         with pytest.warns(UserWarning, match=self.RELOAD_WARNING_EXPECTED_MATCH):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -14,7 +14,8 @@
 import pytest
 import torch
 
-from peft import get_peft_model, LoraConfig
+from peft import LoraConfig, get_peft_model
+
 
 class TestGetPeftModel:
     RELOAD_WARNING_EXPECTED_MATCH = r"You are trying to modify a model .*"


### PR DESCRIPTION
This is a fix for https://github.com/huggingface/peft/issues/2295.

When modifying a model with `get_peft_model` that was already modified in the same way, even specifying a different config may not change the trainable parameter count, e.g. when specifying target modules that are only a subset of the previous target modules.

With this patch a warning will be issued with a hint to `.unload()` when calling `get_peft_model` on an already modified model.