### PR TITLE
Fix multiple methods model dtype issues

### DIFF
--- a/src/peft/helpers.py
+++ b/src/peft/helpers.py
@@ -22,6 +22,7 @@ from torch import nn
 
 from .peft_model import PeftConfig, PeftModel
 from .tuners.lora import LoraLayer
+from .tuners.tuners_utils import BaseTunerLayer
 
 
 def update_forward_signature(model: PeftModel) -> None:
@@ -218,8 +219,6 @@ def disable_input_dtype_casting(model: nn.Module, active: bool = True):
     """
     Context manager disables input dtype casting to the dtype of the weight.
 
-    Currently specifically works for LoRA.
-
     Parameters:
         model (nn.Module):
             The model containing PEFT modules whose input dtype casting is to be adjusted.
@@ -237,7 +236,7 @@ def disable_input_dtype_casting(model: nn.Module, active: bool = True):
 
     original_values = {}
     for name, module in model.named_modules():
-        if not isinstance(module, LoraLayer):
+        if not isinstance(module, BaseTunerLayer):
             continue
         original_values[name] = module.cast_input_dtype_enabled
         module.cast_input_dtype_enabled = False
@@ -246,7 +245,7 @@ def disable_input_dtype_casting(model: nn.Module, active: bool = True):
         yield
     finally:
         for name, module in model.named_modules():
-            if not isinstance(module, LoraLayer):
+            if not isinstance(module, BaseTunerLayer):
                 continue
             if name in original_values:
                 module.cast_input_dtype_enabled = original_values[name]

--- a/src/peft/tuners/boft/layer.py
+++ b/src/peft/tuners/boft/layer.py
@@ -220,6 +220,8 @@ class BOFTLayer(BaseTunerLayer):
         # Mark the weight as unmerged
         self._disable_adapters = False
         self.merged_adapters = []
+        # flag to enable/disable casting of input to weight dtype during forward call
+        self.cast_input_dtype_enabled = True
         self.kwargs = kwargs
 
         base_layer = self.get_base_layer()
@@ -503,13 +505,14 @@ class Linear(nn.Module, BOFTLayer):
         for active_adapter in adapter_names:
             if active_adapter in self.boft_R.keys():
                 base_layer = self.get_base_layer()
+                orig_dtype = base_layer.weight.dtype
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
                     orig_weight = base_layer.weight.data.clone()
                     butterfly_oft_mat, boft_s = self.get_delta_weight(active_adapter)
                     orig_weight = torch.transpose(orig_weight, 0, 1)
-                    orig_weight = torch.mm(butterfly_oft_mat, orig_weight)
+                    orig_weight = torch.mm(butterfly_oft_mat, orig_weight.to(butterfly_oft_mat.dtype))
                     orig_weight = torch.transpose(orig_weight, 0, 1)
                     orig_weight = orig_weight * boft_s
 
@@ -518,16 +521,16 @@ class Linear(nn.Module, BOFTLayer):
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
-                    self.base_layer.weight.data = orig_weight.contiguous()
+                    self.base_layer.weight.data = orig_weight.contiguous().to(orig_dtype)
                 else:
                     butterfly_oft_mat, boft_s = self.get_delta_weight(active_adapter)
                     orig_weight = base_layer.weight.data.clone()
                     orig_weight = torch.transpose(orig_weight, 0, 1)
-                    orig_weight = torch.mm(butterfly_oft_mat, orig_weight)
+                    orig_weight = torch.mm(butterfly_oft_mat, orig_weight.to(butterfly_oft_mat.dtype))
                     orig_weight = torch.transpose(orig_weight, 0, 1)
                     orig_weight = orig_weight * boft_s
 
-                    self.base_layer.weight.data = orig_weight.contiguous()
+                    self.base_layer.weight.data = orig_weight.contiguous().to(orig_dtype)
 
                 self.merged_adapters.append(active_adapter)
 
@@ -538,17 +541,20 @@ class Linear(nn.Module, BOFTLayer):
         if not self.merged:
             warnings.warn("Already unmerged. Nothing to do.")
             return
+
         while len(self.merged_adapters) > 0:
             active_adapter = self.merged_adapters.pop()
+            base_layer = self.get_base_layer()
+            orig_dtype = base_layer.weight.dtype
             if active_adapter in self.boft_R.keys():
                 butterfly_oft_mat, boft_s = self.get_delta_weight(active_adapter)
 
-                orig_weight = self.get_base_layer().weight.data.clone()
+                orig_weight = base_layer.weight.data.clone()
                 orig_weight = torch.transpose(orig_weight, 0, 1)
-                orig_weight = torch.mm(butterfly_oft_mat.t(), orig_weight)
+                orig_weight = torch.mm(butterfly_oft_mat.t(), orig_weight.to(butterfly_oft_mat.dtype))
                 orig_weight = torch.transpose(orig_weight, 0, 1)
 
-                self.get_base_layer().weight.data = orig_weight * (1 / boft_s)
+                base_layer.weight.data = (orig_weight * (1 / boft_s)).to(orig_dtype)
 
     def get_delta_weight(self, adapter) -> tuple[torch.Tensor, torch.Tensor]:
         """
@@ -804,6 +810,7 @@ class Conv2d(nn.Module, BOFTLayer):
         for active_adapter in adapter_names:
             if active_adapter in self.boft_R.keys():
                 base_layer = self.get_base_layer()
+                orig_dtype = base_layer.weight.dtype
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
@@ -814,14 +821,14 @@ class Conv2d(nn.Module, BOFTLayer):
                         self.out_features, self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0]
                     )
                     orig_weight = torch.transpose(orig_weight, 0, 1)
-                    orig_weight = torch.mm(butterfly_oft_mat, orig_weight)
+                    orig_weight = torch.mm(butterfly_oft_mat, orig_weight.to(butterfly_oft_mat.dtype))
                     orig_weight = torch.transpose(orig_weight, 0, 1)
                     orig_weight = orig_weight * boft_s
                     orig_weight = orig_weight.view(
                         self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[0]
                     )
 
