### PR TITLE
TST Refactor (continued) of encoder tests

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -6,6 +6,9 @@ on:
     paths-ignore:
         - 'docs/**'
 
+env:
+  TRANSFORMERS_IS_CI: 1
+
 permissions: {}
 
 jobs:

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -68,7 +68,7 @@ SMALL_GRID_MODELS = [
 ]
 
 
-# Note: Missing from this list are LoKr, LoHa, LN Tuning
+# TODO Missing from this list are LoKr, LoHa, LN Tuning, add them
 ALL_CONFIGS = [
     (
         AdaLoraConfig,

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -36,7 +36,6 @@ from peft import (
     OFTConfig,
     PrefixTuningConfig,
     PromptEncoderConfig,
-    PromptLearningConfig,
     PromptTuningConfig,
     PromptTuningInit,
     VBLoRAConfig,
@@ -45,7 +44,7 @@ from peft import (
 )
 
 from .testing_common import PeftCommonTester
-from .testing_utils import load_dataset_english_quotes
+from .testing_utils import load_dataset_english_quotes, set_init_weights_false
 
 
 PEFT_DECODER_MODELS_TO_TEST = [
@@ -221,31 +220,7 @@ def _skip_adalora_oft_hra_bone_for_gpt2(model_id, config_cls):
         pytest.skip("Skipping AdaLora/BOFT/HRA/OFT/Bone for GPT2LMHeadModel")
 
 
-def set_init_weights_false(config_cls, kwargs):
-    kwargs = kwargs.copy()
-
-    if issubclass(config_cls, PromptLearningConfig):
-        return kwargs
-    if config_cls == VBLoRAConfig:
-        return kwargs
-
-    if (config_cls == LoraConfig) or (config_cls == AdaLoraConfig):
-        kwargs["init_lora_weights"] = False
-    elif config_cls == IA3Config:
-        kwargs["init_ia3_weights"] = False
-    else:
-        kwargs["init_weights"] = False
-    return kwargs
-
-
 class TestDecoderModels(PeftCommonTester):
-    r"""
-    Test if the PeftModel behaves as expected. This includes:
-    - test if the model has the expected methods
-
-    We use pytest for debugging purposes to test each model individually.
-    """
-
     transformers_class = AutoModelForCausalLM
 
     def skipTest(self, reason=""):

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -12,15 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import tempfile
-import unittest
 
+import pytest
 import torch
-from parameterized import parameterized
 from transformers import AutoModelForSeq2SeqLM, AutoModelForTokenClassification
 
-from peft import LoraConfig, PromptEncoderConfig, TaskType, get_peft_model
+from peft import (
+    AdaLoraConfig,
+    BOFTConfig,
+    BoneConfig,
+    FourierFTConfig,
+    HRAConfig,
+    IA3Config,
+    LoraConfig,
+    OFTConfig,
+    PrefixTuningConfig,
+    PromptEncoderConfig,
+    PromptTuningConfig,
+    TaskType,
+    VBLoRAConfig,
+    VeraConfig,
+    get_peft_model,
+)
 
-from .testing_common import PeftCommonTester, PeftTestConfigManager
+from .testing_common import PeftCommonTester
+from .testing_utils import set_init_weights_false
 
 
 PEFT_ENCODER_DECODER_MODELS_TO_TEST = [
@@ -28,18 +44,138 @@ PEFT_ENCODER_DECODER_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-BartForConditionalGeneration",
 ]
 
-FULL_GRID = {"model_ids": PEFT_ENCODER_DECODER_MODELS_TO_TEST, "task_type": "SEQ_2_SEQ_LM"}
+# Note: Missing from this list are LoKr, LoHa, LN Tuning
+ALL_CONFIGS = [
+    (
+        AdaLoraConfig,
+        {
+            "target_modules": None,
+            "total_step": 1,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        BOFTConfig,
+        {
+            "target_modules": None,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        BoneConfig,
+        {
+            "target_modules": None,
+            "r": 2,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        FourierFTConfig,
+        {
+            "n_frequency": 10,
+            "target_modules": None,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        HRAConfig,
+        {
+            "target_modules": None,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        IA3Config,
+        {
+            "target_modules": None,
+            "feedforward_modules": None,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        LoraConfig,
+        {
+            "r": 8,
+            "lora_alpha": 32,
+            "target_modules": None,
+            "lora_dropout": 0.05,
+            "bias": "none",
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        LoraConfig,
+        {
+            "r": 8,
+            "lora_alpha": 32,
+            "target_modules": None,
+            "lora_dropout": 0.05,
+            "bias": "none",
+            "trainable_token_indices": [0, 1, 3],
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        OFTConfig,
+        {
+            "target_modules": None,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        PrefixTuningConfig,
+        {
+            "num_virtual_tokens": 10,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        PromptEncoderConfig,
+        {
+            "num_virtual_tokens": 10,
+            "encoder_hidden_size": 32,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        PromptTuningConfig,
+        {
+            "num_virtual_tokens": 10,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        VBLoRAConfig,
+        {
+            "target_modules": None,
+            "vblora_dropout": 0.05,
+            "vector_length": 1,
+            "num_vectors": 2,
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        VeraConfig,
+        {
+            "r": 8,
+            "target_modules": None,
+            "vera_dropout": 0.05,
+            "projection_prng_key": 0xFF,
+            "d_initial": 0.1,
+            "save_projection": True,
+            "bias": "none",
+            "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+]
 
 
-class PeftEncoderDecoderModelTester(unittest.TestCase, PeftCommonTester):
-    r"""
-    Test if the PeftModel behaves as expected. This includes:
-    - test if the model has the expected methods
-
-    We use parametrized.expand for debugging purposes to test each model individually.
-    """
-
+class TestEncoderDecoderModels(PeftCommonTester):
     transformers_class = AutoModelForSeq2SeqLM
+
+    def skipTest(self, reason=""):
+        # for backwards compatibility with unittest style test classes
+        pytest.skip(reason)
 
     def prepare_inputs_for_testing(self):
         input_ids = torch.tensor([[1, 1, 1], [1, 2, 1]]).to(self.torch_device)
@@ -54,207 +190,169 @@ class PeftEncoderDecoderModelTester(unittest.TestCase, PeftCommonTester):
 
         return input_dict
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_attributes_parametrized(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_attributes_parametrized(self, model_id, config_cls, config_kwargs):
         self._test_model_attr(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_adapter_name(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_adapter_name(self, model_id, config_cls, config_kwargs):
         self._test_adapter_name(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_prepare_for_training_parametrized(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_prepare_for_training_parametrized(self, model_id, config_cls, config_kwargs):
         self._test_prepare_for_training(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_save_pretrained(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_save_pretrained(self, model_id, config_cls, config_kwargs):
         self._test_save_pretrained(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_save_pretrained_pickle(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_save_pretrained_pickle(self, model_id, config_cls, config_kwargs):
         self._test_save_pretrained(model_id, config_cls, config_kwargs, safe_serialization=False)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_save_pretrained_selected_adapters(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_save_pretrained_selected_adapters(self, model_id, config_cls, config_kwargs):
         self._test_save_pretrained_selected_adapters(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_save_pretrained_selected_adapters_pickle(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_save_pretrained_selected_adapters_pickle(self, model_id, config_cls, config_kwargs):
         self._test_save_pretrained_selected_adapters(model_id, config_cls, config_kwargs, safe_serialization=False)
 
     def test_load_model_low_cpu_mem_usage(self):
+        # Using the first model with LoraConfig and an empty config_kwargs.
         self._test_load_model_low_cpu_mem_usage(PEFT_ENCODER_DECODER_MODELS_TO_TEST[0], LoraConfig, {})
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_from_pretrained_config_construction(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_from_pretrained_config_construction(self, model_id, config_cls, config_kwargs):
         self._test_from_pretrained_config_construction(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(
-        PeftTestConfigManager.get_grid_parameters(
-            {
-                "model_ids": PEFT_ENCODER_DECODER_MODELS_TO_TEST,
-                "lora_kwargs": {"init_lora_weights": [False]},
-                "adalora_kwargs": {"init_lora_weights": [False]},
-                "ia3_kwargs": {"init_ia3_weights": [False]},
-                "vera_kwargs": {"init_weights": [False]},
-                "hra_kwargs": {"init_weights": [False]},
-                "bone_kwargs": {"init_weights": [False]},
-                "task_type": "SEQ_2_SEQ_LM",
-            },
-        )
-    )
-    def test_merge_layers(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_merge_layers(self, model_id, config_cls, config_kwargs):
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_merge_layers(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(
-        PeftTestConfigManager.get_grid_parameters(
-            {
-                "model_ids": PEFT_ENCODER_DECODER_MODELS_TO_TEST,
-                "lora_kwargs": {"init_lora_weights": [False]},
-                "task_type": "SEQ_2_SEQ_LM",
-            },
-        )
-    )
-    def test_mixed_adapter_batches(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_mixed_adapter_batches(self, model_id, config_cls, config_kwargs):
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_mixed_adapter_batches(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(
-        PeftTestConfigManager.get_grid_parameters(
-            {
-                "model_ids": PEFT_ENCODER_DECODER_MODELS_TO_TEST,
-                "lora_kwargs": {"init_lora_weights": [False]},
-                "task_type": "SEQ_2_SEQ_LM",
-            },
-        )
-    )
-    def test_generate_with_mixed_adapter_batches(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_generate_with_mixed_adapter_batches(self, model_id, config_cls, config_kwargs):
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_generate_with_mixed_adapter_batches_and_beam_search(model_id, config_cls, config_kwargs)
 
-    # skip non lora models - generate does not work for prefix tuning, prompt tuning
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_generate(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_generate(self, model_id, config_cls, config_kwargs):
         self._test_generate(model_id, config_cls, config_kwargs)
 
-    # skip non lora models - generate does not work for prefix tuning, prompt tuning
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_generate_pos_args(self, test_name, model_id, config_cls, config_kwargs):
-        # positional arguments are not supported for PeftModelForSeq2SeqLM
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_generate_pos_args(self, model_id, config_cls, config_kwargs):
         self._test_generate_pos_args(model_id, config_cls, config_kwargs, raises_err=True)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_generate_half_prec(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_generate_half_prec(self, model_id, config_cls, config_kwargs):
         self._test_generate_half_prec(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_prefix_tuning_half_prec_conversion(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_prefix_tuning_half_prec_conversion(self, model_id, config_cls, config_kwargs):
         self._test_prefix_tuning_half_prec_conversion(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_training_encoder_decoders(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_training_encoder_decoders(self, model_id, config_cls, config_kwargs):
         self._test_training(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_training_encoder_decoders_layer_indexing(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_training_encoder_decoders_layer_indexing(self, model_id, config_cls, config_kwargs):
         self._test_training_layer_indexing(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_training_encoder_decoders_gradient_checkpointing(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_training_encoder_decoders_gradient_checkpointing(self, model_id, config_cls, config_kwargs):
         self._test_training_gradient_checkpointing(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_inference_safetensors(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_inference_safetensors(self, model_id, config_cls, config_kwargs):
         self._test_inference_safetensors(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_peft_model_device_map(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_peft_model_device_map(self, model_id, config_cls, config_kwargs):
         self._test_peft_model_device_map(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_delete_adapter(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_delete_adapter(self, model_id, config_cls, config_kwargs):
         self._test_delete_adapter(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_delete_inactive_adapter(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_delete_inactive_adapter(self, model_id, config_cls, config_kwargs):
         self._test_delete_inactive_adapter(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_adding_multiple_adapters_with_bias_raises(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_adding_multiple_adapters_with_bias_raises(self, model_id, config_cls, config_kwargs):
         self._test_adding_multiple_adapters_with_bias_raises(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(
-        PeftTestConfigManager.get_grid_parameters(
-            {
-                "model_ids": PEFT_ENCODER_DECODER_MODELS_TO_TEST,
-                "lora_kwargs": {"init_lora_weights": [False]},
-                "adalora_kwargs": {"init_lora_weights": [False]},
-                "ia3_kwargs": {"init_ia3_weights": [False]},
-                "boft_kwargs": {"init_weights": [False]},
-                "oft_kwargs": {"init_weights": [False]},
-                "vera_kwargs": {"init_weights": [False]},
-                "hra_kwargs": {"init_weights": [False]},
-                "bone_kwargs": {"init_weights": [False]},
-                "task_type": "SEQ_2_SEQ_LM",
-            },
-        )
-    )
-    def test_unload_adapter(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_unload_adapter(self, model_id, config_cls, config_kwargs):
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_unload_adapter(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(
-        PeftTestConfigManager.get_grid_parameters(
-            {
-                "model_ids": PEFT_ENCODER_DECODER_MODELS_TO_TEST,
-                "lora_kwargs": {"init_lora_weights": [False]},
-                "ia3_kwargs": {"init_ia3_weights": [False]},
-                "bone_kwargs": {"init_weights": [False]},
-                "task_type": "SEQ_2_SEQ_LM",
-            },
-        )
-    )
-    def test_weighted_combination_of_adapters(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_weighted_combination_of_adapters(self, model_id, config_cls, config_kwargs):
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_weighted_combination_of_adapters(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(PeftTestConfigManager.get_grid_parameters(FULL_GRID))
-    def test_training_prompt_learning_tasks(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_training_prompt_learning_tasks(self, model_id, config_cls, config_kwargs):
         self._test_training_prompt_learning_tasks(model_id, config_cls, config_kwargs)
 
-    @parameterized.expand(
-        PeftTestConfigManager.get_grid_parameters(
-            {
-                "model_ids": PEFT_ENCODER_DECODER_MODELS_TO_TEST,
-                "lora_kwargs": {"init_lora_weights": [False]},
-                "adalora_kwargs": {"init_lora_weights": [False]},
-                "ia3_kwargs": {"init_ia3_weights": [False]},
-                "boft_kwargs": {"init_weights": [False]},
-                "oft_kwargs": {"init_weights": [False]},
-                "vera_kwargs": {"init_weights": [False]},
-                "hra_kwargs": {"init_weights": [False]},
-                "bone_kwargs": {"init_weights": [False]},
-                "task_type": "SEQ_2_SEQ_LM",
-            },
-        )
-    )
-    def test_disable_adapter(self, test_name, model_id, config_cls, config_kwargs):
+    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_disable_adapter(self, model_id, config_cls, config_kwargs):
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_disable_adapter(model_id, config_cls, config_kwargs)
 
     def test_active_adapters_prompt_learning(self):
-        # see issue https://github.com/huggingface/transformers/pull/30790#issuecomment-2253808249
-        model = AutoModelForSeq2SeqLM.from_pretrained("hf-internal-testing/tiny-random-BartForConditionalGeneration")
+        model = AutoModelForSeq2SeqLM.from_pretrained(
+            "hf-internal-testing/tiny-random-BartForConditionalGeneration"
+        ).to(self.torch_device)
         # any prompt learning method would work here
         config = PromptEncoderConfig(task_type=TaskType.SEQ_2_SEQ_LM, num_virtual_tokens=10)
         model = get_peft_model(model, config)
         assert model.active_adapters == ["default"]
 
-
-class PeftEncoderDecoderCustomModelTester(unittest.TestCase):
-    """
-    A custom class to write any custom test related with Enc-Dec models
-    """
-
     def test_save_shared_tensors(self):
         model_id = "hf-internal-testing/tiny-random-RobertaModel"
         peft_config = LoraConfig(
-            task_type=TaskType.TOKEN_CLS, inference_mode=False, r=16, lora_alpha=16, lora_dropout=0.1, bias="all"
+            task_type=TaskType.TOKEN_CLS,
+            inference_mode=False,
+            r=16,
+            lora_alpha=16,
+            lora_dropout=0.1,
+            bias="all",
         )
         model = AutoModelForTokenClassification.from_pretrained(model_id, num_labels=11)
         model = get_peft_model(model, peft_config)

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -44,7 +44,7 @@ PEFT_ENCODER_DECODER_MODELS_TO_TEST = [
     "hf-internal-testing/tiny-random-BartForConditionalGeneration",
 ]
 
-# Note: Missing from this list are LoKr, LoHa, LN Tuning
+# TODO Missing from this list are LoKr, LoHa, LN Tuning, add them
 ALL_CONFIGS = [
     (
         AdaLoraConfig,

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -21,6 +21,13 @@ import torch
 from accelerate.test_utils.testing import get_backend
 from datasets import load_dataset
 
+from peft import (
+    AdaLoraConfig,
+    IA3Config,
+    LoraConfig,
+    PromptLearningConfig,
+    VBLoRAConfig,
+)
 from peft.import_utils import (
     is_aqlm_available,
     is_auto_awq_available,
@@ -198,3 +205,20 @@ def load_cat_image():
     dataset = load_dataset("huggingface/cats-image", trust_remote_code=True)
     image = dataset["test"]["image"][0]
     return image
+
+
+def set_init_weights_false(config_cls, kwargs):
+    kwargs = kwargs.copy()
+
+    if issubclass(config_cls, PromptLearningConfig):
+        return kwargs
+    if config_cls == VBLoRAConfig:
+        return kwargs
+
+    if (config_cls == LoraConfig) or (config_cls == AdaLoraConfig):
+        kwargs["init_lora_weights"] = False
+    elif config_cls == IA3Config:
+        kwargs["init_ia3_weights"] = False
+    else:
+        kwargs["init_weights"] = False
+    return kwargs


### PR DESCRIPTION
Follow up to #2462 using the same approach as there.

Test coverage before vs after the refactor is 100% identical.