### PR TITLE
Optimize isinstance Check in LoraParallelLinear

### DIFF
--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -74,7 +74,7 @@ class LoraParallelLinear(nn.Module, LoraLayer):
             init_method = megatron_config.init_method
         input_is_parallel = True
         gather_output = False
-        if isinstance(base_layer, self.backend.RowParallelLinear):
+        if self.is_parallel_a:
             input_is_parallel = base_layer.input_is_parallel
         else:
             gather_output = base_layer.gather_output


### PR DESCRIPTION
The self.is_parallel_a attribute is [set](https://github.com/huggingface/peft/pull/2576/commits/1c96361517881aae57291d890f0b1b226dca80fa#diff-5e62802c7cd4e536708b9ad1b5bfe866d307630079d95d234c2e5cd022aabd9eL66) during initialization based on whether base_layer is an instance of backend.RowParallelLinear. Reperforming the isinstance check is redundant and slightly less performant. 