### PR TITLE
FIX GPTQModel Lora Compat

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -52,7 +52,7 @@ def is_auto_gptq_available():
 @lru_cache
 def is_gptqmodel_available():
     if importlib.util.find_spec("gptqmodel") is not None:
-        GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("1.9.0")
+        GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("1.9.99")
         OPTIMUM_MINIMUM_VERSION = packaging.version.parse("1.23.99")
         version_gptqmodel = packaging.version.parse(importlib_metadata.version("gptqmodel"))
         if GPTQMODEL_MINIMUM_VERSION <= version_gptqmodel:

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 import importlib
 import importlib.metadata as importlib_metadata
+import logging
 import platform
 from functools import lru_cache
 
 import packaging.version
 import torch
 
+log = logging.getLogger(__name__)
 
 @lru_cache
 def is_bnb_available() -> bool:
@@ -50,9 +52,9 @@ def is_auto_gptq_available():
 
 
 @lru_cache
-def is_gptqmodel_available():
+def is_gptqmodel_available(prompt_install: bool = False):
     if importlib.util.find_spec("gptqmodel") is not None:
-        GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("1.7.0")
+        GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("1.9.0")
         OPTIMUM_MINIMUM_VERSION = packaging.version.parse("1.23.99")
         version_gptqmodel = packaging.version.parse(importlib_metadata.version("gptqmodel"))
         if GPTQMODEL_MINIMUM_VERSION <= version_gptqmodel:
@@ -62,18 +64,21 @@ def is_gptqmodel_available():
                     return True
                 else:
                     raise ImportError(
-                        f"gptqmodel requires optimum version {OPTIMUM_MINIMUM_VERSION} or higher. Found version {version_optimum}, "
-                        f"but only versions above {OPTIMUM_MINIMUM_VERSION} are supported"
+                        f"gptqmodel requires optimum version `{OPTIMUM_MINIMUM_VERSION}` or higher. Found version `{version_optimum}`, "
+                        f"but only versions above `{OPTIMUM_MINIMUM_VERSION}` are supported"
                     )
             else:
                 raise ImportError(
-                    f"gptqmodel requires optimum version {OPTIMUM_MINIMUM_VERSION} or higher to be installed."
+                    f"gptqmodel requires optimum version `{OPTIMUM_MINIMUM_VERSION}` or higher to be installed."
                 )
         else:
             raise ImportError(
-                f"Found an incompatible version of gptqmodel. Found version {version_gptqmodel}, "
-                f"but only versions above {GPTQMODEL_MINIMUM_VERSION} are supported"
+                f"Found an incompatible version of gptqmodel. Found version `{version_gptqmodel}`, "
+                f"but only versions above `{GPTQMODEL_MINIMUM_VERSION}` are supported"
             )
+    elif prompt_install:
+        log.info("Please install GPTQModel for required functionality: `pip install -U gptqmodel --no-build-isolation -v`.")
+
 
 
 @lru_cache

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -13,15 +13,11 @@
 # limitations under the License.
 import importlib
 import importlib.metadata as importlib_metadata
-import logging
 import platform
 from functools import lru_cache
 
 import packaging.version
 import torch
-
-
-log = logging.getLogger(__name__)
 
 
 @lru_cache
@@ -54,7 +50,7 @@ def is_auto_gptq_available():
 
 
 @lru_cache
-def is_gptqmodel_available(prompt_install: bool = False):
+def is_gptqmodel_available():
     if importlib.util.find_spec("gptqmodel") is not None:
         GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("1.9.0")
         OPTIMUM_MINIMUM_VERSION = packaging.version.parse("1.23.99")
@@ -78,10 +74,6 @@ def is_gptqmodel_available(prompt_install: bool = False):
                 f"Found an incompatible version of gptqmodel. Found version `{version_gptqmodel}`, "
                 f"but only versions above `{GPTQMODEL_MINIMUM_VERSION}` are supported"
             )
-    elif prompt_install:
-        log.info(
-            "Please install GPTQModel for required functionality: `pip install -U gptqmodel --no-build-isolation -v`."
-        )
 
 
 @lru_cache

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -20,7 +20,9 @@ from functools import lru_cache
 import packaging.version
 import torch
 
+
 log = logging.getLogger(__name__)
+
 
 @lru_cache
 def is_bnb_available() -> bool:
