### PR TITLE
Attempt at adding a cache for models

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Model cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           # Avoid caching HF_HOME/modules and Python cache files to prevent interoperability
           # issues and potential cache poisioning. We also avoid lock files to prevent runs
@@ -79,3 +79,14 @@ jobs:
       - name: Test with pytest
         run: |
           make test
+      - name: Update model cache
+        uses: actions/cache/save@v4
+        # Only let one runner (preferably the one that covers most tests) update the model cache
+        # after *every* run. This way we make sure that our cache is never outdated and we don't
+        # have to keep track of hashes.
+        if: always() && matrix.os == 'ubuntu' && matrix.python-version == '3.10'
+        with:
+          path: |
+            ${{ env.HF_HOME }}/hub/**
+            !${{ env.HF_HOME }}/**/*.pyc
+          key: model-cache-${{ github.run_id }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,8 @@ jobs:
           diff -udp cache_content_initial cache_content_after || true
       - name: Delete old model cache entries
         run: |
-          python scripts/ci_clean_cache.py -d
+          # make sure that cache cleaning doesn't break the pipeline
+          python scripts/ci_clean_cache.py -d || true
       - name: Update model cache
         uses: actions/cache/save@v4
         # Only let one runner (preferably the one that covers most tests) update the model cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,8 +59,11 @@ jobs:
           restore-keys: model-cache-
           enableCrossOsArchive: true
       - name: Dump cache content
+        if: matrix.os != 'windows-latest'
         run: |
-          find "${{ env.HF_HOME }}/hub" -type f -exec sha256sum {} \; > cache_content_initial
+          SHASUM=sha256sum
+          [ -f "$(which shasum)" ] && SHASUM=shasum
+          find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_initial
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -83,8 +86,11 @@ jobs:
         run: |
           make test
       - name: Dump cache content and diff
+        if: matrix.os != 'windows-latest'
         run: |
-          find "${{ env.HF_HOME }}/hub" -type f -exec sha256sum {} \; > cache_content_after
+          SHASUM=sha256sum
+          [ -f "$(which shasum)" ] && SHASUM=shasum
+          find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_after
           diff -udp cache_content_initial cache_content_after
       - name: Update model cache
         uses: actions/cache/save@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           SHASUM=sha256sum
           [ -f "$(which shasum)" ] && SHASUM=shasum
-          find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_initial
+          [ -d "${{ env.HF_HOME }}/hub" ] && find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_initial
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -94,7 +94,7 @@ jobs:
         run: |
           SHASUM=sha256sum
           [ -f "$(which shasum)" ] && SHASUM=shasum
-          find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_after
+          [ -d "${{ env.HF_HOME }}/hub" ] && find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_after
           diff -udp cache_content_initial cache_content_after || true
       - name: Delete old model cache entries
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
         # Only let one runner (preferably the one that covers most tests) update the model cache
         # after *every* run. This way we make sure that our cache is never outdated and we don't
         # have to keep track of hashes.
-        if: always() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
+        if: always() && matrix.os == 'ubuntu-latest'
         with:
           path: |
             ${{ env.HF_HOME }}/hub/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
         # Only let one runner (preferably the one that covers most tests) update the model cache
         # after *every* run. This way we make sure that our cache is never outdated and we don't
         # have to keep track of hashes.
-        if: always() && matrix.os == 'ubuntu' && matrix.python-version == '3.10'
+        if: always() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         with:
           path: |
             ${{ env.HF_HOME }}/hub/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,8 +58,9 @@ jobs:
             ${{ env.HF_HOME }}/hub/**
             !${{ env.HF_HOME }}/hub/.locks/**
             !${{ env.HF_HOME }}/**/*.pyc
-          key: model-cache-${{ runner.os }}-${{ github.run_id }}
-          restore-keys: model-cache-${{ runner.os }}
+          key: model-cache-${{ github.run_id }}
+          restore-keys: model-cache-
+          enableCrossOsArchive: true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           SHASUM=sha256sum
           [ -f "$(which shasum)" ] && SHASUM=shasum
-          [ -d "${{ env.HF_HOME }}/hub" ] && find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_initial
+          find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_initial || true
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -94,7 +94,7 @@ jobs:
         run: |
           SHASUM=sha256sum
           [ -f "$(which shasum)" ] && SHASUM=shasum
-          [ -d "${{ env.HF_HOME }}/hub" ] && find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_after
+          find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_after || true
           diff -udp cache_content_initial cache_content_after || true
       - name: Delete old model cache entries
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,9 @@ jobs:
           key: model-cache-${{ github.run_id }}
           restore-keys: model-cache-
           enableCrossOsArchive: true
+      - name: Dump cache content
+        run: |
+          find "${{ env.HF_HOME }}/hub" -type f -exec sha256sum {} \; > cache_content_initial
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -79,6 +82,10 @@ jobs:
       - name: Test with pytest
         run: |
           make test
+      - name: Dump cache content and diff
+        run: |
+          find "${{ env.HF_HOME }}/hub" -type f -exec sha256sum {} \; > cache_content_after
+          diff -udp cache_content_initial cache_content_after
       - name: Update model cache
         uses: actions/cache/save@v4
         # Only let one runner (preferably the one that covers most tests) update the model cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
         # Only let one runner (preferably the one that covers most tests) update the model cache
         # after *every* run. This way we make sure that our cache is never outdated and we don't
         # have to keep track of hashes.
-        if: always() && matrix.os == 'ubuntu-latest'
+        if: always() && matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         with:
           path: |
             ${{ env.HF_HOME }}/hub/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,15 @@ jobs:
       - name: Model cache
         uses: actions/cache@v4
         with:
-          path: ${{ env.HF_HOME }}
+          # Avoid caching HF_HOME/modules and Python cache files to prevent interoperability
+          # issues and potential cache poisioning. We also avoid lock files to prevent runs
+          # avoiding re-download because they see a lock file.
+          path: |
+            ${{ env.HF_HOME }}/datasets/**
+            !${{ env.HF_HOME }}/datasets/**/*.lock
+            ${{ env.HF_HOME }}/hub/**
+            !${{ env.HF_HOME }}/hub/.locks/**
+            !${{ env.HF_HOME }}/**/*.pyc
           key: model-cache-${{ runner.os }}-${{ github.run_id }}
           restore-keys: model-cache-${{ runner.os }}
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,9 @@ jobs:
           [ -f "$(which shasum)" ] && SHASUM=shasum
           find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_after
           diff -udp cache_content_initial cache_content_after || true
+      - name: Delete old model cache entries
+        run: |
+          python scripts/ci_clean_cache.py -d
       - name: Update model cache
         uses: actions/cache/save@v4
         # Only let one runner (preferably the one that covers most tests) update the model cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - 'docs/**'
 
+env:
+  HF_HOME: .cache/huggingface
+
 jobs:
   check_code_quality:
     runs-on: ubuntu-latest
@@ -43,6 +46,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - name: Model cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.HF_HOME }}
+          key: model-cache-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: model-cache-${{ runner.os }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,10 +53,7 @@ jobs:
           # issues and potential cache poisioning. We also avoid lock files to prevent runs
           # avoiding re-download because they see a lock file.
           path: |
-            ${{ env.HF_HOME }}/datasets/**
-            !${{ env.HF_HOME }}/datasets/**/*.lock
             ${{ env.HF_HOME }}/hub/**
-            !${{ env.HF_HOME }}/hub/.locks/**
             !${{ env.HF_HOME }}/**/*.pyc
           key: model-cache-${{ github.run_id }}
           restore-keys: model-cache-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,7 @@ jobs:
           restore-keys: model-cache-
           enableCrossOsArchive: true
       - name: Dump cache content
+        # TODO: remove this step after 2025-02-15
         if: matrix.os != 'windows-latest'
         run: |
           SHASUM=sha256sum
@@ -86,12 +87,15 @@ jobs:
         run: |
           make test
       - name: Dump cache content and diff
+        # This is just debug info so that we can monitor if the model cache diverges substantially
+        # over time and what the diverging model is.
+        # TODO: remove after 2025-02-15
         if: matrix.os != 'windows-latest'
         run: |
           SHASUM=sha256sum
           [ -f "$(which shasum)" ] && SHASUM=shasum
           find "${{ env.HF_HOME }}/hub" -type f -exec "$SHASUM" {} \; > cache_content_after
-          diff -udp cache_content_initial cache_content_after
+          diff -udp cache_content_initial cache_content_after || true
       - name: Update model cache
         uses: actions/cache/save@v4
         # Only let one runner (preferably the one that covers most tests) update the model cache

--- a/scripts/ci_clean_cache.py
+++ b/scripts/ci_clean_cache.py
@@ -1,0 +1,61 @@
+"""
+Utility to clean cache files that exceed a specific time in days according to their
+last access time recorded in the cache.
+
+Exit code:
+- 1 if no candidates are found
+- 0 if candidates are found
+
+Deletion can be enabled by passing `-d` parameter, otherwise it will only list the candidates.
+"""
+import sys
+import argparse
+from huggingface_hub import scan_cache_dir
+from datetime import datetime as dt
+
+
+def find_old_revisions(scan_results, max_age_days=30):
+    """Find commit hashes of objects in the cache. These objects need a last access time that
+    is above the passed `max_age_days` parameter. Returns an empty list if no objects are found.
+    Time measurement is based of the current time and the recorded last access tiem in the cache.
+    """
+    now = dt.now()
+    revisions = [(i.revisions, i.last_accessed) for i in scan_results.repos]
+    revisions_ages = [(rev, (now - dt.fromtimestamp(ts_access)).days) for rev, ts_access in revisions]
+    delete_candidates = [rev for rev, age in revisions_ages if age > max_age_days]
+    hashes = [n.commit_hash for rev in delete_candidates for n in rev]
+
+    return hashes
+
+
+def delete_old_revisions(scan_results, delete_candidates, do_delete=False):
+    delete_operation = scan_results.delete_revisions(*delete_candidates)
+    print(f'Would free {delete_operation.expected_freed_size_str}')
+    print(f'Candidates: {delete_candidates}')
+
+    if do_delete:
+        print("Deleting now.")
+        delete_operation.execute()
+    else:
+        print("Not deleting, pass the -d flag.")
+
+
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser()
+    parser.add_argument('-a', '--max-age', type=int, default=30, help="Max. age in days items in the cache may have.")
+    parser.add_argument('-d', '--delete', action='store_true', help=(
+        "Delete mode; Really delete items if there are candidates. Exit code = 0 when we found something to delete, 1 "
+        "otherwise."
+    ))
+    args = parser.parse_args()
+
+    scan_results = scan_cache_dir()
+
+    delete_candidates = find_old_revisions(scan_results, args.max_age)
+    if not delete_candidates:
+        print('No delete candidates found, not deleting anything.')
+        sys.exit(1)
+
+    delete_old_revisions(scan_results, delete_candidates, do_delete=args.delete)

--- a/scripts/ci_clean_cache.py
+++ b/scripts/ci_clean_cache.py
@@ -8,10 +8,11 @@ Exit code:
 
 Deletion can be enabled by passing `-d` parameter, otherwise it will only list the candidates.
 """
+
 import sys
-import argparse
-from huggingface_hub import scan_cache_dir
 from datetime import datetime as dt
+
+from huggingface_hub import scan_cache_dir
 
 
 def find_old_revisions(scan_results, max_age_days=30):
@@ -30,8 +31,8 @@ def find_old_revisions(scan_results, max_age_days=30):
 
 def delete_old_revisions(scan_results, delete_candidates, do_delete=False):
     delete_operation = scan_results.delete_revisions(*delete_candidates)
-    print(f'Would free {delete_operation.expected_freed_size_str}')
-    print(f'Candidates: {delete_candidates}')
+    print(f"Would free {delete_operation.expected_freed_size_str}")
+    print(f"Candidates: {delete_candidates}")
 
     if do_delete:
         print("Deleting now.")
@@ -44,18 +45,23 @@ if __name__ == "__main__":
     from argparse import ArgumentParser
 
     parser = ArgumentParser()
-    parser.add_argument('-a', '--max-age', type=int, default=30, help="Max. age in days items in the cache may have.")
-    parser.add_argument('-d', '--delete', action='store_true', help=(
-        "Delete mode; Really delete items if there are candidates. Exit code = 0 when we found something to delete, 1 "
-        "otherwise."
-    ))
+    parser.add_argument("-a", "--max-age", type=int, default=30, help="Max. age in days items in the cache may have.")
+    parser.add_argument(
+        "-d",
+        "--delete",
+        action="store_true",
+        help=(
+            "Delete mode; Really delete items if there are candidates. Exit code = 0 when we found something to delete, 1 "
+            "otherwise."
+        ),
+    )
     args = parser.parse_args()
 
     scan_results = scan_cache_dir()
 
     delete_candidates = find_old_revisions(scan_results, args.max_age)
     if not delete_candidates:
-        print('No delete candidates found, not deleting anything.')
+        print("No delete candidates found, not deleting anything.")
         sys.exit(1)
 
     delete_old_revisions(scan_results, delete_candidates, do_delete=args.delete)


### PR DESCRIPTION
This PR introduces CI caching for datasets and hub artifacts across runner operating systems with the intended goal to minimize the number of failed test runs because of network faults. As  an additional bonus it might make the CI a bit faster.

The following artifacts are cached: `${HF_HOME}/hub/**`

Note that we're avoiding `.lock` files as well as `*.pyc` files. We're not simply caching `$HF_HOME` since there is also the  datasets and `modules` where the former was acting up when testing (no details, just dropped, we may explore this later but we're not using that many datasets) and the latter is just code which is probably not a good idea to cache anyway.

There is a post process for the cache action which uploads new data to the cache - only one runner can access the cache for uploading. This is done because github actions is locking cache creation, so if there's a concurrent cache creation, both may fail. This runner is currently set to **ubuntu** in the **python 3.10** run.

If this modification turns out to be ineffective we can move to forbidding access to the hub in general (`HF_HUB_OFFLINE=1`) and updating the cache once per day but let's first try out if this is already enough to decrease the fail rate.