### PR TITLE
FIX: Reinstate PEFT_TYPE_TO_MODEL_MAPPING variable with deprecation

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -3022,3 +3022,19 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
         devices=devices,
     )
     return adapter_model_status
+
+
+def __getattr__(name):
+    if name == "PEFT_TYPE_TO_MODEL_MAPPING":
+        # This is for backwards compatibility: In #2282, PEFT_TYPE_TO_MODEL_MAPPING was removed as it was redundant with
+        # PEFT_TYPE_TO_TUNER_MAPPING. However, third party code could still use this mapping, e.g.:
+        # https://github.com/AutoGPTQ/AutoGPTQ/blob/6689349625de973b9ee3016c28c11f32acf7f02c/auto_gptq/utils/peft_utils.py#L8
+        # TODO: Remove after 2026-01
+        msg = (
+            "PEFT_TYPE_TO_MODEL_MAPPING is deprecated, please use `from peft import PEFT_TYPE_TO_TUNER_MAPPING` instead. "
+            "The deprecated variable will be removed in 2026."
+        )
+        warnings.warn(msg, category=DeprecationWarning)
+        return PEFT_TYPE_TO_TUNER_MAPPING
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -2980,6 +2980,6 @@ def test_import_peft_type_to_model_mapping_deprecation_warning(recwarn):
 
     from peft.peft_model import PEFT_TYPE_TO_MODEL_MAPPING  # noqa
 
-    # check that there is a warning with this message after importing the method
+    # check that there is a warning with this message after importing the variable
     warnings = (w.message.args[0] for w in recwarn.list)
     assert any(w.startswith(expected) for w in warnings)


### PR DESCRIPTION
This is for backwards compatibility: In #2282, `PEFT_TYPE_TO_MODEL_MAPPING` was removed as it was redundant with `PEFT_TYPE_TO_TUNER_MAPPING`. However, third party code could still use this mapping, e.g.:

https://github.com/AutoGPTQ/AutoGPTQ/blob/6689349625de973b9ee3016c28c11f32acf7f02c/auto_gptq/utils/peft_utils.py#L8

Therefore, it is reinstated here, but a `DeprecationWarning` will be given if it's used.