### PR TITLE
FIX: Transformers VLM architecture changes

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -459,8 +459,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         # don't have the "base_model.model." prefix, which we need to remove before mapping. Instead just using
         # "base_model.". This could be fine, we could only remove "base_model.", However, the subsequent sub-module
         # could also be called "model", resulting in what looks like "base_model.model.". To avoid this confusion, we
-        # skip prefix tuning. Since it should be applied to the language model part directly and applies itself on the
-        # outer model (unlike LoRA et al), skipping should be fine.
+        # skip prompt learning. Since it applies itself directly to the pre-trained model (unlike LoRA et al that target
+        # sub-modules), skipping should be fine.
         if (key_mapping is None) and (not config.is_prompt_learning):
             key_mapping = getattr(model, "_checkpoint_conversion_mapping", {})
 

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -583,10 +583,14 @@ def load_peft_weights(
         remapped_adapters_weights = adapters_weights
     else:
         # See discussion in https://github.com/huggingface/transformers/pull/38627
+        # Remap adapter weight names according to the provided key_mapping.
         remapped_adapters_weights = {}
-        prefix = "base_model.model."
         for key, val in adapters_weights.items():
-            if not key.startswith(prefix):
+            if key.startswith("base_model.model."):
+                prefix = "base_model.model."
+            elif key.startswith("base_model."):
+                prefix = "base_model."
+            else:
                 raise ValueError(
                     "An error occurred while trying to load a PEFT state_dict with key_mapping. This should not "
                     "happen. Please open an issue on https://github.com/huggingface/peft/issues and report the error."


### PR DESCRIPTION
Follow up to #2554
See discussion in https://github.com/huggingface/transformers/pull/38627

## Description

To quote:

> transformers PR #37033 re-arranges the way visual language models are built by moving the LM head from the language model to the top-level VLM (among other things).

A consequence of this is that the keys in the PEFT `state_dict` now also follow the new architecture. This means that:

1. If a PEFT checkpoint was saved with the old architecture but is loaded with the new architecture, loading fails.
2. If a PEFT checkpoint was saved with the new architecture but is loaded with the old architecture, loading fails.

Point 1. can be addressed by making use of the newly added `_checkpoint_conversion_mapping` attribute for models with the new architecture. In transformers, this is used to map old model `state_dict`s to the new `state_dict` format. In PEFT, with some fiddling, we can use the same mapping to make old PEFT `state_dict`s compatible with the new architecture (backwards compatibility).

However, 2. is not easily addressed. We would need a reverse mapping for this. This could be easily derived from `_checkpoint_conversion_mapping`, but since this attribute doesn't exist on old models, we cannot do that. Therefore, new checkpoints created with PEFT on these models won't load successfully when users use old transformers (forward compatibility).

These cases are covered by the added unit tests, which means that the test covering case 2 currently fails.

If we could reliably detect that we are in case 2, we could warn the user and advise them to upgrade transformers, but I don't know if it's possible to figure this out.

## Notes

We skip prompt learning methods when applying the mapping. This is because they don't have the `"base_model.model."` prefix, which we need to remove before mapping. Instead just using `"base_model."`. This could be fine, we could only remove `"base_model."`, However, the subsequent sub-module could also be called `"model"`, resulting in what looks like `"base_model.model."`. To avoid this confusion, we skip prompt learning. Since it should be applied to the language model part directly and applies itself on the outer model (unlike LoRA et al.), skipping should be fine.

We also allow users to pass their own `key_mapping` to `from_pretrained` and `load_adapter`, though the documentation advises against it. This argument could theoretically be used as a workaround in case there is indeed an issue with prompt learning s`tate_dicts`.

Apart from these changes, I also made a small change to account for https://github.com/huggingface/transformers/issues/38017#issuecomment-2935889679.