### PR TITLE
Use Python 3.9 as RUFF target version and apply fixes

### DIFF
--- a/examples/boft_controlnet/utils/light_controlnet.py
+++ b/examples/boft_controlnet/utils/light_controlnet.py
@@ -14,7 +14,7 @@
 
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 from diffusers.configuration_utils import ConfigMixin, register_to_config
@@ -34,7 +34,7 @@ logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
 @dataclass
 class ControlNetOutput(BaseOutput):
-    down_block_res_samples: Tuple[torch.Tensor]
+    down_block_res_samples: tuple[torch.Tensor]
     mid_block_res_sample: torch.Tensor
 
 
@@ -52,7 +52,7 @@ class ControlNetConditioningEmbedding(nn.Module):
         self,
         conditioning_embedding_channels: int,
         conditioning_channels: int = 3,
-        block_out_channels: Tuple[int] = (16, 32, 96, 256),
+        block_out_channels: tuple[int] = (16, 32, 96, 256),
     ):
         super().__init__()
 
@@ -92,7 +92,7 @@ class ControlNetModel(ModelMixin, ConfigMixin):
         in_channels: int = 4,
         out_channels: int = 320,
         controlnet_conditioning_channel_order: str = "rgb",
-        conditioning_embedding_out_channels: Optional[Tuple[int]] = (16, 32, 96, 256),
+        conditioning_embedding_out_channels: Optional[tuple[int]] = (16, 32, 96, 256),
     ):
         super().__init__()
 
@@ -104,7 +104,7 @@ class ControlNetModel(ModelMixin, ConfigMixin):
 
     @property
     # Copied from diffusers.models.unet_2d_condition.UNet2DConditionModel.attn_processors
