### PR TITLE
LoRA variant init now also receives kwargs

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -41,6 +41,9 @@ class LoraVariant:
 
     This class should be subclassed and the methods below should be implemented accordingly. The methods should be
     implemented as static methods, this makes it easier to combine variants.
+
+    Note for developers: These methods are prone to change and should thus considered to be "private". Use at your own
+    discretion.
     """
 
     @staticmethod
@@ -180,6 +183,10 @@ class LoraLayer(BaseTunerLayer):
         use_dora: bool = False,
         lora_bias: bool = False,
     ):
+        # collect the kwargs
+        kwargs = locals().copy()
+        del kwargs["self"]
+
         # This code works for linear layers, override for other layer types
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
@@ -229,7 +236,7 @@ class LoraLayer(BaseTunerLayer):
         self._move_adapter_to_device_of_base_layer(adapter_name)
 
         if adapter_name in self.lora_variant:
-            self.lora_variant[adapter_name].init(self, adapter_name=adapter_name)
+            self.lora_variant[adapter_name].init(self, **kwargs)
 
         self.set_adapter(self.active_adapters)
 
@@ -796,6 +803,10 @@ class Embedding(nn.Module, LoraLayer):
     def update_layer(
         self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora, use_dora, lora_bias
     ):
+        # collect the kwargs
+        kwargs = locals().copy()
+        del kwargs["self"]
+
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
 
@@ -834,7 +845,7 @@ class Embedding(nn.Module, LoraLayer):
         self._move_adapter_to_device_of_base_layer(adapter_name)
 
         if adapter_name in self.lora_variant:
-            self.lora_variant[adapter_name].init(self, adapter_name=adapter_name)
+            self.lora_variant[adapter_name].init(self, **kwargs)
 
         self.set_adapter(self.active_adapters)
 
@@ -1054,6 +1065,10 @@ class _ConvNd(nn.Module, LoraLayer):
     def update_layer(
         self, adapter_name, r, lora_alpha, lora_dropout, init_lora_weights, use_rslora, use_dora, lora_bias
     ):
+        # collect the kwargs
+        kwargs = locals().copy()
+        del kwargs["self"]
+
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
 
@@ -1098,7 +1113,7 @@ class _ConvNd(nn.Module, LoraLayer):
         self._move_adapter_to_device_of_base_layer(adapter_name)
 
         if adapter_name in self.lora_variant:
-            self.lora_variant[adapter_name].init(self, adapter_name=adapter_name)
+            self.lora_variant[adapter_name].init(self, **kwargs)
 
         self.set_adapter(self.active_adapters)
 

--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -112,6 +112,10 @@ class LoraParallelLinear(nn.Module, LoraLayer):
         gather_output=False,
         **parallel_linear_kwargs,
     ):
+        # collect the kwargs
+        kwargs = locals().copy()
+        del kwargs["self"]
+
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
         self.r[adapter_name] = r
@@ -176,7 +180,7 @@ class LoraParallelLinear(nn.Module, LoraLayer):
         self._move_adapter_to_device_of_base_layer(adapter_name)
 
         if adapter_name in self.lora_variant:
-            self.lora_variant[adapter_name].init(self, adapter_name=adapter_name)
+            self.lora_variant[adapter_name].init(self, **kwargs)
 
         self.set_adapter(self.active_adapters)
 

--- a/src/peft/tuners/lora/variants.py
+++ b/src/peft/tuners/lora/variants.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import annotations
 
+from typing import Any
+
 import torch
 from accelerate.utils.imports import is_xpu_available
 from torch import nn
@@ -25,7 +27,7 @@ from .layer import Conv2d, Conv3d, Embedding, Linear, LoraVariant, _ConvNd
 
 class DoraLinearVariant(LoraVariant):
     @staticmethod
-    def init(module: Linear, adapter_name: str) -> None:
+    def init(module: Linear, adapter_name: str, **kwargs: Any) -> None:
         if not module.lora_magnitude_vector:
             # first dora layer being added, add lora_magnitude_vector to the list of learnable parameters
             module.adapter_layer_names = module.adapter_layer_names[:] + ("lora_magnitude_vector",)
@@ -123,7 +125,7 @@ class DoraLinearVariant(LoraVariant):
 
 class DoraEmbeddingVariant(DoraLinearVariant):
     @staticmethod
-    def init(module: Embedding, adapter_name: str) -> None:
+    def init(module: Embedding, adapter_name: str, **kwargs: Any) -> None:
         if module.lora_magnitude_vector is None:
             # first dora layer being added, add lora_magnitude_vector to the list of learnable parameters
             module.adapter_layer_names = module.adapter_layer_names[:] + ("lora_magnitude_vector",)
@@ -275,13 +277,13 @@ class _DoraConvNdVariant(LoraVariant):
 
 class DoraConv2dVariant(_DoraConvNdVariant):
     @staticmethod
-    def init(module: Conv2d, adapter_name: str) -> None:
+    def init(module: Conv2d, adapter_name: str, **kwargs: Any) -> None:
         dora_layer = DoraConv2dLayer(fan_in_fan_out=False)
         _DoraConvNdVariant.init_convd_variant(module, adapter_name, dora_layer=dora_layer)
 
 
 class DoraConv3dVariant(_DoraConvNdVariant):
     @staticmethod
-    def init(module: Conv3d, adapter_name: str) -> None:
+    def init(module: Conv3d, adapter_name: str, **kwargs: Any) -> None:
         dora_layer = DoraConv3dLayer(fan_in_fan_out=False)
         _DoraConvNdVariant.init_convd_variant(module, adapter_name, dora_layer=dora_layer)

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -1382,7 +1382,7 @@ class PeftGPUCommonTests(unittest.TestCase):
             for device_B in possible_combinations:
                 lb = lora_B.to(device_B)
                 layer.lora_A, layer.lora_B = la, lb
-                layer.lora_variant[adapter_name].init(layer, adapter_name)  # should not raise an error
+                layer.lora_variant[adapter_name].init(layer, adapter_name=adapter_name)  # should not raise an error
 
     def test_apply_GS_hra_inference(self):
         # check for different result with and without apply_GS


### PR DESCRIPTION
The `kwargs` might be required for some LoRA variants for proper initialization.