### PR TITLE
Release 0.15.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.14.1.dev0"
+VERSION = "0.15.0"
 
 extras = {}
 extras["quality"] = [

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
 )
 
 # Release checklist
-# 1. Change the version in __init__.py and setup.py to the release version, e.g. from "0.6.0.dev0" to "0.6.0"
+# 1. Change the version in __init__.py and setup.py to the release version, e.g. from "0.6.1.dev0" to "0.7.0"
 # 2. Check if there are any deprecations that need to be addressed for this release by searching for "# TODO" in the code
 # 3. Commit these changes with the message: "Release: VERSION", create a PR and merge it.
 # 4. Add a tag in git to mark the release: "git tag -a VERSION -m 'Adds tag VERSION for pypi' "
@@ -107,4 +107,4 @@ setup(
 #      twine upload dist/* -r pypi
 # 9. Add release notes to the tag on https://github.com/huggingface/peft/releases once everything is looking hunky-dory.
 #      Check the notes here: https://docs.google.com/document/d/1k-sOIfykuKjWcOIALqjhFKz4amFEp-myeJUJEzNgjoU/edit?usp=sharing
-# 10. Update the version in __init__.py, setup.py to the bumped minor version + ".dev0" (e.g. from "0.6.0" to "0.7.0.dev0")
+# 10. Update the version in __init__.py, setup.py to the bumped patch version + ".dev0" (e.g. from "0.7.0" to "0.7.1.dev0")

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.14.1.dev0"
+__version__ = "0.15.0"
 
 from .auto import (
     MODEL_TYPE_TO_PEFT_MODEL_MAPPING,

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -21,7 +21,6 @@ import huggingface_hub
 import torch
 from huggingface_hub import file_exists, hf_hub_download
 from huggingface_hub.errors import EntryNotFoundError, LocalEntryNotFoundError
-from packaging import version
 from safetensors.torch import load_file as safe_load_file
 
 from peft.mapping import PEFT_TYPE_TO_PREFIX_MAPPING

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -468,15 +468,13 @@ def set_peft_model_state_dict(
     return load_result
 
 
+# TODO: remove this function, use vanilla torch.load as soon as torch < 2.6.0 is no longer supported
 def torch_load(*args, weights_only=True, **kwargs):
     """Call torch.load and handle weights_only.
 
     Defaults to weights_only=True to anticipate upcoming switch on the PyTorch side.
 
     """
-    # TODO: weights_only was added in 1.13, remove if 1.12 no longer needs to be supported
-    if version.parse(torch.__version__) < version.parse("1.13"):
-        return torch.load(*args, **kwargs)
     return torch.load(*args, weights_only=weights_only, **kwargs)
 
 


### PR DESCRIPTION
- bump versions
- remove piece of code required for torch <= 1.12
- Small adjustments to release instructions regarding versions