### PR TITLE
ENH: Extend the regex for rank/alpha pattern

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -19,7 +19,7 @@ import os
 import re
 import warnings
 from contextlib import nullcontext
-from typing import Any, Optional, Union
+from typing import Any, Optional, Sequence, Union
 
 import accelerate
 import torch
@@ -1089,6 +1089,12 @@ def check_file_exists_on_hf_hub(repo_id: str, filename: str, **kwargs) -> Option
     return exists
 
 
-def get_pattern_key(pattern_keys, key_to_match):
+def get_pattern_key(pattern_keys: Sequence[str], key_to_match: str) -> str:
     """Match a substring of key_to_match in pattern keys"""
-    return next(filter(lambda key: re.match(rf".*\.{key}$", key_to_match), pattern_keys), key_to_match)
+    for key in pattern_keys:
+        match = re.match(rf"(.*\.)?({key})$", key_to_match)
+        if not match:
+            continue
+        return key
+
+    return key_to_match

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -291,7 +291,7 @@ class TestLoraInitialization:
         assert model.conv2d.scaling["default"] == expected_scaling
 
     # testcase for bugfix for issue 2194
-    def test_pattern_override(self):
+    def test_rank_alpha_pattern_override(self):
         torch.manual_seed(0)
 
         layer = self.get_model()


### PR DESCRIPTION
Supersedes #2382

Right now, the regex used to match the keys passed for `rank_pattern` and `alpha_pattern` requires that either:

1. The module name is identical to the key
2. The module name having a prefix and then ending on the key

This is restrictive, since it doesn't allow to disambiguate between all cases. E.g. if we have a model with these attributes:

- `model.foo`
- `model.bar.foo`

Then we:

- can target both by passing `"foo"` to the `rank_pattern` / `alpha_pattern` dict
- can target only `model.bar.foo` by passing `"bar.foo"`
- *cannot*  target only `model.foo`

This PR makes it possible to pass "^foo" as a key. This way, only `model.foo` but not `model.bar.foo` is targeted, as the latter's name does not start with `"foo"`.

As a general rule for users, if they intend to have a full match, they should pass the full name of the module preceded by a `^`. This is the least ambiguous way.

When running the test case with the old code, all the test cases with `^` will fail, which is fine, since `^` was not working anyway. At the same time, all test cases not using `^` pass, which means they are backwards compatible.

TODO: update docs