### PR TITLE
[WIP] CI Use in memory temp directory for fast IO

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
 env:
   HF_HOME: .cache/huggingface
   TRANSFORMERS_IS_CI: 1
+  PYTEST_PROGRESS_PERCENTAGE_THRESHOLD: 10  # report pytest progress every 10%
 
 permissions: {}
 
@@ -42,7 +43,7 @@ jobs:
       # TODO: remove 'fail-fast' line once timeout issue from the Hub is solved
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -77,7 +78,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools
+          pip install setuptools pytest-random-order
           # cpu version of pytorch
           pip install -e .[test]
       - name: Downgrade numpy on MacOS and Windows
@@ -86,15 +87,6 @@ jobs:
         if: matrix.os == 'windows-latest' || matrix.os == 'macos-13'
         run: |
           pip install --force-reinstall -U "numpy<2.0.0"
-      - name: Prepare in-memory temp
-        # force bash on all runners so our shell logic works uniformly
-        shell: bash
-        run: |
-          if [[ "${RUNNER_OS}" == "Linux" ]]; then
-            echo "TMPDIR=/dev/shm" >> $GITHUB_ENV
-          else
-            echo "Windows and MacOS runners: skipping RAM-disk setup"
-          fi
       - name: Test with pytest
         run: |
           make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,8 @@ jobs:
       # TODO: remove 'fail-fast' line once timeout issue from the Hub is solved
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: ["ubuntu-latest", "macos-13", "windows-latest"]
+        python-version: ["3.12"]
+        os: ["ubuntu-latest"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -86,6 +86,15 @@ jobs:
         if: matrix.os == 'windows-latest' || matrix.os == 'macos-13'
         run: |
           pip install --force-reinstall -U "numpy<2.0.0"
+      - name: Prepare in-memory temp
+        # force bash on all runners so our shell logic works uniformly
+        shell: bash
+        run: |
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+            echo "TMPDIR=/dev/shm" >> $GITHUB_ENV
+          else
+            echo "Windows and MacOS runners: skipping RAM-disk setup"
+          fi
       - name: Test with pytest
         run: |
           make test

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ style:
 	doc-builder style src/peft tests docs/source --max_len 119
 
 test:
-	python -m pytest -n 3 tests/ $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
+	python -m pytest --random-order tests/ $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
 
 tests_examples_multi_gpu:
 	python -m pytest -m multi_gpu_tests tests/test_gpu_examples.py $(if $(IS_GITHUB_CI),--report-log "multi_gpu_examples.log",)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import platform
 import re
+import time
 
 import pytest
 
@@ -67,3 +69,63 @@ def pytest_runtest_makereport(item, call):
             # for this attribute, see:
             # https://github.com/pytest-dev/pytest/blob/bd6877e5874b50ee57d0f63b342a67298ee9a1c3/src/_pytest/reports.py#L266C5-L266C13
             rep.wasxfail = "Error known to occur on MacOS with older torch versions, won't be fixed"
+
+
+#############################
+# REPORT PROGRESS OF PYTEST #
+#############################
+
+# note: *does not work* with pytest-xdist yet
+
+# only show progress when PYTEST_PROGRESS_PERCENTAGE_THRESHOLD is set, it must be an integer between 0 and 100
+PYTEST_PROGRESS_PERCENTAGE_THRESHOLD = os.getenv("PYTEST_PROGRESS_PERCENTAGE_THRESHOLD")
+if PYTEST_PROGRESS_PERCENTAGE_THRESHOLD:
+    PYTEST_PROGRESS_PERCENTAGE_THRESHOLD = int(PYTEST_PROGRESS_PERCENTAGE_THRESHOLD)
+    assert 0 < PYTEST_PROGRESS_PERCENTAGE_THRESHOLD < 100
+
+
+def pytest_sessionstart(session):
+    if PYTEST_PROGRESS_PERCENTAGE_THRESHOLD:
+        session._t0 = time.perf_counter()
+        session._last = session._t0
+        session._next_pct = PYTEST_PROGRESS_PERCENTAGE_THRESHOLD
+        session._progress_entries = []
+
+
+def pytest_collection_finish(session):
+    if PYTEST_PROGRESS_PERCENTAGE_THRESHOLD:
+        session._total = len(session.items)
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    yield
+    if not PYTEST_PROGRESS_PERCENTAGE_THRESHOLD:
+        return
+
+    session = item.session
+
+    done = getattr(session, "_done", 0) + 1
+    setattr(session, "_done", done)
+    pct = done / session._total * 100
+
+    if pct >= session._next_pct:
+        now = time.perf_counter()
+        inc = now - session._last
+        total = now - session._t0
+        session._last = now
+        # NEW: save instead of printing immediately
+        session._progress_entries.append((session._next_pct, done, session._total, inc, total))
+        session._next_pct += PYTEST_PROGRESS_PERCENTAGE_THRESHOLD
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Print the accumulated progress report once, after the whole suite is done."""
+    if not PYTEST_PROGRESS_PERCENTAGE_THRESHOLD:
+        return
+
+    tr = session.config.pluginmanager.get_plugin("terminalreporter")
+    for pct, done, total, inc, elapsed in session._progress_entries:
+        tr.write_line(
+            f"[progress] {pct:>3}% | done: {done:>6}/{total} | time: {inc:>7.1f}s | elapsed {elapsed:>7.1f}s"
+        )


### PR DESCRIPTION
**Conclusion from this test**

- In memory temp fs, at least the way it's implemented here, does not help
- Since the first 50% of tests seem to run faster than the last 50%, I wanted to check if it's just the order of tests or if there is a slowdown. Thus I added test order randomization (which still runs one module after the other, so not completely random) and progress reporting. Then I ran 4 Ubuntu tests, using different Python versions as "test groups". The results show that there doesn't seem to be a slow down. The initial observation was therefore just due to the test order.

```
Python 3.9
[progress]  10% | done:   1414/14131 | time:   270.0s | elapsed   270.0s
[progress]  20% | done:   2827/14131 | time:    89.9s | elapsed   359.9s
[progress]  30% | done:   4240/14131 | time:    18.2s | elapsed   378.1s
[progress]  40% | done:   5653/14131 | time:    16.2s | elapsed   394.2s
[progress]  50% | done:   7066/14131 | time:    17.1s | elapsed   411.3s
[progress]  60% | done:   8479/14131 | time:   220.7s | elapsed   632.0s
[progress]  70% | done:   9892/14131 | time:   229.0s | elapsed   861.1s
[progress]  80% | done:  11305/14131 | time:   286.6s | elapsed  1147.6s
[progress]  90% | done:  12718/14131 | time:   296.3s | elapsed  1443.9s
[progress] 100% | done:  14131/14131 | time:   374.8s | elapsed  1818.7s

Python 3.10
[progress]  10% | done:   1414/14131 | time:   291.6s | elapsed   291.6s
[progress]  20% | done:   2827/14131 | time:   239.9s | elapsed   531.4s
[progress]  30% | done:   4240/14131 | time:   293.8s | elapsed   825.2s
[progress]  40% | done:   5653/14131 | time:   282.4s | elapsed  1107.6s
[progress]  50% | done:   7066/14131 | time:   283.3s | elapsed  1390.9s
[progress]  60% | done:   8479/14131 | time:   136.8s | elapsed  1527.7s
[progress]  70% | done:   9892/14131 | time:    16.8s | elapsed  1544.4s
[progress]  80% | done:  11305/14131 | time:    17.4s | elapsed  1561.8s
[progress]  90% | done:  12718/14131 | time:    18.1s | elapsed  1579.9s
[progress] 100% | done:  14131/14131 | time:   189.5s | elapsed  1769.5s

Python 3.11
[progress]  10% | done:   1414/14131 | time:   372.8s | elapsed   372.8s
[progress]  20% | done:   2827/14131 | time:   301.6s | elapsed   674.4s
[progress]  30% | done:   4240/14131 | time:   306.5s | elapsed   980.8s
[progress]  40% | done:   5653/14131 | time:   304.5s | elapsed  1285.3s
[progress]  50% | done:   7066/14131 | time:   457.0s | elapsed  1742.3s
[progress]  60% | done:   8479/14131 | time:   108.0s | elapsed  1850.4s
[progress]  70% | done:   9892/14131 | time:    16.2s | elapsed  1866.6s
[progress]  80% | done:  11305/14131 | time:    18.7s | elapsed  1885.2s
[progress]  90% | done:  12718/14131 | time:    19.5s | elapsed  1904.8s
[progress] 100% | done:  14131/14131 | time:    17.4s | elapsed  1922.1s

Python 3.12
[progress]  10% | done:   1414/14131 | time:   344.6s | elapsed   344.6s
[progress]  20% | done:   2827/14131 | time:   285.8s | elapsed   630.4s
[progress]  30% | done:   4240/14131 | time:   277.8s | elapsed   908.2s
[progress]  40% | done:   5653/14131 | time:   280.3s | elapsed  1188.5s
[progress]  50% | done:   7066/14131 | time:   415.7s | elapsed  1604.2s
[progress]  60% | done:   8479/14131 | time:   105.2s | elapsed  1709.4s
[progress]  70% | done:   9892/14131 | time:    19.6s | elapsed  1728.9s
[progress]  80% | done:  11305/14131 | time:    18.3s | elapsed  1747.2s
[progress]  90% | done:  12718/14131 | time:    18.6s | elapsed  1765.8s
[progress] 100% | done:  14131/14131 | time:    47.7s | elapsed  1813.5s
```