@@ -77,8 +79,9 @@ def is_gptqmodel_available(prompt_install: bool = False):
                 f"but only versions above `{GPTQMODEL_MINIMUM_VERSION}` are supported"
             )
     elif prompt_install:
-        log.info("Please install GPTQModel for required functionality: `pip install -U gptqmodel --no-build-isolation -v`.")
-
+        log.info(
+            "Please install GPTQModel for required functionality: `pip install -U gptqmodel --no-build-isolation -v`."
+        )
 
 
 @lru_cache

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -52,8 +52,8 @@ def is_auto_gptq_available():
 @lru_cache
 def is_gptqmodel_available():
     if importlib.util.find_spec("gptqmodel") is not None:
-        GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("1.9.99")
-        OPTIMUM_MINIMUM_VERSION = packaging.version.parse("1.23.99")
+        GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("2.0.0")
+        OPTIMUM_MINIMUM_VERSION = packaging.version.parse("1.24.0")
         version_gptqmodel = packaging.version.parse(importlib_metadata.version("gptqmodel"))
         if GPTQMODEL_MINIMUM_VERSION <= version_gptqmodel:
             if is_optimum_available():

--- a/src/peft/tuners/lora/__init__.py
+++ b/src/peft/tuners/lora/__init__.py
@@ -17,7 +17,7 @@ from peft.utils import register_peft_method
 
 from .config import EvaConfig, LoftQConfig, LoraConfig, LoraRuntimeConfig
 from .eva import get_eva_state_dict, initialize_lora_eva_weights
-from .gptq import QuantLinear
+from .gptq import GPTQLoraLinear
 from .layer import Conv2d, Conv3d, Embedding, Linear, LoraLayer
 from .model import LoraModel
 
