### PR TITLE
Skip Lora layers with zero scale

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -736,6 +736,9 @@ class Linear(nn.Module, LoraLayer):
                 lora_B = self.lora_B[active_adapter]
                 dropout = self.lora_dropout[active_adapter]
                 scaling = self.scaling[active_adapter]
+                if scaling == 0:
+                    continue
+                
                 x = self._cast_input_dtype(x, lora_A.weight.dtype)
                 if active_adapter not in self.lora_variant:  # vanilla LoRA
                     result = result + lora_B(lora_A(dropout(x))) * scaling


### PR DESCRIPTION
Hi, i know that this fix may seem a little random and maybe it would make sense to add similar lines to all other adapters, i just don't have time to do that. But i noticed that currently even if you have many adapters disabled (with zero weights) we still do matmul for them which is useless. On my local machine this change gives extra +2-3% speedup for each zero scaled lora. In case when there are lots of them loaded, this has noticeable effect