### PR TITLE
MNT Update ruff to v0.9.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.1
+    rev: v0.9.2
     hooks:
       - id: ruff
         args:

--- a/examples/causal_language_modeling/peft_lora_clm_accelerate_ds_zero3_offload.py
+++ b/examples/causal_language_modeling/peft_lora_clm_accelerate_ds_zero3_offload.py
@@ -297,9 +297,9 @@ def main():
 
         correct = 0
         total = 0
-        assert len(eval_preds) == len(
-            dataset["train"][label_column]
-        ), f"{len(eval_preds)} != {len(dataset['train'][label_column])}"
+        assert len(eval_preds) == len(dataset["train"][label_column]), (
+            f"{len(eval_preds)} != {len(dataset['train'][label_column])}"
+        )
         for pred, true in zip(eval_preds, dataset["train"][label_column]):
             if pred.strip() == true.strip():
                 correct += 1

--- a/examples/conditional_generation/peft_lora_seq2seq_accelerate_ds_zero3_offload.py
+++ b/examples/conditional_generation/peft_lora_seq2seq_accelerate_ds_zero3_offload.py
@@ -247,9 +247,9 @@ def main():
 
         correct = 0
         total = 0
-        assert len(eval_preds) == len(
-            dataset["train"][label_column]
-        ), f"{len(eval_preds)} != {len(dataset['train'][label_column])}"
+        assert len(eval_preds) == len(dataset["train"][label_column]), (
+            f"{len(eval_preds)} != {len(dataset['train'][label_column])}"
+        )
         for pred, true in zip(eval_preds, dataset["train"][label_column]):
             if pred.strip() == true.strip():
                 correct += 1

