### PR TITLE
FIX: Failing single GPU tests related to hotswapping

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4210,7 +4210,7 @@ class TestHotSwapping:
             output1 = model(inputs).logits
 
         # sanity check:
-        tol = 1e-5
+        tol = 1e-4
         assert not torch.allclose(output0, output1, atol=tol, rtol=tol)
 
         with tempfile.TemporaryDirectory() as tmp_dirname:
@@ -4351,7 +4351,9 @@ class TestHotSwapping:
 
     @pytest.mark.skipif(not is_diffusers_available(), reason="Test requires diffusers to be installed")
     @pytest.mark.xfail(
-        strict=True, reason="Requires hotswap to be implemented in diffusers", raises=torch._dynamo.exc.RecompileError
+        strict=True,
+        reason="Requires hotswap to be implemented in diffusers",
+        raises=ValueError,
     )
     # it is important to check hotswapping small to large ranks and large to small ranks
     @pytest.mark.parametrize("ranks", [(11, 11), (7, 13), (13, 7)])


### PR DESCRIPTION
After unblocking single GPU tests with #2380, a couple of tests related to hotswapping failed. This PR should (hopefully) address this.

1. Wrong error type caught with `xfail`

I set the wrong error type for the `xfail`ing compiled hotswap diffusers tests. This was because I hadn't checked out diffusers main when I was checking locally.

2. Loosen tolerance

Some tests fail because an `allclose` does not match even though the numbers in the logs look pretty much identical:

https://github.com/huggingface/peft/actions/runs/13404117333/job/37440752790#step:6:1929

This is most likely a problem with tolerances being too strict. Unfortunately, I can't reproduce the error locally, so I have to guess that moving from `1e-5` to `1e-4` will the issue.

Note: Since this only affects GPU tests, the normal CI won't cover it.