-                    self.base_layer.weight.data = orig_weight.contiguous()
+                    self.base_layer.weight.data = orig_weight.contiguous().to(orig_dtype)
                 else:
                     butterfly_oft_mat, boft_s = self.get_delta_weight(active_adapter)
 
@@ -830,14 +837,14 @@ class Conv2d(nn.Module, BOFTLayer):
                         self.out_features, self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0]
                     )
                     orig_weight = torch.transpose(orig_weight, 0, 1)
-                    orig_weight = torch.mm(butterfly_oft_mat, orig_weight)
+                    orig_weight = torch.mm(butterfly_oft_mat, orig_weight.to(butterfly_oft_mat.dtype))
                     orig_weight = torch.transpose(orig_weight, 0, 1)
                     orig_weight = orig_weight * boft_s
                     orig_weight = orig_weight.view(
                         self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[0]
                     )
 
-                    self.base_layer.weight.data = orig_weight.contiguous()
+                    self.base_layer.weight.data = orig_weight.contiguous().to(orig_dtype)
 
                 self.merged_adapters.append(active_adapter)
 
@@ -850,26 +857,28 @@ class Conv2d(nn.Module, BOFTLayer):
             return
         while len(self.merged_adapters) > 0:
             active_adapter = self.merged_adapters.pop()
+            base_layer = self.get_base_layer()
+            orig_dtype = base_layer.weight.dtype
             if active_adapter in self.boft_R.keys():
                 butterfly_oft_mat, boft_s = self.get_delta_weight(active_adapter)
 
-                orig_weight = self.get_base_layer().weight.data.clone()
+                orig_weight = base_layer.weight.data.clone()
                 orig_weight = orig_weight.view(
                     self.out_features,
-                    self.in_features * self.get_base_layer().kernel_size[0] * self.get_base_layer().kernel_size[0],
+                    self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0],
                 )
                 orig_weight = torch.transpose(orig_weight, 0, 1)
-                orig_weight = torch.mm(butterfly_oft_mat.t(), orig_weight)
+                orig_weight = torch.mm(butterfly_oft_mat.t(), orig_weight.to(butterfly_oft_mat.dtype))
                 orig_weight = torch.transpose(orig_weight, 0, 1)
                 orig_weight = orig_weight * (1 / boft_s)
                 orig_weight = orig_weight.view(
                     self.out_features,
                     self.in_features,
-                    self.get_base_layer().kernel_size[0],
-                    self.get_base_layer().kernel_size[0],
+                    base_layer.kernel_size[0],
+                    base_layer.kernel_size[0],
                 )
 
-                self.get_base_layer().weight.data = orig_weight
+                self.get_base_layer().weight.data = orig_weight.to(orig_dtype)
 
     def get_delta_weight(self, adapter) -> tuple[torch.Tensor, torch.Tensor]:
         """
@@ -968,10 +977,12 @@ class Conv2d(nn.Module, BOFTLayer):
             scaled_rotated_weight = scaled_rotated_weight.view(
                 self.out_features, self.in_features, self.base_layer.kernel_size[0], self.base_layer.kernel_size[0]
             )
+            x = self._cast_input_dtype(x, scaled_rotated_weight.dtype)
+            bias = self._cast_input_dtype(self.base_layer.bias, scaled_rotated_weight.dtype)
             result = F.conv2d(
                 input=x,
                 weight=scaled_rotated_weight,
-                bias=self.base_layer.bias,
+                bias=bias,
                 padding=self.base_layer.padding[0],
                 stride=self.base_layer.stride[0],
             )

--- a/src/peft/tuners/bone/layer.py
+++ b/src/peft/tuners/bone/layer.py
@@ -35,6 +35,8 @@ class BoneLayer(BaseTunerLayer):
         # Mark the weight as unmerged
         self._disable_adapters = False
         self.merged_adapters = []
+        # flag to enable/disable casting of input to weight dtype during forward call
+        self.cast_input_dtype_enabled = True
         self.kwargs = kwargs
 
         base_layer = self.get_base_layer()
@@ -150,6 +152,7 @@ class BoneLinear(nn.Module, BoneLayer):
         for active_adapter in adapter_names:
             if active_adapter in self.bone_block.keys():
                 base_layer = self.get_base_layer()
+                orig_dtype = base_layer.weight.dtype
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
@@ -166,14 +169,14 @@ class BoneLinear(nn.Module, BoneLayer):
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
-                    self.base_layer.weight.data = orig_weight
+                    self.base_layer.weight.data = orig_weight.to(orig_dtype)
                 else:
                     if self.bone_fn == "bat":
                         delta_weight = self.get_delta_weight(active_adapter, self.base_layer.weight.data)
-                        self.base_layer.weight.data += delta_weight
+                        self.base_layer.weight.data += delta_weight.to(orig_dtype)
                     else:
                         delta_weight = self.get_delta_weight_bone(active_adapter, self.base_layer.weight.data)
-                        self.base_layer.weight.data = delta_weight
+                        self.base_layer.weight.data = delta_weight.to(orig_dtype)
                 self.merged_adapters.append(active_adapter)
 
     def unmerge(self) -> None:
@@ -183,8 +186,11 @@ class BoneLinear(nn.Module, BoneLayer):
         if not self.merged:
             warnings.warn("Already unmerged. Nothing to do.")
             return
+
         while len(self.merged_adapters) > 0:
             active_adapter = self.merged_adapters.pop()
+            base_layer = self.get_base_layer()
+            orig_dtype = base_layer.weight.dtype
             if active_adapter in self.bone_block.keys():
                 orig_weight = self.get_base_layer().weight.data.clone()
                 if self.bone_fn == "bat":
@@ -192,7 +198,7 @@ class BoneLinear(nn.Module, BoneLayer):
                 else:
                     delta_weight = self.get_delta_weight_bone(active_adapter, orig_weight, re=True)
 
-                self.get_base_layer().weight.data = delta_weight
+                base_layer.weight.data = delta_weight.to(orig_dtype)
 
     def get_delta_weight(self, adapter, orig_weight, re: bool = False) -> torch.Tensor:
         """
