### PR TITLE
TST make 3 flaky test cases always pass on XPU

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -85,6 +85,7 @@ from .testing_utils import (
     require_auto_awq,
     require_auto_gptq,
     require_bitsandbytes,
+    require_deterministic_for_xpu,
     require_eetq,
     require_hqq,
     require_multi_accelerator,
@@ -4027,6 +4028,7 @@ class TestPTuningReproducibility:
     device = infer_device()
 
     @require_non_cpu
+    @require_deterministic_for_xpu
     def test_p_tuning_exactly_reproducible_after_loading(self, tmp_path):
         # See: https://github.com/huggingface/peft/issues/2043#issuecomment-2321522577
         # Ensure that after loading a p-tuning checkpoint, results are exactly reproducible (before the patch, they were

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1286,6 +1286,7 @@ class TestLokrInitialization:
     def data(self):
         return torch.rand(10, 1000).to(self.torch_device)
 
+    @require_deterministic_for_xpu
     def test_lokr_linear_init_default(self, data):
         torch.manual_seed(0)
 
@@ -1384,6 +1385,7 @@ class TestAdaLoraInitialization:
     def data(self):
         return torch.rand(10, 1000).to(self.torch_device)
 
+    @require_deterministic_for_xpu
     def test_adalora_default_init_identity(self, data):
         # default is True
         torch.manual_seed(0)


### PR DESCRIPTION
PASSED tests/test_initialization.py::TestAdaLoraInitialization::test_adalora_default_init_identity
PASSED tests/test_initialization.py::TestLokrInitialization::test_lokr_linear_init_default
PASSED tests/test_gpu_examples.py::TestPTuningReproducibility::test_p_tuning_exactly_reproducible_after_loading