### PR TITLE
FIX: Small fixes to hotswapping

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -160,3 +160,8 @@ def is_xpu_available(check_device=False):
             except RuntimeError:
                 return False
         return hasattr(torch, "xpu") and torch.xpu.is_available()
+
+
+@lru_cache
+def is_diffusers_available():
+    return importlib.util.find_spec("diffusers") is not None

--- a/src/peft/utils/hotswap.py
+++ b/src/peft/utils/hotswap.py
@@ -450,7 +450,7 @@ def hotswap_adapter_from_state_dict(
                 )
 
 
-def _check_hotswap_configs_compatible(config0: PeftConfig, config1: PeftConfig) -> None:
+def check_hotswap_configs_compatible(config0: PeftConfig, config1: PeftConfig) -> None:
     """
     Check if two configs are compatible for hot-swapping.
 
@@ -556,7 +556,7 @@ def hotswap_adapter(model, model_name_or_path, adapter_name, torch_device=None, 
     ]
     config = config_cls.from_pretrained(model_name_or_path, **kwargs)
     # config keys that could affect the model output besides what is determined by the state_dict
-    _check_hotswap_configs_compatible(model.active_peft_config, config)
+    check_hotswap_configs_compatible(model.active_peft_config, config)
 
     state_dict = load_peft_weights(model_name_or_path, device=torch_device, **kwargs)
 

--- a/src/peft/utils/hotswap.py
+++ b/src/peft/utils/hotswap.py
@@ -431,11 +431,19 @@ def hotswap_adapter_from_state_dict(
         # Compiled models don't work with swap_tensors because there are weakrefs for the tensor. It is unclear if
         # this workaround could not cause trouble but the tests indicate that it works.
         if old_val.shape == new_val.shape:
+            # either
+            # - adapters had the same rank
+            # - adapters were padded with prepare_model_for_compiled_hotswap and 2nd adapter was larger
             old_val.data = new_val.data
         else:
-            if old_val.dim() != 2:
-                # TODO conv2d
-                raise NotImplementedError
+            # if 2nd adapter was smaller, ensure to fill up to adapter dimension and set the rest to zeros
+            if old_val.dim() not in (2, 4):
+                raise NotImplementedError(
+                    f"Trying to hotswap an adapter whose weight has {old_val.dim()} dimensions, but only Conv2d and "
+                    "Linear are supported"
+                )
+
+            # Linear or Conv2d: the check for dim 0 or 1 works for both of these layer types
             if old_val.shape[0] > new_val.shape[0]:
                 old_val.data.fill_(0)
                 old_val.data[: new_val.shape[0]] = new_val.data

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4337,10 +4337,10 @@ class TestHotSwapping:
             unet(**dummy_input)["sample"]
 
             if do_hotswap:
-                unet.load_lora_adapter(file_name1, adapter_name="default_0", hotswap=True)
+                unet.load_lora_adapter(file_name1, adapter_name="adapter0", hotswap=True)
             else:
                 # offloading the old and loading the new adapter will result in recompilation
-                self.set_lora_device(unet, adapter_names=["default_0"], device="cpu")
+                self.set_lora_device(unet, adapter_names=["adapter0"], device="cpu")
                 unet.load_lora_adapter(file_name1, adapter_name="other_name", hotswap=False)
 
             # we need to call forward to potentially trigger recompilation

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4316,8 +4316,8 @@ class TestHotSwapping:
         unet = self.get_small_unet()
         rank0, rank1 = ranks
         alpha0, alpha1 = alpha_scalings
-        lora_config0 = self.get_unet_lora_config(rank0, alpha0, target_modules=["conv", "conv1", "conv2"])
-        lora_config1 = self.get_unet_lora_config(rank1, alpha1, target_modules=["conv", "conv1", "conv2"])
+        lora_config0 = self.get_unet_lora_config(rank0, alpha0, target_modules=target_modules)
+        lora_config1 = self.get_unet_lora_config(rank1, alpha1, target_modules=target_modules)
         unet.add_adapter(lora_config0, adapter_name="adapter0")
         unet.add_adapter(lora_config1, adapter_name="adapter1")
 


### PR DESCRIPTION
A couple of smaller issues that surfaced when working on the diffusers integration are not fixed.

- Better detection if model is compiled in `prepare_model_for_compiled_hotswap`
- Fix handling of models that are compiled but where compilation is not detected (from "inside" the model, discussed internally)
- Handle device of swapped in adapter weights.
- Wrong adapter name in compiled diffusion model test
- Add hotswap test for different alphas and ranks but model not being compiled (linear and conv2d)
- Make diffusers import local in test file to avoid bnb nightly tests from failing owing to the missing import