### PR TITLE
Use locked install for zizmor

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -23,6 +23,6 @@ jobs:
         with:
           persist-credentials: false
       - name: Install zizmor
-        run: cargo install zizmor
+        run: cargo install --locked zizmor
       - name: Run zizmor
         run: zizmor .github/workflows


### PR DESCRIPTION
To be on the safe side when installing zizmor and it's dependencies we're using a locked installation, meaning that the dependencies and their versions are taken from the Cargo.lock file.

This will hopefully reduce the chances of having the pipeline randomly fail due to updated dependencies down the line.