### PR TITLE
O(n^m) to O(n) for finding no target names

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -464,9 +464,9 @@ class BaseTuner(nn.Module, ABC):
             names_no_target = []
             for name in key_list:
                 parts = name.split('.')
-                key_list_suffixes = ['.'.join(parts[i:]) for i in range(len(parts))]
+                suffixes = ['.'.join(parts[i:]) for i in range(len(parts))]
                 # Check if any of the suffixes (i.e. ['a.b.c', 'b.c', 'c']) are in the target_modules_set
-                if not any(suffix in target_modules_set for suffix in key_list_suffixes):
+                if not any(suffix in target_modules_set for suffix in suffixes):
                     names_no_target.append(name)
 
             new_target_modules = _find_minimal_target_modules(peft_config.target_modules, names_no_target)

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -460,11 +460,15 @@ class BaseTuner(nn.Module, ABC):
             isinstance(peft_config.target_modules, (list, set))
             and len(peft_config.target_modules) >= MIN_TARGET_MODULES_FOR_OPTIMIZATION
         ):
-            names_no_target = [
-                name
-                for name in key_list
-                if not any((name == suffix) or name.endswith("." + suffix) for suffix in peft_config.target_modules)
-            ]
+            target_modules_set = set(peft_config.target_modules)
+            names_no_target = []
+            for name in key_list:
+                parts = name.split('.')
+                key_list_suffixes = ['.'.join(parts[i:]) for i in range(len(parts))]
+                # Check if any of the suffixes (i.e. ['a.b.c', 'b.c', 'c']) are in the target_modules_set
+                if not any(suffix in target_modules_set for suffix in key_list_suffixes):
+                    names_no_target.append(name)
+
             new_target_modules = _find_minimal_target_modules(peft_config.target_modules, names_no_target)
             if len(new_target_modules) < len(peft_config.target_modules):
                 peft_config.target_modules = new_target_modules


### PR DESCRIPTION
The code snippet finds modules that are not targeted by the LoRA adaptor. 

Previous implementation is a double for-loop along the modules in the model and lora targets, and has a `O(n*m)` runtime, where `n` can be up to a 1000 and `m` can be up to 500 depending on the LoRA. The logic is meant to find model modules that don't contain a suffix (starting with a `'.'` or the beginning of the word) found in LoRA targets. 

Instead of a double for loop, we could split module names by `'.'` to find all potential suffixes, and check if any of them are contained in the LoRA targets, which have been turned into a lookup table. Module names are split into less than 10 suffixes, so it is effectively an O(n) operation

This change reduces  the latency of `load_lora_weights()` by around 0.6 seconds on an Azure A100 machine, for a 300MB Flux adaptor ([kishlaykumar1995/blinky-flux-lora-32](https://huggingface.co/kishlaykumar1995/blinky-flux-lora-32)). When the lora `state_dict` is loaded on the GPU already, `load_lora_weights()` used to take around 1.1 secs, so it achieves a 50% reduction in latency of applying LoRA