### PR TITLE
SEC Bump transformers version used in examples

### DIFF
--- a/examples/boft_controlnet/requirements.txt
+++ b/examples/boft_controlnet/requirements.txt
@@ -1,6 +1,6 @@
 datasets==2.16.1
 diffusers==0.17.1
-transformers==4.36.2
+transformers=>4.48.0
 accelerate==0.25.0
 wandb==0.16.1
 scikit-image==0.22.0

--- a/examples/boft_dreambooth/requirements.txt
+++ b/examples/boft_dreambooth/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.36.2
+transformers=>4.48.0
 accelerate==0.25.0
 evaluate
 tqdm

--- a/examples/hra_dreambooth/requirements.txt
+++ b/examples/hra_dreambooth/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.36.2
+transformers=>4.48.0
 accelerate==0.25.0
 evaluate
 tqdm


### PR DESCRIPTION
There were approximately 322 [dependabot security advisories](https://github.com/huggingface/peft/security/dependabot/15) for this, so let's bump the transformers version used in the requirements.txt of a couple of examples. Note that this is not a real security issue, as that issue is with another model that's not being used in the examples.