### PR TITLE
TST: AQLM test no longer x-fails

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -2880,8 +2880,6 @@ class PeftAqlmGPUTests(unittest.TestCase):
         model.train(training)
 
     @pytest.mark.single_gpu_tests
-    # see https://github.com/Vahe1994/AQLM/pull/139
-    @pytest.mark.xfail(reason="AQLM does not work with PyTorch 2.5 (yet)", strict=True, raises=AttributeError)
     def test_causal_lm_training_aqlm(self):
         r"""
         Test the CausalLM training on a single GPU device. The test would simply fail if the adapters are not set


### PR DESCRIPTION
There has been an [AQLM release](https://pypi.org/project/aqlm/#history) with the fix to the issue that originally broke the test.