### PR TITLE
Fix: Ensure hf_hub_download arguments are used when loading locally

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -505,6 +505,7 @@ def load_peft_weights(model_id: str, device: Optional[str] = None, **hf_hub_down
     elif huggingface_hub.constants.HF_HUB_OFFLINE:
         # if in offline mode, check if we can find the adapter file locally
         hub_filename = get_hub_filename(use_safetensors=True)
+        hf_hub_download_kwargs.pop("local_files_only", None)
         try:
             filename = hf_hub_download(model_id, hub_filename, local_files_only=True, **hf_hub_download_kwargs)
             use_safetensors = True

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -506,13 +506,13 @@ def load_peft_weights(model_id: str, device: Optional[str] = None, **hf_hub_down
         # if in offline mode, check if we can find the adapter file locally
         hub_filename = get_hub_filename(use_safetensors=True)
         try:
-            filename = hf_hub_download(model_id, hub_filename, local_files_only=True)
+            filename = hf_hub_download(model_id, hub_filename, local_files_only=True, **hf_hub_download_kwargs)
             use_safetensors = True
         except LocalEntryNotFoundError:
             # Could not find safetensors, try pickle. If this also fails, it's fine to let the error be raised here, as
             # it means that the user tried to load a non-cached model in offline mode.
             hub_filename = get_hub_filename(use_safetensors=False)
-            filename = hf_hub_download(model_id, hub_filename, local_files_only=True)
+            filename = hf_hub_download(model_id, hub_filename, local_files_only=True, **hf_hub_download_kwargs)
             use_safetensors = False
     else:
         token = hf_hub_download_kwargs.get("token", None)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 import pytest
 import torch
 from datasets import Dataset, load_dataset
+from huggingface_hub import snapshot_download
 from huggingface_hub.utils import reset_sessions
 from safetensors.torch import load_file
 from scipy import stats
@@ -1563,8 +1564,11 @@ class TestNoInfiniteRecursionDeepspeed:
 
 
 class TestLoadAdapterOfflineMode:
+    
+    base_model = "hf-internal-testing/tiny-random-OPTForCausalLM"
+    peft_model_id = "peft-internal-testing/tiny-OPTForCausalLM-lora"
+    
     # make sure that PEFT honors offline mode
-
     @contextmanager
     def hub_offline_ctx(self):
         # this is required to simulate offline mode, setting the env var dynamically inside the test does not work
@@ -1576,18 +1580,36 @@ class TestLoadAdapterOfflineMode:
 
     def test_load_from_hub_then_offline_model(self):
         # this uses LoRA but it's the same mechanism for other methods
-        peft_model_id = "peft-internal-testing/gpt2-lora-random"
-        base_model = AutoModelForCausalLM.from_pretrained("gpt2")
+        base_model = AutoModelForCausalLM.from_pretrained(self.base_model)
 
         # first ensure that the adapter model has been downloaded
-        PeftModel.from_pretrained(base_model, peft_model_id)
+        PeftModel.from_pretrained(base_model, self.peft_model_id)
 
         del base_model
 
-        base_model = AutoModelForCausalLM.from_pretrained("gpt2")
+        base_model = AutoModelForCausalLM.from_pretrained(self.base_model)
         with self.hub_offline_ctx():
             # does not raise
-            PeftModel.from_pretrained(base_model, peft_model_id)
+            PeftModel.from_pretrained(base_model, self.peft_model_id)
+    
+    @pytest.fixture
+    def changed_default_cache_dir(self, tmp_path, monkeypatch):
+        # ensure that this test does not interact with other tests that may use the HF cache
+        monkeypatch.setattr("huggingface_hub.constants.HF_HOME", tmp_path)
+        monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", tmp_path / "hub")
+        monkeypatch.setattr("huggingface_hub.constants.HF_TOKEN_PATH", tmp_path / "token")
+    
+    def load_checkpoints(self, cache_dir):
+        # download model and lora checkpoint to a specific cache dir
+        snapshot_download(self.base_model, cache_dir=cache_dir)
+        snapshot_download(self.peft_model_id, cache_dir=cache_dir)
+
+    def test_load_checkpoint_offline_non_default_cache_dir(self, changed_default_cache_dir, tmp_path):
+        # See #2373 for context
+        self.load_checkpoints(tmp_path)
+        with self.hub_offline_ctx():
+            base_model = AutoModelForCausalLM.from_pretrained(self.base_model, cache_dir=tmp_path)
+            PeftModel.from_pretrained(base_model, self.peft_model_id, cache_dir=tmp_path)
 
 
 class TestCustomModelConfigWarning:

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1564,10 +1564,9 @@ class TestNoInfiniteRecursionDeepspeed:
 
 
 class TestLoadAdapterOfflineMode:
-    
     base_model = "hf-internal-testing/tiny-random-OPTForCausalLM"
     peft_model_id = "peft-internal-testing/tiny-OPTForCausalLM-lora"
-    
+
     # make sure that PEFT honors offline mode
     @contextmanager
     def hub_offline_ctx(self):
@@ -1591,14 +1590,14 @@ class TestLoadAdapterOfflineMode:
         with self.hub_offline_ctx():
             # does not raise
             PeftModel.from_pretrained(base_model, self.peft_model_id)
-    
+
     @pytest.fixture
     def changed_default_cache_dir(self, tmp_path, monkeypatch):
         # ensure that this test does not interact with other tests that may use the HF cache
         monkeypatch.setattr("huggingface_hub.constants.HF_HOME", tmp_path)
         monkeypatch.setattr("huggingface_hub.constants.HF_HUB_CACHE", tmp_path / "hub")
         monkeypatch.setattr("huggingface_hub.constants.HF_TOKEN_PATH", tmp_path / "token")
-    
+
     def load_checkpoints(self, cache_dir):
         # download model and lora checkpoint to a specific cache dir
         snapshot_download(self.base_model, cache_dir=cache_dir)


### PR DESCRIPTION
This PR solves the issue that:
When loading a PEFT model locally, the provided arguments for hf_hub_download (e.g., local_dir and cache_dir) are not being passed correctly. As a result, custom paths specified by the user are ignored, leading to potential issues with file loading.