### PR TITLE
Ci macos version update arm64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        # FIXME
+        # os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["macos-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: ["ubuntu-latest", "macos-13", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
       - name: Downgrade numpy on MacOS and Windows
         # TODO: remove numpy downgrade on MacOS & Windows once torch fixes numpy 2.0 issue
         shell: bash
-        if: matrix.os == 'windows-latest' || matrix.os == 'macos-13'
+        if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
         run: |
           pip install --force-reinstall -U "numpy<2.0.0"
       - name: Test with pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   HF_HOME: .cache/huggingface
+  PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.0
 
 permissions: {}
 
@@ -39,7 +40,8 @@ jobs:
     needs: check_code_quality
     strategy:
       # TODO: remove 'fail-fast' line once timeout issue from the Hub is solved
-      fail-fast: false
+      # FIXME
+      fail-fast: true
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         # FIXME


### PR DESCRIPTION
Don't merge yet

As of now, we're using MacOS-13 in the CI, which is the last Intel x86 Mac version provided by the [GH runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories). However, the latest PyTorch version for x86 Macs is 2.2.2, which is quite old at this point. Let's try to upgrade to MacOS latest, which uses arm64.