### PR TITLE
FIX: AutoPeftModels never reduce embedding size

### DIFF
--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -130,11 +130,14 @@ class _BaseAutoPeftModel:
                 token=token,
             )
 
-        if tokenizer_exists:
+        if tokenizer_exists and hasattr(base_model, "get_input_embeddings"):
             tokenizer = AutoTokenizer.from_pretrained(
                 pretrained_model_name_or_path, trust_remote_code=kwargs.get("trust_remote_code", False)
             )
-            base_model.resize_token_embeddings(len(tokenizer))
+            embedding_size = base_model.get_input_embeddings().weight.shape[0]
+            if len(tokenizer) > embedding_size:
+                # only resize if the tokenizer has a larger vocab size than there are embeddings
+                base_model.resize_token_embeddings(len(tokenizer))
 
         return cls._target_peft_class.from_pretrained(
             base_model,


### PR DESCRIPTION
Resolves #2415

There was a bug in `AutoPeftModel`s where the embedding was always resized to the vocab size of the tokenizer when the tokenizer was found. This makes sense if the vocabulary was extended, but some models like Qwen already start out with "spare" embeddings, i.e. the embedding size is larger than the vocab size. This could result in the embedding being shrunk, which in turn resulted in an error when loading the weights.