### PR TITLE
Address changes in transformers VLM architecture

### DIFF
--- a/src/peft/mapping_func.py
+++ b/src/peft/mapping_func.py
@@ -109,6 +109,8 @@ def get_peft_model(
         # note: PeftMixedModel does not support autocast_adapter_dtype, so don't pass it
         return PeftMixedModel(model, peft_config, adapter_name=adapter_name)
 
+    # We explicitly exclude prompt learning here since prompt learning is specific to the task and needs special
+    # handling in the PEFT model's forward method.
     if peft_config.task_type not in MODEL_TYPE_TO_PEFT_MODEL_MAPPING.keys() and not peft_config.is_prompt_learning:
         return PeftModel(
             model,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -605,9 +605,15 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 # For reference refer to issue: https://github.com/huggingface/peft/issues/996
                 deepspeed_distributed_tensor_shape = getattr(value, "ds_shape", None)
 
-                if value.shape[0] == self.base_model.config.vocab_size or (
+                # Handle VLM case with separate text and vision configs
+                if 'text_config' in self.base_model.config:
+                    vocab_size = self.base_model.config.text_config.vocab_size
+                else:
+                    vocab_size = self.base_model.config.vocab_size
+
+                if value.shape[0] == vocab_size or (
                     deepspeed_distributed_tensor_shape is not None
-                    and deepspeed_distributed_tensor_shape[0] == self.base_model.config.vocab_size
+                    and deepspeed_distributed_tensor_shape[0] == vocab_size
                 ):
                     word_embeddings = transformer_backbone.get_submodule(named_param.replace(".weight", ""))
                     break

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -891,6 +891,10 @@ def _set_adapter(model, adapter_name):
 
 
 def _prepare_prompt_learning_config(peft_config, model_config):
+    # In case of VLM we focus on the language model portion of the model.
+    if 'text_config' in model_config:
+        model_config = model_config['text_config']
+
     if peft_config.num_layers is None:
         if "num_hidden_layers" in model_config:
             num_layers = model_config["num_hidden_layers"]

--- a/tests/test_vision_models.py
+++ b/tests/test_vision_models.py
@@ -67,11 +67,11 @@ class TestPastKV:
         )
         processor = AutoProcessor.from_pretrained(model_id)
         raw_image = np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8)
-        inputs = processor(prompt, raw_image, return_tensors="pt")
+        inputs = processor(text=prompt, images=raw_image, return_tensors="pt")
 
         # get peft model
         peft_config = PrefixTuningConfig(task_type="CAUSAL_LM", num_virtual_tokens=20)
-        model.language_model = get_peft_model(model.language_model, peft_config)
+        model = get_peft_model(model, peft_config)
         # check that this does not raise
         model(**inputs, output_hidden_states=True)
 


### PR DESCRIPTION
[transformers PR #37033](https://github.com/huggingface/transformers/pull/37033) re-arranges the way visual language models are built by moving the LM head from the language model to the top-level VLM (among other things).

This breaks the following code (from `test_vision_models`):

```python
peft_config = PrefixTuningConfig(task_type="CAUSAL_LM", num_virtual_tokens=20)
model.language_model = get_peft_model(model.language_model, peft_config)
```

with

```
AttributeError: 'LlamaModel' object has no attribute 'prepare_inputs_for_generation'
```

Reason being that `model.language_model` is not a `*CausalLM` anymore but a base model (e.g., `LlamaModel`).
PEFT assumes that the model is specific and all soft-prompting methods need a task type since each task type has specific handling of the soft prompt (e.g., padding the labels according to the number of virtual tokens for causal LM). We also can't simply use `task_type='FEATURE_EXTRACTION'` as a workaround because this would not deal with `labels` either.

Luckily the newly structured VLM is almost behaving like a LM (e.g., `get_input_embeddings` just refers to the underlying LM), therefore we can target the VLM itself and need to have the soft prompt methods detect if we're fine-tuning a VLM so that we take the respective config variables from the `base_model.text_config` instead of `base_model` directly.

## Backward compatibility

Old models trained with PEFT should still work since VLM models like llava use the `lm_head` and `language_model` from the state dict and re-arrange them accordingly. **However**, old code that uses `model.language_model` as a target will fail with `AttributeError: 'LlamaModel' object has no attribute 'prepare_inputs_for_generation'`. I fear that we have no way of mitigating this since we don't have access to the 'top-level' model, the only thing we could do is to raise a more helpful error message but for reliably detecting the case that we're targeting a VLM's language model we'd need the VLM's model config (e.g., to check for the `text_config` key) or have access to the VLM itself. We cannot do much here, sadly.