### PR TITLE
ENH prepare_model_for_compiled_hotswap raises when no adapter was found

### DIFF
--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -3279,6 +3279,12 @@ class TestHotSwapping:
         with pytest.raises(ValueError, match=msg):
             prepare_model_for_compiled_hotswap(model)
 
+    def test_prepare_model_for_compiled_hotswap_model_no_adapter_raises(self):
+        model = self.get_model()
+        msg = re.escape("No adapter layers found on the model")
+        with pytest.raises(ValueError, match=msg):
+            prepare_model_for_compiled_hotswap(model)
+
     def test_prepare_model_for_compiled_hotswap_does_not_change_output(self):
         # preparing the model for hotswapping should not change the model output
         inputs = torch.rand(3, 10).to(self.torch_device)


### PR DESCRIPTION
When erroneously calling `prepare_model_for_compiled_hotswap` before loading any LoRA adapter, right now, nothing happens. Later, users will run into an error because the model was not prepared. Therefore, we now raise an error when the function did not detect any adapter layers and give an appropriate error message.