@@ -213,12 +219,15 @@ class BoneLinear(nn.Module, BoneLayer):
 
         if cast_to_fp32:
             weight_bone = weight_bone.float()
+        orig_weight = orig_weight.to(weight_bone.dtype)
 
         r = weight_bone.size(-1)
         if re:
             o = orig_weight.reshape(orig_weight.size(0) // r, r, orig_weight.size(1) // r, r).permute(2, 0, 1, 3)
             one = torch.eye(weight_bone.size(-1)).to(weight_bone.device)
+            # inverse must be in float32, after that the dtype can be adjusted if needed
             inv_I_plus_b = torch.inverse(one + weight_bone)
+            inv_I_plus_b = inv_I_plus_b.to(weight_bone.dtype)
             w = (o - weight_bone) @ inv_I_plus_b
             output_tensor = w.permute(1, 2, 0, 3).reshape(*orig_weight.shape)
         else:
@@ -318,7 +327,9 @@ class BoneLinear(nn.Module, BoneLayer):
                     delta_weight = self.get_delta_weight(active_adapter, orig_weight)
                     orig_weight = orig_weight + delta_weight
 
-                result = F.linear(input=x, weight=orig_weight, bias=self.base_layer.bias)
+                x = self._cast_input_dtype(x, orig_weight.dtype)
+                bias = self.base_layer.bias.to(orig_weight.dtype)
+                result = F.linear(input=x, weight=orig_weight, bias=bias)
             else:
                 result = self.base_layer(x, *args, **kwargs)
                 for active_adapter in self.active_adapters:
@@ -329,6 +340,7 @@ class BoneLinear(nn.Module, BoneLayer):
                     if x.size(-1) % r != 0:
                         padding_size = (r - x.size(-1) % r) % r
                         x = F.pad(x, (0, padding_size))
+                    x = self._cast_input_dtype(x, bone.dtype)
                     result = result + torch.sum(x.reshape(*x.shape[:-1], x.size(-1) // r, r), dim=-2) @ bone
 
         result = result.to(previous_dtype)

--- a/src/peft/tuners/hra/layer.py
+++ b/src/peft/tuners/hra/layer.py
@@ -37,6 +37,8 @@ class HRALayer(BaseTunerLayer):
         # Mark the weight as unmerged
         self._disable_adapters = False
         self.merged_adapters = []
+        # flag to enable/disable casting of input to weight dtype during forward call
+        self.cast_input_dtype_enabled = True
         self.kwargs = kwargs
 
         base_layer = self.get_base_layer()
@@ -162,22 +164,24 @@ class HRALinear(nn.Module, HRALayer):
         for active_adapter in adapter_names:
             if active_adapter in self.hra_u.keys():
                 base_layer = self.get_base_layer()
+                orig_dtype = base_layer.weight.dtype
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
                     orig_weight = base_layer.weight.data.clone()
                     delta_weight = self.get_delta_weight(active_adapter)
-                    orig_weight = torch.mm(orig_weight, delta_weight)
+                    orig_weight = torch.mm(orig_weight.to(delta_weight.dtype), delta_weight)
 
                     if not torch.isfinite(orig_weight).all():
                         raise ValueError(
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
-                    self.base_layer.weight.data = orig_weight
+                    base_layer.weight.data = orig_weight
                 else:
                     delta_weight = self.get_delta_weight(active_adapter)
-                    self.base_layer.weight.data = torch.mm(self.base_layer.weight.data, delta_weight)
+                    new_weight = torch.mm(base_layer.weight.data.to(delta_weight.dtype), delta_weight)
+                    base_layer.weight.data = new_weight.to(orig_dtype)
                 self.merged_adapters.append(active_adapter)
 
     def unmerge(self) -> None:
@@ -187,12 +191,16 @@ class HRALinear(nn.Module, HRALayer):
         if not self.merged:
             warnings.warn("Already unmerged. Nothing to do.")
             return
+
         while len(self.merged_adapters) > 0:
             active_adapter = self.merged_adapters.pop()
+            base_layer = self.get_base_layer()
+            orig_dtype = base_layer.weight.dtype
             if active_adapter in self.hra_u.keys():
-                orig_weight = self.get_base_layer().weight.data.clone()
+                orig_weight = base_layer.weight.data.clone()
                 delta_weight = self.get_delta_weight(active_adapter, reverse=True)
-                self.get_base_layer().weight.data = torch.mm(orig_weight, delta_weight)
+                new_weight = torch.mm(orig_weight.to(delta_weight.dtype), delta_weight)
+                base_layer.weight.data = new_weight.to(orig_dtype)
 
     def get_delta_weight(self, adapter_name: str, reverse: bool = False) -> torch.Tensor:
         rank = self.hra_r[adapter_name]
@@ -240,13 +248,18 @@ class HRALinear(nn.Module, HRALayer):
                 if active_adapter not in self.hra_u.keys():
                     continue
                 delta_weight = self.get_delta_weight(active_adapter)
-                new_weight = torch.mm(new_weight, delta_weight)
+                new_weight = torch.mm(new_weight.to(delta_weight.dtype), delta_weight)
 
-            x = x.to(self.get_base_layer().weight.data.dtype)
             orig_weight = self.get_base_layer().weight.data
+            orig_weight = self._cast_input_dtype(orig_weight, new_weight.dtype)
             new_weight = torch.mm(orig_weight, new_weight)
+            bias = self._cast_input_dtype(self.base_layer.bias, new_weight.dtype)
 
-            result = F.linear(input=x, weight=new_weight, bias=self.base_layer.bias)
+            if self.cast_input_dtype_enabled:
+                x = self._cast_input_dtype(x, new_weight.dtype)
+            else:
+                x = x.to(self.get_base_layer().weight.data.dtype)
+            result = F.linear(input=x, weight=new_weight, bias=bias)
 
         result = result.to(previous_dtype)
         return result
@@ -294,21 +307,22 @@ class HRAConv2d(nn.Module, HRALayer):
         for active_adapter in adapter_names:
             if active_adapter in self.hra_u.keys():
                 base_layer = self.get_base_layer()
+                orig_dtype = base_layer.weight.dtype
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
                     orig_weight = base_layer.weight.data.clone()
                     orig_weight = orig_weight.view(
                         self.out_features,
-                        self.in_features * self.base_layer.kernel_size[0] * self.base_layer.kernel_size[0],
+                        self.in_features * base_layer.kernel_size[0] * self.base_layer.kernel_size[0],
                     )
                     delta_weight = self.get_delta_weight(active_adapter)
-                    orig_weight = torch.mm(orig_weight, delta_weight)
+                    orig_weight = torch.mm(orig_weight.to(delta_weight.dtype), delta_weight)
                     orig_weight = orig_weight.view(
                         self.out_features,
                         self.in_features,
-                        self.base_layer.kernel_size[0],
-                        self.base_layer.kernel_size[0],
+                        base_layer.kernel_size[0],
+                        base_layer.kernel_size[0],
                     )
 
                     if not torch.isfinite(orig_weight).all():
@@ -316,7 +330,7 @@ class HRAConv2d(nn.Module, HRALayer):
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
-                    self.base_layer.weight.data = orig_weight
+                    base_layer.weight.data = orig_weight.to(orig_dtype)
                 else:
                     orig_weight = base_layer.weight.data
                     orig_weight = orig_weight.view(
@@ -324,15 +338,15 @@ class HRAConv2d(nn.Module, HRALayer):
                         self.in_features * self.base_layer.kernel_size[0] * self.base_layer.kernel_size[0],
                     )
                     delta_weight = self.get_delta_weight(active_adapter)
-                    orig_weight = torch.mm(orig_weight, delta_weight)
+                    orig_weight = torch.mm(orig_weight.to(delta_weight.dtype), delta_weight)
                     orig_weight = orig_weight.view(
                         self.out_features,
                         self.in_features,
-                        self.base_layer.kernel_size[0],
-                        self.base_layer.kernel_size[0],
+                        base_layer.kernel_size[0],
+                        base_layer.kernel_size[0],
                     )
 
-                    self.base_layer.weight.data = orig_weight
+                    base_layer.weight.data = orig_weight.to(orig_dtype)
                 self.merged_adapters.append(active_adapter)
 
     def unmerge(self) -> None:
@@ -344,19 +358,21 @@ class HRAConv2d(nn.Module, HRALayer):
             return
         while len(self.merged_adapters) > 0:
             active_adapter = self.merged_adapters.pop()
+            base_layer = self.get_base_layer()
+            orig_dtype = base_layer.weight.dtype
             if active_adapter in self.hra_u.keys():
-                orig_weight = self.get_base_layer().weight.data.clone()
+                orig_weight = base_layer.weight.data.clone()
                 orig_weight = orig_weight.view(
                     self.out_features,
-                    self.in_features * self.base_layer.kernel_size[0] * self.base_layer.kernel_size[0],
+                    self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0],
                 )
                 delta_weight = self.get_delta_weight(active_adapter, reverse=True)
-                orig_weight = torch.mm(orig_weight, delta_weight)
+                orig_weight = torch.mm(orig_weight.to(delta_weight.dtype), delta_weight)
                 orig_weight = orig_weight.view(
-                    self.out_features, self.in_features, self.base_layer.kernel_size[0], self.base_layer.kernel_size[0]
+                    self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[0]
                 )
 
-                self.get_base_layer().weight.data = orig_weight
+                base_layer.weight.data = orig_weight.to(orig_dtype)
 
     def get_delta_weight(self, adapter_name: str, reverse: bool = False) -> torch.Tensor:
         rank = self.hra_r[adapter_name]
@@ -401,21 +417,21 @@ class HRAConv2d(nn.Module, HRALayer):
             new_weight = torch.eye(
                 self.in_features * self.base_layer.kernel_size[0] * self.base_layer.kernel_size[0],
                 device=x.device,
-                dtype=previous_dtype,
             )
             for active_adapter in self.active_adapters:
                 if active_adapter not in self.hra_u.keys():
                     continue
                 delta_weight = self.get_delta_weight(active_adapter)
-                new_weight = torch.mm(new_weight, delta_weight)
-
-            x = x.to(self.base_layer.weight.data.dtype)
+                new_weight = torch.mm(new_weight.to(delta_weight.dtype), delta_weight)
 
             orig_weight = self.base_layer.weight.data
             orig_weight = orig_weight.view(
                 self.out_features,
                 self.in_features * self.base_layer.kernel_size[0] * self.base_layer.kernel_size[0],
             )
+            orig_weight = self._cast_input_dtype(orig_weight, new_weight.dtype)
+            bias = self._cast_input_dtype(self.base_layer.bias, new_weight.dtype)
+
             new_weight = torch.mm(orig_weight, new_weight)
             new_weight = new_weight.view(
                 self.out_features,
@@ -424,10 +440,14 @@ class HRAConv2d(nn.Module, HRALayer):
                 self.base_layer.kernel_size[0],
             )
 
+            if self.cast_input_dtype_enabled:
+                x = self._cast_input_dtype(x, new_weight.dtype)
+            else:
+                x = x.to(self.get_base_layer().weight.data.dtype)
             result = F.conv2d(
                 input=x,
                 weight=new_weight,
-                bias=self.base_layer.bias,
+                bias=bias,
                 padding=self.base_layer.padding[0],
                 stride=self.base_layer.stride[0],
             )

--- a/src/peft/tuners/ln_tuning/model.py
+++ b/src/peft/tuners/ln_tuning/model.py
@@ -203,3 +203,9 @@ class LNTuningModel(BaseTuner):
         self, progressbar: bool = False, safe_merge: bool = False, adapter_names: Optional[list[str]] = None
     ) -> nn.Module:
         return self._unload_and_optionally_merge(merge=True)
+
+    def _cast_adapter_dtype(self, adapter_name: str, autocast_adapter_dtype: bool = True) -> None:
+        # Note: LN Tuning does not add adapter layers, instead it creates copies of the original layer. For this reason,
+        # we need to skip adapter autocasting, otherwise we would change the dtype of copies of the original layer,
+        # resulting in dtype errors down the line.
+        pass

--- a/src/peft/tuners/loha/layer.py
+++ b/src/peft/tuners/loha/layer.py
@@ -239,6 +239,7 @@ class Linear(LoHaLayer):
         self, adapter_name: str, input: torch.Tensor, *args: Any, **kwargs: Any
     ) -> torch.Tensor:
         delta_weight = self.get_delta_weight(adapter_name)
+        input = self._cast_input_dtype(input, delta_weight.dtype)
         # don't add bias here, because the bias is already included in the output of the base_layer
         return F.linear(input, delta_weight)
 
@@ -274,6 +275,7 @@ class Conv2d(LoHaLayer):
         self, adapter_name: str, input: torch.Tensor, *args: Any, **kwargs: Any
     ) -> torch.Tensor:
         delta_weight = self.get_delta_weight(adapter_name)
