### PR TITLE
ENH: Method comparison allow full finetuning

### DIFF
--- a/method_comparison/MetaMathQA/experiments/full-finetuning/llama-3.2-3B-lr_0.00001/training_params.json
+++ b/method_comparison/MetaMathQA/experiments/full-finetuning/llama-3.2-3B-lr_0.00001/training_params.json
@@ -1,0 +1,6 @@
+{
+  "optimizer_kwargs": {
+    "lr": 1e-5
+  }
+}
+

--- a/method_comparison/MetaMathQA/run.py
+++ b/method_comparison/MetaMathQA/run.py
@@ -268,7 +268,6 @@ def train(
                         "valid accuracy": accuracy,
                         "train loss": loss_avg,
                         "train samples": total_samples,
-                        "loss avg": loss_avg,
                         "train time": dur_train,
                         "eval time": dur_eval,
                         "tokens / sec": tokens_per_sec,

--- a/method_comparison/app.py
+++ b/method_comparison/app.py
@@ -32,7 +32,7 @@ metric_preferences = {
     "train_time": "lower",
     "file_size": "lower",
     "test_accuracy": "higher",
-    "test_loss": "lower",
+    "train_loss": "lower",
 }
 
 

--- a/method_comparison/processing.py
+++ b/method_comparison/processing.py
@@ -35,7 +35,7 @@ def preprocess(rows, task_name: str, print_fn=print):
             skipped += 1
             continue
 
-        test_metrics = train_info["metrics"][-1]
+        train_metrics = train_info["metrics"][-1]
 
         # extract the fields that make most sense
         dct = {
@@ -51,10 +51,10 @@ def preprocess(rows, task_name: str, print_fn=print):
             "total_time": run_info["total_time"],
             "train_time": train_info["train_time"],
             "file_size": train_info["file_size"],
-            "test_accuracy": test_metrics["test accuracy"],
-            "test_loss": test_metrics["train loss"],
-            "train_samples": test_metrics["train samples"],
-            "train_total_tokens": test_metrics["train total tokens"],
+            "test_accuracy": train_metrics["test accuracy"],
+            "train_loss": train_metrics["train loss"],
+            "train_samples": train_metrics["train samples"],
+            "train_total_tokens": train_metrics["train total tokens"],
             "peft_version": meta_info["package_info"]["peft-version"],
             "peft_branch": run_info["peft_branch"],
             "transformers_version": meta_info["package_info"]["transformers-version"],
@@ -100,7 +100,7 @@ def load_df(path, task_name, print_fn=print):
         "train_time": float,
         "file_size": int,
         "test_accuracy": float,
-        "test_loss": float,
+        "train_loss": float,
         "train_samples": int,
         "train_total_tokens": int,
         "peft_version": "string",
@@ -127,7 +127,7 @@ def load_df(path, task_name, print_fn=print):
         "total_time",
         "train_time",
         "test_accuracy",
-        "test_loss",
+        "train_loss",
         "cuda_memory_max",
         "cuda_memory_reserved_99th",
         "cuda_memory_reserved_avg",

--- a/method_comparison/processing.py
+++ b/method_comparison/processing.py
@@ -27,6 +27,10 @@ def preprocess(rows, task_name: str, print_fn=print):
         run_info = row["run_info"]
         train_info = row["train_info"]
         meta_info = row["meta_info"]
+        if run_info["peft_config"]:
+            peft_type = run_info["peft_config"]["peft_type"]
+        else:
+            peft_type = "full-finetuning"
         if train_info["status"] != "success":
             skipped += 1
             continue
@@ -39,7 +43,7 @@ def preprocess(rows, task_name: str, print_fn=print):
             "experiment_name": run_info["experiment_name"],
             "model_id": run_info["train_config"]["model_id"],
             "train_config": run_info["train_config"],
-            "peft_type": run_info["peft_config"]["peft_type"],
+            "peft_type": peft_type,
             "peft_config": run_info["peft_config"],
             "cuda_memory_reserved_avg": train_info["cuda_memory_reserved_avg"],
             "cuda_memory_max": train_info["cuda_memory_max"],


### PR DESCRIPTION
Enable full fine-tuning on MetaMathQA for the method comparison suite.

I ran the full fine-tuning experiment, here are some key results:

```json
    ...
    "cuda_memory_reserved_avg": 33098872284,
    "cuda_memory_max": 37241225216,
    "cuda_memory_reserved_99th": 33573390254,
    "train_time": 3249.7733414780005,
    ...
        "test accuracy": 0.5064442759666414,
        "train loss": 0.5987803322076798,
        "train samples": 20000,
        "train total tokens": 4198051
```

Furthermore, I found a duplicate key in the logs, which I removed, and noticed an incorrect column name in the app, which is renamed now.

~~After checking in a proper training run result, we should consider adjusting `app.py` to remove the full fine-tuning results from the plot (but still keep it in the df) as its values are often outliers and would skew the plot.~~ Just checked locally, I think we can keep the results in the graph, it doesn't impede readability.