### PR TITLE
Expose the config network error.

### DIFF
--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -201,7 +201,7 @@ class PeftConfigMixin(PushToHubMixin):
                     pretrained_model_name_or_path, CONFIG_NAME, subfolder=subfolder, **hf_hub_download_kwargs
                 )
             except Exception as exc:
-                raise ValueError(f"Can't find '{CONFIG_NAME}' at '{pretrained_model_name_or_path}'") from exc
+                raise ValueError(f"Can't find '{CONFIG_NAME}' at '{pretrained_model_name_or_path}' ({exc.args[0]})") from exc
 
         loaded_attributes = cls.from_json_file(config_file)
         kwargs = {**class_kwargs, **loaded_attributes}
@@ -264,8 +264,8 @@ class PeftConfigMixin(PushToHubMixin):
                     CONFIG_NAME,
                     **hf_hub_download_kwargs,
                 )
-            except Exception:
-                raise ValueError(f"Can't find '{CONFIG_NAME}' at '{model_id}'")
+            except Exception as exc:
+                raise ValueError(f"Can't find '{CONFIG_NAME}' at '{model_id}' ({exc.args[0]})") from exc
 
         loaded_attributes = cls.from_json_file(config_file)
         return loaded_attributes["peft_type"]


### PR DESCRIPTION
I was getting an error "Can't find 'adapter_config.json' at 'unsloth/mistral-7b-instruct-v0.3-bnb-4bit'" but I had no clue why I was getting this error or what the problem was.

This error message is not useful as end users don't know where it's trying to find adapter_config.json, I thought it was trying to find it locally but it turned out it's a web request that's failing which makes way more sense.

I added the error message that was caught to the thrown error message so that the user of the library can actually see what the network error was and which url it failed to fetch. I don't know the convention you follow for error messages, feel free to change it but please include the HTTP error code and the URL that was attempted in the thrown errors.