### PR TITLE
Simple variant application test

### DIFF
--- a/tests/test_lora_variants.py
+++ b/tests/test_lora_variants.py
@@ -120,7 +120,7 @@ class TestLoraVariants:
         """Ensure that the parameters added by the DoRA variant are participating in the output computation."""
         layer_names = ["linear1", "linear2", "conv1d", "conv2d", "embedding"]
         peft_config = LoraConfig(target_modules=layer_names, use_dora=True)
-        base_model, peft_config, peft_model = self.custom_model_with_loss_backpropagated(peft_config)
+        base_model, peft_model = self.custom_model_with_loss_backpropagated(peft_config)
 
         for layer in layer_names:
             assert getattr(peft_model.base_model.model, layer).lora_magnitude_vector["default"].weight.grad is not None

--- a/tests/test_lora_variants.py
+++ b/tests/test_lora_variants.py
@@ -1,0 +1,90 @@
+import pytest
+from torch import nn
+
+from peft import LoraConfig, get_peft_model
+from peft.tuners.lora.layer import Conv1d as LoraConv1d
+from peft.tuners.lora.layer import Conv2d as LoraConv2d
+from peft.tuners.lora.layer import Embedding as LoraEmbedding
+from peft.tuners.lora.layer import Linear as LoraLinear
+from peft.tuners.lora.variants import (
+    DoraConv1dVariant,
+    DoraConv2dVariant,
+    DoraEmbeddingVariant,
+    DoraLinearVariant,
+)
+
+
+class CustomModel(nn.Module):
+    """pytorch module that contains common targetable layers (linear, embedding, conv, ...)"""
+
+    def __init__(self, num_embeddings=100, embedding_dim=16, num_classes=10):
+        super().__init__()
+        self.embedding = nn.Embedding(num_embeddings, embedding_dim)
+        self.conv1d = nn.Conv1d(in_channels=embedding_dim, out_channels=32, kernel_size=3, padding=1)
+        self.conv2d = nn.Conv2d(in_channels=1, out_channels=16, kernel_size=3, stride=1, padding=1)
+        self.flatten = nn.Flatten()
+        self.dummy_conv2d_output_dim = 16 * 10 * 10
+        self.linear1 = nn.Linear(self.dummy_conv2d_output_dim, 64)
+        self.linear2 = nn.Linear(64, num_classes)
+        self.relu = nn.ReLU()
+
+    def forward(self, input_ids, dummy_image_input):
+        # Path 1: Embedding -> Conv1d
+        x1 = self.embedding(input_ids)  # (batch_size, seq_len, embedding_dim)
+        x1 = x1.transpose(1, 2)  # (batch_size, embedding_dim, seq_len)
+        x1 = self.relu(self.conv1d(x1))  # (batch_size, 32, seq_len)
+        x1_flat = self.flatten(x1)
+        # Path 2: Conv2d -> Linear
+        x2 = self.relu(self.conv2d(dummy_image_input))  # (batch_size, 16, H, W)
+        x2_flat = self.flatten(x2)  # (batch_size, 16*H*W)
+        # Combine or select paths if making a functional model.
+        # For this test, we mainly care about layer types, so forward might not be fully executed.
+        # Let's use x2_flat for subsequent linear layers.
+        output = self.relu(self.linear1(x2_flat))
+        output = self.linear2(output)
+        return output
+
+
+VARIANT_MAP = {
+    "dora": {
+        LoraLinear: DoraLinearVariant,
+        LoraEmbedding: DoraEmbeddingVariant,
+        LoraConv1d: DoraConv1dVariant,
+        LoraConv2d: DoraConv2dVariant,
+    }
+}
+
+
+class TestLoraVariants:
+    @pytest.mark.parametrize(
+        "test_name, variant_name, config_cls, config_kwargs",
+        [
+            (
+                "DoRA 1",
+                "dora",
+                LoraConfig,
+                {"target_modules": ["linear0", "linear1", "conv1d", "conv2d", "embedding"], "use_dora": True},
+            ),
+        ],
+    )
+    def test_variant_is_applied_to_layers(self, test_name, variant_name, config_cls, config_kwargs):
+        # This test assumes that targeting and replacing layers works and that after `get_peft_model` we
+        # have a model with LoRA layers. We just make sure that each LoRA layer has its variant set and
+        # it is also the correct variant for that layer.
+        base_model = CustomModel()
+        peft_config = config_cls(**config_kwargs)
+        peft_model = get_peft_model(base_model, peft_config)
+
+        layer_type_map = VARIANT_MAP[variant_name]
+
+        for _, module in peft_model.named_modules():
+            if not hasattr(module, "lora_variant"):
+                continue
+
+            # Note that not every variant supports every layer. If it is not mapped it is deemed unsupported and
+            # will not be tested.
+            expected_variant_type = layer_type_map.get(type(module), None)
+            if not expected_variant_type:
+                continue
+
+            assert isinstance(module.lora_variant["default"], expected_variant_type)


### PR DESCRIPTION
This change adds a place for future lora variant tests to linger and also adds a basic test that checks whether the variant was correctly applied to the lora layer if so requested. This does not cover quantized layers yet but it should be similar to add thanks to the mapping.

Since we're expecting a lot more variants to be added in the future it is probably sensible to start early in establishing a place for testing.