### PR TITLE
FIX: Avoid caching in X-LoRA generate

### DIFF
--- a/src/peft/tuners/xlora/model.py
+++ b/src/peft/tuners/xlora/model.py
@@ -314,6 +314,7 @@ class XLoraModel(BaseTuner):
                     param.requires_grad = False
 
     def generate(self, *args, **kwargs):
+        kwargs["use_cache"] = False
         res = self.lora_model.generate(*args, **kwargs)  # type: ignore
         #  This is necessary because we use PeftModel.disable_adapter() which reenables the adapters
         self._maybe_freeze_all_adapters()

--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -28,6 +28,7 @@ from peft.utils import infer_device
 
 def flaky(num_tries: int):
     """Decorator for test functions that are flaky"""
+
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -38,7 +39,9 @@ def flaky(num_tries: int):
                     print(f"Failed test {func.__name__} with error: {e}")
                     continue
             raise AssertionError(f"Failed test {func.__name__} after {num_tries} tries")
+
         return wrapper
+
     return decorator
 
 

--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -128,8 +128,6 @@ class TestXlora:
         )
         assert torch.isfinite(outputs[: inputs.shape[1] :]).all()
 
-    # TODO: fix the xfailing test
-    @pytest.mark.xfail
     def test_scalings_logging_methods(self, tokenizer, model):
         model.enable_scalings_logging()
 
@@ -182,8 +180,6 @@ class TestXlora:
 
         assert str(model) is not None
 
-    # TODO: On CI (but not locally), this test seems to have become flaky with the latest transformers changes (v4.45).
-    @pytest.mark.xfail
     def test_save_load_functional(self, tokenizer, model, tmp_path):
         inputs = tokenizer.encode("Python is a", add_special_tokens=False, return_tensors="pt")
         outputs = model.generate(


### PR DESCRIPTION
Supersedes #2383.

X-LoRA tests started failing after this transformers PR (see e.g. [here](https://github.com/huggingface/peft/actions/runs/13374222006/job/37349744808?pr=2382)):

https://github.com/huggingface/transformers/pull/35724

The solution appears to be to disable caching completely when calling generate on the X-LoRA model. This also makes some previously xfail-ing tests pass.

I tested this locally with transformers checked out before and after the mentioned PR and the tests pass in both circumstances. I also tested changing the base model from "facebook/opt-125m" to "trl-internal-testing/tiny-random-LlamaForCausalLM" and the tests passed with both.