### PR TITLE
FIX: Avoid possible CUDA Graph re-record when hotswapping LoRAs.

### DIFF
--- a/src/peft/utils/hotswap.py
+++ b/src/peft/utils/hotswap.py
@@ -480,7 +480,7 @@ def hotswap_adapter_from_state_dict(
             # either
             # - adapters had the same rank
             # - adapters were padded with prepare_model_for_compiled_hotswap and 2nd adapter was larger
-            old_val.data = new_val.data
+            old_val.data.copy_(new_val.data)
         else:
             # if 2nd adapter was smaller, ensure to fill up to adapter dimension and set the rest to zeros
             if old_val.dim() not in (2, 4):
@@ -492,10 +492,10 @@ def hotswap_adapter_from_state_dict(
             # Linear or Conv2d: the check for dim 0 or 1 works for both of these layer types
             if old_val.shape[0] > new_val.shape[0]:
                 old_val.data.fill_(0)
-                old_val.data[: new_val.shape[0]] = new_val.data
+                old_val.data[: new_val.shape[0]].copy_(new_val.data)
             elif old_val.shape[1] > new_val.shape[1]:
                 old_val.data.fill_(0)
-                old_val.data[:, : new_val.shape[1]] = new_val.data
+                old_val.data[:, : new_val.shape[1]].copy_(new_val.data)
             else:
                 raise ValueError(
                     f"Incompatible shapes found for LoRA weights {key}: {old_val.shape} vs {new_val.shape}. Please "

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4631,7 +4631,9 @@ class TestHotSwapping:
     # it is important to check hotswapping small to large ranks and large to small ranks
     @pytest.mark.parametrize("ranks", [(11, 11), (7, 13), (13, 7)])
     def test_hotswapping_compiled_model_does_not_trigger_recompilation(self, ranks):
-        with torch._dynamo.config.patch(error_on_recompile=True):  # raise an error on recompilation
+        dynamo_config_ctx = torch._dynamo.config.patch(error_on_recompile=True)
+        inductor_config_ctx = torch._inductor.config.patch("triton.cudagraph_unexpected_rerecord_limit", 0)
+        with dynamo_config_ctx, inductor_config_ctx:
             self.check_hotswap(do_hotswap=True, ranks=ranks, alpha_scalings=ranks)
 
     def test_no_hotswapping_compiled_model_triggers_recompilation(self):


### PR DESCRIPTION
Motivation:

In some cases, recorded CUDA Graph gets silently invalided if `TORCH_LOGS="perf_hints"` not provided, due to data pointer changes.

Torch log:

```
static input data pointer changed.
...
input name: arg17_1. data pointer changed from x to y. input stack trace:
...
  File "/opt/conda/lib/python3.11/site-packages/diffusers/models/resnet.py", line 346, in forward
    temb = self.time_emb_proj(temb)[:, :, None, None]
  File "/opt/conda/lib/python3.11/site-packages/peft/tuners/lora/layer.py", line 727, in forward
    result = result + lora_B(lora_A(dropout(x))) * scaling
...
```

This leads to an [unexpected CUDA Graph re-record.](https://github.com/pytorch/pytorch/blob/134179474539648ba7dee1317959529fbd0e7f89/torch/_inductor/cudagraph_trees.py#L2151)

We can avoid this by copying LoRA weights in place without changing underlying tensor itself. I didn't see any performance regressions with in place copy.