### PR TITLE
FIX low_cpu_mem_usage=True with 8bit bitsandbytes

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -248,15 +248,6 @@ class LoraModel(BaseTuner):
             child = child.base_layer
 
         meta = torch.device("meta")
-
-        # handle .state attribute of 8 bit bnb
-        if (getattr(child, "state", None) is not None) and not any(p.device == meta for p in new_module.parameters()):
-            if hasattr(new_module, "base_layer"):
-                new_module.base_layer.state = child.state
-            else:
-                new_module.state = child.state
-            new_module.to(child.weight.device)
-
         # dispatch to correct device
         for name, module in new_module.named_modules():
             if (self.prefix in name) or ("ranknum" in name):


### PR DESCRIPTION
There was a bug in PEFT that occurred when trying to use the `low_cpu_mem_usage=True` option with 8bit bitsandbytes quantized models. This bug is fixed now.

See https://github.com/huggingface/diffusers/issues/10550 for the bug report.