### PR TITLE
LORA/MODEL: Discard `rank_pattern`, `rank_alpha` for `add_weighted_adapter`

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -675,6 +675,8 @@ class LoraModel(BaseTuner):
             r=new_rank,
             lora_alpha=new_rank,
             target_modules=new_target_modules,
+            alpha_pattern={},
+            rank_pattern={},
         )
         self.inject_adapter(self.model, adapter_name)
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2067,7 +2067,7 @@ class PeftCustomModelTester(unittest.TestCase, PeftCommonTester):
     @parameterized.expand([IA3Config, LoHaConfig, LoKrConfig, LoraConfig, HRAConfig, BoneConfig])
     def test_add_weighted_adapter_cat_with_rank_pattern(self, config_cls):
         # Fixes a bug described in #2512, which resulted from the rank_pattern not being taken into account
-        config0 = LoraConfig(target_modules=["lin0", "lin1"], r=8)
+        config0 = LoraConfig(target_modules=["lin0", "lin1"], r=8, rank_pattern={"lin0": 2})
         config1 = LoraConfig(target_modules=["lin0", "lin1"], r=8, rank_pattern={"lin0": 16})
         model = MLP()
         model = get_peft_model(model, config0).to(self.torch_device)


### PR DESCRIPTION
Oversight from #2512 where the 0 config's rank/alpha pattern was inherited despite the newly adapter needing uniform based on `_check_add_weighted_adapter`'s calcs.

Can `pytest tests -k test_add_weighted_adapter_cat_with_rank_pattern` against `d6948f3192600e641907df0e4ada7c18581a664d` to repro

cc @BenjaminBossan 