### PR TITLE
[DOC] Updated documentation for `get_peft_model()` for in-place base model modification

### DIFF
--- a/docs/source/tutorial/peft_model_config.md
+++ b/docs/source/tutorial/peft_model_config.md
@@ -138,7 +138,7 @@ lora_model.print_trainable_parameters()
 > [!WARNING]
 > When calling [`get_peft_model`], the base model will be modified *in-place*. That means, when modifying a model with [`get_peft_model`] that was already modified in the same way before, even specifying a different configuration may not change the trainable parameter count (e.g., when specifying target modules that are only a subset of the previous target modules).
 ><br>
-> Therefore, if you would like to modify your PEFT configuration after having called [`get_peft_model()`] before, you would first have unload the model with [`~LoraModel.unload`] and then call [`get_peft_model()`] with your new configuration.
+> Therefore, if you would like to modify your PEFT configuration after having called [`get_peft_model()`] before, you would first have to unload the model with [`~LoraModel.unload`] and then call [`get_peft_model()`] with your new configuration.
 
 Now you can train the [`PeftModel`] with your preferred training framework! After training, you can save your model locally with [`~PeftModel.save_pretrained`] or upload it to the Hub with the [`~transformers.PreTrainedModel.push_to_hub`] method.
 

--- a/docs/source/tutorial/peft_model_config.md
+++ b/docs/source/tutorial/peft_model_config.md
@@ -135,6 +135,11 @@ lora_model.print_trainable_parameters()
 "trainable params: 1,572,864 || all params: 332,769,280 || trainable%: 0.472659014678278"
 ```
 
+> [!WARNING]
+> When calling [`get_peft_model`], the base model will be modified *in-place*. That means, when modifying a model with [`get_peft_model`] that was already modified in the same way before, even specifying a different configuration may not change the trainable parameter count (e.g., when specifying target modules that are only a subset of the previous target modules).
+><br>
+> Therefore, if you would like to modify your PEFT configuration after having called [`get_peft_model()`] before, you would first have unload the model with [`~LoraModel.unload`] and then call [`get_peft_model()`] with your new configuration.
+
 Now you can train the [`PeftModel`] with your preferred training framework! After training, you can save your model locally with [`~PeftModel.save_pretrained`] or upload it to the Hub with the [`~transformers.PreTrainedModel.push_to_hub`] method.
 
 ```py

--- a/docs/source/tutorial/peft_model_config.md
+++ b/docs/source/tutorial/peft_model_config.md
@@ -136,9 +136,7 @@ lora_model.print_trainable_parameters()
 ```
 
 > [!WARNING]
-> When calling [`get_peft_model`], the base model will be modified *in-place*. That means, when modifying a model with [`get_peft_model`] that was already modified in the same way before, even specifying a different configuration may not change the trainable parameter count (e.g., when specifying target modules that are only a subset of the previous target modules).
-><br>
-> Therefore, if you would like to modify your PEFT configuration after having called [`get_peft_model()`] before, you would first have to unload the model with [`~LoraModel.unload`] and then call [`get_peft_model()`] with your new configuration.
+> When calling [`get_peft_model`], the base model will be modified *in-place*. That means, when modifying a model with [`get_peft_model`] that was already modified in the same way before, even specifying a different configuration may not change the trainable parameter count (e.g., when specifying target modules that are only a subset of the previous target modules). Therefore, if you would like to modify your PEFT configuration after having called [`get_peft_model()`] before, you would first have to unload the model with [`~LoraModel.unload`] and then call [`get_peft_model()`] with your new configuration.
 
 Now you can train the [`PeftModel`] with your preferred training framework! After training, you can save your model locally with [`~PeftModel.save_pretrained`] or upload it to the Hub with the [`~transformers.PreTrainedModel.push_to_hub`] method.
 

--- a/docs/source/tutorial/peft_model_config.md
+++ b/docs/source/tutorial/peft_model_config.md
@@ -136,7 +136,7 @@ lora_model.print_trainable_parameters()
 ```
 
 > [!WARNING]
-> When calling [`get_peft_model`], the base model will be modified *in-place*. That means, when modifying a model with [`get_peft_model`] that was already modified in the same way before, even specifying a different configuration may not change the trainable parameter count (e.g., when specifying target modules that are only a subset of the previous target modules). Therefore, if you would like to modify your PEFT configuration after having called [`get_peft_model()`] before, you would first have to unload the model with [`~LoraModel.unload`] and then call [`get_peft_model()`] with your new configuration.
+> When calling [`get_peft_model`], the base model will be modified *in-place*. That means, when calling [`get_peft_model`] on a model that was already modified in the same way before, this model will be further mutated. Therefore, if you would like to modify your PEFT configuration after having called [`get_peft_model()`] before, you would first have to unload the model with [`~LoraModel.unload`] and then call [`get_peft_model()`] with your new configuration. Alternatively, you can re-initialize the model to ensure a fresh, unmodified state before applying a new PEFT configuration.
 
 Now you can train the [`PeftModel`] with your preferred training framework! After training, you can save your model locally with [`~PeftModel.save_pretrained`] or upload it to the Hub with the [`~transformers.PreTrainedModel.push_to_hub`] method.
 

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -154,7 +154,7 @@ def get_peft_model(
     low_cpu_mem_usage: bool = False,
 ) -> PeftModel | PeftMixedModel:
     """
-    Returns a Peft model object from a model and a config.
+    Returns a Peft model object from a model and a config, where the model will be modified in-place.
 
     Args:
         model ([`transformers.PreTrainedModel`]):


### PR DESCRIPTION
closes #2295 along with FIX #2306 

Updates documentation for `get_peft_model()` that the base model will be modified in-place:
- tutorial/peft_model_config
- `get_peft_model()` docstring