### PR TITLE
FIX: CPT should not be tested with sequence classification

### DIFF
--- a/src/peft/tuners/cpt/config.py
+++ b/src/peft/tuners/cpt/config.py
@@ -82,7 +82,8 @@ class CPTConfig(PromptLearningConfig):
         self.peft_type = PeftType.CPT  # Specifies that the PEFT type is CPT.
         if self.task_type != TaskType.CAUSAL_LM:
             warnings.warn(
-                f"{self.__class__.__name__} only supports task_type = {TaskType.CAUSAL_LM}, setting it automatically."
+                f"{self.__class__.__name__} only supports task_type = {TaskType.CAUSAL_LM.value}, "
+                "setting it automatically."
             )
             self.task_type = "CAUSAL_LM"  # Ensures task type is causal language modeling.
 

--- a/src/peft/tuners/cpt/config.py
+++ b/src/peft/tuners/cpt/config.py
@@ -84,7 +84,7 @@ class CPTConfig(PromptLearningConfig):
             # TODO: adjust this to raise an error with PEFT v0.18.0
             warnings.warn(
                 f"{self.__class__.__name__} only supports task_type = {TaskType.CAUSAL_LM.value}, "
-                "setting it automatically. In the future, this will raise an error starting from PEFT v0.18.0.",
+                "setting it automatically. This will raise an error starting from PEFT v0.18.0.",
                 FutureWarning,
             )
             self.task_type = TaskType.CAUSAL_LM  # Ensures task type is causal language modeling.

--- a/src/peft/tuners/cpt/config.py
+++ b/src/peft/tuners/cpt/config.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Literal, Optional
 
 from peft.config import PromptLearningConfig
-from peft.utils import PeftType
+from peft.utils import PeftType, TaskType
 
 
 @dataclass
@@ -79,7 +80,11 @@ class CPTConfig(PromptLearningConfig):
         self.num_attention_heads = None  # Number of attention heads (if applicable).
         self.num_transformer_submodules = 1  # Number of transformer submodules used.
         self.peft_type = PeftType.CPT  # Specifies that the PEFT type is CPT.
-        self.task_type = "CAUSAL_LM"  # Ensures task type is causal language modeling.
+        if self.task_type != TaskType.CAUSAL_LM:
+            warnings.warn(
+                f"{self.__class__.__name__} only supports task_type = {TaskType.CAUSAL_LM}, setting it automatically."
+            )
+            self.task_type = "CAUSAL_LM"  # Ensures task type is causal language modeling.
 
         if self.cpt_token_ids is None:
             self.cpt_token_ids = [0]

--- a/src/peft/tuners/cpt/config.py
+++ b/src/peft/tuners/cpt/config.py
@@ -85,7 +85,7 @@ class CPTConfig(PromptLearningConfig):
                 f"{self.__class__.__name__} only supports task_type = {TaskType.CAUSAL_LM.value}, "
                 "setting it automatically."
             )
-            self.task_type = "CAUSAL_LM"  # Ensures task type is causal language modeling.
+            self.task_type = TaskType.CAUSAL_LM  # Ensures task type is causal language modeling.
 
         if self.cpt_token_ids is None:
             self.cpt_token_ids = [0]

--- a/src/peft/tuners/cpt/config.py
+++ b/src/peft/tuners/cpt/config.py
@@ -81,9 +81,11 @@ class CPTConfig(PromptLearningConfig):
         self.num_transformer_submodules = 1  # Number of transformer submodules used.
         self.peft_type = PeftType.CPT  # Specifies that the PEFT type is CPT.
         if self.task_type != TaskType.CAUSAL_LM:
+            # TODO: adjust this to raise an error with PEFT v0.18.0
             warnings.warn(
                 f"{self.__class__.__name__} only supports task_type = {TaskType.CAUSAL_LM.value}, "
-                "setting it automatically."
+                "setting it automatically. In the future, this will raise an error starting from PEFT v0.18.0.",
+                FutureWarning,
             )
             self.task_type = TaskType.CAUSAL_LM  # Ensures task type is causal language modeling.
 

--- a/tests/test_cpt.py
+++ b/tests/test_cpt.py
@@ -228,8 +228,9 @@ def test_model_initialization_random(global_tokenizer, config_random):
 
 
 def test_model_initialization_wrong_task_type_warns():
