### PR TITLE
FIX Update signature for resolve_lora_variant

### DIFF
--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -315,7 +315,7 @@ if is_bnb_4bit_available():
                 lora_bias=lora_bias,
             )
 
-        def resolve_lora_variant(self, *, use_dora: bool) -> Optional[LoraVariant]:
+        def resolve_lora_variant(self, *, use_dora: bool, **kwargs) -> Optional[LoraVariant]:
             if not use_dora:
                 return None
 


### PR DESCRIPTION
The function signature was missing `**kwargs`, which results in a [failure](https://github.com/huggingface/peft/actions/runs/15916801267/job/44895818094) after merging #2571.