### PR TITLE
Documentation & error checking for AdaLoRA timing

### DIFF
--- a/docs/source/conceptual_guides/adapter.md
+++ b/docs/source/conceptual_guides/adapter.md
@@ -93,6 +93,8 @@ OFT preserves the hyperspherical energy by learning an orthogonal transformation
 
 [AdaLoRA](https://hf.co/papers/2303.10512) manages the parameter budget introduced from LoRA by allocating more parameters - in other words, a higher rank `r` - for important weight matrices that are better adapted for a task and pruning less important ones. The rank is controlled by a method similar to singular value decomposition (SVD). The ∆W is parameterized with two orthogonal matrices and a diagonal matrix which contains singular values. This parametrization method avoids iteratively applying SVD which is computationally expensive. Based on this method, the rank of ∆W is adjusted according to an importance score. ∆W is divided into triplets and each triplet is scored according to its contribution to model performance. Triplets with low importance scores are pruned and triplets with high importance scores are kept for finetuning.
 
+Training with AdaLoRA has three phases: the init phase, the budgeting phase and the final phase. In the initial phase, no budgeting is applied, therefore the ranks are not touched. During the budgeting phase the process described above is applied and the rank is redistributed according to a budget, aiming to give more important adapters more rank and less important layers less. When reaching the final phase, budgeting has ended, the ranks are redistributed but we may continue training for a while with the redistributed ranks to further improve performance.
+
 ## Llama-Adapter
 
 [Llama-Adapter](https://hf.co/papers/2303.16199) is a method for adapting Llama into a instruction-following model. To help adapt the model for instruction-following, the adapter is trained with a 52K instruction-output dataset.

--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -98,7 +98,10 @@ class AdaLoraConfig(LoraConfig):
                 "If you intended to set the initial rank, use `init_r` instead."
             )
 
-        if tinit > (total_step - tfinal):
+        if self.total_step is None or self.total_step <= 0:
+            raise ValueError("AdaLoRA does not work when `total_step` is None, supply a value > 0.")
+
+        if self.tinit >= (self.total_step - self.tfinal):
             raise ValueError(
                 "The supplied schedule values don't allow for a budgeting phase. Decrease `tfinal`/`tinit` or "
                 "increase `total_step`."

--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -38,10 +38,10 @@ class AdaLoraConfig(LoraConfig):
     The last phase, beginning once `total_step - tfinal` steps are reached, does not change the layer ranks anymore but
     fine-tunes the reduced-rank layers that resulted from the previous phase.
 
-    A practical example: `tinit` is 10, `tfinal` is 20, `total_step` is 100.  We spend 10 steps doing pre-training
+    A practical example: `tinit` is 10, `tfinal` is 20, `total_step` is 100. We spend 10 steps doing pre-training
     without rank reduction because our budget is constant (init phase), then we spend 80 (100-20) steps in the
-    reduction phase where our budget decreases step-wise and, finally, 20 steps in the final fine-tuning stage
-    without reduction.
+    reduction phase where our budget decreases step-wise and, finally, 20 steps in the final fine-tuning stage without
+    reduction.
 
     Args:
         target_r (`int`): The target average rank of incremental matrix.

--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -25,11 +25,29 @@ class AdaLoraConfig(LoraConfig):
     """
     This is the configuration class to store the configuration of a [`~peft.AdaLora`].
 
+    AdaLoRA has three phases defined by `tinit`, `tfinal` and `total_step`.
+
+    The initial phase can be understood as a step for pre-training the adapters so that when reducing their rank, there
+    is already some information encoded that can be reduced instead of random matrices. This phase is defined by
+    supplying `tinit`.
+
+    After the initial phase is over (`tinit` steps have passed) and the final phase has not begun, AdaLoRA reduces the
+    budget of how much rank each layer is allowed to have with each step. This is where the reduction of rank is
+    happening. This goes on until `total_step - tfinal` steps are reached.
+
+    The last phase, beginning once `total_step - tfinal` steps are reached, does not change the layer ranks anymore but
+    fine-tunes the reduced-rank layers that resulted from the previous phase.
+
+    A practical example: `tinit` is 10, `tfinal` is 20, `total_step` is 100.  We spend 10 steps doing pre-training
+    without rank reduction because our budget is constant (init phase), then we spend 80 (100-20) steps in the
+    reduction phase where our budget decreases step-wise and, finally, 20 steps in the final fine-tuning stage
+    without reduction.
+
     Args:
         target_r (`int`): The target average rank of incremental matrix.
         init_r (`int`): The initial rank for each incremental matrix.
         tinit (`int`): The steps of initial fine-tuning warmup.
-        tfinal (`int`): The step of final fine-tuning.
+        tfinal (`int`): The number of steps of final fine-tuning.
         deltaT (`int`): The time internval between two budget allocations.
         beta1 (`float`): The hyperparameter of EMA for sensitivity smoothing.
         beta2 (`float`): The hyperparameter of EMA for undertainty quantification.
@@ -78,4 +96,10 @@ class AdaLoraConfig(LoraConfig):
             warnings.warn(
                 "Note that `r` is not used in AdaLora and will be ignored."
                 "If you intended to set the initial rank, use `init_r` instead."
+            )
+
+        if tinit > (total_step - tfinal):
+            raise ValueError(
+                "The supplied schedule values don't allow for a budgeting phase. Decrease `tfinal`/`tinit` or "
+                "increase `total_step`."
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -332,31 +332,37 @@ class TestPeftConfig:
     def test_adalora_config_correct_timing_still_works(self):
         pass
 
-    @pytest.mark.parametrize('timing_kwargs', [
-        {'total_step': 100, 'tinit': 0, 'tfinal': 0},
-        {'total_step': 100, 'tinit': 10, 'tfinal': 10},
-        {'total_step': 100, 'tinit': 79, 'tfinal': 20},
-        {'total_step': 100, 'tinit': 80, 'tfinal': 19},
-    ])
+    @pytest.mark.parametrize(
+        "timing_kwargs",
+        [
+            {"total_step": 100, "tinit": 0, "tfinal": 0},
+            {"total_step": 100, "tinit": 10, "tfinal": 10},
+            {"total_step": 100, "tinit": 79, "tfinal": 20},
+            {"total_step": 100, "tinit": 80, "tfinal": 19},
+        ],
+    )
     def test_adalora_config_valid_timing_works(self, timing_kwargs):
         # Make sure that passing correct timing values is not prevented by faulty config checks.
-        AdaLoraConfig(**timing_kwargs) # does not raise
+        AdaLoraConfig(**timing_kwargs)  # does not raise
 
     def test_adalora_config_invalid_total_step_raises(self):
         with pytest.raises(ValueError) as e:
             AdaLoraConfig(total_step=None)
         assert "AdaLoRA does not work when `total_step` is None, supply a value > 0." in str(e)
 
-    @pytest.mark.parametrize('timing_kwargs', [
-        {'total_step': 100, 'tinit': 20, 'tfinal': 80},
-        {'total_step': 100, 'tinit': 80, 'tfinal': 20},
-        {'total_step': 10, 'tinit': 20, 'tfinal': 0},
-        {'total_step': 10, 'tinit': 0, 'tfinal': 10},
-        {'total_step': 10, 'tinit': 10, 'tfinal': 0},
-        {'total_step': 10, 'tinit': 20, 'tfinal': 0},
-        {'total_step': 10, 'tinit': 20, 'tfinal': 20},
-        {'total_step': 10, 'tinit': 0, 'tfinal': 20},
-    ])
+    @pytest.mark.parametrize(
+        "timing_kwargs",
+        [
+            {"total_step": 100, "tinit": 20, "tfinal": 80},
+            {"total_step": 100, "tinit": 80, "tfinal": 20},
+            {"total_step": 10, "tinit": 20, "tfinal": 0},
+            {"total_step": 10, "tinit": 0, "tfinal": 10},
+            {"total_step": 10, "tinit": 10, "tfinal": 0},
+            {"total_step": 10, "tinit": 20, "tfinal": 0},
+            {"total_step": 10, "tinit": 20, "tfinal": 20},
+            {"total_step": 10, "tinit": 0, "tfinal": 20},
+        ],
+    )
     def test_adalora_config_timing_bounds_error(self, timing_kwargs):
         # Check if the user supplied timing values that will certainly fail because it breaks
         # AdaLoRA assumptions.

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1725,7 +1725,7 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
             LoraConfig(target_modules=["lin0"], init_lora_weights=False),
             LoKrConfig(target_modules=["lin0"], init_weights=False),
             LoHaConfig(target_modules=["lin0"], init_weights=False),
-            AdaLoraConfig(target_modules=["lin0"], init_lora_weights=False),
+            AdaLoraConfig(target_modules=["lin0"], init_lora_weights=False, total_step=1),
             IA3Config(target_modules=["lin0"], feedforward_modules=["lin0"], init_ia3_weights=False),
             OFTConfig(target_modules=["lin0"], init_weights=False, r=2),
             BOFTConfig(target_modules=["lin0"], init_weights=False, boft_block_size=2),

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -395,7 +395,7 @@ class TestMixedAdapterTypes(unittest.TestCase):
                 LoraConfig(target_modules=["lin0"], init_lora_weights=False),
                 LoHaConfig(target_modules=["lin0"], init_weights=False),
                 LoKrConfig(target_modules=["lin0"], init_weights=False),
-                AdaLoraConfig(target_modules=["lin0"], init_lora_weights=False),
+                AdaLoraConfig(target_modules=["lin0"], init_lora_weights=False, total_step=1),
             ],
             r=2,
         ),
@@ -415,7 +415,7 @@ class TestMixedAdapterTypes(unittest.TestCase):
                 LoraConfig(target_modules=["lin1"], init_lora_weights=False),
                 LoHaConfig(target_modules=["lin1"], init_weights=False),
                 LoKrConfig(target_modules=["lin1"], init_weights=False),
-                AdaLoraConfig(target_modules=["lin1"], init_lora_weights=False),
+                AdaLoraConfig(target_modules=["lin1"], init_lora_weights=False, total_step=1),
             ],
             r=2,
         ),
@@ -439,7 +439,7 @@ class TestMixedAdapterTypes(unittest.TestCase):
                 LoraConfig(init_lora_weights=False),
                 LoHaConfig(init_weights=False),
                 LoKrConfig(init_weights=False),
-                AdaLoraConfig(init_lora_weights=False),
+                AdaLoraConfig(init_lora_weights=False, total_step=1),
             ],
             r=2,
         ),
@@ -480,8 +480,8 @@ class TestMixedAdapterTypes(unittest.TestCase):
                 LoKrConfig(target_modules=["lin1"], init_weights=False),
             ),
             (
-                AdaLoraConfig(target_modules=["lin1"], init_lora_weights=False),
-                AdaLoraConfig(target_modules=["lin1"], init_lora_weights=False),
+                AdaLoraConfig(target_modules=["lin1"], init_lora_weights=False, total_step=1),
+                AdaLoraConfig(target_modules=["lin1"], init_lora_weights=False, total_step=1),
             ),
         ],
         name_func=_param_name_func,
@@ -509,8 +509,8 @@ class TestMixedAdapterTypes(unittest.TestCase):
                 LoKrConfig(target_modules=["lin0"], init_weights=False),
             ),
             (
-                AdaLoraConfig(target_modules=["lin0"], init_lora_weights=False),
-                AdaLoraConfig(target_modules=["lin0"], init_lora_weights=False),
+                AdaLoraConfig(target_modules=["lin0"], init_lora_weights=False, total_step=1),
+                AdaLoraConfig(target_modules=["lin0"], init_lora_weights=False, total_step=1),
             ),
         ],
         name_func=_param_name_func,
@@ -542,7 +542,7 @@ class TestMixedAdapterTypes(unittest.TestCase):
         config1 = LoHaConfig(r=4, alpha=4, target_modules=["lin0"], init_weights=False)
         peft_model.add_adapter("adapter1", config1)
 
-        config2 = AdaLoraConfig(r=4, lora_alpha=4, target_modules=["lin1"], init_lora_weights=False)
+        config2 = AdaLoraConfig(r=4, lora_alpha=4, target_modules=["lin1"], init_lora_weights=False, total_step=1)
         peft_model.add_adapter("adapter2", config2)
 
         config3 = LoKrConfig(r=4, alpha=4, target_modules=["lin0", "lin1"], init_weights=False)
@@ -683,7 +683,7 @@ class TestMixedAdapterTypes(unittest.TestCase):
         assert trainable_params1 == (params_lora + params_loha)
         assert all_param1 == ((params_base + params_lora) + params_loha)
 
-        config2 = AdaLoraConfig(target_modules=["lin0", "lin1"])
+        config2 = AdaLoraConfig(target_modules=["lin0", "lin1"], total_step=1)
         peft_model.add_adapter("adapter2", config2)
         peft_model.set_adapter(["adapter0", "adapter1", "adapter2"])
         params_adalora = sum(p.numel() for n, p in model.named_parameters() if "adapter2" in n)
@@ -732,7 +732,7 @@ class TestMixedAdapterTypes(unittest.TestCase):
         assert not torch.allclose(output0, output1)
 
         torch.manual_seed(2)
-        config2 = AdaLoraConfig(task_type="CAUSAL_LM", init_lora_weights=False)
+        config2 = AdaLoraConfig(task_type="CAUSAL_LM", init_lora_weights=False, total_step=1)
         peft_model.add_adapter("adapter2", config2)
         peft_model.set_adapter(["adapter0", "adapter1", "adapter2"])
         output2 = peft_model.generate(**input_dict)


### PR DESCRIPTION
The documentation about how the AdaLoRA works was a bit unclear. Especially that `tfinal` is not a point in time but a duration.

It was also possible to build schedules that never budget and therefore lead to an exception because the code does not expect this case (which is OK). We prevent such a scenario now by treating this configuration as invalid. (Issue #2337)

Additionally, it was possible to provide `total_step=None` (the default) which is certainly going to lead to errors. This is technically a breaking change but the same could be said for the new check of the timing values. They both lead to errors in the code.