### PR TITLE
React on new zizmor version findings

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -3,8 +3,6 @@ name: CI security linting
 on:
   push:
     branches: ["main"]
-    paths:
-      - '.github/**'
   pull_request:
     branches: ["*"]
     paths:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -3,3 +3,13 @@ rules:
     ignore:
       # this workflow is only triggered after maintainer approval
       - upload_pr_documentation.yml:3:1
+  cache-poisoning:
+    ignore:
+      # the docker buildx binary is cached and zizmor warns about a cache poisoning attack.
+      # OTOH this cache would make us more resilient against an intrusion on docker-buildx' side.
+      # There is no obvious benefit so we leave it as it is.
+      - build_docker_images.yml:35:9
+      - build_docker_images.yml:68:9
+      - build_docker_images.yml:101:9
+      - build_docker_images.yml:134:9
+      - build_docker_images.yml:167:9


### PR DESCRIPTION
Zizmor detected a potential cache poisoning attack via `setup-docker-buildx`. There is an argument to this (an attacker with a valid github token could modify the cache, change the buildx binary and tamper with Docker build releases) but there is also an argument against it: the buildx cache would prevent general information leaks when a new buildx release is tampered with. Since there is no obvious benefit from either side, we ignore this hint and deem it uncritical.

We also change the trigger of zizmor runs to pushes on main, regardless of whether workflow files are changed or not to catch new audits from more recent zizmor versions.