### PR TITLE
FIX Issue with DeepSpeed and modules_to_save

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -197,7 +197,9 @@ def get_peft_model_state_dict(
     # ADDITIONAL TRAINING MODULES / MODULES_TO_SAVE
     for name, module in model.named_modules():
         if isinstance(module, AuxiliaryTrainingWrapper):
-            to_return.update({f"{name}.{k}": v for k, v in module.adapter_state_dict(adapter_name).items()})
+            to_return.update(
+                {f"{name}.{k}": v for k, v in module.adapter_state_dict(adapter_name, state_dict).items()}
+            )
 
     # DEAL WITH EMBEDDINGS
     # check the common embedding layers in `target_modules` to reset `save_embedding_layers` if necessary


### PR DESCRIPTION
See #2450

The problem is that with DeepSpeed (and possibly in other distributed settings), the `state_dict` fetched from the module can have empty weights. Therefore, use the existing `state_dict` where possible.

This is a bit of an ugly workaround but has been tested successfully with the DeepSpeed script in `examples/sft`.

Gathering the weights in DeepSpeed context was not enough to resolve the issue.