### PR TITLE
FIX Account for attention mask being a dict, fix generate issues with gemma

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1962,11 +1962,16 @@ class PeftModelForCausalLM(PeftModel):
                     bs = attention_mask.shape[0]
                     total_seq_len = prefix_attention_mask.shape[1] + attention_mask.shape[2]
                     attention_mask_2d = torch.ones((bs, total_seq_len), dtype=attention_mask.dtype)
-                    if model_kwargs["cache_position"][0] == 0:
-                        # heuristic to determine if we're in prefill stage
+
+                    # heuristic to determine if we're in prefill stage
+                    is_prefill = model_kwargs["cache_position"][0] == 0
+                    if is_prefill and (peft_config.peft_type != PeftType.PREFIX_TUNING):
+                        # if in prefill stage, for prompt learning methods that are not prefix tuning, new tokens
+                        # (embeddings) are inserted
                         cache_position_ = torch.arange(total_seq_len, device=model_kwargs["input_ids"].device)
                     else:
                         cache_position_ = model_kwargs["cache_position"]
+
                     attention_mask_new = create_attention_mask(
                         self.get_base_model(),
                         model_input=None,
@@ -2012,11 +2017,16 @@ class PeftModelForCausalLM(PeftModel):
                 model_kwargs["inputs_embeds"] = torch.cat((prompts, inputs_embeds), dim=1)
                 model_kwargs["input_ids"] = None
 
-        # For transformers>=4.38.0 - for some architectures such as Llama, `cache_position` is
-        # passed in the forward pass to keep track of the position ids of the cache. We have to
-        # pop that from `model_kwargs` as `cache_position` is properly created by the model, using the passed
-        # `inputs_embeds`: https://github.com/huggingface/transformers/blob/593230f0a1150ea9c0477b9d859f25daf73c8c33/src/transformers/models/llama/modeling_llama.py#L956
-        _ = model_kwargs.pop("cache_position", None)
+        # if cache_position exists and if we're in the prefill stage
+        if (model_kwargs.get("cache_position") is not None) and (model_kwargs["cache_position"][0] == 0):
+            if peft_config.peft_type == PeftType.PREFIX_TUNING:
+                # for prefix tuning, the past_key_values have been prefilled
+                model_kwargs["cache_position"] += peft_config.num_virtual_tokens
+            else:
+                # for other prompt learning methods, the inputs_embeds have been extended
+                device = model_kwargs["cache_position"].device
+                new_seq_length = model_kwargs["cache_position"].shape[0] + peft_config.num_virtual_tokens
+                model_kwargs["cache_position"] = torch.arange(new_seq_length).to(device)
 
         return model_kwargs
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1942,6 +1942,16 @@ class PeftModelForCausalLM(PeftModel):
                     model_kwargs["input_ids"] = model_kwargs["input_ids"][:, -1:]
 
             if (attention_mask := model_kwargs.get("attention_mask", None)) is not None:
+                if isinstance(attention_mask, dict):
+                    # see: https://github.com/huggingface/transformers/pull/37866
+                    # For now, just deal with the case of a single attention mask
+                    if len(attention_mask) != 1:
+                        raise ValueError(
+                            f"Expected a single attention mask, got {len(attention_mask)} instead, please open an "
+                            "issue (https://github.com/huggingface/peft/issues) and report the error."
+                        )
+                    attention_mask = list(attention_mask.values())[0]
+
                 size = model_kwargs["input_ids"].shape[0], peft_config.num_virtual_tokens
                 prefix_attention_mask = torch.ones(size).to(model_kwargs["input_ids"].device)
                 if attention_mask.dim() == 4:

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1282,7 +1282,7 @@ def create_attention_mask(
     try:
         from transformers.masking_utils import create_masks_for_generate
     except ImportError as exc:
-        raise ImportError("Your transformers version is too old, please upgrade it to >= 4.53.3") from exc
+        raise ImportError("Your transformers version is too old, please upgrade it to > 4.52") from exc
 
     # Create the causal mask with fixed shape in advance, to reduce recompilations. If the function to create
     # the 4D causal mask exists, it should be present in the base model (XXXModel class) or in its decoder.

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1272,3 +1272,49 @@ def set_additional_trainable_modules(model, peft_config, model_config, adapter_n
                 token_indices=token_adapter.token_indices[adapter_name],
                 tied_adapter=model.get_input_embeddings().token_adapter,
             )
+
+
+def create_attention_mask(
+    model, *, model_input, attention_mask, past_key_values, cache_position, batch_size, sequence_length
+):
+    # adapted from:
+    # https://github.com/huggingface/transformers/blob/cb4c56ce0dfa1350267ed28e57760986a58a9ba4/src/transformers/generation/utils.py#L644-L680
+    try:
+        from transformers.masking_utils import create_masks_for_generate
+    except ImportError as exc:
+        raise ImportError("Your transformers version is too old, please upgrade it to >= 4.53.3") from exc
+
+    # Create the causal mask with fixed shape in advance, to reduce recompilations. If the function to create
+    # the 4D causal mask exists, it should be present in the base model (XXXModel class) or in its decoder.
+    base_model = getattr(model, model.base_model_prefix, model)
+    decoder = base_model.get_decoder() if hasattr(base_model, "get_decoder") else None
+    causal_mask_creation_function = getattr(base_model, "_prepare_4d_causal_attention_mask_with_cache_position", None)
+    if causal_mask_creation_function is None and decoder is not None:  # it may be in the decoder
+        causal_mask_creation_function = getattr(decoder, "_prepare_4d_causal_attention_mask_with_cache_position", None)
+
+    # If it's not defined, it means the model uses the new general mask API
+    if causal_mask_creation_function is None:  # can't be found
+        token_type_ids = getattr(model_input, "token_type_ids", None)
+        # Some models may overwrite the general one
+        causal_mask_creation_function = getattr(model, "create_masks_for_generate", create_masks_for_generate)
+        attention_mask = causal_mask_creation_function(
+            config=model.config,
+            # we only need batch size, seq_length and dtype here - we don't care about the values of the embeddings
+            input_embeds=torch.empty((batch_size, sequence_length), dtype=model.dtype),
+            attention_mask=attention_mask,
+            cache_position=cache_position,
+            past_key_values=past_key_values,
+            token_type_ids=token_type_ids,
+        )
+    else:
+        attention_mask = causal_mask_creation_function(
+            attention_mask,
+            sequence_length=sequence_length,
+            target_length=past_key_values.get_max_cache_shape(),
+            dtype=model.dtype,
+            cache_position=cache_position,
+            batch_size=batch_size,
+            config=model.config,
+            past_key_values=past_key_values,
+        )
+    return attention_mask

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1279,6 +1279,9 @@ def create_attention_mask(
 ):
     # adapted from:
     # https://github.com/huggingface/transformers/blob/cb4c56ce0dfa1350267ed28e57760986a58a9ba4/src/transformers/generation/utils.py#L644-L680
+    # In PEFT, we sometimes need to re-create the attention mask. This is because some prompt learning methods insert
+    # new items into the sequence, which results in the attention mask needing an update. We re-use transformers code
+    # for this as much as possible.
     try:
         from transformers.masking_utils import create_masks_for_generate
     except ImportError as exc:

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -372,16 +372,12 @@ class TestDecoderModels(PeftCommonTester):
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate(self, model_id, config_cls, config_kwargs):
-        if (config_cls in (PrefixTuningConfig, VBLoRAConfig)) and ("gemma" in model_id.lower()):
-            pytest.skip("Generating with gemma and prefix tuning/VBLoRA currently fails")
         _skip_if_not_conv1d_supported(model_id, config_cls)
         self._test_generate(model_id, config_cls, config_kwargs.copy())
 
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate_pos_args(self, model_id, config_cls, config_kwargs):
-        if (config_cls in (PrefixTuningConfig, VBLoRAConfig)) and ("gemma" in model_id.lower()):
-            pytest.skip("Generating with gemma and prefix tuning/VBLoRA currently fails")
         _skip_if_not_conv1d_supported(model_id, config_cls)
         self._test_generate_pos_args(model_id, config_cls, config_kwargs.copy(), raises_err=False)
 
@@ -393,15 +389,11 @@ class TestDecoderModels(PeftCommonTester):
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate_half_prec(self, model_id, config_cls, config_kwargs):
-        if config_cls == PrefixTuningConfig and ("gemma" in model_id.lower()):
-            pytest.skip("Generating with gemma and prefix tuning currently fails")
         self._test_generate_half_prec(model_id, config_cls, config_kwargs.copy())
 
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_prefix_tuning_half_prec_conversion(self, model_id, config_cls, config_kwargs):
-        if config_cls == PrefixTuningConfig and ("gemma" in model_id.lower()):
-            pytest.skip("Generating with gemma and prefix tuning currently fails")
         self._test_prefix_tuning_half_prec_conversion(model_id, config_cls, config_kwargs.copy())
 
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
@@ -471,8 +463,6 @@ class TestDecoderModels(PeftCommonTester):
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_disable_adapter(self, model_id, config_cls, config_kwargs):
-        if config_cls == PrefixTuningConfig and ("gemma" in model_id.lower()):
-            pytest.skip("Generating with gemma and prefix tuning currently fails")
         _skip_if_not_conv1d_supported(model_id, config_cls)
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_disable_adapter(model_id, config_cls, config_kwargs.copy())

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -372,12 +372,16 @@ class TestDecoderModels(PeftCommonTester):
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate(self, model_id, config_cls, config_kwargs):
+        if (config_cls in (PrefixTuningConfig, VBLoRAConfig)) and ("gemma" in model_id.lower()):
+            pytest.skip("Generating with gemma and prefix tuning/VBLoRA currently fails")
         _skip_if_not_conv1d_supported(model_id, config_cls)
         self._test_generate(model_id, config_cls, config_kwargs.copy())
 
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate_pos_args(self, model_id, config_cls, config_kwargs):
+        if (config_cls in (PrefixTuningConfig, VBLoRAConfig)) and ("gemma" in model_id.lower()):
+            pytest.skip("Generating with gemma and prefix tuning/VBLoRA currently fails")
         _skip_if_not_conv1d_supported(model_id, config_cls)
         self._test_generate_pos_args(model_id, config_cls, config_kwargs.copy(), raises_err=False)
 
@@ -389,11 +393,15 @@ class TestDecoderModels(PeftCommonTester):
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate_half_prec(self, model_id, config_cls, config_kwargs):
+        if config_cls == PrefixTuningConfig and ("gemma" in model_id.lower()):
+            pytest.skip("Generating with gemma and prefix tuning currently fails")
         self._test_generate_half_prec(model_id, config_cls, config_kwargs.copy())
 
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_prefix_tuning_half_prec_conversion(self, model_id, config_cls, config_kwargs):
+        if config_cls == PrefixTuningConfig and ("gemma" in model_id.lower()):
+            pytest.skip("Generating with gemma and prefix tuning currently fails")
         self._test_prefix_tuning_half_prec_conversion(model_id, config_cls, config_kwargs.copy())
 
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
@@ -463,6 +471,8 @@ class TestDecoderModels(PeftCommonTester):
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_disable_adapter(self, model_id, config_cls, config_kwargs):
+        if config_cls == PrefixTuningConfig and ("gemma" in model_id.lower()):
+            pytest.skip("Generating with gemma and prefix tuning currently fails")
         _skip_if_not_conv1d_supported(model_id, config_cls)
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_disable_adapter(model_id, config_cls, config_kwargs.copy())


### PR DESCRIPTION
See also #2580

Resolves CI errors such as this one:

https://github.com/huggingface/peft/actions/runs/15481482956/job/43588020111#step:5:53182

This PR resolves 2 issues:

## 1. attention mask being a dict

After the transformers change in https://github.com/huggingface/transformers/pull/37866, it can happen that:

> Models using different types of attention in different layers (i.e. gemma3) will now have a dict returned by prepare_inputd_for_generation (one dict entry per attention type)

As PEFT operates on the attention mask for prompt learning methods, we need to adjust the code for the possibility of `attention_mask` being a dict. Right now, I simply extract the single value if the dict is just one element. For other sizes, I just raise an error, as I don't know how to deal with that. For our tests, this is enough but we might need to find a better solution in the future.

## 2. torch.compile errors during generation

#2458 fixed an issue with 4d attention masks and added gemma3 to the test suite, which uses 4d attention masks. However, the solution was insufficient, as it involves replacing the 4d attention mask with a 2d mask and handing it off to the model to create the correct 4d attention mask. The problem is that mask creation triggers an error with `torch.compile` and thus needs to be performed outside of the compile context, i.e. during  `prepare_inputs_for_generation`. This PR now uses the same logic as transformers to do exactly that.

There are still issues with prefix tuning and incorrect shapes, which may be solvable, but require further work. Similarly, there is an issue with VBLoRA because this line is not `torch.compile` friendly:

https://github.com/huggingface/peft/blob/e67052b18cb3c58370e0339ecf76a5faf447f2ff/src/peft/tuners/vblora/layer.py#L191

The corresponding tests are skipped for now.

Finally, for these fixes to work, two more changes are needed on the transformers side:

1. Await a new transformers release (>4.52) so that we can use [`create_masks_for_generate`](https://github.com/huggingface/transformers/blob/380e6ea4065afc4f639d7b1bed990e18020b7270/src/transformers/masking_utils.py#L921).
2. ~For prompt learning, we [remove the `cache_position` argument](https://github.com/huggingface/peft/blob/e67052b18cb3c58370e0339ecf76a5faf447f2ff/src/peft/peft_model.py#L1997), I'm not quite sure if there is not a better solution. Anyway, because of this it needs to be recomputed but models like [gemma recompute in a way that is not torch.compile-friendly](https://github.com/huggingface/transformers/blob/8ff22e9d3b0d14a4ae18890fbabe5ffc2d9a037b/src/transformers/models/gemma3/modeling_gemma3.py#L544-L548). They should use a [compile friendly method](https://github.com/huggingface/transformers/blob/8ff22e9d3b0d14a4ae18890fbabe5ffc2d9a037b/src/transformers/generation/utils.py#L1796) instead. When I locally patch transformers to do so, the tests pass.~ `cache_position` is no longer being removed from the `model_kwargs`, thus the aforementioned problem does not occur.

For these reasons, this PR stays in draft status for now and #2580 is used to make the CI green for the time being.