--- a/examples/corda_finetuning/datautils.py
+++ b/examples/corda_finetuning/datautils.py
@@ -68,7 +68,7 @@ def get_redpajama_train(tokenizer, percent=10, seed=3, batch_size=128, max_lengt
         return tokenizer(example["text"], truncation=True, max_length=max_length)
 
     if percent != 100:
-        split = f"train[:{int(850000*percent/100)}]"
+        split = f"train[:{int(850000 * percent / 100)}]"
     else:
         split = "train"
     dataset = load_dataset("togethercomputer/RedPajama-Data-1T-Sample", split=split)
@@ -105,7 +105,7 @@ llama_chat_format = """<s>[INST] <<SYS>>
 
 def get_calib_data(name, tokenizer, model_id, nsamples, seqlen=2048, seed=3):
     print(f" get_data_from: {name}, nsamples={nsamples}, seqlen={seqlen}, {seed}")
-    cache_file = f"cache/{name}_{model_id.replace('/','_')}_{nsamples}_{seqlen}_{seed}.pt"
+    cache_file = f"cache/{name}_{model_id.replace('/', '_')}_{nsamples}_{seqlen}_{seed}.pt"
     traindataset = []
     if not os.path.exists("cache"):
         os.makedirs("cache")

--- a/examples/feature_extraction/peft_lora_embedding_semantic_search.py
+++ b/examples/feature_extraction/peft_lora_embedding_semantic_search.py
@@ -440,13 +440,13 @@ def main():
                 completed_steps += 1
 
             if (step + 1) % 100 == 0:
-                logger.info(f"Step: {step+1}, Loss: {total_loss/(step+1)}")
+                logger.info(f"Step: {step + 1}, Loss: {total_loss / (step + 1)}")
                 if args.with_tracking:
                     accelerator.log({"train/loss": total_loss / (step + 1)}, step=completed_steps)
 
             if isinstance(checkpointing_steps, int):
                 if completed_steps % checkpointing_steps == 0:
-                    output_dir = f"step_{completed_steps }"
+                    output_dir = f"step_{completed_steps}"
                     if args.output_dir is not None:
                         output_dir = os.path.join(args.output_dir, output_dir)
                     accelerator.save_state(output_dir)

--- a/examples/fp4_finetuning/finetune_fp4_opt_bnb_peft.py
+++ b/examples/fp4_finetuning/finetune_fp4_opt_bnb_peft.py
@@ -38,7 +38,7 @@ Here let's load the `opt-6.7b` model, its weights in half-precision (float16) ar
 
 
 free_in_GB = int(torch.cuda.mem_get_info()[0] / 1024**3)
-max_memory = f"{free_in_GB-2}GB"
+max_memory = f"{free_in_GB - 2}GB"
 
 n_gpus = torch.cuda.device_count()
 max_memory = {i: max_memory for i in range(n_gpus)}

--- a/examples/int8_training/peft_adalora_whisper_large_training.py
+++ b/examples/int8_training/peft_adalora_whisper_large_training.py
@@ -494,7 +494,7 @@ def main():
     raw_datasets = raw_datasets.cast_column("audio", Audio(sampling_rate=16000))
 
     logger.info("Dataset loaded: %s", raw_datasets)
-    logger.info(f'{raw_datasets["train"][0]}')
+    logger.info(f"{raw_datasets['train'][0]}")
 
     vectorized_datasets = raw_datasets.map(
         prepare_dataset,

--- a/examples/lora_dreambooth/convert_peft_sd_lora_to_kohya_ss.py
+++ b/examples/lora_dreambooth/convert_peft_sd_lora_to_kohya_ss.py
@@ -30,7 +30,7 @@ def get_module_kohya_state_dict(
 
         # Set alpha parameter
         if "lora_down" in kohya_key:
-            alpha_key = f'{kohya_key.split(".")[0]}.alpha'
+            alpha_key = f"{kohya_key.split('.')[0]}.alpha"
             kohya_ss_state_dict[alpha_key] = torch.tensor(module.peft_config[adapter_name].lora_alpha).to(dtype)
 
     return kohya_ss_state_dict

--- a/scripts/log_reports.py
+++ b/scripts/log_reports.py
@@ -37,7 +37,7 @@ def main(slack_channel_name=None):
                 if line.get("nodeid", "") != "":
                     test = line["nodeid"]
                     if line.get("duration", None) is not None:
-                        duration = f'{line["duration"]:.4f}'
+                        duration = f"{line['duration']:.4f}"
                         if line.get("outcome", "") == "failed":
                             section_num_failed += 1
                             failed.append([test, duration, log.name.split("_")[0]])

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras = {}
 extras["quality"] = [
     "black",  # doc-builder has an implicit dependency on Black, see huggingface/doc-builder#434
     "hf-doc-builder",
-    "ruff~=0.6.1",
+    "ruff~=0.9.2",
 ]
 extras["docs_specific"] = [
     "black",  # doc-builder has an implicit dependency on Black, see huggingface/doc-builder#434

--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -97,7 +97,7 @@ class _BaseAutoPeftModel:
             expected_target_class = MODEL_TYPE_TO_PEFT_MODEL_MAPPING[task_type]
             if cls._target_peft_class.__name__ != expected_target_class.__name__:
                 raise ValueError(
-                    f"Expected target PEFT class: {expected_target_class.__name__}, but you have asked for: {cls._target_peft_class.__name__ }"
+                    f"Expected target PEFT class: {expected_target_class.__name__}, but you have asked for: {cls._target_peft_class.__name__}"
                     " make sure that you are loading the correct model for your task type."
                 )
         elif task_type is None and getattr(peft_config, "auto_mapping", None) is not None:

--- a/src/peft/tuners/_buffer_dict.py
+++ b/src/peft/tuners/_buffer_dict.py
@@ -136,8 +136,7 @@ class BufferDict(Module):
             for j, p in enumerate(buffers):
                 if not isinstance(p, collections.abc.Iterable):
                     raise TypeError(
-                        "BufferDict update sequence element "
-                        "#" + str(j) + " should be Iterable; is" + type(p).__name__
+                        "BufferDict update sequence element #" + str(j) + " should be Iterable; is" + type(p).__name__
                     )
                 if not len(p) == 2:
                     raise ValueError(

--- a/src/peft/tuners/adaption_prompt/model.py
+++ b/src/peft/tuners/adaption_prompt/model.py
@@ -71,8 +71,7 @@ class AdaptionPromptModel(nn.Module):
                 parents.append(par)
         if len(parents) < config.adapter_layers:
             raise ValueError(
-                f"Config specifies more adapter layers '{config.adapter_layers}'"
-                f" than the model has '{len(parents)}'."
+                f"Config specifies more adapter layers '{config.adapter_layers}' than the model has '{len(parents)}'."
             )
         # Note that if the target modules are not in Sequential, ModuleList, or
         # some other PyTorch ordered container, the behavior is undefined as we

--- a/src/peft/tuners/boft/layer.py
+++ b/src/peft/tuners/boft/layer.py
@@ -276,7 +276,7 @@ class BOFTLayer(BaseTunerLayer):
         boft_n_butterfly_factor = boft_n_butterfly_factor - 1
         if boft_n_butterfly_factor < 0:
             raise ValueError(
-                f"You can only specify boft_n_butterfly_factor {boft_n_butterfly_factor+1} to be a positive integer number."
+                f"You can only specify boft_n_butterfly_factor {boft_n_butterfly_factor + 1} to be a positive integer number."
             )
 
         # Initialize the MultiplicativeDropoutLayer for boft_dropout > 0.0.
@@ -295,11 +295,11 @@ class BOFTLayer(BaseTunerLayer):
             if boft_n_butterfly_factor != 0:
                 if boft_n_butterfly_factor > int(math.log2(boft_block_num)):
                     raise ValueError(
-                        f"Invalid combination of boft_n_butterfly_factor ({boft_n_butterfly_factor+1}) and boft_block_num ({boft_block_num})!"
+                        f"Invalid combination of boft_n_butterfly_factor ({boft_n_butterfly_factor + 1}) and boft_block_num ({boft_block_num})!"
                     )
                 if boft_block_num % (2**boft_n_butterfly_factor) != 0:
                     raise ValueError(
-                        f"boft_block_num ({boft_block_num}) must be a multiple of 2 raised to the power of boft_n_butterfly_factor ({boft_n_butterfly_factor+1})!"
+                        f"boft_block_num ({boft_block_num}) must be a multiple of 2 raised to the power of boft_n_butterfly_factor ({boft_n_butterfly_factor + 1})!"
                     )
 
             boft_block_size = int(self.in_features // boft_block_num)
@@ -313,11 +313,11 @@ class BOFTLayer(BaseTunerLayer):
             if boft_n_butterfly_factor != 0:
                 if self.in_features < (boft_block_size * (2**boft_n_butterfly_factor)):
                     raise ValueError(
-                        f"Invalid combination of in_features ({self.in_features}), boft_n_butterfly_factor ({boft_n_butterfly_factor+1}) and boft_block_size ({boft_block_size})!"
+                        f"Invalid combination of in_features ({self.in_features}), boft_n_butterfly_factor ({boft_n_butterfly_factor + 1}) and boft_block_size ({boft_block_size})!"
                     )
                 if self.in_features % (boft_block_size * (2**boft_n_butterfly_factor)) != 0:
                     raise ValueError(
-                        f"Invalid combination of in_features ({self.in_features}), boft_n_butterfly_factor ({boft_n_butterfly_factor+1}) and boft_block_size ({boft_block_size})!"
+                        f"Invalid combination of in_features ({self.in_features}), boft_n_butterfly_factor ({boft_n_butterfly_factor + 1}) and boft_block_size ({boft_block_size})!"
                     )
 
             boft_block_num = int(self.in_features // boft_block_size)
@@ -694,7 +694,7 @@ class Conv2d(nn.Module, BOFTLayer):
         boft_n_butterfly_factor = boft_n_butterfly_factor - 1
         if boft_n_butterfly_factor < 0:
             raise ValueError(
-                f"You can only specify boft_n_butterfly_factor {boft_n_butterfly_factor+1} to be a positive integer number."
+                f"You can only specify boft_n_butterfly_factor {boft_n_butterfly_factor + 1} to be a positive integer number."
             )
 
         # Initialize the MultiplicativeDropoutLayer for boft_dropout > 0.0.
@@ -718,11 +718,11 @@ class Conv2d(nn.Module, BOFTLayer):
             if boft_n_butterfly_factor != 0:
                 if boft_n_butterfly_factor > int(math.log2(boft_block_num)):
                     raise ValueError(
-                        f"Invalid combination of boft_n_butterfly_factor ({boft_n_butterfly_factor+1}) and boft_block_num ({boft_block_num})!"
+                        f"Invalid combination of boft_n_butterfly_factor ({boft_n_butterfly_factor + 1}) and boft_block_num ({boft_block_num})!"
                     )
                 if boft_block_num % (2**boft_n_butterfly_factor) != 0:
                     raise ValueError(
-                        f"boft_block_num ({boft_block_num}) must be a multiple of 2 raised to the power of boft_n_butterfly_factor ({boft_n_butterfly_factor+1})!"
+                        f"boft_block_num ({boft_block_num}) must be a multiple of 2 raised to the power of boft_n_butterfly_factor ({boft_n_butterfly_factor + 1})!"
                     )
 
             boft_block_size = int(conv_filter_dim // boft_block_num)
@@ -736,11 +736,11 @@ class Conv2d(nn.Module, BOFTLayer):
             if boft_n_butterfly_factor != 0:
                 if conv_filter_dim < (boft_block_size * (2**boft_n_butterfly_factor)):
                     raise ValueError(
-                        f"Invalid combination of convolutional kernel dimension ({conv_filter_dim}), boft_n_butterfly_factor ({boft_n_butterfly_factor+1}) and boft_block_size ({boft_block_size})!"
+                        f"Invalid combination of convolutional kernel dimension ({conv_filter_dim}), boft_n_butterfly_factor ({boft_n_butterfly_factor + 1}) and boft_block_size ({boft_block_size})!"
                     )
                 if conv_filter_dim % (boft_block_size * (2**boft_n_butterfly_factor)) != 0:
                     raise ValueError(
-                        f"Invalid combination of convolutional kernel dimension ({conv_filter_dim}), boft_n_butterfly_factor ({boft_n_butterfly_factor+1}) and boft_block_size ({boft_block_size})!"
+                        f"Invalid combination of convolutional kernel dimension ({conv_filter_dim}), boft_n_butterfly_factor ({boft_n_butterfly_factor + 1}) and boft_block_size ({boft_block_size})!"
                     )
 
             boft_block_num = int(conv_filter_dim // boft_block_size)

--- a/src/peft/tuners/bone/model.py
+++ b/src/peft/tuners/bone/model.py
@@ -197,7 +197,7 @@ class BoneModel(BaseTuner):
             new_module = BoneLinear(target, adapter_name, **kwargs)
         else:
             raise ValueError(
-                f"Target module {target} is not supported. " "Currently, only `torch.nn.Linear` is supported."
+                f"Target module {target} is not supported. Currently, only `torch.nn.Linear` is supported."
             )
 
         return new_module

--- a/src/peft/tuners/fourierft/model.py
+++ b/src/peft/tuners/fourierft/model.py
@@ -190,8 +190,7 @@ class FourierFTModel(BaseTuner):
             kwargs["is_target_conv_1d_layer"] = True
             if not kwargs["fan_in_fan_out"]:
                 warnings.warn(
-                    "fan_in_fan_out is set to False but the target module is `Conv1D`. "
-                    "Setting fan_in_fan_out to True."
+                    "fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True."
                 )
                 kwargs["fan_in_fan_out"] = fourierft_config.fan_in_fan_out = True
         else:

--- a/src/peft/tuners/ia3/model.py
+++ b/src/peft/tuners/ia3/model.py
@@ -133,8 +133,7 @@ class IA3Model(BaseTuner):
         elif isinstance(target_base_layer, Conv1D):
             if not kwargs["fan_in_fan_out"]:
                 warnings.warn(
-                    "fan_in_fan_out is set to False but the target module is `Conv1D`. "
-                    "Setting fan_in_fan_out to True."
+                    "fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True."
                 )
                 kwargs["fan_in_fan_out"] = ia3_config.fan_in_fan_out = True
             new_module = Linear(

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -1724,7 +1724,7 @@ def dispatch_default(
     elif isinstance(target_base_layer, Conv1D):
         if not kwargs["fan_in_fan_out"]:
             warnings.warn(
-                "fan_in_fan_out is set to False but the target module is `Conv1D`. " "Setting fan_in_fan_out to True."
+                "fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True."
             )
             kwargs["fan_in_fan_out"] = lora_config.fan_in_fan_out = True
         kwargs.update(lora_config.loftq_config)

--- a/src/peft/tuners/vblora/model.py
+++ b/src/peft/tuners/vblora/model.py
@@ -213,8 +213,7 @@ class VBLoRAModel(BaseTuner):
             kwargs["is_target_conv_1d_layer"] = True
             if not kwargs["fan_in_fan_out"]:
                 warnings.warn(
-                    "fan_in_fan_out is set to False but the target module is `Conv1D`. "
-                    "Setting fan_in_fan_out to True."
+                    "fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True."
                 )
                 kwargs["fan_in_fan_out"] = vblora_config.fan_in_fan_out = True
         else:

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -340,8 +340,7 @@ class VeraModel(BaseTuner):
             kwargs["is_target_conv_1d_layer"] = True
             if not kwargs["fan_in_fan_out"]:
                 warnings.warn(
-                    "fan_in_fan_out is set to False but the target module is `Conv1D`. "
-                    "Setting fan_in_fan_out to True."
+                    "fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True."
                 )
                 kwargs["fan_in_fan_out"] = vera_config.fan_in_fan_out = True
         else:

--- a/src/peft/utils/loftq_utils.py
+++ b/src/peft/utils/loftq_utils.py
@@ -203,8 +203,7 @@ def loftq_init(weight: Union[torch.Tensor, torch.nn.Parameter], num_bits: int, r
     dtype = weight.dtype
 
     logging.info(
-        f"Weight: ({out_feature}, {in_feature}) | Rank: {reduced_rank} "
-        f"| Num Iter: {num_iter} | Num Bits: {num_bits}"
+        f"Weight: ({out_feature}, {in_feature}) | Rank: {reduced_rank} | Num Iter: {num_iter} | Num Bits: {num_bits}"
     )
     if not is_bnb_4bit_available() or num_bits in [2, 8]:
         quantizer = NFQuantizer(num_bits=num_bits, device=device, method="normal", block_size=64)

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1959,9 +1959,9 @@ class TestMultiRankAdapter(unittest.TestCase):
                 if isinstance(module, BaseTunerLayer):
                     rank_expected = rank_pattern.get(key, r)
                     rank_current = module.lora_A[adapter].weight.shape[0]
-                    assert (
-                        rank_current == rank_expected
-                    ), f"Rank {rank_current} is not equal to expected {rank_expected}"
+                    assert rank_current == rank_expected, (
+                        f"Rank {rank_current} is not equal to expected {rank_expected}"
+                    )
 
 
 class TestRepr(unittest.TestCase):

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -495,9 +495,9 @@ class PeftDecoderModelTester(unittest.TestCase, PeftCommonTester):
             and layers[2].mlp.up_proj.lora_A.default.weight.data.storage().data_ptr()
             != layers[3].mlp.up_proj.lora_A.default.weight.data.storage().data_ptr()
         ), "Expected all LoRA adapters to have distinct weights"
-        assert (
-            len([n for n, _ in model.named_parameters() if ".lora_A." in n]) == 8
-        ), "Expected 8 LoRA adapters since we are adding one each for up and down."
+        assert len([n for n, _ in model.named_parameters() if ".lora_A." in n]) == 8, (
+            "Expected 8 LoRA adapters since we are adding one each for up and down."
+        )
         self._test_prepare_for_training(model_id, LoraConfig, config_kwargs)
         self._test_generate(model_id, LoraConfig, config_kwargs)
 

--- a/tests/test_incremental_pca.py
+++ b/tests/test_incremental_pca.py
@@ -93,7 +93,7 @@ def test_incremental_pca_validation():
     n_components = 3
     with pytest.raises(
         ValueError,
-        match=(f"n_components={n_components} must be" " less or equal to the batch number of" f" samples {n_samples}"),
+        match=(f"n_components={n_components} must be less or equal to the batch number of samples {n_samples}"),
     ):
         IncrementalPCA(n_components=n_components).partial_fit(X)
 


### PR DESCRIPTION
## Description

We use ruff for linting. The version is fixed because otherwise, we formatting changes would creep into random PRs. Thus far, the version was ~0.6.1 but that's already quite old by now, thus moving to ~v0.9.2.

The ruff changes themselves are all about:

1. Other line breaking logic for asserts with messages
2. More aggressive string normalizaton

## Comment

Making these changes is always a bit annoying since existing PRs might need to be updated, but there is never a really good time to do it.