+        input = self._cast_input_dtype(input, delta_weight.dtype)
         # don't add bias here, because the bias is already included in the output of the base_layer
         base_layer = self.get_base_layer()
         return F.conv2d(

--- a/src/peft/tuners/lokr/layer.py
+++ b/src/peft/tuners/lokr/layer.py
@@ -303,6 +303,7 @@ class Linear(LoKrLayer):
         self, adapter_name: str, input: torch.Tensor, *args: Any, **kwargs: Any
     ) -> torch.Tensor:
         delta_weight = self.get_delta_weight(adapter_name)
+        input = self._cast_input_dtype(input, delta_weight.dtype)
         # don't add bias here, because the bias is already included in the output of the base_layer
         return F.linear(input, delta_weight)
 
@@ -340,6 +341,7 @@ class Conv2d(LoKrLayer):
         self, adapter_name: str, input: torch.Tensor, *args: Any, **kwargs: Any
     ) -> torch.Tensor:
         delta_weight = self.get_delta_weight(adapter_name)
+        input = self._cast_input_dtype(input, delta_weight.dtype)
         # don't add bias here, because the bias is already included in the output of the base_layer
         base_layer = self.get_base_layer()
         return F.conv2d(

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -1501,7 +1501,7 @@ class MultiheadAttention(nn.Module, LoraLayer):
                     # TODO: work with separate weights
                     # merging in_proj (nn.Parameter)
                     orig_weights_in = base_layer.in_proj_weight.data.detach().clone()
-                    orig_weights_in += self.get_delta_weight(active_adapter).to(base_layer.in_proj_weight.dtype)
+                    orig_weights_in += self.get_delta_weight(active_adapter).to(orig_dtype)
                     if not torch.isfinite(orig_weights_in).all():
                         raise ValueError(
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
@@ -1526,7 +1526,7 @@ class MultiheadAttention(nn.Module, LoraLayer):
                 else:
                     # merging in_proj (nn.Parameter)
                     # TODO: work with separate weights
-                    delta_weight = self.get_delta_weight(active_adapter).to(base_layer.in_proj_weight.dtype)
+                    delta_weight = self.get_delta_weight(active_adapter).to(orig_dtype)
                     weight_merged = base_layer.in_proj_weight.data.detach() + delta_weight
 
                     # unregister parameter implicitly and overwrite using merged weights; gradients are computed after
@@ -1560,7 +1560,7 @@ class MultiheadAttention(nn.Module, LoraLayer):
                 # requires_grad was False when the optimizer was initialized, but still let's try to be correct here.
 
                 # in_proj
-                delta_weight = self.get_delta_weight(active_adapter).to(base_layer.in_proj_weight.dtype)
+                delta_weight = self.get_delta_weight(active_adapter).to(orig_dtype)
                 old_weight = base_layer.in_proj_weight.data - delta_weight
                 del base_layer.in_proj_weight
                 base_layer.register_parameter("in_proj_weight", nn.Parameter(old_weight, requires_grad=False))

--- a/src/peft/tuners/lycoris_utils.py
+++ b/src/peft/tuners/lycoris_utils.py
@@ -77,6 +77,8 @@ class LycorisLayer(BaseTunerLayer):
         # Tuner info
         self._disable_adapters = False
         self.merged_adapters = []
+        # flag to enable/disable casting of input to weight dtype during forward call
+        self.cast_input_dtype_enabled = True
 
     @property
     @abstractmethod

--- a/src/peft/tuners/oft/layer.py
+++ b/src/peft/tuners/oft/layer.py
@@ -101,6 +101,8 @@ class OFTLayer(BaseTunerLayer):
         # Mark the weight as unmerged
         self._disable_adapters = False
         self.merged_adapters = []
+        # flag to enable/disable casting of input to weight dtype during forward call
+        self.cast_input_dtype_enabled = True
         self.kwargs = kwargs
 
         base_layer = self.get_base_layer()
@@ -344,13 +346,14 @@ class Linear(nn.Module, OFTLayer):
         for active_adapter in adapter_names:
             if active_adapter in self._available_adapters:
                 base_layer = self.get_base_layer()
+                orig_dtype = base_layer.weight.dtype
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
                     orig_weights = base_layer.weight.data
                     oft_mat, oft_s = self.get_delta_weight(active_adapter)
                     orig_weights = torch.transpose(orig_weights, 0, 1)
-                    orig_weights = torch.mm(oft_mat, orig_weights)
+                    orig_weights = torch.mm(oft_mat, orig_weights.to(oft_mat.dtype))
                     orig_weights = torch.transpose(orig_weights, 0, 1)
                     orig_weights = orig_weights * oft_s
 
@@ -359,16 +362,16 @@ class Linear(nn.Module, OFTLayer):
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
-                    base_layer.weight.data = orig_weights.contiguous()
+                    base_layer.weight.data = orig_weights.contiguous().to(orig_dtype)
                 else:
                     oft_mat, oft_s = self.get_delta_weight(active_adapter)
                     orig_weights = base_layer.weight.data
                     orig_weights = torch.transpose(orig_weights, 0, 1)
-                    orig_weights = torch.mm(oft_mat, orig_weights)
+                    orig_weights = torch.mm(oft_mat, orig_weights.to(oft_mat.dtype))
                     orig_weights = torch.transpose(orig_weights, 0, 1)
                     orig_weights = orig_weights * oft_s
 
-                    base_layer.weight.data = orig_weights.contiguous()
+                    base_layer.weight.data = orig_weights.contiguous().to(orig_dtype)
 
                 self.merged_adapters.append(active_adapter)
 
@@ -379,6 +382,9 @@ class Linear(nn.Module, OFTLayer):
         if not self.merged:
             warnings.warn("Already unmerged. Nothing to do.")
             return
+
+        base_layer = self.get_base_layer()
+        orig_dtype = base_layer.weight.dtype
         while len(self.merged_adapters) > 0:
             active_adapter = self.merged_adapters.pop()
             if active_adapter in self.oft_r.keys():
@@ -386,10 +392,10 @@ class Linear(nn.Module, OFTLayer):
 
                 orig_weights = self.get_base_layer().weight.data
                 orig_weights = torch.transpose(orig_weights, 0, 1)
-                orig_weights = torch.mm(oft_mat.t(), orig_weights)
+                orig_weights = torch.mm(oft_mat.t(), orig_weights.to(oft_mat.dtype))
                 orig_weights = torch.transpose(orig_weights, 0, 1)
 
-                self.get_base_layer().weight.data = orig_weights * (1 / oft_s)
+                base_layer.weight.data = (orig_weights * (1 / oft_s)).to(orig_dtype)
 
     def get_delta_weight(self, adapter_name) -> tuple[torch.Tensor, torch.Tensor]:
         """
@@ -445,7 +451,7 @@ class Linear(nn.Module, OFTLayer):
 
                 orth_rotate = self._cayley_batch(oft_r)
                 orth_rotate = dropout(orth_rotate)
-                oft_mat = self._block_diagonal(orth_rotate, rank)
+                oft_mat = self._block_diagonal(orth_rotate, rank).to(previous_dtype)
 
                 oft_rotation = oft_mat @ oft_rotation
                 oft_scale = oft_s * oft_scale
@@ -454,15 +460,12 @@ class Linear(nn.Module, OFTLayer):
 
             orig_weight = self.get_base_layer().weight.data
             orig_weight = torch.transpose(orig_weight, 0, 1)
-            oft_rotation = oft_rotation.to(previous_dtype)
-            orig_weight = orig_weight.to(previous_dtype)
             rotated_weight = torch.mm(oft_rotation, orig_weight)
             rotated_weight = torch.transpose(rotated_weight, 0, 1)
-
             scaled_rotated_weight = rotated_weight * oft_scale
 
-            scaled_rotated_weight = scaled_rotated_weight.to(previous_dtype)
-            bias = self.get_base_layer().bias.to(previous_dtype) if self.get_base_layer().bias is not None else None
+            x = self._cast_input_dtype(x, scaled_rotated_weight.dtype)
+            bias = self._cast_input_dtype(self.get_base_layer().bias, scaled_rotated_weight.dtype)
             result = F.linear(input=x, weight=scaled_rotated_weight, bias=bias)
 
         result = result.to(previous_dtype)
@@ -580,6 +583,7 @@ class Conv2d(nn.Module, OFTLayer):
         for active_adapter in adapter_names:
             if active_adapter in self.oft_r.keys():
                 base_layer = self.get_base_layer()
+                orig_dtype = base_layer.weight.dtype
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
@@ -590,14 +594,14 @@ class Conv2d(nn.Module, OFTLayer):
                         self.out_features, self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0]
                     )
                     orig_weights = torch.transpose(orig_weights, 0, 1)
-                    orig_weights = torch.mm(oft_mat, orig_weights)
+                    orig_weights = torch.mm(oft_mat, orig_weights.to(oft_mat.dtype))
                     orig_weights = torch.transpose(orig_weights, 0, 1)
                     orig_weights = orig_weights * oft_s
                     orig_weights = orig_weights.view(
                         self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[0]
                     )
 
-                    base_layer.weight.data = orig_weights.contiguous()
+                    base_layer.weight.data = orig_weights.contiguous().to(orig_dtype)
                 else:
                     oft_mat, oft_s = self.get_delta_weight(active_adapter)
 
@@ -606,14 +610,14 @@ class Conv2d(nn.Module, OFTLayer):
                         self.out_features, self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0]
                     )
                     orig_weights = torch.transpose(orig_weights, 0, 1)
-                    orig_weights = torch.mm(oft_mat, orig_weights)
+                    orig_weights = torch.mm(oft_mat, orig_weights.to(oft_mat.dtype))
                     orig_weights = torch.transpose(orig_weights, 0, 1)
                     orig_weights = orig_weights * oft_s
                     orig_weights = orig_weights.view(
                         self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[0]
                     )
 
-                    base_layer.weight.data = orig_weights.contiguous()
+                    base_layer.weight.data = orig_weights.contiguous().to(orig_dtype)
 
                 self.merged_adapters.append(active_adapter)
 
@@ -624,6 +628,9 @@ class Conv2d(nn.Module, OFTLayer):
         if not self.merged:
             warnings.warn("Already unmerged. Nothing to do.")
             return
+
+        base_layer = self.get_base_layer()
+        orig_dtype = base_layer.weight.dtype
         while len(self.merged_adapters) > 0:
             active_adapter = self.merged_adapters.pop()
             if active_adapter in self.oft_r.keys():
@@ -635,7 +642,7 @@ class Conv2d(nn.Module, OFTLayer):
                     self.in_features * self.get_base_layer().kernel_size[0] * self.get_base_layer().kernel_size[0],
                 )
                 orig_weights = torch.transpose(orig_weights, 0, 1)
-                orig_weights = torch.mm(oft_mat.t(), orig_weights)
+                orig_weights = torch.mm(oft_mat.t(), orig_weights.to(oft_mat.dtype))
                 orig_weights = torch.transpose(orig_weights, 0, 1)
                 orig_weights = orig_weights * (1 / oft_s)
                 orig_weights = orig_weights.view(
@@ -645,7 +652,7 @@ class Conv2d(nn.Module, OFTLayer):
                     self.get_base_layer().kernel_size[0],
                 )
 
-                self.get_base_layer().weight.data = orig_weights
+                base_layer.weight.data = orig_weights.to(orig_dtype)
 
     def get_delta_weight(self, adapter_name) -> tuple[torch.Tensor, torch.Tensor]:
         """
@@ -684,7 +691,6 @@ class Conv2d(nn.Module, OFTLayer):
             oft_rotation = torch.eye(
                 self.in_features * self.get_base_layer().kernel_size[0] * self.get_base_layer().kernel_size[0],
                 device=x.device,
-                dtype=previous_dtype,
             )
             oft_scale = torch.ones((int(self.out_features), 1), device=x.device, dtype=previous_dtype)
 
@@ -707,10 +713,8 @@ class Conv2d(nn.Module, OFTLayer):
                 orth_rotate = dropout(orth_rotate)
                 oft_mat = self._block_diagonal(orth_rotate, rank)
 
-                oft_rotation = oft_mat @ oft_rotation
+                oft_rotation = oft_mat @ oft_rotation.to(oft_mat.dtype)
                 oft_scale = oft_s * oft_scale
-
-            x = x.to(self.get_base_layer().weight.data.dtype)
 
             orig_weights = self.base_layer.weight.data
             orig_weights = orig_weights.view(
@@ -731,10 +735,12 @@ class Conv2d(nn.Module, OFTLayer):
                 self.get_base_layer().kernel_size[0],
                 self.get_base_layer().kernel_size[0],
             )
+            x = self._cast_input_dtype(x, scaled_rotated_weight.dtype)
+            bias = self._cast_input_dtype(self.get_base_layer().bias, scaled_rotated_weight.dtype)
             result = F.conv2d(
                 input=x,
                 weight=scaled_rotated_weight,
-                bias=self.get_base_layer().bias,
+                bias=bias,
                 padding=self.get_base_layer().padding[0],
                 stride=self.get_base_layer().stride[0],
             )

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -686,9 +686,10 @@ class MLP(nn.Module):
         self.drop = nn.Dropout(0.5)
         self.lin1 = nn.Linear(20, 2, bias=bias)
         self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
 
     def forward(self, X):
-        X = X.float()
+        X = X.to(self.dtype)
         X = self.lin0(X)
         X = self.relu(X)
         X = self.drop(X)
@@ -706,9 +707,10 @@ class MLPWithGRU(nn.Module):
         self.gru = nn.GRU(input_size=20, hidden_size=20, num_layers=1, batch_first=True, bias=bias)
         self.fc = nn.Linear(20, 2, bias=bias)
         self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
 
     def forward(self, X):
-        X = X.float()
+        X = X.to(self.dtype)
         X = self.lin0(X)
         X = self.relu(X)
         X = self.drop(X)
@@ -730,9 +732,10 @@ class MLP_LayerNorm(nn.Module):
         self.layernorm1 = nn.LayerNorm(20, 20)
         self.lin1 = nn.Linear(20, 2, bias=bias)
         self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
 
     def forward(self, X):
-        X = X.float()
+        X = X.to(self.dtype)
         X = self.layernorm0(X)
         X = self.lin0(X)
         X = self.relu(X)
@@ -751,9 +754,10 @@ class MLP2(nn.Module):
         self.drop = nn.Dropout(0.5)
         self.lin1 = nn.Linear(32, 2, bias=bias)
         self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
 
     def forward(self, X):
-        X = X.float()
+        X = X.to(self.dtype)
         X = self.lin0(X)
         X = self.relu(X)
         X = self.drop(X)
@@ -850,9 +854,11 @@ class ModelConv1D(nn.Module):
         self.flat = nn.Flatten()
         self.lin0 = nn.Linear(9, 2)
         self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
 
     def forward(self, X):
-        X = X.float().reshape(-1, 1, 10)
+        X = X.to(self.dtype)
+        X = X.reshape(-1, 1, 10)
         X = self.conv1d(X)
         X = self.relu(X)
         X = self.flat(X)
@@ -869,9 +875,11 @@ class ModelConv2D(nn.Module):
         self.flat = nn.Flatten()
         self.lin0 = nn.Linear(10, 2)
         self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
 
     def forward(self, X):
-        X = X.float().reshape(-1, 5, 3, 3)
+        X = X.to(self.dtype)
+        X = X.reshape(-1, 5, 3, 3)
         X = self.conv2d(X)
         X = self.relu(X)
         X = self.flat(X)
@@ -889,9 +897,10 @@ class ModelConv2D2(nn.Module):
         self.flat = nn.Flatten()
         self.lin1 = nn.Linear(32, 2)
         self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
 
     def forward(self, X):
-        X = X.float()
+        X = X.to(self.dtype)
         X = self.lin0(X)
         X = self.relu(X)
         X = X.reshape(-1, 8, 3, 3)
@@ -911,12 +920,14 @@ class ModelConv3D(nn.Module):
         self.flat = nn.Flatten()
         self.lin0 = nn.Linear(10, 2)
         self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
 
     def forward(self, X):
+        X = X.to(self.dtype)
         # If necessary, convert from 2D image to 3D volume
         if X.dim() == 2:
             X = torch.stack([X] * 3, dim=-1)
-        X = X.float().reshape(-1, 5, 3, 3, 3)
+        X = X.reshape(-1, 5, 3, 3, 3)
         X = self.conv3d(X)
         X = self.relu(X)
         X = self.flat(X)
@@ -931,9 +942,10 @@ class ModelMha(nn.Module):
         self.mha = nn.MultiheadAttention(10, 2)
         self.lin0 = nn.Linear(10, 2)
         self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
 
     def forward(self, X):
-        X = X.float()
+        X = X.to(self.dtype)
         X, _ = self.mha(X, X, X)
         X = self.lin0(X)
         X = self.sm(X)
@@ -1135,6 +1147,120 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         with torch.no_grad():
             output = model(**X)
         assert torch.isfinite(output).all()
+
+    @parameterized.expand(TEST_CASES)
+    def test_forward_float16(self, test_name, model_id, config_cls, config_kwargs):
+        # The user manually sets the dtype of the base model to fp16 precision. This should not cause an error for the
+        # different PEFT methods.
+        try:
+            torch.zeros(1, dtype=torch.float16)
+        except Exception:
+            # skip this test if float16 is not supported on this machine
+            self.skipTest(reason="Test requires float16 support")
+
+        X = self.prepare_inputs_for_testing()
+        model = self.transformers_class.from_pretrained(model_id, torch_dtype=torch.float16).to(self.torch_device)
+        model.dtype = torch.float16
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config)
+        model.eval()
+
+        # check that none of this raises an error
+        model(**X)
+        model.merge_adapter()
+        model(**X)
+        model.unmerge_adapter()
+        model(**X)
+        model = model.merge_and_unload()
+        model(**X)
+
+    @parameterized.expand(TEST_CASES)
+    def test_forward_bfloat16(self, test_name, model_id, config_cls, config_kwargs):
+        # The user manually sets the dtype of the base model to bf16 precision. This should not cause an error for the
+        # different PEFT methods.
+        try:
+            torch.zeros(1, dtype=torch.bfloat16)
+        except Exception:
+            # skip this test if float16 is not supported on this machine
+            self.skipTest(reason="Test requires bfloat16 support")
+
+        X = self.prepare_inputs_for_testing()
+        model = self.transformers_class.from_pretrained(model_id, torch_dtype=torch.bfloat16).to(self.torch_device)
+        model.dtype = torch.bfloat16
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config)
+        model.eval()
+
+        # check that none of this raises an error
+        model(**X)
+        model.merge_adapter()
+        model(**X)
+        model.unmerge_adapter()
+        model(**X)
+        model = model.merge_and_unload()
+        model(**X)
+
+    @parameterized.expand(TEST_CASES)
+    def test_forward_float16_no_autocast(self, test_name, model_id, config_cls, config_kwargs):
+        # Same as above but don't autocast adapter weights to float32 automatically
+        try:
+            torch.zeros(1, dtype=torch.float16)
+        except Exception:
+            # skip this test if float16 is not supported on this machine
+            self.skipTest(reason="Test requires float16 support")
+
+        X = self.prepare_inputs_for_testing()
+        model = self.transformers_class.from_pretrained(model_id, torch_dtype=torch.float16).to(self.torch_device)
+        model.dtype = torch.float16
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config, autocast_adapter_dtype=False)
+        model.eval()
+
+        # check that none of this raises an error
+        model(**X)
+        model.merge_adapter()
+        model(**X)
+        model.unmerge_adapter()
+        model(**X)
+        model = model.merge_and_unload()
+        model(**X)
+
+    @parameterized.expand(TEST_CASES)
+    def test_forward_bfloat16_no_autocast(self, test_name, model_id, config_cls, config_kwargs):
+        # Same as above but don't autocast adapter weights to float32 automatically
+        try:
+            torch.zeros(1, dtype=torch.bfloat16)
+        except Exception:
+            # skip this test if float16 is not supported on this machine
+            self.skipTest(reason="Test requires bfloat16 support")
+
+        X = self.prepare_inputs_for_testing()
+        model = self.transformers_class.from_pretrained(model_id, torch_dtype=torch.bfloat16).to(self.torch_device)
+        model.dtype = torch.bfloat16
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config, autocast_adapter_dtype=False)
+        model.eval()
+
+        # check that none of this raises an error
+        model(**X)
+        model.merge_adapter()
+        model(**X)
+        model.unmerge_adapter()
+        model(**X)
+        model = model.merge_and_unload()
+        model(**X)
 
     @parameterized.expand(TEST_CASES)
     def test_only_params_are_updated(self, test_name, model_id, config_cls, config_kwargs):


