### PR TITLE
FIX Prefix tuning test w/ rotary emb on multi GPU

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4043,6 +4043,7 @@ class TestPrefixTuning:
             "model.layers.0": 0,
             "model.layers.1": 1,
             "model.norm": 1,
+            "model.rotary_emb": 1,
             "lm_head": 1,
         }
         model = AutoModelForCausalLM.from_pretrained(model_id, device_map=device_map)


### PR DESCRIPTION
See https://github.com/huggingface/transformers/pull/35235#issuecomment-2575500996 for context.

There has been a [refactor in transformers](https://github.com/huggingface/transformers/pull/35235) that resulted in the rotary embedding of Mistral (and probably others) moving to the model level. This led to a device map used in one of the tests to being incorrect and thus a [failing nightly CI](https://github.com/huggingface/peft/actions/runs/12644013486/job/35230888688). This PR fixes the device map.

Notes:

- This fix doesn't really have anything to do with prefix tuning, the error occurred even before prefix tuning is used.
- The error won't be caught by the PR CI, as it requires 2 GPUs to run and thus is only tested in the nightly CI.