### PR TITLE
FIX: Type annotation error in PEFT method comparison script

### DIFF
--- a/method_comparison/MetaMathQA/run.py
+++ b/method_comparison/MetaMathQA/run.py
@@ -25,7 +25,7 @@ import random
 import sys
 import textwrap
 import time
-from contextlib import ContextManager, nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from functools import partial
 from typing import Any, Callable, Literal, Optional
 
@@ -140,7 +140,7 @@ def train(
     total_tokens = []  # total number of tokens over all epochs
     if use_amp:
         grad_scaler: GradScaler | DummyGradScaler = GradScaler(device="cuda")
-        autocast_ctx: Callable[[], ContextManager[Any]] = partial(autocast, device_type="cuda")
+        autocast_ctx: Callable[[], AbstractContextManager[Any]] = partial(autocast, device_type="cuda")
     else:
         grad_scaler = DummyGradScaler()
         autocast_ctx = nullcontext


### PR DESCRIPTION
Resolves an issue introduced by #2617

In the long run, we should probably add some basic testing for the PEFT method comparison.