### PR TITLE
Extend usage for olora finetune script

### DIFF
--- a/examples/olora_finetuning/README.md
+++ b/examples/olora_finetuning/README.md
@@ -45,6 +45,7 @@ If you want to run DDP by accelerate, please run `accelerate config` to set your
 ```bash
 accelerate launch examples/olora_finetuning/olora_finetuning.py --base_model facebook/opt-350m
 ```
+please add `--device_map cpu` if you want to run finetune on CPU.
 
 
 ## Use the model

--- a/examples/olora_finetuning/README.md
+++ b/examples/olora_finetuning/README.md
@@ -41,13 +41,17 @@ python3 examples/olora_finetuning/olora_finetuning.py --base_model facebook/opt-
 ```
 or you can just pass a quantized model without the quantize flag.
 
-If you want to run DDP by accelerate, please run `accelerate config` to set your ddp config, and run:
+If you want to run DDP by [accelerate](https://huggingface.co/docs/accelerate/en/index), please run `accelerate config` to set your ddp config, and run:
 ```bash
 accelerate launch examples/olora_finetuning/olora_finetuning.py --base_model facebook/opt-350m
 ```
 please add `--device_map cpu` if you want to run finetune on CPU.
 
-If you want to train a quantized model like AWQ and GPTQ which do not support olora init method, please pass `--init_lora_weights gaussian`.
+If you want to train a quantized model like AWQ and GPTQ which do not support olora init method, please pass `--init_lora_weights gaussian`. For example:
+```bash
+python3 examples/olora_finetuning/olora_finetuning.py --base_model hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4 --init_lora_weights gaussian
+
+```
 
 
 ## Use the model

--- a/examples/olora_finetuning/README.md
+++ b/examples/olora_finetuning/README.md
@@ -47,6 +47,8 @@ accelerate launch examples/olora_finetuning/olora_finetuning.py --base_model fac
 ```
 please add `--device_map cpu` if you want to run finetune on CPU.
 
+If you want to train a quantized model like AWQ and GPTQ which do not support olora init method, please pass `--init_lora_weights gaussian`.
+
 
 ## Use the model
 You can load and use the model as any other 🤗 PEFT model

--- a/examples/olora_finetuning/README.md
+++ b/examples/olora_finetuning/README.md
@@ -39,6 +39,8 @@ OLoRA also supports quantization. To use 4-bit quantization try:
 ```bash
 python3 examples/olora_finetuning/olora_finetuning.py --base_model facebook/opt-350m --quantize
 ```
+or you can just pass a quantized model without the quantiza flag.
+
 If you want to run DDP by accelerate, please run `accelerate config` to set your ddp config, and run:
 ```bash
 accelerate launch examples/olora_finetuning/olora_finetuning.py --base_model facebook/opt-350m

--- a/examples/olora_finetuning/README.md
+++ b/examples/olora_finetuning/README.md
@@ -39,6 +39,10 @@ OLoRA also supports quantization. To use 4-bit quantization try:
 ```bash
 python3 examples/olora_finetuning/olora_finetuning.py --base_model facebook/opt-350m --quantize
 ```
+If you want to run DDP by accelerate, please run `accelerate config` to set your ddp config, and run:
+```bash
+accelerate launch examples/olora_finetuning/olora_finetuning.py --base_model facebook/opt-350m
+```
 
 
 ## Use the model

--- a/examples/olora_finetuning/README.md
+++ b/examples/olora_finetuning/README.md
@@ -39,7 +39,7 @@ OLoRA also supports quantization. To use 4-bit quantization try:
 ```bash
 python3 examples/olora_finetuning/olora_finetuning.py --base_model facebook/opt-350m --quantize
 ```
-or you can just pass a quantized model without the quantiza flag.
+or you can just pass a quantized model without the quantize flag.
 
 If you want to run DDP by accelerate, please run `accelerate config` to set your ddp config, and run:
 ```bash

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -44,7 +44,7 @@ def train(
     lora_alpha: int = 16,
     lora_dropout: float = 0.05,
     lora_target_modules: List[str] = None,
-    seed: int = None,
+    seed: Optional[int] = None,
     torch_dtype: str = "float16",
     init_lora_weights="olora",
 ):

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -50,7 +50,7 @@ def train(
 ):
     # Set device_map to the right place when enabling DDP.
     world_size = int(os.environ.get("WORLD_SIZE", 0)) or int(os.environ.get("PMI_SIZE", 0))
-    if world_size > 1:
+    if world_size > 1 and device_map != "cpu":
         from accelerate import Accelerator
         device_map = {'': Accelerator().process_index}
     # Set seed

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 
+import os
 from typing import List, Optional
 
-import os
 import torch
 import transformers
 from datasets import load_dataset
