### PR TITLE
Prepare 0.15.1 patch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.15.0"
+VERSION = "0.15.1"
 
 extras = {}
 extras["quality"] = [

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 from .auto import (
     MODEL_TYPE_TO_PEFT_MODEL_MAPPING,


### PR DESCRIPTION
This release is a patch release to release a fix for #2450 which might result in loss of `modules_to_save` when trained with deepspeed ZeRO stage 3.

Only the squashed commit from #2456 and the version bump are included in this PR.