### PR TITLE
TST Use different diffusion model for testing

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -179,7 +179,7 @@ class TestScalingAdapters:
         assert torch.allclose(logits_base_model, logits_lora_model)
 
     def test_diffusers_pipeline(self):
-        model_id = "hf-internal-testing/tiny-stable-diffusion-torch"
+        model_id = "hf-internal-testing/tiny-sd-pipe"
         pipeline = StableDiffusionPipeline.from_pretrained(model_id)
 
         text_encoder_kwargs = {

--- a/tests/test_stablediffusion.py
+++ b/tests/test_stablediffusion.py
@@ -36,7 +36,7 @@ from .testing_common import ClassInstantier, PeftCommonTester
 from .testing_utils import temp_seed
 
 
-PEFT_DIFFUSERS_SD_MODELS_TO_TEST = ["hf-internal-testing/tiny-stable-diffusion-torch"]
+PEFT_DIFFUSERS_SD_MODELS_TO_TEST = ["hf-internal-testing/tiny-sd-pipe"]
 CONFIG_TESTING_KWARGS = (
     {
         "text_encoder": {

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -331,7 +331,7 @@ class PeftCustomKwargsTester(unittest.TestCase):
             assert new_config.target_modules == expected_target_modules
 
     def test_maybe_include_all_linear_layers_diffusion(self):
-        model_id = "hf-internal-testing/tiny-stable-diffusion-torch"
+        model_id = "hf-internal-testing/tiny-sd-pipe"
         model = StableDiffusionPipeline.from_pretrained(model_id)
         config = LoraConfig(base_model_name_or_path=model_id, target_modules="all-linear")
 


### PR DESCRIPTION
So far, tests are using `hf-internal-testing/tiny-stable-diffusion-torch` for testing diffusion models. However, this model has some issues:

- still uses pickle (.bin) instead of safetensors
- there is a `FutureWarning` because of the config

Now, using `hf-internal-testing/tiny-sd-pipe` (thanks Sayak for suggesting) instead which doesn't have those issues.

On top of that, there is often a Hub error when loading the diffusion model, although it's unclear why this particular model is so prone to that. Maybe the new model eschews this error, but even if it doesn't, it is better to make the switch.