### PR TITLE
FIX Bug with PeftConfig.from_pretrained

### DIFF
--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -155,7 +155,7 @@ class PeftConfigMixin(PushToHubMixin):
             if "got an unexpected keyword argument" not in str(exc):
                 raise exc
 
-            filtered_kwargs, unexpected_kwargs = _check_and_remove_unused_kwargs(cls, kwargs)
+            filtered_kwargs, unexpected_kwargs = _check_and_remove_unused_kwargs(config_cls, kwargs)
             if not MIN_EXPECTED_CONFIG_KEYS.issubset(set(filtered_kwargs.keys())):
                 raise TypeError(
                     f"The {cls.__name__} config that is trying to be loaded is missing required keys: "
@@ -163,7 +163,7 @@ class PeftConfigMixin(PushToHubMixin):
                 )
 
             warnings.warn(
-                f"Unexpected keyword arguments {sorted(unexpected_kwargs)} for class {cls.__name__}, these are "
+                f"Unexpected keyword arguments {sorted(unexpected_kwargs)} for class {config_cls.__name__}, these are "
                 "ignored. This probably means that you're loading a configuration file that was saved using a "
                 "higher version of the library and additional parameters have been introduced since. It is "
                 "highly recommended to upgrade the PEFT version before continuing (e.g. by running `pip install "

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -405,6 +405,36 @@ class TestPeftConfig:
         assert isinstance(config_from_pretrained, config_class)
 
     @pytest.mark.parametrize("config_class, mandatory_kwargs", ALL_CONFIG_CLASSES)
+    def test_from_pretrained_forward_compatible_load_from_peft_config(
+        self, config_class, mandatory_kwargs, tmp_path, recwarn
+    ):
+        """Exact same test as before, but instead of using LoraConfig.from_pretrained, AdaLoraconfig.from_pretrained,
+        etc. use PeftConfig.from_pretrained. This covers a previously existing bug where only the known arguments from
+        PeftConfig would be used instead of the more specific config (which is known thanks to the peft_type
+        attribute).
+
+        """
+        config = config_class(**mandatory_kwargs)
+        config.save_pretrained(tmp_path)
+        # add a spurious key to the config
+        with open(tmp_path / "adapter_config.json") as f:
+            config_dict = json.load(f)
+        config_dict["foobar"] = "baz"
+        config_dict["spam"] = 123
+        with open(tmp_path / "adapter_config.json", "w") as f:
+            json.dump(config_dict, f)
+
+        msg = f"Unexpected keyword arguments ['foobar', 'spam'] for class {config_class.__name__}, these are ignored."
+        config_from_pretrained = PeftConfig.from_pretrained(tmp_path)  # <== use PeftConfig here
+
+        assert len(recwarn) == 1
+        assert recwarn.list[0].message.args[0].startswith(msg)
+        assert "foo" not in config_from_pretrained.to_dict()
+        assert "spam" not in config_from_pretrained.to_dict()
+        assert config.to_dict() == config_from_pretrained.to_dict()
+        assert isinstance(config_from_pretrained, config_class)
+
+    @pytest.mark.parametrize("config_class, mandatory_kwargs", ALL_CONFIG_CLASSES)
     def test_from_pretrained_sanity_check(self, config_class, mandatory_kwargs, tmp_path):
         """Following up on the previous test about forward compatibility, we *don't* want any random json to be accepted as
         a PEFT config. There should be a minimum set of required keys.


### PR DESCRIPTION
In #2038, we added a change to PEFT to make PEFT configs forward compatible. To recap, when we add a new config value, say `foo`, for the `LoraConfig`, normally users of older PEFT versions would get an error when trying to load it because `LoraConfig` would not accept a `foo` argument. Now, we remove this unknown arg and just give a warning.

In general, this worked well, but there was a bug when using `PeftConfig.from_pretrained` instead of the more specific `LoraConfig.from_pretrained` etc. In that case, we would check the known arguments from the `PeftConfig` type, which are only a few. This means that we would ignore parameters like the rank `r` for LoRA.

With this PR, that bug is fixed. As we know the specific PEFT config, we can use that instead of the `PeftConfig` super type to determine the unknown parameters. Therefore, `PeftConfig.from_pretrained` will work the same as `LoraConfig.from_pretrained` etc.

Note that when a user uses `PeftModel.from_pretrained`, under the hood it will use the more specific PEFT config, i.e. `LoraConfig` etc. Therefore, the described bug would not occur there. It is thus very unlikely that this bug affected many (or any) users in the wild.