### PR TITLE
CI Skip audio test on single GPU CI

### DIFF
--- a/.github/workflows/nightly-bnb.yml
+++ b/.github/workflows/nightly-bnb.yml
@@ -194,11 +194,6 @@ jobs:
           status: ${{ steps.import.outcome }}
           slack_token: ${{ secrets.SLACK_CIFEEDBACK_BOT_TOKEN }}
 
-      - name: Run core GPU tests on multi-gpu
-        if: always()
-        run: |
-          source activate peft
-
       - name: Run examples on multi GPU
         id: examples_tests
         if: always()

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -682,6 +682,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
             # assert loss is not None
             assert trainer.state.log_history[-1]["train_loss"] is not None
 
+    # TODO skipping to see if this leads to single GPU tests passing
+    @pytest.mark.skip
     @pytest.mark.single_gpu_tests
     def test_audio_model_training(self):
         r"""


### PR DESCRIPTION
It appears that the single GPU tests are always failing at this test ("The operation was canceled"), probably because it is hanging (after more than 5h). Let's try to debug by skipping this test.

Moreover, remove a superfluous step in the BNB CI workflow (correct step is defined [further below](https://github.com/huggingface/peft/blob/1e2d6b5832401e07e917604dfb080ec474818f2b/.github/workflows/nightly.yml#L106-L109)).