### PR TITLE
FIX: Faulty OFT parameter device test

### DIFF
--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -1884,7 +1884,7 @@ class TestSameAdapterDifferentDevices:
         config = OFTConfig(target_modules=["lin0"])
         model = get_peft_model(mlp, config)
         model = model.to(self.device)
-        model.lin0.oft_R.default.weight.cpu()
+        model.lin0.oft_R.default.cpu()
 
         # check that the adapter is indeed on CPU and the base model on GPU
         assert model.lin0.oft_R.default.weight.device.type == "cpu"


### PR DESCRIPTION
There is an error in an OFT test because `.cpu()` is called on a parameter instead of a module. Calling it on parameter is not an in-place operation, so it has no effect.

FYI @zqiu24