### PR TITLE
Merge LoRA Adapters with AWQ BaseModels [Experimental]

### DIFF
--- a/src/peft/tuners/lora/awq.py
+++ b/src/peft/tuners/lora/awq.py
@@ -21,7 +21,7 @@ from peft.import_utils import is_auto_awq_available
 from peft.tuners.lora.layer import LoraLayer
 from peft.tuners.tuners_utils import BaseTunerLayer
 
-from awq.utils.packing_utils import unpack_awq, reverse_awq_order, dequantize_gemm
+from awq.utils.packing_utils import unpack_awq, reverse_awq_order
 from awq.modules.linear.gemm import WQLinear_GEMM
 
 

--- a/src/peft/tuners/lora/awq.py
+++ b/src/peft/tuners/lora/awq.py
@@ -96,7 +96,7 @@ class AwqLoraLinear(torch.nn.Module, LoraLayer):
             requires_conversion = not torch.is_autocast_enabled()
             if requires_conversion:
                 expected_dtype = result.dtype
-                x = x.to(lora_A.weight.dtype)
+                x = self._cast_input_dtype(x, lora_A.weight.dtype)
 
             output = lora_B(lora_A(dropout(x)))
             if requires_conversion:


### PR DESCRIPTION
This PR extends the AwqLoraLinear class to allow merging in of LoRA Adapters. 
Instead of re-quantizing the whole model, we use the original quantization scales and zeros.