### PR TITLE
fix LoraParallelLinear missing  the definition of self.lora_bias[adapter_name]

### DIFF
--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -120,6 +120,7 @@ class LoraParallelLinear(nn.Module, LoraLayer):
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
         self.r[adapter_name] = r
         self.lora_alpha[adapter_name] = lora_alpha
+        self.lora_bias[adapter_name] = False
         if lora_dropout > 0.0:
             lora_dropout_layer = nn.Dropout(p=lora_dropout)
         else:


### PR DESCRIPTION
fix LoraParallelLinear missing  the definition of self.lora_bias[adapter_name]

When using LoraParallelLinear with Megatron, the following issue was encountered:

before:
```
type(linear)=<class 'megatron.core.tensor_parallel.layers.ColumnParallelLinear'>
net=testNet(
  (linear): ColumnParallelLinear(in_features=32, out_features=32, bias=False, TP=1)
)
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/xxxxxxxxx/mcore/Megatron-LM/run_column_lora.py", line 92, in <module>
[rank0]:     net = get_peft_model(net, lora_config)
[rank0]:           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/mapping_func.py", line 123, in get_peft_model
[rank0]:     return MODEL_TYPE_TO_PEFT_MODEL_MAPPING[peft_config.task_type](
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/peft_model.py", line 1722, in __init__
[rank0]:     super().__init__(model, peft_config, adapter_name, **kwargs)
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/peft_model.py", line 132, in __init__
[rank0]:     self.base_model = cls(model, {adapter_name: peft_config}, adapter_name)
[rank0]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/tuners/lora/model.py", line 142, in __init__
[rank0]:     super().__init__(model, config, adapter_name, low_cpu_mem_usage=low_cpu_mem_usage)
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/tuners/tuners_utils.py", line 180, in __init__
[rank0]:     self.inject_adapter(self.model, adapter_name, low_cpu_mem_usage=low_cpu_mem_usage)
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/tuners/tuners_utils.py", line 508, in inject_adapter
[rank0]:     self._create_and_replace(peft_config, adapter_name, target, target_name, parent, current_key=key)
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/tuners/lora/model.py", line 237, in _create_and_replace
[rank0]:     new_module = self._create_new_module(lora_config, adapter_name, target, device_map=device_map, **kwargs)
[rank0]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/tuners/lora/model.py", line 342, in _create_new_module
[rank0]:     new_module = dispatcher(target, adapter_name, lora_config=lora_config, **kwargs)
[rank0]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/tuners/lora/tp_layer.py", line 397, in dispatch_megatron
[rank0]:     new_module = LoraParallelLinear(
[rank0]:                  ^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/tuners/lora/tp_layer.py", line 81, in __init__
[rank0]:     self.update_layer(
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/tuners/lora/tp_layer.py", line 171, in update_layer
[rank0]:     self.reset_lora_parameters(adapter_name, init_lora_weights)
[rank0]:   File "/usr/local/lib/python3.12/dist-packages/peft/tuners/lora/layer.py", line 194, in reset_lora_parameters
[rank0]:     if self.lora_bias[adapter_name]:
[rank0]:        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^
[rank0]: KeyError: 'default'
```

Since the tp layer is not support lora_bias, we can simply set `self.lora_bias[adapter_name] = False`

https://github.com/huggingface/peft/blob/456292649aea64ef6b00f05b93aa9d1d93b31862/src/peft/tuners/lora/tp_layer.py#L56-L57


After:

```
type(linear)=<class 'megatron.core.tensor_parallel.layers.ColumnParallelLinear'>
net=PeftModelForCausalLM(
  (base_model): LoraModel(
    (model): testNet(
      (linear): lora.LoraParallelLinear(
        (base_layer): ColumnParallelLinear(in_features=32, out_features=32, bias=False, TP=1)
        (lora_dropout): ModuleDict(
          (default): Identity()
        )
        (lora_A): ModuleDict(
          (default): Linear(in_features=32, out_features=8, bias=False)
        )
        (lora_B): ModuleDict(
          (default): ColumnParallelLinear(in_features=8, out_features=32, bias=False, TP=1)
        )
        (lora_embedding_A): ParameterDict()
        (lora_embedding_B): ParameterDict()
        (lora_magnitude_vector): ModuleDict()
      )
    )
  )
)
```

# Attachment

My test script, which is ruunning under the root dir of megatron core_r0.12.0
```python
import os
os.environ['MASTER_ADDR'] = 'localhost'
os.environ['MASTER_PORT'] = '15267'

from megatron.core.tensor_parallel.layers import ColumnParallelLinear
from megatron.core.model_parallel_config import ModelParallelConfig
from megatron.core.utils import init_method_normal
import torch
from megatron.core import parallel_state
from megatron.core.transformer.transformer_config import TransformerConfig
import torch.nn.functional as F
import numpy as np
torch.set_printoptions(precision=8)
np.set_printoptions(precision=8)
def initialize_distributed(tensor_model_parallel_size=1, pipeline_model_parallel_size=1):
    # Torch setup for distributed training
    rank = 0
    world_size = 1
    torch.distributed.init_process_group(world_size=world_size, rank=rank)

    # Megatron core distributed training initialization
    parallel_state.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=1)

hidden_size = 32
data_parallel_size = 1
tensor_model_parallel_size = 1

bias = True
skip_bias_add = False
skip_weight_param_allocation = False
use_weight_tensor = False

initialize_distributed(tensor_model_parallel_size, 1)

config_ = TransformerConfig(
    num_layers=1,
    hidden_size=32,
    num_attention_heads=32,
    ffn_hidden_size=32,
    gated_linear_unit=True,
    use_cpu_initialization=True,
    activation_func=F.silu,
    sequence_parallel=False
)
config_.tensor_model_parallel_size = tensor_model_parallel_size
config_.bf16 = True
config_.params_dtype = torch.float32

class testNet(torch.nn.Module):
    def __init__(self, linear):
        super().__init__()
        self.linear = linear
        
    def prepare_inputs_for_generation(self,):
        pass
        
    def forward(self,x):
        return self.linear(x)
        

linear = ColumnParallelLinear(
    input_size=hidden_size,
    output_size=hidden_size,
    config=config_,
    skip_bias_add=skip_bias_add,
    init_method=init_method_normal(sigma=0.01),
    skip_weight_param_allocation=skip_weight_param_allocation,
    gather_output=True,
    bias=bias
)

net = testNet(linear)


from peft import get_peft_model, LoraConfig, TaskType
lora_config = LoraConfig(
    task_type=TaskType.CAUSAL_LM,
    r=8,
    lora_alpha=32,
    target_modules='linear',
    lora_dropout=0.0,
    bias="none",
    megatron_config=config_
)

net = get_peft_model(net, lora_config)
print(f"{type(linear)=}")
print(f"{net=}")
```
