### PR TITLE
Auto-tagging of PEFT models

### DIFF
--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -266,6 +266,14 @@ class PeftCommonTester:
         else:  # a custom model
             assert "base_model" not in dct
 
+        # There must be at least one tag with the PEFT method that was used.
+        assert len([t for t in dct["tags"] if t.startswith("peft:method:")]) > 0
+
+        # The Hub expects the lora tag to be set for PEFT LoRA models since they
+        # have explicit support for things like inference.
+        if model.active_peft_config.peft_type.value == "LORA":
+            assert "lora" in dct["tags"]
+
     def check_config_json(self, tmp_dirname, model):
         # check the generated config.json
         filename = os.path.join(tmp_dirname, "adapter_config.json")


### PR DESCRIPTION
Features like inference need correctly set tags on the repo / the model card in order to be available. Also the Hub uses tags to index the models and make them searchable.

With this change PEFT tags models automatically as lora if they happen to be trained with LoRA, the base model and a custom `peft:method:<the method>` tag.

@Vaibhavs10 as discussed. This would ensure that new models are always tagged correctly and work out-of-the-box with, say, inference providers. We also took the liberty to introduce a `peft:method:<the_method>` tag (e.g., `peft:method:bone` or `peft:method:lora`). This is not final, feel free to discuss but we thought it may make sense to have this so that users can explore adapters a bit more deeply.