### PR TITLE
ENH Method comparison: temporary and cancelled result files include timestamp

### DIFF
--- a/method_comparison/MetaMathQA/run.py
+++ b/method_comparison/MetaMathQA/run.py
@@ -25,14 +25,11 @@ import random
 import sys
 import textwrap
 import time
-from contextlib import nullcontext
+from contextlib import ContextManager, nullcontext
 from functools import partial
-from typing import Any, Callable, ContextManager, Literal, Optional
+from typing import Any, Callable, Literal, Optional
 
 import torch
-from data import (
-    get_train_valid_test_datasets,
-)
 from torch import nn
 from torch.amp import GradScaler, autocast
 from tqdm import tqdm
@@ -56,6 +53,7 @@ from utils import (
     validate_experiment_path,
 )
 
+from data import get_train_valid_test_datasets
 from peft import AdaLoraConfig, PeftConfig
 from peft.utils import CONFIG_NAME
 

--- a/method_comparison/MetaMathQA/utils.py
+++ b/method_comparison/MetaMathQA/utils.py
@@ -594,9 +594,14 @@ def log_to_console(log_data: dict[str, Any], print_fn: Callable[..., None]) -> N
 
 
 def log_to_file(
-    *, log_data: dict, save_dir: str, experiment_name: str, print_fn: Callable[..., None]
+    *, log_data: dict, save_dir: str, experiment_name: str, timestamp: str, print_fn: Callable[..., None]
 ) -> None:
-    file_name = f"{experiment_name.replace(os.path.sep, '--')}.json"
+    if save_dir.endswith(RESULT_PATH):
+        file_name = f"{experiment_name.replace(os.path.sep, '--')}.json"
+    else:
+        # For cancelled and temporary runs, we want to include the timestamp, as these runs are not tracked in git, thus
+        # we need unique names to avoid losing history.
+        file_name = f"{experiment_name.replace(os.path.sep, '--')}--{timestamp.replace(':', '-')}.json"
     file_name = os.path.join(save_dir, file_name)
     with open(file_name, "w") as f:
         json.dump(log_data, f, indent=2)
@@ -693,5 +698,5 @@ def log_results(
 
     log_to_console(log_data, print_fn=print)  # use normal print to be able to redirect if so desired
     log_to_file(
-        log_data=log_data, save_dir=save_dir, experiment_name=experiment_name, print_fn=print_fn
+        log_data=log_data, save_dir=save_dir, experiment_name=experiment_name, timestamp=start_date, print_fn=print_fn
     )


### PR DESCRIPTION
In #2593, the timestamp was removed from the file name of result files. This makes sense for the proper results, as those should have unique file names and are tracked in git. However, for temporary and cancelled results, this is not true. Therefore, the timestamp is added back in.

Moreover, I applied ruff to the `MetaMathQA/` directory (it's not applied automatically) and fixed some imports. Ruff seems to get confused about local modules, thus the `data` and `utils` import are treated differently, but IMO no big deal.