### PR TITLE
TST Mark AutoAWQ as xfail for now

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -3423,6 +3423,12 @@ class PeftAwqGPUTests(unittest.TestCase):
             assert trainer.state.log_history[-1]["train_loss"] is not None
 
     @pytest.mark.multi_gpu_tests
+    # TODO remove marker if/once issue is resolved, most likely requiring a fix in AutoAWQ:
+    # https://github.com/casper-hansen/AutoAWQ/issues/754
+    @pytest.mark.xfail(
+        reason="Multi-GPU test currently not working with AutoAWQ and PyTorch 2.7",
+        strict=True,
+    )
     @require_torch_multi_gpu
     def test_causal_lm_training_multi_gpu(self):
         r"""


### PR DESCRIPTION
The AutoAWQ multi GPU test is currently failing on CI. This is most likely an issue of AutoAWQ with PyTorch 2.7. The issue has been reported but there is no reaction so far. Thus let's skip the test for the time being.

Since the PR marks the test as strictly x-failing, we will know when there is a new release with a fix.