### PR TITLE
Fix Typos in Test Comments

### DIFF
--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -1574,7 +1574,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     @require_non_cpu
     @pytest.mark.single_gpu_tests
     def test_r_odd_hra_inference(self):
-        # check that an untrained HRA adapter can't be initialized as an identity tranformation
+        # check that an untrained HRA adapter can't be initialized as an identity transformation
         # when r is an odd number
         model = AutoModelForCausalLM.from_pretrained(
             "facebook/opt-125m",

--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -337,7 +337,7 @@ class TestXlora:
         assert torch.isfinite(outputs[: inputs.shape[1] :]).all()
 
     def test_xlora_loading_valid(self):
-        # This test also simulatenously tests the loading-from-hub functionality!
+        # This test also simultaneously tests the loading-from-hub functionality!
         torch.manual_seed(123)
 
         model_id = "facebook/opt-125m"


### PR DESCRIPTION

Description:  
This pull request corrects minor typos in comments within the test files. Specifically, it fixes the spelling of "transformation" and "simultaneously" in the following files:
- tests/test_common_gpu.py
- tests/test_xlora.py

No functional code changes were made; only comment text was updated for clarity and accuracy.