### PR TITLE
LORA/MODEL: Use max rank of pattern for `add_weighted_adapter`

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -564,7 +564,7 @@ class LoraModel(BaseTuner):
 
         adapters_ranks: list[int] = [
             # When allocating tensors for the new adapter, we need the maximum possible rank to not overflow
-            config.r if not config.rank_pattern else max([config.r, *config.rank_pattern.values()])
+            config.r if not config.rank_pattern else max(config.r, *config.rank_pattern.values())
             for config in (self.peft_config[adapter] for adapter in adapters)
         ]
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2027,6 +2027,18 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
         with pytest.raises(ValueError, match=msg):
             model.add_weighted_adapter(["default", "other"], weights=[1.0, 1.0], adapter_name="merged")
 
+    @parameterized.expand([IA3Config, LoHaConfig, LoKrConfig, LoraConfig, HRAConfig, BoneConfig])
+    def test_add_weighted_adapter_cat_with_rank_pattern(self, config_cls):
+        # Fixes a bug described in #2512, which resulted from the rank_pattern not being taken into account
+        config0 = LoraConfig(target_modules=["lin0", "lin1"], r=8)
+        config1 = LoraConfig(target_modules=["lin0", "lin1"], r=8, rank_pattern={"lin0": 16})
+        model = MLP()
+        model = get_peft_model(model, config0).to(self.torch_device)
+        model.add_adapter("other", config1)
+        model.add_weighted_adapter(
+            ["default", "other"], weights=[1.0, 1.0], adapter_name="merged", combination_type="cat"
+        )
+
     def test_multiple_adapters_no_needless_copy_modules_to_save(self):
         # See 2206
         # The problem was that we keep a "global" modules_to_save on the model which contains all possible


### PR DESCRIPTION
Otherwise it's possible that the new merged adapter won't allocate enough space when a patterned rank is larger than config.r.

For example, the `cat` method uses `sum(adapters_ranks)` for the empty tensor alloc, so if `cat(loras)` for a given layer is ever > the sum of `config.r` the assignment will overflow.

Local test fails but it's all entirely the TestEvaInitialization module which appears completely unrelated.