### PR TITLE
FIX: Create mask function signature change in transformers 4.53.1

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2050,6 +2050,7 @@ class PeftModelForCausalLM(PeftModel):
                         cache_position=cache_position_,
                         batch_size=bs,
                         sequence_length=total_seq_len,
+                        position_ids=model_kwargs.get("position_ids", None),
                     )
                     model_kwargs["attention_mask"] = attention_mask_new
                 else:


### PR DESCRIPTION
We use `create_mask_for_generate` from transformers. It was introduced in v4.53.0 but in v4.53.1, the function signature was changed to include `position_ids` as mandatory argument:

https://github.com/huggingface/transformers/pull/39194

This breaks our function call in PEFT. This PR fixes the function call by passing position_ids. This in turn would break the function call with transformers v4.53.0, thus a strict version check is being used for >= v4.53.1.