### PR DESCRIPTION
As a user, it should be possible to manually cast the base model to a lower precision dtype, float16 or bfloat16, and still have the different PEFT methods work correctly. Currently, this is not the case for many PEFT methods, as can be replicated by the added tests.

To understand the problem, it helps to take a step back. By default, PEFT will treat the adapter weights with high precision, i.e. with float32. When the base model is lower precision, the user needs to pass inputs in lower precision too, as otherwise `self.base_layer(x)` would fail. However, this low precision input clashes with the high precision adapter weights.

The solution implemented in this PR is to cast the input to a higher dtype [1]. That way, the whole adapter operation is conducted in high precision. Only once that has finished will the final result be cast to the original dtype if necessary. This should lead to better results thanks to the high precision, but it may require more memory. Note that this is how LoRA is implemented, so the changes in this PR bring the other methods more in line with what LoRA does.

If the user does not want the adapter to be in float32, they can always pass `autocast_adapter_dtype=False` when calling `get_peft_model` or `PeftModel.from_pretrained` etc. This is also tested.

Besides adjusting the forward method to account for these changes, the `merge` and `unmerge` methods also often had to be adjusted, as they did not correctly account for the base model dtype. Now, those methods should always conserve the original dtype of the base model.

Note that if, for whatever reason, the input casting in [1] is not desired, users can use the `disable_input_dtype_casting` context manager to disable it (more context information on this feature can be found in PR #2353). I updated the corresponding code to be agnostic to the specific PEFT method (beforehand, it was only for LoRA). This is why I had to move the `_cast_input_dtype` method from LoRA to the `BaseTunerLayer`.

TODO: Notify the contributors of the individual methods. Their approval is not required for this PR to be merged, but they might be able to better identify any potential issues.