+    # TODO: adjust this test to check for an error with PEFT v0.18.0
     msg = "CPTConfig only supports task_type = CAUSAL_LM, setting it automatically"
-    with pytest.warns(UserWarning, match=msg):
+    with pytest.warns(FutureWarning, match=msg):
         config = CPTConfig(task_type=TaskType.SEQ_CLS)
     assert config.task_type == TaskType.CAUSAL_LM
 

--- a/tests/test_cpt.py
+++ b/tests/test_cpt.py
@@ -27,7 +27,7 @@ from transformers import (
     TrainingArguments,
 )
 
-from peft import CPTConfig, get_peft_model
+from peft import CPTConfig, TaskType, get_peft_model
 
 
 TEMPLATE = {"input": "input: {}", "intra_seperator": " ", "output": "output: {}", "inter_seperator": "\n"}
@@ -225,6 +225,14 @@ def test_model_initialization_random(global_tokenizer, config_random):
 
     model = get_peft_model(base_model, config_random)
     assert model is not None, "PEFT model initialization failed"
+
+
+def test_model_initialization_wrong_task_type_warns(recwarn):
+    config = CPTConfig(task_type=TaskType.SEQ_CLS)
+    assert config.task_type == TaskType.CAUSAL_LM
+    assert recwarn.list
+    expected = "CPTConfig only supports task_type = TaskType.CAUSAL_LM, setting it automatically."
+    assert any(expected in str(w.message) for w in recwarn.list)
 
 
 def test_model_training_random(sst_data, global_tokenizer, collator, config_random):

--- a/tests/test_cpt.py
+++ b/tests/test_cpt.py
@@ -227,12 +227,11 @@ def test_model_initialization_random(global_tokenizer, config_random):
     assert model is not None, "PEFT model initialization failed"
 
 
-def test_model_initialization_wrong_task_type_warns(recwarn):
-    config = CPTConfig(task_type=TaskType.SEQ_CLS)
+def test_model_initialization_wrong_task_type_warns():
+    msg = "CPTConfig only supports task_type = CAUSAL_LM, setting it automatically"
+    with pytest.warns(UserWarning, match=msg):
+        config = CPTConfig(task_type=TaskType.SEQ_CLS)
     assert config.task_type == TaskType.CAUSAL_LM
-    assert recwarn.list
-    expected = "CPTConfig only supports task_type = TaskType.CAUSAL_LM, setting it automatically."
-    assert any(expected in str(w.message) for w in recwarn.list)
 
 
 def test_model_training_random(sst_data, global_tokenizer, collator, config_random):

--- a/tests/test_seq_classifier.py
+++ b/tests/test_seq_classifier.py
@@ -19,7 +19,6 @@ from peft import (
     AdaLoraConfig,
     BOFTConfig,
     BoneConfig,
-    CPTConfig,
     FourierFTConfig,
     HRAConfig,
     IA3Config,
@@ -65,15 +64,6 @@ ALL_CONFIGS = [
             "task_type": "SEQ_CLS",
             "target_modules": None,
             "r": 2,
-        },
-    ),
-    (
-        CPTConfig,
-        {
-            "task_type": "SEQ_CLS",
-            "cpt_token_ids": [0, 1, 2, 3, 4, 5, 6, 7],  # Example token IDs for testing
-            "cpt_mask": [1, 1, 1, 1, 1, 1, 1, 1],
-            "cpt_tokens_type_mask": [1, 2, 2, 2, 3, 3, 4, 4],
         },
     ),
     (


### PR DESCRIPTION
PR #2481 added sequence classification tests to PEFT. The test matrix included CPT. However, CPT only supports the task type `CAUSAL_LM`. These tests still passed but now [started failing](https://github.com/huggingface/peft/actions/runs/14592717272/job/40931414213) with:

> AttributeError: object has no attribute 'prepare_inputs_for_generation'

This is probably a change in transformers but since causal LM was never meant to work, the actual fix is to remove CPT from the seq cls test matrix.

Since CPT automatically changes the task type to `CAUSAL_LM`, this mistake can be hard to spot. Therefore, this PR also adds a warning if users pass the wrong task type.