### PR TITLE
Use baddbmm_() in LoRA code for memory savings

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -730,11 +730,18 @@ class Linear(nn.Module, LoraLayer):
                 x = self._cast_input_dtype(x, lora_A.weight.dtype)
 
                 if not self.use_dora[active_adapter]:
-                    if (hasattr(lora_A, 'bias') and lora_A.bias is not None) or (hasattr(lora_B, 'bias') and lora_B.bias is not None):
+                    if (hasattr(lora_A, "bias") and lora_A.bias is not None) or (
+                        hasattr(lora_B, "bias") and lora_B.bias is not None
+                    ):
                         result = result + lora_B(lora_A(dropout(x))) * scaling
                     elif len(x.shape) == 3:
                         # In-place fused operations use less memory
-                        result.baddbmm_(dropout(x) @ lora_A.weight.T, lora_B.weight.T.expand(x.size(0), -1, -1), beta=1.0, alpha=scaling)
+                        result.baddbmm_(
+                            dropout(x) @ lora_A.weight.T,
+                            lora_B.weight.T.expand(x.size(0), -1, -1),
+                            beta=1.0,
+                            alpha=scaling,
+                        )
                     elif len(x.shape) == 2:
                         result.addmm_(dropout(x) @ lora_A.weight.T, lora_B.weight.T, beta=1.0, alpha=scaling)
                     else:


### PR DESCRIPTION
Use in-place baddbmm_() and addmm_() operations in LoRA forward() method, to save memory by doing in-place operations without creating new tensors. VRAM usage, fine-tuning Llama-3-8B on sequences of length 131,072 with QLoRA:

Before: 23456 MiB
After: 20386 MiB

Ran the tests on my local desktop