@@ -27,13 +27,13 @@ __all__ = [
     "Conv3d",
     "Embedding",
     "EvaConfig",
+    "GPTQLoraLinear",
     "Linear",
     "LoftQConfig",
     "LoraConfig",
     "LoraLayer",
     "LoraModel",
     "LoraRuntimeConfig",
-    "QuantLinear",
     "get_eva_state_dict",
     "initialize_lora_eva_weights",
 ]

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -115,8 +115,11 @@ def dispatch_gptq(
     cfg = kwargs.get("gptq_quantization_config", None)
 
     if is_gptqmodel_available():
-        new_module = GPTQLoraLinear(target, adapter_name, **kwargs)
-        target.qweight = target_base_layer.qweight
+        from gptqmodel.nn_modules.qlinear import BaseQuantLinear
+
+        if isinstance(target_base_layer, BaseQuantLinear):
+            new_module = GPTQLoraLinear(target, adapter_name, **kwargs)
+            target.qweight = target_base_layer.qweight
     else:
         quant_linear = get_auto_gptq_quant_linear(cfg)
 

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -83,12 +83,7 @@ class GPTQLoraLinear(torch.nn.Module, LoraLayer):
                 expected_dtype = result.dtype
                 x = self._cast_input_dtype(x, lora_A.weight.dtype)
 
-            # lora_dropout float value is not stored so we need to check for cls
-            if isinstance(dropout, torch.nn.Dropout):
-                output = lora_B(lora_A(dropout(x)))
-            else:
-                # dropout == Identity which is no-op if lora_dropout == 0.0
-                output = lora_B(lora_A(x))
+            output = lora_B(lora_A(dropout(x)))
 
             if requires_conversion:
                 output = output.to(expected_dtype)

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -184,7 +184,10 @@ class GPTQLoraLinear(torch.nn.Module, LoraLayer):
             output = lora_B(lora_A(dropout(x)))
             if requires_conversion:
                 output = output.to(expected_dtype)
-            output = output * scaling
+
+            if scaling != 1:
+                output = output * scaling
+
             result = result + output
         return result
 

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -115,11 +115,8 @@ def dispatch_gptq(
     cfg = kwargs.get("gptq_quantization_config", None)
 
     if is_gptqmodel_available():
-        from gptqmodel.nn_modules.qlinear import BaseQuantLinear
-
-        if isinstance(target_base_layer, BaseQuantLinear):
-            new_module = GPTQLoraLinear(target, adapter_name, **kwargs)
-            target.qweight = target_base_layer.qweight
+        new_module = GPTQLoraLinear(target, adapter_name, **kwargs)
+        target.qweight = target_base_layer.qweight
     else:
         quant_linear = get_auto_gptq_quant_linear(cfg)
 

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -15,6 +15,7 @@
 from typing import Any, Optional
 
 import torch
+from gptqmodel.nn_modules.qlinear import BaseQuantLinear
 
 from peft.import_utils import is_gptqmodel_available
 from peft.tuners.lora.layer import LoraLayer
@@ -109,14 +110,84 @@ def dispatch_gptq(
 
     cfg = kwargs.get("gptq_quantization_config", None)
 
-    if is_gptqmodel_available():
-        device_map = kwargs.get("device_map", None)
-        quant_linear = get_gptqmodel_quant_linear(cfg, device_map=device_map)
+    if is_gptqmodel_available(prompt_install=True):
+        from gptqmodel.nn_modules.qlinear import BaseQuantLinear
+
+        if isinstance(target_base_layer, BaseQuantLinear):
+            new_module = GPTQLoraLinear(target, adapter_name, **kwargs)
+            target.qweight = target_base_layer.qweight
     else:
         quant_linear = get_auto_gptq_quant_linear(cfg)
 
-    if quant_linear is not None and isinstance(target_base_layer, quant_linear):
-        new_module = QuantLinear(target, adapter_name, **kwargs)
-        target.qweight = target_base_layer.qweight
+        if quant_linear is not None and isinstance(target_base_layer, quant_linear):
+            new_module = QuantLinear(target, adapter_name, **kwargs)
+            target.qweight = target_base_layer.qweight
 
     return new_module
+
+
+class GPTQLoraLinear(torch.nn.Module, LoraLayer):
+    def __init__(
+        self,
+        base_layer,
+        adapter_name,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        init_lora_weights: bool = True,
+        use_rslora: bool = False,
+        use_dora: bool = False,
+        lora_bias: bool = False,
+        **kwargs,
+    ):
+        if use_dora:
+            raise ValueError(f"{self.__class__.__name__} does not support DoRA yet, please set it to False")
+
+        super().__init__()
+        LoraLayer.__init__(self, base_layer)
+
+        # self.base_layer and self.quant_linear_module are the same; we need the former for consistency and the latter
+        # for backwards compatibility
+        self.quant_linear_module = base_layer
+
+        self._active_adapter = adapter_name
+        self.update_layer(
+            adapter_name,
+            r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            init_lora_weights=init_lora_weights,
+            use_rslora=use_rslora,
+            use_dora=use_dora,
+            lora_bias=lora_bias,
+        )
+
+    def forward(self, x: torch.Tensor):
+        result = self.quant_linear_module(x)
+
+        if self.disable_adapters:
+            return result
+
+        for active_adapter in self.active_adapters:
+            if active_adapter not in self.lora_A.keys():
+                continue
+            lora_A = self.lora_A[active_adapter]
+            lora_B = self.lora_B[active_adapter]
+            dropout = self.lora_dropout[active_adapter]
+            scaling = self.scaling[active_adapter]
+
+            requires_conversion = not torch.is_autocast_enabled()
+            if requires_conversion:
+                expected_dtype = result.dtype
+                x = self._cast_input_dtype(x, lora_A.weight.dtype)
+
+            output = lora_B(lora_A(dropout(x)))
+            if requires_conversion:
+                output = output.to(expected_dtype)
+            output = output * scaling
+            result = result + output
+        return result
+
+    def __repr__(self) -> str:
+        rep = super().__repr__()
+        return "lora." + rep

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -58,7 +58,7 @@ class GPTQLoraLinear(torch.nn.Module, LoraLayer):
         )
 
     @lru_cache
-    def _adapter_in_lora_keys(self, adapter):
+    def _adapter_in_lora_keys(self, adapter: str):
         # only need to check lora_A as result is same for lora_B
         return adapter in self.lora_A.keys()
 

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -124,7 +124,7 @@ def dispatch_gptq(
 
     cfg = kwargs.get("gptq_quantization_config", None)
 
-    if is_gptqmodel_available(prompt_install=True):
+    if is_gptqmodel_available():
         from gptqmodel.nn_modules.qlinear import BaseQuantLinear
 
         if isinstance(target_base_layer, BaseQuantLinear):

--- a/src/peft/tuners/lora/gptq.py
+++ b/src/peft/tuners/lora/gptq.py
@@ -15,12 +15,11 @@
 from typing import Any, Optional
 
 import torch
-from gptqmodel.nn_modules.qlinear import BaseQuantLinear
 
 from peft.import_utils import is_gptqmodel_available
 from peft.tuners.lora.layer import LoraLayer
 from peft.tuners.tuners_utils import BaseTunerLayer
-from peft.utils import get_auto_gptq_quant_linear, get_gptqmodel_quant_linear
+from peft.utils import get_auto_gptq_quant_linear
 
 
 class QuantLinear(torch.nn.Module, LoraLayer):

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -736,15 +736,9 @@ class Linear(nn.Module, LoraLayer):
                 if not self.use_dora[active_adapter]:
                     # Loras such as EoRA will always be scaling == 1 so we can skip the no-op math
                     if scaling == 1:
-                        if isinstance(dropout, nn.Dropout):
-                            result = result + lora_B(lora_A(dropout(x)))
-                        else:
-                            result = result + lora_B(lora_A(x))
+                        result = result + lora_B(lora_A(dropout(x)))
                     else:
-                        if isinstance(dropout, nn.Dropout):
-                            result = result + lora_B(lora_A(dropout(x))) * scaling
-                        else:
-                            result = result + lora_B(lora_A(x)) * scaling
+                        result = result + lora_B(lora_A(dropout(x))) * scaling
                 else:
                     if isinstance(dropout, nn.Identity) or not self.training:
                         base_result = result

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -490,7 +490,7 @@ class LoraLayer(BaseTunerLayer):
             # layer output
             sub_batch = x[sub_batch_indices_list[i]].to(lora_A.weight.dtype)
 
-            if scaling == 1: # no scaling
+            if scaling == 1:  # no scaling
                 lora_output = lora_B(lora_A(dropout(sub_batch)))
             else:
                 lora_output = lora_B(lora_A(dropout(sub_batch))) * scaling
@@ -726,7 +726,7 @@ class Linear(nn.Module, LoraLayer):
                 x = self._cast_input_dtype(x, lora_A.weight.dtype)
 
                 if not self.use_dora[active_adapter]:
-                    if scaling == 1: # no scaling
+                    if scaling == 1:  # no scaling
                         result = result + lora_B(lora_A(dropout(x)))
                     else:
                         result = result + lora_B(lora_A(dropout(x))) * scaling

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -491,7 +491,8 @@ class LoraLayer(BaseTunerLayer):
             # layer output
             sub_batch = x[sub_batch_indices_list[i]].to(lora_A.weight.dtype)
 
-            if scaling == 1:  # no scaling
+            # Loras such as EoRA will always be scaling == 1 so we can skip the no-op math
+            if scaling == 1:
                 lora_output = lora_B(lora_A(dropout(sub_batch)))
             else:
                 lora_output = lora_B(lora_A(dropout(sub_batch))) * scaling
@@ -733,7 +734,8 @@ class Linear(nn.Module, LoraLayer):
                 x = self._cast_input_dtype(x, lora_A.weight.dtype)
 
                 if not self.use_dora[active_adapter]:
-                    if scaling == 1:  # no scaling
+                    # Loras such as EoRA will always be scaling == 1 so we can skip the no-op math
+                    if scaling == 1:
                         if isinstance(dropout, nn.Dropout):
                             result = result + lora_B(lora_A(dropout(x)))
                         else:

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -489,7 +489,12 @@ class LoraLayer(BaseTunerLayer):
             # getting the sub-batch, passing it to LoRA layers and updating the corresponding indices of the linear
             # layer output
             sub_batch = x[sub_batch_indices_list[i]].to(lora_A.weight.dtype)
-            lora_output = lora_B(lora_A(dropout(sub_batch))) * scaling
+
+            if scaling == 1: # no scaling
+                lora_output = lora_B(lora_A(dropout(sub_batch)))
+            else:
+                lora_output = lora_B(lora_A(dropout(sub_batch))) * scaling
+
             result[sub_batch_indices_list[i]] += lora_output.to(torch_result_dtype)
 
         return result
@@ -721,7 +726,10 @@ class Linear(nn.Module, LoraLayer):
                 x = self._cast_input_dtype(x, lora_A.weight.dtype)
 
                 if not self.use_dora[active_adapter]:
-                    result = result + lora_B(lora_A(dropout(x))) * scaling
+                    if scaling == 1: # no scaling
+                        result = result + lora_B(lora_A(dropout(x)))
+                    else:
+                        result = result + lora_B(lora_A(dropout(x))) * scaling
                 else:
                     if isinstance(dropout, nn.Identity) or not self.training:
                         base_result = result

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import copy
-import logging
 import os
 import re
 import textwrap
@@ -44,9 +43,6 @@ from peft.utils.peft_types import PeftType, TaskType
 from ..config import PeftConfig
 from ..utils import ModulesToSaveWrapper, _get_submodules
 from ._buffer_dict import BufferDict
-
-
-logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -168,7 +164,7 @@ class BaseTuner(nn.Module, ABC):
         if not hasattr(self, "peft_config"):
             self.peft_config = {adapter_name: peft_config} if isinstance(peft_config, PeftConfig) else peft_config
         else:
-            logger.warning(
+            warnings.warn(
                 "Already found a `peft_config` attribute in the model. This will lead to having multiple adapters"
                 " in the model. Make sure to know what you are doing!"
             )

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -168,7 +168,7 @@ class BaseTuner(nn.Module, ABC):
         if not hasattr(self, "peft_config"):
             self.peft_config = {adapter_name: peft_config} if isinstance(peft_config, PeftConfig) else peft_config
         else:
-            logger.info(
+            logger.warning(
                 "Already found a `peft_config` attribute in the model. This will lead to having multiple adapters"
                 " in the model. Make sure to know what you are doing!"
             )

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -934,7 +934,7 @@ def get_gptqmodel_quant_linear(gptq_quantization_config, device_map=None):
     if gptq_quantization_config is None:
         return None
 
-    if not is_gptqmodel_available(prompt_install=True):
+    if not is_gptqmodel_available():
         return None
 
     from gptqmodel.utils.importer import hf_select_quant_linear

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -934,7 +934,7 @@ def get_gptqmodel_quant_linear(gptq_quantization_config, device_map=None):
     if gptq_quantization_config is None:
         return None
 
-    if not is_gptqmodel_available():
+    if not is_gptqmodel_available(prompt_install=True):
         return None
 
     from gptqmodel.utils.importer import hf_select_quant_linear

--- a/tests/test_gptqmodel.py
+++ b/tests/test_gptqmodel.py
@@ -349,15 +349,12 @@ class PeftGPTQModelTests(unittest.TestCase):
         assert n_trainable_default == n_trainable_other
         assert n_total_default == n_total_other
 
-    @staticmethod
-    def test_load_lora():
+    def test_load_lora(self):
         model_id = "ModelCloud/Llama-3.2-1B-gptqmodel-ci-4bit"
         adapter_id = "ModelCloud/Llama-3.2-1B-gptqmodel-ci-4bit-lora"
 
         model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto")
         model.load_adapter(adapter_id)
-
-        print("peft model", model)
 
         # assert dynamic rank
         v_proj_module = model.model.layers[5].self_attn.v_proj
@@ -374,4 +371,4 @@ class PeftGPTQModelTests(unittest.TestCase):
         tokens = model.generate(**inp)[0]
         result = tokenizer.decode(tokens)
 
-        print("result: ", result)
+        assert "paris" in result.lower()

--- a/tests/test_gptqmodel.py
+++ b/tests/test_gptqmodel.py
@@ -187,6 +187,7 @@ class PeftGPTQModelTests(unittest.TestCase):
             # assert loss is not None
             assert trainer.state.log_history[-1]["train_loss"] is not None
 
+    @pytest.mark.single_gpu_tests
     def test_adalora_causalLM(self):
         r"""
         Tests the gptq training with adalora

--- a/tests/test_gptqmodel.py
+++ b/tests/test_gptqmodel.py
@@ -203,10 +203,11 @@ class PeftGPTQModelTests(unittest.TestCase):
         model = prepare_model_for_kbit_training(model)
 
         peft_config = AdaLoraConfig(
+            total_step=40,
             init_r=6,
             target_r=4,
-            tinit=50,
-            tfinal=100,
+            tinit=10,
+            tfinal=20,
             deltaT=5,
             beta1=0.3,
             beta2=0.3,


### PR DESCRIPTION
PR Changes:

* FIX GPTQ linear layers from GPTQModel is not compatible with PEFT Lora wrapper
* Skip `Scaling`  multiply ops if `Scaling == 1` (Unsure gpu is smart enough to no-op this micro optimizaton so doing this manually). The loras we are testing for GPTQ does not use Scale so `scale = r / lora_alpha` where `r == lora_alpha`

Notes:

* `GPTQLoraLinear` copies most of the code and structure from `AwqLoraLinear`. 

TODO:

* [ ] Add CI test for GPTQmodel + Lora