### PR TITLE
Enable grad checkpointing after get_peft_model

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1378,6 +1378,13 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         card.text = "\n".join(lines)
         card.save(filename)
 
+    def gradient_checkpointing_enable(self):
+        if hasattr(self.base_model, "gradient_checkpointing_enable"):
+            self.base_model.gradient_checkpointing_enable()
+            self.base_model = self._prepare_model_for_gradient_checkpointing(self.base_model)
+        else:
+            raise AttributeError("gradient_checkpointing_enable is not defined")
+
 
 class PeftModelForSequenceClassification(PeftModel):
     """


### PR DESCRIPTION
# What does this PR do ?

Fixes https://github.com/huggingface/transformers/issues/35826
This PR enables grad checkpointing even if the model is already converted to a PeftModel. I can add a test if needed, but where should I put it ? I see that you have `_test_training_gradient_checkpointing` but it is a common test. 

The following works:
```python
model = ...
model.enable_gradient_checkpointing()
config = ...
model = get_peft_model(model, config)
```

but not that (with this PR, it should work now) : 
```python
model = ...
config = ...
model = get_peft_model(model, config)
model.enable_gradient_checkpointing() # doesn't return an error or a warning, so the users think that it worked
```