-    def attn_processors(self) -> Dict[str, AttentionProcessor]:
+    def attn_processors(self) -> dict[str, AttentionProcessor]:
         r"""
         Returns:
             `dict` of attention processors: A dictionary containing all attention processors used in the model with
@@ -113,7 +113,7 @@ class ControlNetModel(ModelMixin, ConfigMixin):
         # set recursively
         processors = {}
 
-        def fn_recursive_add_processors(name: str, module: torch.nn.Module, processors: Dict[str, AttentionProcessor]):
+        def fn_recursive_add_processors(name: str, module: torch.nn.Module, processors: dict[str, AttentionProcessor]):
             if hasattr(module, "set_processor"):
                 processors[f"{name}.processor"] = module.processor
 
@@ -128,7 +128,7 @@ class ControlNetModel(ModelMixin, ConfigMixin):
         return processors
 
     # Copied from diffusers.models.unet_2d_condition.UNet2DConditionModel.set_attn_processor
-    def set_attn_processor(self, processor: Union[AttentionProcessor, Dict[str, AttentionProcessor]]):
+    def set_attn_processor(self, processor: Union[AttentionProcessor, dict[str, AttentionProcessor]]):
         r"""
         Parameters:
             `processor (`dict` of `AttentionProcessor` or `AttentionProcessor`):
@@ -220,7 +220,7 @@ class ControlNetModel(ModelMixin, ConfigMixin):
         # Recursively walk through all the children.
         # Any children which exposes the set_attention_slice method
         # gets the message
-        def fn_recursive_set_attention_slice(module: torch.nn.Module, slice_size: List[int]):
+        def fn_recursive_set_attention_slice(module: torch.nn.Module, slice_size: list[int]):
             if hasattr(module, "set_attention_slice"):
                 module.set_attention_slice(slice_size.pop())
 
@@ -238,7 +238,7 @@ class ControlNetModel(ModelMixin, ConfigMixin):
     def forward(
         self,
         controlnet_cond: torch.FloatTensor,
-    ) -> Union[ControlNetOutput, Tuple]:
+    ) -> Union[ControlNetOutput, tuple]:
         # check channel order
         channel_order = self.config.controlnet_conditioning_channel_order
 

--- a/examples/boft_controlnet/utils/pipeline_controlnet.py
+++ b/examples/boft_controlnet/utils/pipeline_controlnet.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 import PIL.Image
@@ -42,8 +42,8 @@ class LightControlNetPipelineOutput(BaseOutput):
             (nsfw) content, or `None` if safety checking could not be performed.
     """
 
-    images: Union[List[PIL.Image.Image], np.ndarray]
-    nsfw_content_detected: Optional[List[bool]]
+    images: Union[list[PIL.Image.Image], np.ndarray]
+    nsfw_content_detected: Optional[list[bool]]
 
 
 class LightControlNetPipeline(StableDiffusionControlNetPipeline):
@@ -164,23 +164,23 @@ class LightControlNetPipeline(StableDiffusionControlNetPipeline):
     @torch.no_grad()
     def __call__(
         self,
-        prompt: Union[str, List[str]] = None,
+        prompt: Union[str, list[str]] = None,
         image: Union[
             torch.FloatTensor,
             PIL.Image.Image,
             np.ndarray,
-            List[torch.FloatTensor],
-            List[PIL.Image.Image],
-            List[np.ndarray],
+            list[torch.FloatTensor],
+            list[PIL.Image.Image],
+            list[np.ndarray],
         ] = None,
         height: Optional[int] = None,
         width: Optional[int] = None,
         num_inference_steps: int = 50,
         guidance_scale: float = 7.5,
-        negative_prompt: Optional[Union[str, List[str]]] = None,
+        negative_prompt: Optional[Union[str, list[str]]] = None,
         num_images_per_prompt: Optional[int] = 1,
         eta: float = 0.0,
-        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        generator: Optional[Union[torch.Generator, list[torch.Generator]]] = None,
         latents: Optional[torch.FloatTensor] = None,
         prompt_embeds: Optional[torch.FloatTensor] = None,
         negative_prompt_embeds: Optional[torch.FloatTensor] = None,
@@ -188,8 +188,8 @@ class LightControlNetPipeline(StableDiffusionControlNetPipeline):
         return_dict: bool = True,
         callback: Optional[Callable[[int, int, torch.FloatTensor], None]] = None,
         callback_steps: int = 1,
-        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
-        controlnet_conditioning_scale: Union[float, List[float]] = 1.0,
+        cross_attention_kwargs: Optional[dict[str, Any]] = None,
+        controlnet_conditioning_scale: Union[float, list[float]] = 1.0,
         guess_mode: bool = False,
     ):
         r"""

--- a/examples/boft_controlnet/utils/unet_2d_condition.py
+++ b/examples/boft_controlnet/utils/unet_2d_condition.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import torch
 from diffusers.models import UNet2DConditionModel
@@ -44,13 +44,13 @@ class UNet2DConditionNewModel(UNet2DConditionModel):
         class_labels: Optional[torch.Tensor] = None,
         timestep_cond: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
-        cross_attention_kwargs: Optional[Dict[str, Any]] = None,
-        added_cond_kwargs: Optional[Dict[str, torch.Tensor]] = None,
-        down_block_additional_residuals: Optional[Tuple[torch.Tensor]] = None,
+        cross_attention_kwargs: Optional[dict[str, Any]] = None,
+        added_cond_kwargs: Optional[dict[str, torch.Tensor]] = None,
+        down_block_additional_residuals: Optional[tuple[torch.Tensor]] = None,
         mid_block_additional_residual: Optional[torch.Tensor] = None,
         encoder_attention_mask: Optional[torch.Tensor] = None,
         return_dict: bool = True,
-    ) -> Union[UNet2DConditionOutput, Tuple]:
+    ) -> Union[UNet2DConditionOutput, tuple]:
         r"""
         Args:
             sample (`torch.FloatTensor`): (batch, channel, height, width) noisy inputs tensor

--- a/examples/corda_finetuning/corda_finetuning.py
+++ b/examples/corda_finetuning/corda_finetuning.py
@@ -14,8 +14,9 @@
 
 import copy
 import os
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence
+from typing import Optional
 
 import torch
 import transformers
@@ -65,7 +66,7 @@ class TrainingArguments(transformers.TrainingArguments):
     model_name_or_path: Optional[str] = field(default="facebook/opt-125m")
     data_path: str = field(default=None, metadata={"help": "Path to the training data."})
     dataset_split: str = field(default="train[:100000]", metadata={"help": "(`['train', 'test', 'eval']`):"})
-    dataset_field: List[str] = field(default=None, metadata={"help": "Fields of dataset input and output."})
+    dataset_field: list[str] = field(default=None, metadata={"help": "Fields of dataset input and output."})
     dataloader_num_proc: int = field(default=16, metadata={"help": "Number of processes to load dataset"})
     dataloader_batch_size: int = field(
         default=3000,
@@ -95,7 +96,7 @@ def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: st
 
 
 def smart_tokenizer_and_embedding_resize(
-    special_tokens_dict: Dict,
+    special_tokens_dict: dict,
     tokenizer: transformers.PreTrainedTokenizer,
     model: transformers.PreTrainedModel,
 ):
@@ -117,7 +118,7 @@ def smart_tokenizer_and_embedding_resize(
         output_embeddings[-num_new_tokens:] = output_embeddings_avg
 
 
-def _tokenize_fn(strings: Sequence[str], tokenizer: transformers.PreTrainedTokenizer) -> Dict:
+def _tokenize_fn(strings: Sequence[str], tokenizer: transformers.PreTrainedTokenizer) -> dict:
     """Tokenize a list of strings."""
     tokenized_list = [
         tokenizer(
@@ -145,7 +146,7 @@ def preprocess(
     sources: Sequence[str],
     targets: Sequence[str],
     tokenizer: transformers.PreTrainedTokenizer,
-) -> Dict:
+) -> dict:
     """Preprocess the data by tokenizing."""
     examples = [s + t for s, t in zip(sources, targets)]
     examples_tokenized, sources_tokenized = (_tokenize_fn(strings, tokenizer) for strings in (examples, sources))
@@ -165,7 +166,7 @@ class DataCollatorForSupervisedDataset:
 
     tokenizer: transformers.PreTrainedTokenizer
 
-    def __call__(self, instances: Sequence[Dict]) -> Dict[str, torch.Tensor]:
+    def __call__(self, instances: Sequence[dict]) -> dict[str, torch.Tensor]:
         input_ids, labels = tuple([instance[key] for instance in instances] for key in ("input_ids", "labels"))
         input_ids = [torch.tensor(x) for x in input_ids]
         input_ids = torch.nn.utils.rnn.pad_sequence(

--- a/examples/int8_training/peft_adalora_whisper_large_training.py
+++ b/examples/int8_training/peft_adalora_whisper_large_training.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from random import randint
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 # datasets imports
 import datasets
@@ -337,7 +337,7 @@ def load_model_hook(models, input_dir):
 class DataCollatorSpeechSeq2SeqWithPadding:
     processor: Any
 
-    def __call__(self, features: List[Dict[str, Union[List[int], torch.Tensor]]]) -> Dict[str, torch.Tensor]:
+    def __call__(self, features: list[dict[str, Union[list[int], torch.Tensor]]]) -> dict[str, torch.Tensor]:
         # split inputs and labels since they have to be of different lengths and need different padding methods
         # first treat the audio inputs by simply returning torch tensors
         input_features = [{"input_features": feature["input_features"]} for feature in features]

--- a/examples/lora_dreambooth/convert_kohya_ss_sd_lora_to_peft.py
+++ b/examples/lora_dreambooth/convert_kohya_ss_sd_lora_to_peft.py
@@ -2,7 +2,7 @@ import argparse
 import os
 from collections import Counter
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Optional
 
 import safetensors
 import torch
@@ -30,13 +30,13 @@ class LoRAInfo:
     lora_A: Optional[torch.Tensor] = None
     lora_B: Optional[torch.Tensor] = None
 
-    def peft_state_dict(self) -> Dict[str, torch.Tensor]:
+    def peft_state_dict(self) -> dict[str, torch.Tensor]:
         if self.lora_A is None or self.lora_B is None:
             raise ValueError("At least one of lora_A or lora_B is None, they must both be provided")
         return {f"{peft_key}.lora_A.weight": self.lora_A, f"{peft_key}.lora_B.weight": self.lora_A}
 
 
-def construct_peft_loraconfig(info: Dict[str, LoRAInfo]) -> LoraConfig:
+def construct_peft_loraconfig(info: dict[str, LoRAInfo]) -> LoraConfig:
     """Constructs LoraConfig from data extracted from kohya checkpoint
 
     Args:
@@ -75,7 +75,7 @@ def construct_peft_loraconfig(info: Dict[str, LoRAInfo]) -> LoraConfig:
     return config
 
 
-def combine_peft_state_dict(info: Dict[str, LoRAInfo]) -> Dict[str, torch.Tensor]:
+def combine_peft_state_dict(info: dict[str, LoRAInfo]) -> dict[str, torch.Tensor]:
     result = {}
     for key_name, key_info in info.items():
         result[f"base_model.model.{key_name}.lora_A.weight"] = key_info.lora_A
@@ -115,7 +115,7 @@ if __name__ == "__main__":
         )
 
     # Store conversion info (model_type -> peft_key -> LoRAInfo)
-    lora_info: Dict[str, Dict[str, LoRAInfo]] = {
+    lora_info: dict[str, dict[str, LoRAInfo]] = {
         "text_encoder": {},
         "unet": {},
     }

--- a/examples/lora_dreambooth/convert_peft_sd_lora_to_kohya_ss.py
+++ b/examples/lora_dreambooth/convert_peft_sd_lora_to_kohya_ss.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-from typing import Dict
 
 import torch
 from diffusers import UNet2DConditionModel
@@ -19,7 +18,7 @@ LORA_ADAPTER_NAME = "default"
 
 def get_module_kohya_state_dict(
     module: PeftModel, prefix: str, dtype: torch.dtype, adapter_name: str = LORA_ADAPTER_NAME
-) -> Dict[str, torch.Tensor]:
+) -> dict[str, torch.Tensor]:
     kohya_ss_state_dict = {}
     for peft_key, weight in get_peft_model_state_dict(module, adapter_name=adapter_name).items():
         kohya_key = peft_key.replace("base_model.model", prefix)

--- a/examples/olora_finetuning/olora_finetuning.py
+++ b/examples/olora_finetuning/olora_finetuning.py
@@ -14,7 +14,7 @@
 
 
 import os
-from typing import List, Optional
+from typing import Optional
 
 import torch
 import transformers
@@ -43,7 +43,7 @@ def train(
     lora_r: int = 32,
     lora_alpha: int = 16,
     lora_dropout: float = 0.05,
-    lora_target_modules: List[str] = None,
+    lora_target_modules: list[str] = None,
     torch_dtype: str = "float16",
     init_lora_weights="olora",
     seed: Optional[int] = None,

--- a/examples/stable_diffusion/convert_sd_adapter_to_peft.py
+++ b/examples/stable_diffusion/convert_sd_adapter_to_peft.py
@@ -5,7 +5,7 @@ import os
 from collections import Counter
 from dataclasses import dataclass
 from operator import attrgetter
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 import safetensors
 import torch
@@ -35,7 +35,7 @@ class LoRAInfo:
     lora_A: Optional[torch.Tensor] = None
     lora_B: Optional[torch.Tensor] = None
 
-    def peft_state_dict(self) -> Dict[str, torch.Tensor]:
+    def peft_state_dict(self) -> dict[str, torch.Tensor]:
         if self.lora_A is None or self.lora_B is None:
             raise ValueError("At least one of lora_A or lora_B is None, they must both be provided")
         return {
@@ -57,7 +57,7 @@ class LoHaInfo:
     hada_t1: Optional[torch.Tensor] = None
     hada_t2: Optional[torch.Tensor] = None
 
-    def peft_state_dict(self) -> Dict[str, torch.Tensor]:
+    def peft_state_dict(self) -> dict[str, torch.Tensor]:
         if self.hada_w1_a is None or self.hada_w1_b is None or self.hada_w2_a is None or self.hada_w2_b is None:
             raise ValueError(
                 "At least one of hada_w1_a, hada_w1_b, hada_w2_a, hada_w2_b is missing, they all must be provided"
@@ -92,7 +92,7 @@ class LoKrInfo:
     lokr_w2_b: Optional[torch.Tensor] = None
     lokr_t2: Optional[torch.Tensor] = None
 
-    def peft_state_dict(self) -> Dict[str, torch.Tensor]:
+    def peft_state_dict(self) -> dict[str, torch.Tensor]:
         if (self.lokr_w1 is None) and ((self.lokr_w1_a is None) or (self.lokr_w1_b is None)):
             raise ValueError("Either lokr_w1 or both lokr_w1_a and lokr_w1_b should be provided")
 
@@ -119,7 +119,7 @@ class LoKrInfo:
         return state_dict
 
 
-def construct_peft_loraconfig(info: Dict[str, LoRAInfo], **kwargs) -> LoraConfig:
+def construct_peft_loraconfig(info: dict[str, LoRAInfo], **kwargs) -> LoraConfig:
     """Constructs LoraConfig from data extracted from adapter checkpoint
 
     Args:
@@ -158,7 +158,7 @@ def construct_peft_loraconfig(info: Dict[str, LoRAInfo], **kwargs) -> LoraConfig
     return config
 
 
-def construct_peft_lohaconfig(info: Dict[str, LoHaInfo], **kwargs) -> LoHaConfig:
+def construct_peft_lohaconfig(info: dict[str, LoHaInfo], **kwargs) -> LoHaConfig:
     """Constructs LoHaConfig from data extracted from adapter checkpoint
 
     Args:
@@ -201,7 +201,7 @@ def construct_peft_lohaconfig(info: Dict[str, LoHaInfo], **kwargs) -> LoHaConfig
     return config
 
 
-def construct_peft_lokrconfig(info: Dict[str, LoKrInfo], decompose_factor: int = -1, **kwargs) -> LoKrConfig:
+def construct_peft_lokrconfig(info: dict[str, LoKrInfo], decompose_factor: int = -1, **kwargs) -> LoKrConfig:
     """Constructs LoKrConfig from data extracted from adapter checkpoint
 
     Args:
@@ -272,14 +272,14 @@ def construct_peft_lokrconfig(info: Dict[str, LoKrInfo], decompose_factor: int =
     return config
 
 
-def combine_peft_state_dict(info: Dict[str, Union[LoRAInfo, LoHaInfo]]) -> Dict[str, torch.Tensor]:
+def combine_peft_state_dict(info: dict[str, Union[LoRAInfo, LoHaInfo]]) -> dict[str, torch.Tensor]:
     result = {}
     for key_info in info.values():
         result.update(key_info.peft_state_dict())
     return result
 
 
-def detect_adapter_type(keys: List[str]) -> PeftType:
+def detect_adapter_type(keys: list[str]) -> PeftType:
     # Detect type of adapter by keys
     # Inspired by this:
     # https://github.com/bmaltais/kohya_ss/blob/ed4e3b0239a40506de9a17e550e6cf2d0b867a4f/tools/lycoris_utils.py#L312
@@ -348,7 +348,7 @@ if __name__ == "__main__":
         )
 
     # Store conversion info (model_type -> peft_key -> LoRAInfo | LoHaInfo | LoKrInfo)
-    adapter_info: Dict[str, Dict[str, Union[LoRAInfo, LoHaInfo, LoKrInfo]]] = {
+    adapter_info: dict[str, dict[str, Union[LoRAInfo, LoHaInfo, LoKrInfo]]] = {
         "text_encoder": {},
         "unet": {},
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ line-length = 119
 target-version = ['py38']
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 119
 extend-exclude = ["*.ipynb"]
 
@@ -26,6 +26,7 @@ ignore = [
     "E501", # Line length (handled by ruff-format)
     "F841", # unused variable
     "UP007", # X | Y style Unions
+    "C420", # dict.fromkeys
 ]
 
 [tool.ruff.lint.isort]

--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -16,7 +16,7 @@ import json
 import os
 import warnings
 from dataclasses import asdict, dataclass, field
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 from huggingface_hub import hf_hub_download
 from transformers.utils import PushToHubMixin
@@ -68,7 +68,7 @@ class PeftConfigMixin(PushToHubMixin):
                 f"Invalid task type: '{self.task_type}'. Must be one of the following task types: {', '.join(TaskType)}."
             )
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         r"""
         Returns the configuration for your adapter model as a dictionary.
         """

--- a/src/peft/tuners/adalora/layer.py
+++ b/src/peft/tuners/adalora/layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import warnings
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import packaging
 import torch
@@ -105,7 +105,7 @@ class SVDLinear(nn.Module, AdaLoraLayer):
         self._active_adapter = adapter_name
         self.update_layer(adapter_name, r, lora_alpha, lora_dropout, init_lora_weights)
 
-    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
 

--- a/src/peft/tuners/adaption_prompt/model.py
+++ b/src/peft/tuners/adaption_prompt/model.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
 
 import torch.nn as nn
 
@@ -40,16 +39,16 @@ class AdaptionPromptModel(nn.Module):
     - Disabling the adapter would also result in the modules being removed from the model.
     """
 
-    def __init__(self, model, configs: Dict, adapter_name: str):
+    def __init__(self, model, configs: dict, adapter_name: str):
         super().__init__()
         self.model = model
         # Store adapter configs by name.
-        self.peft_config: Dict[str, AdaptionPromptConfig] = {}
+        self.peft_config: dict[str, AdaptionPromptConfig] = {}
         # Store lists of the parents of the affected attention modules by adapter name.
         # We keep references to the parents so we can swap the adapters in-and-out of the model.
-        self._parents: Dict[str, List[nn.Module]] = {}
+        self._parents: dict[str, list[nn.Module]] = {}
         # Store lists of cached AdaptedAttention modules by name.
-        self._cached_adapters: Dict[str, List] = {}
+        self._cached_adapters: dict[str, list] = {}
         # The name of the currently active adapter.
         self._active_adapter = None
         # Whether the adapter is enabled.
@@ -116,7 +115,7 @@ class AdaptionPromptModel(nn.Module):
         self._enabled = False
         self._remove_adapted_attentions(self._active_adapter)
 
-    def _create_adapted_attentions(self, config: AdaptionPromptConfig, parents: List[nn.Module]) -> None:
+    def _create_adapted_attentions(self, config: AdaptionPromptConfig, parents: list[nn.Module]) -> None:
         """Wrap LlamaAttention modules with newly created AdaptedAttention modules."""
         for par in parents:
             attn = AdaptedAttention(

--- a/src/peft/tuners/boft/model.py
+++ b/src/peft/tuners/boft/model.py
@@ -18,7 +18,7 @@
 import warnings
 from dataclasses import asdict
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 import torch
 from torch import nn
@@ -272,7 +272,7 @@ class BOFTModel(BaseTuner):
         merge=True,
         progressbar: bool = False,
         safe_merge: bool = False,
-        adapter_names: Optional[List[str]] = None,
+        adapter_names: Optional[list[str]] = None,
     ):
         if merge:
             self._check_merge_allowed()
@@ -324,7 +324,7 @@ class BOFTModel(BaseTuner):
         self.active_adapter = new_adapter or []
 
     def merge_and_unload(
-        self, progressbar: bool = False, safe_merge: bool = False, adapter_names: Optional[List[str]] = None
+        self, progressbar: bool = False, safe_merge: bool = False, adapter_names: Optional[list[str]] = None
     ) -> torch.nn.Module:
         r"""
         This method merges the BOFT layers into the base model. This is needed if someone wants to use the base model

--- a/src/peft/tuners/bone/layer.py
+++ b/src/peft/tuners/bone/layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import math
 import warnings
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -131,7 +131,7 @@ class BoneLinear(nn.Module, BoneLayer):
         self.update_layer(adapter_name, r, init_weights, **kwargs)
         self.bone_fn = init_weights
 
-    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
 

--- a/src/peft/tuners/bone/model.py
+++ b/src/peft/tuners/bone/model.py
@@ -15,7 +15,7 @@
 import warnings
 from dataclasses import asdict
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 import torch
 from torch import nn
@@ -263,7 +263,7 @@ class BoneModel(BaseTuner):
         merge=True,
         progressbar: bool = False,
         safe_merge: bool = False,
-        adapter_names: Optional[List[str]] = None,
+        adapter_names: Optional[list[str]] = None,
     ):
         self._unloading_checks(adapter_names)
         key_list = [key for key, _ in self.model.named_modules() if self.prefix not in key]
@@ -307,7 +307,7 @@ class BoneModel(BaseTuner):
         self.active_adapter = new_adapter or []
 
     def merge_and_unload(
-        self, progressbar: bool = False, safe_merge: bool = False, adapter_names: Optional[List[str]] = None
+        self, progressbar: bool = False, safe_merge: bool = False, adapter_names: Optional[list[str]] = None
     ) -> torch.nn.Module:
         r"""
         This method merges the Bone layers into the base model. This is needed if someone wants to use the base model

--- a/src/peft/tuners/fourierft/layer.py
+++ b/src/peft/tuners/fourierft/layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import warnings
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -112,7 +112,7 @@ class FourierFTLinear(nn.Module, FourierFTLayer):
         self._active_adapter = adapter_name
         self.update_layer(adapter_name, n_frequency, scaling, init_weights, random_loc_seed)
 
-    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
 

--- a/src/peft/tuners/hra/layer.py
+++ b/src/peft/tuners/hra/layer.py
@@ -14,7 +14,7 @@
 
 import math
 import warnings
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -143,7 +143,7 @@ class HRALinear(nn.Module, HRALayer):
         self._active_adapter = adapter_name
         self.update_layer(adapter_name, r, apply_GS, init_weights, **kwargs)
 
-    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
 
@@ -286,7 +286,7 @@ class HRAConv2d(nn.Module, HRALayer):
         self._active_adapter = adapter_name
         self.update_layer(adapter_name, r, apply_GS, init_weights, **kwargs)
 
-    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
 

--- a/src/peft/tuners/hra/model.py
+++ b/src/peft/tuners/hra/model.py
@@ -15,7 +15,7 @@
 import warnings
 from dataclasses import asdict
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 import torch
 from torch import nn
@@ -268,7 +268,7 @@ class HRAModel(BaseTuner):
         merge=True,
         progressbar: bool = False,
         safe_merge: bool = False,
-        adapter_names: Optional[List[str]] = None,
+        adapter_names: Optional[list[str]] = None,
     ):
         self._unloading_checks(adapter_names)
         key_list = [key for key, _ in self.model.named_modules() if self.prefix not in key]
@@ -312,7 +312,7 @@ class HRAModel(BaseTuner):
         self.active_adapter = new_adapter or []
 
     def merge_and_unload(
-        self, progressbar: bool = False, safe_merge: bool = False, adapter_names: Optional[List[str]] = None
+        self, progressbar: bool = False, safe_merge: bool = False, adapter_names: Optional[list[str]] = None
     ) -> torch.nn.Module:
         r"""
         This method merges the HRA layers into the base model. This is needed if someone wants to use the base model as

--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import warnings
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
@@ -89,7 +89,7 @@ class Linear(nn.Module, IA3Layer):
         self._active_adapter = adapter_name
         self.update_layer(adapter_name, init_ia3_weights)
 
-    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
 
@@ -213,7 +213,7 @@ class _ConvNd(nn.Module, IA3Layer):
         self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
-    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
 

--- a/src/peft/tuners/ln_tuning/layer.py
+++ b/src/peft/tuners/ln_tuning/layer.py
@@ -14,7 +14,7 @@
 
 import warnings
 from copy import deepcopy
-from typing import List, Optional
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -60,7 +60,7 @@ class LNTuningLayer(nn.Module, BaseTunerLayer):
                 layer.requires_grad_(False)
             self._disable_adapters = True
 
-    def merge(self, adapter_names: Optional[List[str]] = None, safe_merge: bool = False):
+    def merge(self, adapter_names: Optional[list[str]] = None, safe_merge: bool = False):
         # note that there is no actual merging, so whether safe_merge is True or False is irrelevant
         adapter_names = check_adapters_to_merge(self, adapter_names)
         if not adapter_names:

--- a/src/peft/tuners/loha/layer.py
+++ b/src/peft/tuners/loha/layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import Any, Set, Tuple
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -40,10 +40,10 @@ class LoHaLayer(nn.Module, LycorisLayer):
         self.hada_t2 = nn.ParameterDict({})
 
     @property
-    def _available_adapters(self) -> Set[str]:
+    def _available_adapters(self) -> set[str]:
         return {*self.hada_w1_a, *self.hada_w1_b, *self.hada_w2_a, *self.hada_w2_b, *self.hada_t1, *self.hada_t2}
 
-    def create_adapter_parameters(self, adapter_name: str, r: int, shape: Tuple[int, ...]):
+    def create_adapter_parameters(self, adapter_name: str, r: int, shape: tuple[int, ...]):
         # https://github.com/KohakuBlueleaf/LyCORIS/blob/eb460098187f752a5d66406d3affade6f0a07ece/lycoris/modules/loha.py#L130C9-L143C75
         if len(shape) == 4:
             self.hada_t1[adapter_name] = nn.Parameter(torch.empty(r, r, shape[2], shape[3]))

--- a/src/peft/tuners/loha/model.py
+++ b/src/peft/tuners/loha/model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Type, Union
+from typing import Union
 
 import torch
 from torch import nn
@@ -82,7 +82,7 @@ class LoHaModel(LycorisTuner):
     """
 
     prefix: str = "hada_"
-    layers_mapping: Dict[Type[torch.nn.Module], Type[LoHaLayer]] = {
+    layers_mapping: dict[type[torch.nn.Module], type[LoHaLayer]] = {
         torch.nn.Conv2d: Conv2d,
         torch.nn.Linear: Linear,
     }

--- a/src/peft/tuners/lokr/layer.py
+++ b/src/peft/tuners/lokr/layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import Any, Optional, Set, Tuple, Union
+from typing import Any, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -49,7 +49,7 @@ class LoKrLayer(nn.Module, LycorisLayer):
         self.lokr_t2 = nn.ParameterDict({})
 
     @property
-    def _available_adapters(self) -> Set[str]:
+    def _available_adapters(self) -> set[str]:
         return {
             *self.lokr_w1,
             *self.lokr_w1_a,
@@ -361,7 +361,7 @@ class Conv2d(LoKrLayer):
 # Below code is a direct copy from https://github.com/KohakuBlueleaf/LyCORIS/blob/eb460098187f752a5d66406d3affade6f0a07ece/lycoris/modules/lokr.py#L11
 
 
-def factorization(dimension: int, factor: int = -1) -> Tuple[int, int]:
+def factorization(dimension: int, factor: int = -1) -> tuple[int, int]:
     """Factorizes the provided number into the product of two numbers
 
     Args:

--- a/src/peft/tuners/lokr/model.py
+++ b/src/peft/tuners/lokr/model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Type, Union
+from typing import Union
 
 import torch
 from torch import nn
@@ -83,7 +83,7 @@ class LoKrModel(LycorisTuner):
     """
 
     prefix: str = "lokr_"
-    layers_mapping: Dict[Type[torch.nn.Module], Type[LoKrLayer]] = {
+    layers_mapping: dict[type[torch.nn.Module], type[LoKrLayer]] = {
         torch.nn.Conv2d: Conv2d,
         torch.nn.Linear: Linear,
     }

--- a/src/peft/tuners/lora/corda.py
+++ b/src/peft/tuners/lora/corda.py
@@ -16,7 +16,8 @@
 # Reference paper: https://arxiv.org/abs/2406.05223
 
 import os
-from typing import Any, Callable, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any, Callable, Optional
 
 import torch
 import torch.nn as nn

--- a/src/peft/tuners/lora/eetq.py
+++ b/src/peft/tuners/lora/eetq.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import torch
 
@@ -85,7 +85,7 @@ if is_eetq_available():
                 result = result + output
             return result
 
-        def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+        def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
             raise AttributeError("Merging LoRA layers is not supported for Eetq layers.")
 
         def unmerge(self) -> None:

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -14,12 +14,12 @@
 
 import warnings
 from collections import Counter, defaultdict
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from contextlib import nullcontext
 from copy import deepcopy
 from functools import partial
 from itertools import cycle
-from typing import Dict, Iterable, Optional, Union
+from typing import Optional, Union
 
 import torch
 import torch.distributed as dist
@@ -293,7 +293,7 @@ def _get_eva_state_dict(
     target_module_check_fn: callable,
     forward_fn: Optional[callable],
     prepare_model_inputs_fn: Optional[callable],
-    prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None],
+    prepare_layer_inputs_fn: Union[callable, dict[str, callable], None],
     gather_distributed_inputs: bool,
     show_progress_bar: bool,
 ) -> dict:
@@ -565,7 +565,7 @@ def get_eva_state_dict(
     peft_config: Optional[LoraConfig] = None,
     forward_fn: Optional[callable] = forward_fn_dict,
     prepare_model_inputs_fn: Optional[callable] = prepare_model_inputs_fn_language_modeling,
-    prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
+    prepare_layer_inputs_fn: Union[callable, dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
     adapter_name: str = "default",
     gather_distributed_inputs: bool = True,
     show_progress_bar: bool = True,
@@ -663,7 +663,7 @@ def initialize_lora_eva_weights(
     eva_state_dict: Optional[dict] = None,
     forward_fn: Optional[callable] = forward_fn_dict,
     prepare_model_inputs_fn: Optional[callable] = prepare_model_inputs_fn_language_modeling,
-    prepare_layer_inputs_fn: Union[callable, Dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
+    prepare_layer_inputs_fn: Union[callable, dict[str, callable], None] = prepare_layer_inputs_fn_language_modeling,
     adapter_name: str = "default",
     gather_distributed_inputs: bool = True,
     show_progress_bar: bool = True,

--- a/src/peft/tuners/oft/model.py
+++ b/src/peft/tuners/oft/model.py
@@ -15,7 +15,7 @@
 import warnings
 from dataclasses import asdict
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 import torch
 from torch import nn
@@ -293,7 +293,7 @@ class OFTModel(BaseTuner):
         merge=True,
         progressbar: bool = False,
         safe_merge: bool = False,
-        adapter_names: Optional[List[str]] = None,
+        adapter_names: Optional[list[str]] = None,
     ):
         if merge:
             self._check_merge_allowed()
@@ -345,7 +345,7 @@ class OFTModel(BaseTuner):
         self.active_adapter = new_adapter or []
 
     def merge_and_unload(
-        self, progressbar: bool = False, safe_merge: bool = False, adapter_names: Optional[List[str]] = None
+        self, progressbar: bool = False, safe_merge: bool = False, adapter_names: Optional[list[str]] = None
     ) -> torch.nn.Module:
         r"""
         This method merges the OFT layers into the base model. This is needed if someone wants to use the base model as

--- a/src/peft/tuners/vblora/layer.py
+++ b/src/peft/tuners/vblora/layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import warnings
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -133,7 +133,7 @@ class Linear(nn.Linear, VBLoRALayer):
         )
         self.is_target_conv_1d_layer = is_target_conv_1d_layer
 
-    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
 
@@ -183,7 +183,7 @@ class Linear(nn.Linear, VBLoRALayer):
         topk_weights = F.softmax(top_k_logits, dim=-1)
         return (topk_weights.unsqueeze(-1) * vblora_vector_bank[indices]).sum(-2)
 
-    def _get_lora_matrices(self, adapter, cast_to_fp32=False) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _get_lora_matrices(self, adapter, cast_to_fp32=False) -> tuple[torch.Tensor, torch.Tensor]:
         vblora_logits_A = self.vblora_logits_A[adapter]
         vblora_logits_B = self.vblora_logits_B[adapter]
 

--- a/src/peft/tuners/vera/layer.py
+++ b/src/peft/tuners/vera/layer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import warnings
-from typing import List, Optional
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -163,7 +163,7 @@ class Linear(nn.Linear, VeraLayer):
         self.update_layer(adapter_name, vera_A, vera_B, r, vera_dropout, init_weights, d_initial=d_initial)
         self.is_target_conv_1d_layer = is_target_conv_1d_layer
 
-    def merge(self, safe_merge: bool = False, adapter_names: Optional[List[str]] = None) -> None:
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
 

--- a/src/peft/utils/incremental_pca.py
+++ b/src/peft/utils/incremental_pca.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 
@@ -125,7 +125,7 @@ class IncrementalPCA:
     @staticmethod
     def _incremental_mean_and_var(
         X, last_mean, last_variance, last_sample_count
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Computes the incremental mean and variance for the data `X`.
 
@@ -180,7 +180,7 @@ class IncrementalPCA:
         return updated_mean, updated_variance, updated_sample_count
 
     @staticmethod
-    def _svd_flip(u, v, u_based_decision=True) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _svd_flip(u, v, u_based_decision=True) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Adjusts the signs of the singular vectors from the SVD decomposition for deterministic output.
 

--- a/src/peft/utils/merge_utils.py
+++ b/src/peft/utils/merge_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import warnings
-from typing import List, Literal
+from typing import Literal
 
 import torch
 
@@ -141,7 +141,7 @@ def disjoint_merge(task_tensors: torch.Tensor, majority_sign_mask: torch.Tensor)
     return mixed_task_tensors / torch.clamp(num_params_preserved, min=1.0)
 
 
-def task_arithmetic(task_tensors: List[torch.Tensor], weights: torch.Tensor) -> torch.Tensor:
+def task_arithmetic(task_tensors: list[torch.Tensor], weights: torch.Tensor) -> torch.Tensor:
     """
     Merge the task tensors using `task arithmetic`.
 
@@ -160,7 +160,7 @@ def task_arithmetic(task_tensors: List[torch.Tensor], weights: torch.Tensor) -> 
     return mixed_task_tensors
 
 
-def magnitude_prune(task_tensors: List[torch.Tensor], weights: torch.Tensor, density: float) -> torch.Tensor:
+def magnitude_prune(task_tensors: list[torch.Tensor], weights: torch.Tensor, density: float) -> torch.Tensor:
     """
     Merge the task tensors using `task arithmetic`.
 
@@ -183,7 +183,7 @@ def magnitude_prune(task_tensors: List[torch.Tensor], weights: torch.Tensor, den
 
 
 def ties(
-    task_tensors: List[torch.Tensor],
+    task_tensors: list[torch.Tensor],
     weights: torch.Tensor,
     density: float,
     majority_sign_method: Literal["total", "frequency"] = "total",
@@ -214,7 +214,7 @@ def ties(
     return mixed_task_tensors
 
 
-def dare_linear(task_tensors: List[torch.Tensor], weights: torch.Tensor, density: float) -> torch.Tensor:
+def dare_linear(task_tensors: list[torch.Tensor], weights: torch.Tensor, density: float) -> torch.Tensor:
     """
     Merge the task tensors using `dare linear`.
 
@@ -237,7 +237,7 @@ def dare_linear(task_tensors: List[torch.Tensor], weights: torch.Tensor, density
 
 
 def dare_ties(
-    task_tensors: List[torch.Tensor],
+    task_tensors: list[torch.Tensor],
     weights: torch.Tensor,
     density: float,
     majority_sign_method: Literal["total", "frequency"] = "total",

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -18,8 +18,9 @@ import inspect
 import os
 import re
 import warnings
+from collections.abc import Sequence
 from contextlib import nullcontext
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Optional, Union
 
 import accelerate
 import torch

--- a/tests/test_cpt.py
+++ b/tests/test_cpt.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import pytest
 import torch
@@ -98,7 +98,7 @@ def collator(global_tokenizer):
             self.training = training
             self.tokenizer.add_special_tokens({"pad_token": "[PAD]"})  # mk check why needed
 
-        def torch_call(self, examples: List[Union[List[int], Any, Dict[str, Any]]]) -> Dict[str, Any]:
+        def torch_call(self, examples: list[Union[list[int], Any, dict[str, Any]]]) -> dict[str, Any]:
             # Handle dict or lists with proper padding and conversion to tensor.
             list_sample_mask = []
             for i in range(len(examples)):

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -20,7 +20,7 @@ import unittest
 from collections import Counter, defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import pytest
 import torch
@@ -111,7 +111,7 @@ class DataCollatorSpeechSeq2SeqWithPadding:
 
     processor: Any
 
-    def __call__(self, features: List[Dict[str, Union[List[int], torch.Tensor]]]) -> Dict[str, torch.Tensor]:
+    def __call__(self, features: list[dict[str, Union[list[int], torch.Tensor]]]) -> dict[str, torch.Tensor]:
         # split inputs and labels since they have to be of different lengths and need different padding methods
         # first treat the audio inputs by simply returning torch tensors
         input_features = [{"input_features": feature["input_features"]} for feature in features]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -210,8 +210,9 @@ class TestScalingAdapters:
         text_scales_before_scaling = self.get_scale_from_modules(pipeline.text_encoder)
         unet_scales_before_scaling = self.get_scale_from_modules(pipeline.unet)
 
-        with rescale_adapter_scale(model=pipeline.text_encoder, multiplier=0.5), rescale_adapter_scale(
-            model=pipeline.unet, multiplier=0.5
+        with (
+            rescale_adapter_scale(model=pipeline.text_encoder, multiplier=0.5),
+            rescale_adapter_scale(model=pipeline.unet, multiplier=0.5),
         ):
             text_scales_during_scaling = self.get_scale_from_modules(pipeline.text_encoder)
             unet_scales_during_scaling = self.get_scale_from_modules(pipeline.unet)


### PR DESCRIPTION
Apply RUFF fixes based on Python 3.9 features. Most changes are about type annotations. Rule `C420` has been disabled for readability. Overall, it's safe to merge them. 