@@ -56,7 +56,7 @@ def train(
     # Set seed
     if seed is not None:
         set_seed(seed)
-    model_kwargs = dict(torch_dtype=getattr(torch, torch_dtype), device_map=device_map)
+    model_kwargs = {"torch_dtype": getattr(torch, torch_dtype), "device_map": device_map}
     if quantize:
         model_kwargs["quantization_config"] = BitsAndBytesConfig(
             load_in_4bit=True,

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -67,8 +67,9 @@ def train(
     model = AutoModelForCausalLM.from_pretrained(base_model, **model_kwargs)
 
     tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
+    # For some tokenizer with no pad token like llama
     if tokenizer.pad_token is None:
-        tokenizer.pad_token_id = 0  # unk. we want this to be different from the eos token
+        tokenizer.pad_token_id = 0
 
     def tokenize(prompt, add_eos_token=True):
         result = tokenizer(

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -50,7 +50,7 @@ def train(
 ):
     # Set device_map="auto" if no ditributed training
     world_size = int(os.environ.get("WORLD_SIZE", 0)) or int(os.environ.get("PMI_SIZE", 0))
-    if world_size <= 1:
+    if world_size <= 1 and device_map is None:
         device_map = "auto"
     # Set seed
     if seed:

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -71,7 +71,7 @@ def train(
 
     tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
     if tokenizer.pad_token is None:
-        tokenizer.add_special_tokens({'pad_token': '<pad>'})
+        tokenizer.pad_token_id = 0  # unk. we want this to be different from the eos token
 
     def tokenize(prompt, add_eos_token=True):
         result = tokenizer(
@@ -124,7 +124,6 @@ def train(
             warmup_steps=100,
             num_train_epochs=num_epochs,
             learning_rate=learning_rate,
-            fp16=True,
             logging_steps=100,
             optim="adamw_torch",
             evaluation_strategy="steps",
@@ -134,6 +133,7 @@ def train(
             output_dir=output_dir,
             save_total_limit=3,
             load_best_model_at_end=True,
+            ddp_find_unused_parameters=False if world_size > 1 else True,
         ),
         data_collator=transformers.DataCollatorForSeq2Seq(
             tokenizer, pad_to_multiple_of=8, return_tensors="pt", padding=True

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -54,7 +54,7 @@ def train(
         from accelerate import Accelerator
         device_map = {'': Accelerator().process_index}
     # Set seed
-    if seed:
+    if seed is not None:
         set_seed(seed)
     model_kwargs = dict(torch_dtype=getattr(torch, torch_dtype), device_map=device_map)
     if quantize:

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import List
+from typing import List, Optional
 
 import os
 import torch
@@ -44,9 +44,9 @@ def train(
     lora_alpha: int = 16,
     lora_dropout: float = 0.05,
     lora_target_modules: List[str] = None,
-    seed: Optional[int] = None,
     torch_dtype: str = "float16",
     init_lora_weights="olora",
+    seed: Optional[int] = None,
 ):
     # Set device_map to the right place when enabling DDP.
     world_size = int(os.environ.get("WORLD_SIZE", 0)) or int(os.environ.get("PMI_SIZE", 0))
@@ -69,7 +69,7 @@ def train(
     tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
     # For some tokenizer with no pad token like llama
     if tokenizer.pad_token is None:
-        tokenizer.pad_token_id = 0
+        tokenizer.pad_token = tokenizer.eos_token
 
     def tokenize(prompt, add_eos_token=True):
         result = tokenizer(
@@ -169,9 +169,9 @@ if __name__ == "__main__":
     parser.add_argument("--lora_alpha", type=int, default=16)
     parser.add_argument("--lora_dropout", type=float, default=0.05)
     parser.add_argument("--lora_target_modules", type=str, default=None)
-    parser.add_argument("--seed", type=int, default=None)
     parser.add_argument("--torch_dtype", type=str, default="float16")
     parser.add_argument("--init_lora_weights", type=str, default="olora")
+    parser.add_argument("--seed", type=int, default=None)
 
     args = parser.parse_args()
 
@@ -192,7 +192,7 @@ if __name__ == "__main__":
         lora_alpha=args.lora_alpha,
         lora_dropout=args.lora_dropout,
         lora_target_modules=args.lora_target_modules,
-        seed=args.seed,
         torch_dtype=args.torch_dtype,
         init_lora_weights=args.init_lora_weights,
+        seed=args.seed,
     )

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -52,7 +52,8 @@ def train(
     world_size = int(os.environ.get("WORLD_SIZE", 0)) or int(os.environ.get("PMI_SIZE", 0))
     if world_size > 1 and device_map != "cpu":
         from accelerate import Accelerator
-        device_map = {'': Accelerator().process_index}
+
+        device_map = {"": Accelerator().process_index}
     # Set seed
     if seed is not None:
         set_seed(seed)

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -131,7 +131,7 @@ def train(
             output_dir=output_dir,
             save_total_limit=3,
             load_best_model_at_end=True,
-            ddp_find_unused_parameters=False if world_size > 1 else True,
+            ddp_find_unused_parameters=False if world_size > 1 else None,
         ),
         data_collator=transformers.DataCollatorForSeq2Seq(
             tokenizer, pad_to_multiple_of=8, return_tensors="pt", padding=True

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -70,6 +70,8 @@ def train(
     )
 
     tokenizer = AutoTokenizer.from_pretrained(base_model, trust_remote_code=True)
+    if tokenizer.pad_token is None:
+        tokenizer.add_special_tokens({'pad_token': '<pad>'})
 
     def tokenize(prompt, add_eos_token=True):
         result = tokenizer(

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -88,7 +88,7 @@ def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
     # BNB requires CUDA weights
     device = weight.device
     is_cpu = device.type == torch.device("cpu").type
-    if is_cpu:
+    if is_cpu and torch.cuda.is_available():
         weight = weight.to(torch.device("cuda"))
 
     cls_name = weight.__class__.__name__


### PR DESCRIPTION
I compared a lot of lora finetune script and found this script is the best, it's so clear and easy to understand. So I want to extend the usage for this script to support more platforms and also DDP with minimum changes.

I currently test the script on cuda and cpu with 4 DDP on opt and llama-3. It shows reasonable results. 

It would be great if this PR can be merged so we can apply it on more models and devices.

