### PR TITLE
FIX: Correctly skip AWQ test based on torch version

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -3553,7 +3553,7 @@ class PeftAwqGPUTests(unittest.TestCase):
     # TODO remove marker if/once issue is resolved, most likely requiring a fix in AutoAWQ:
     # https://github.com/casper-hansen/AutoAWQ/issues/754
     @pytest.mark.xfail(
-        condition=is_torch_version("==", "2.7"),
+        condition=is_torch_version("==", "2.7.0") or is_torch_version("==", "2.7.1"),
         reason="Multi-GPU test currently not working with AutoAWQ and PyTorch 2.7",
         strict=True,
     )


### PR DESCRIPTION
There is currently an issue with a multi-GPU test using AutoAWQ. Thus, PR #2529 introduced an unconditional `skip` for this test. In #2596, a condition was added to only skip with torch 2.7, as other torch versions are not affected. However, the `is_torch_version` function does not actually match minor and patch versions, so

`is_torch_version("==", "2.7")`

returns `False` when using version 2.7.1.

This PR fixes that by checking both `"2.7.0"` and `"2.7.1"` explicitly. This is not very robust in case that there are further patch releases of PyTorch. However, that is unlikely, and introducing a more general solution is IMO not worth it just for this instance.

FYI @yao-matrix