### PR TITLE
FIX Revert optimization for LoRA scaling == 1

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -489,7 +489,7 @@ class LoraLayer(BaseTunerLayer):
             # getting the sub-batch, passing it to LoRA layers and updating the corresponding indices of the linear
             # layer output
             sub_batch = x[sub_batch_indices_list[i]].to(lora_A.weight.dtype)
-            lora_output = result + lora_B(lora_A(dropout(x))) * scaling
+            lora_output = lora_B(lora_A(dropout(sub_batch))) * scaling
             result[sub_batch_indices_list[i]] += lora_output.to(torch_result_dtype)
 
         return result

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -489,13 +489,7 @@ class LoraLayer(BaseTunerLayer):
             # getting the sub-batch, passing it to LoRA layers and updating the corresponding indices of the linear
             # layer output
             sub_batch = x[sub_batch_indices_list[i]].to(lora_A.weight.dtype)
-
-            # Loras such as EoRA will always be scaling == 1 so we can skip the no-op math
-            if scaling == 1:
-                lora_output = lora_B(lora_A(dropout(sub_batch)))
-            else:
-                lora_output = lora_B(lora_A(dropout(sub_batch))) * scaling
-
+            lora_output = result + lora_B(lora_A(dropout(x))) * scaling
             result[sub_batch_indices_list[i]] += lora_output.to(torch_result_dtype)
 
         return result
@@ -730,11 +724,7 @@ class Linear(nn.Module, LoraLayer):
                 x = self._cast_input_dtype(x, lora_A.weight.dtype)
 
                 if not self.use_dora[active_adapter]:
-                    # Loras such as EoRA will always be scaling == 1 so we can skip the no-op math
-                    if scaling == 1:
-                        result = result + lora_B(lora_A(dropout(x)))
-                    else:
-                        result = result + lora_B(lora_A(dropout(x))) * scaling
+                    result = result + lora_B(lora_A(dropout(x))) * scaling
                 else:
                     if isinstance(dropout, nn.Identity) or not self.training:
                         base_result = result


### PR DESCRIPTION
The PR #2404 introduced an optimization for LoRA in case that scaling == 1 (see
https://github.com/huggingface/peft/pull/2404#discussion_r1975145200). This unfortunately leads to recompilation when the model is compiled, as witnessed by the failing CI here:

https://github.com/huggingface/peft/actions/runs/13755365121/job/38461837691#step:6:157

For now, let's revert the optimization. If we have concrete numbers that show that the optimization makes a significant difference, we can start thinking about how to optimize this code path in a compile-friendly way.

Here is a minimal reproducer:

```python
import pytest
import torch

from transformers import AutoModelForCausalLM
from peft import LoraConfig, get_peft_model
from peft.utils.hotswap import prepare_model_for_compiled_hotswap

class TestHotSwapping:
    torch_device = 0

    @pytest.fixture(autouse=True)
    def reset_dynamo_cache(self):
        yield
        torch.compiler.reset()

    def check_hotswap(self, do_hotswap, ranks, alpha_scalings):
        model_id = "hf-internal-testing/tiny-random-OPTForCausalLM"
        model = AutoModelForCausalLM.from_pretrained(model_id).to(self.torch_device)
        config = LoraConfig(init_lora_weights=False, r=8, lora_alpha=8, target_modules=["q_proj", "v_proj"])
        model = get_peft_model(model, config, adapter_name="adapter0").eval()
        prepare_model_for_compiled_hotswap(model, config=model.peft_config, target_rank=max(ranks))
        model = torch.compile(model, mode="reduce-overhead")

        inputs = torch.arange(10).view(-1, 1).to(self.torch_device)
        model(inputs)

    @pytest.mark.parametrize("ranks", [(11, 11), (7, 13)])
    def test_hotswapping_compiled_model_does_not_trigger_recompilation(self, ranks):
        with torch._dynamo.config.patch(error_on_recompile=True):  # raise an error on recompilation
            self.check_hotswap(do_hotswap=True, ranks=ranks, alpha_scalings=ranks)
```