### PR TITLE
Fix sft example script trl and env var

### DIFF
--- a/examples/sft/train.py
+++ b/examples/sft/train.py
@@ -124,6 +124,7 @@ def main(model_args, data_args, training_args):
         model=model,
         processing_class=tokenizer,
         args=training_args,
+        train_dataset=train_dataset,
         eval_dataset=eval_dataset,
         peft_config=peft_config,
     )

--- a/examples/sft/train.py
+++ b/examples/sft/train.py
@@ -122,9 +122,8 @@ def main(model_args, data_args, training_args):
     # trainer
     trainer = SFTTrainer(
         model=model,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         args=training_args,
-        train_dataset=train_dataset,
         eval_dataset=eval_dataset,
         peft_config=peft_config,
     )

--- a/examples/sft/utils.py
+++ b/examples/sft/utils.py
@@ -177,7 +177,7 @@ def create_and_prepare_model(args, data_args, training_args):
         # embedding could be on meta device, therefore, we set mean_resizing=False in that case (i.e. the status quo
         # ante). See https://github.com/huggingface/accelerate/issues/1620.
         uses_transformers_4_46 = packaging.version.parse(transformers.__version__) >= packaging.version.parse("4.46.0")
-        uses_fsdp = os.environ.get("ACCELERATE_USE_FSDP").lower() == "true"
+        uses_fsdp = os.environ.get("ACCELERATE_USE_FSDP", "false").lower() == "true"
         if (bnb_config is not None) and uses_fsdp and uses_transformers_4_46:
             model.resize_token_embeddings(len(tokenizer), pad_to_multiple_of=8, mean_resizing=False)
         else:


### PR DESCRIPTION
There were 2 minor issues:

1. Using DeepSpeed, an env var is not set, leading to an error.
2. TRL renamed the `tokenizer` argument and to `processing_class` in v0.12.0.