### PR TITLE
FIX: Adaption prompt errors after changes from transformers #35235

### DIFF
--- a/src/peft/tuners/adaption_prompt/layer.py
+++ b/src/peft/tuners/adaption_prompt/layer.py
@@ -48,8 +48,12 @@ class AdaptedAttention(nn.Module):
         target_dtype = (
             model.q_proj.weight.dtype if model.q_proj.weight.dtype not in [torch.int8, torch.uint8] else torch.float32
         )
+        if hasattr(self.model, "hidden_size"):
+            hidden_size = self.model.hidden_size
+        else:  # changed in https://github.com/huggingface/transformers/pull/35235
+            hidden_size = self.model.config.hidden_size
         self.adaption_prompt = nn.Parameter(
-            torch.empty(1, adapter_len, self.model.hidden_size, device=device, dtype=target_dtype).normal_()
+            torch.empty(1, adapter_len, hidden_size, device=device, dtype=target_dtype).normal_()
         )
         # Initialize the gate to 0 as this is "zero-init".
         self.adaption_gate = nn.Parameter(torch.zeros(1, device=device, dtype=target_dtype))
@@ -67,7 +71,7 @@ class AdaptedAttention(nn.Module):
         if kwargs.get("output_attention", False):
             raise NotImplementedError("output_attention is not currently supported.")
 
-        output, _, past_key_value = self.model(**kwargs)
+        output, *_ = self.model(**kwargs)
         bsz = output.shape[0]
         q_len = output.shape[1]
         embed_dim = output.shape[2]
@@ -84,14 +88,18 @@ class AdaptedAttention(nn.Module):
             key = getattr(self.model, k_proj_layer)(self.adaption_prompt)
             value = getattr(self.model, v_proj_layer)(self.adaption_prompt)
 
+        if hasattr(self.model, "num_heads"):
+            num_heads = self.model.num_heads
+        else:  # changed in https://github.com/huggingface/transformers/pull/35235
+            num_heads = self.model.config.num_attention_heads
         # (bsz, num_key_value_heads, adapter_len, head_dim)
         adapter_k = (
-            key.view(1, self.adapter_len, (self.model.num_heads // factor), self.model.head_dim)
+            key.view(1, self.adapter_len, (num_heads // factor), self.model.head_dim)
             .repeat(bsz, 1, 1, 1)
             .transpose(1, 2)
         )
         adapter_v = (
-            value.view(1, self.adapter_len, (self.model.num_heads // factor), self.model.head_dim)
+            value.view(1, self.adapter_len, (num_heads // factor), self.model.head_dim)
             .repeat(bsz, 1, 1, 1)
             .transpose(1, 2)
         )
@@ -125,4 +133,4 @@ class AdaptedAttention(nn.Module):
 
         # Restore original dtype.
         output = output.to(previous_dtype)
-        return output, None, past_key_value
+        return output, *_

--- a/src/peft/tuners/adaption_prompt/layer.py
+++ b/src/peft/tuners/adaption_prompt/layer.py
@@ -49,6 +49,7 @@ class AdaptedAttention(nn.Module):
             model.q_proj.weight.dtype if model.q_proj.weight.dtype not in [torch.int8, torch.uint8] else torch.float32
         )
         if hasattr(self.model, "hidden_size"):
+            # TODO: remove this clause after 2026-01-01
             hidden_size = self.model.hidden_size
         else:  # changed in https://github.com/huggingface/transformers/pull/35235
             hidden_size = self.model.config.hidden_size
@@ -89,6 +90,7 @@ class AdaptedAttention(nn.Module):
             value = getattr(self.model, v_proj_layer)(self.adaption_prompt)
 
         if hasattr(self.model, "num_heads"):
+            # TODO: remove this clause after 2026-01-01
             num_heads = self.model.num_heads
         else:  # changed in https://github.com/huggingface/transformers/pull/35235
             num_heads = self.model.config.num_attention_heads

--- a/src/peft/tuners/adaption_prompt/utils.py
+++ b/src/peft/tuners/adaption_prompt/utils.py
@@ -68,6 +68,7 @@ def llama_compute_query_states(model: nn.Module, **kwargs) -> torch.Tensor:
     past_key_value = kwargs.get("past_key_value")
     bsz, q_len, _ = hidden_states.size()
     if hasattr(model, "num_heads"):
+        # TODO: remove this clause after 2026-01-01
         num_heads = model.num_heads
     else:  # changed in https://github.com/huggingface/transformers/pull/35235
         num_heads = model.config.num_attention_heads


### PR DESCRIPTION
The changes in https://github.com/huggingface/transformers/pull/35235 resulted in a couple of adaption prompt tests to fail. This PR fixes these failures while maintaining compatibility with older transformers versions.

Required changes:

- `hidden_size` attribute removed from model, now `config.hidden_size`
- `num_heads` attribute removed from model, now `config.num_attention_heads`
- `forward` now returns 2 outputs instead of 3, rewritten to be agnostic towards the number of outputs