### PR TITLE
make test_lora_use_dora_linear pass on XPU

### DIFF
--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -60,6 +60,7 @@ from .testing_utils import (
     device_count,
     load_cat_image,
     require_bitsandbytes,
+    require_deterministic,
     require_multi_accelerator,
     require_non_cpu,
 )
@@ -1124,8 +1125,8 @@ class PeftGPUCommonTests(unittest.TestCase):
 
     @require_non_cpu
     @pytest.mark.single_gpu_tests
+    @require_deterministic
     @require_bitsandbytes
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="XPU have numerial errors")
     def test_4bit_dora_inference(self):
         # check for same result with and without DoRA when initializing with init_lora_weights=False
         bnb_config = BitsAndBytesConfig(
@@ -1164,8 +1165,8 @@ class PeftGPUCommonTests(unittest.TestCase):
 
     @require_non_cpu
     @pytest.mark.single_gpu_tests
+    @require_deterministic
     @require_bitsandbytes
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="XPU have numerial errors")
     def test_8bit_dora_inference(self):
         # check for same result with and without DoRA when initializing with init_lora_weights=False
         model = AutoModelForCausalLM.from_pretrained(

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -60,7 +60,7 @@ from .testing_utils import (
     device_count,
     load_cat_image,
     require_bitsandbytes,
-    require_deterministic,
+    require_deterministic_for_xpu,
     require_multi_accelerator,
     require_non_cpu,
 )
@@ -1125,7 +1125,7 @@ class PeftGPUCommonTests(unittest.TestCase):
 
     @require_non_cpu
     @pytest.mark.single_gpu_tests
-    @require_deterministic
+    @require_deterministic_for_xpu
     @require_bitsandbytes
     def test_4bit_dora_inference(self):
         # check for same result with and without DoRA when initializing with init_lora_weights=False
@@ -1165,7 +1165,7 @@ class PeftGPUCommonTests(unittest.TestCase):
 
     @require_non_cpu
     @pytest.mark.single_gpu_tests
-    @require_deterministic
+    @require_deterministic_for_xpu
     @require_bitsandbytes
     def test_8bit_dora_inference(self):
         # check for same result with and without DoRA when initializing with init_lora_weights=False

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -64,7 +64,7 @@ from peft.tuners.lora.layer import LoraLayer
 from peft.utils import infer_device
 from peft.utils.hotswap import hotswap_adapter, prepare_model_for_compiled_hotswap
 
-from .testing_utils import load_dataset_english_quotes, require_deterministic
+from .testing_utils import load_dataset_english_quotes, require_deterministic_for_xpu
 
 
 class TestLoraInitialization:
@@ -1053,7 +1053,7 @@ class TestLoraInitialization:
         assert model.embed.scaling["default"] == expected_scaling["embed"]
         assert model.conv2d.scaling["default"] == expected_scaling["conv2d"]
 
-    @require_deterministic
+    @require_deterministic_for_xpu
     def test_lora_use_dora_linear(self, data):
         # check that dora is a no-op when initialized
         torch.manual_seed(0)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -66,6 +66,7 @@ from peft.utils.hotswap import hotswap_adapter, prepare_model_for_compiled_hotsw
 
 from .testing_utils import load_dataset_english_quotes, require_deterministic
 
+
 class TestLoraInitialization:
     """Test class to check the initialization of LoRA adapters."""
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -64,8 +64,7 @@ from peft.tuners.lora.layer import LoraLayer
 from peft.utils import infer_device
 from peft.utils.hotswap import hotswap_adapter, prepare_model_for_compiled_hotswap
 
-from .testing_utils import load_dataset_english_quotes
-
+from .testing_utils import load_dataset_english_quotes, require_deterministic
 
 class TestLoraInitialization:
     """Test class to check the initialization of LoRA adapters."""
@@ -1053,6 +1052,7 @@ class TestLoraInitialization:
         assert model.embed.scaling["default"] == expected_scaling["embed"]
         assert model.conv2d.scaling["default"] == expected_scaling["conv2d"]
 
+    @require_deterministic
     def test_lora_use_dora_linear(self, data):
         # check that dora is a no-op when initialized
         torch.manual_seed(0)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 from contextlib import contextmanager
-from functools import lru_cache
+from functools import wraps, lru_cache
 
 import numpy as np
 import pytest
@@ -158,6 +158,16 @@ def require_torchao(test_case):
     """
     return unittest.skipUnless(is_torchao_available(), "test requires torchao")(test_case)
 
+def require_deterministic(test_case):
+    @wraps(test_case)
+    def wrapper(*args, **kwargs):
+        original_state = torch.are_deterministic_algorithms_enabled()
+        try:
+            torch.use_deterministic_algorithms(True)
+            return test_case(*args, **kwargs)
+        finally:
+            torch.use_deterministic_algorithms(original_state)
+    return wrapper
 
 @contextmanager
 def temp_seed(seed: int):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -158,6 +158,7 @@ def require_torchao(test_case):
     """
     return unittest.skipUnless(is_torchao_available(), "test requires torchao")(test_case)
 
+
 def require_deterministic(test_case):
     @wraps(test_case)
     def wrapper(*args, **kwargs):
@@ -167,7 +168,9 @@ def require_deterministic(test_case):
             return test_case(*args, **kwargs)
         finally:
             torch.use_deterministic_algorithms(original_state)
+
     return wrapper
+
 
 @contextmanager
 def temp_seed(seed: int):

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -159,15 +159,18 @@ def require_torchao(test_case):
     return unittest.skipUnless(is_torchao_available(), "test requires torchao")(test_case)
 
 
-def require_deterministic(test_case):
+def require_deterministic_for_xpu(test_case):
     @wraps(test_case)
     def wrapper(*args, **kwargs):
-        original_state = torch.are_deterministic_algorithms_enabled()
-        try:
-            torch.use_deterministic_algorithms(True)
+        if torch_device is "xpu":
+            original_state = torch.are_deterministic_algorithms_enabled()
+            try:
+                torch.use_deterministic_algorithms(True)
+                return test_case(*args, **kwargs)
+            finally:
+                torch.use_deterministic_algorithms(original_state)
+        else:
             return test_case(*args, **kwargs)
-        finally:
-            torch.use_deterministic_algorithms(original_state)
 
     return wrapper
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 from contextlib import contextmanager
-from functools import wraps, lru_cache
+from functools import lru_cache, wraps
 
 import numpy as np
 import pytest

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -162,7 +162,7 @@ def require_torchao(test_case):
 def require_deterministic_for_xpu(test_case):
     @wraps(test_case)
     def wrapper(*args, **kwargs):
-        if torch_device is "xpu":
+        if torch_device == "xpu":
             original_state = torch.are_deterministic_algorithms_enabled()
             try:
                 torch.use_deterministic_algorithms(True)


### PR DESCRIPTION
**command**
`pytest -rA tests/test_initialization.py::TestLoraInitialization::test_lora_use_dora_linear`

**symptom**
This test is flaky on XPU, `torch.use_deterministic_algorithms()` can make it always pass by enabling deterministic algorithms.

**proposed fix**
I added a `require_deterministic` decorator for such cases: while entering this decorator, it will save current deterministic state and enable deterministic algorithm for target test case; while exiting from this decorator, it will restore before deterministic state.

**impact**
XPU: before this PR **fail**, after this PR **pass**
A100: before this PR **pass**, after this PR **pass**


Also the new decorator can fix below 2 fails mentioned in https://github.com/huggingface/peft/pull/2471, @jiqing-feng, so I remove them from skip cases.