### PR TITLE
Fix #2634: Allow peft_type to be a string

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1443,7 +1443,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         base model is important for enabling support for HF inference providers but it also makes models more
         searchable on the HF hub.
         """
-        peft_method = self.active_peft_config.peft_type.value
+        peft_method = self.active_peft_config.peft_type
+        if not isinstance(peft_method, str):
+            peft_method = peft_method.value
 
         tags = []
 

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -218,3 +218,19 @@ class TestModelCard:
 
         assert model_card.data.tags is not None
         assert "transformers" not in model_card.data.tags
+
+    def test_custom_peft_type_does_not_raise(self, tmp_path):
+        # Passing a string value as peft_type value in the config is valid, so it should work.
+        # See https://github.com/huggingface/peft/issues/2634
+        model_id = "hf-internal-testing/tiny-random-Gemma3ForCausalLM"
+        with hub_online_once(model_id):
+            base_model = AutoModelForCausalLM.from_pretrained(model_id)
+            peft_config = LoraConfig()
+
+            # We simulate a custom PEFT type by using a string value of an existing method.  This skips the need for
+            # registering a new method but tests the case where we pass a string value instead of an enum.
+            peft_type = "LORA"
+            peft_config.peft_type = peft_type
+
+            peft_model = get_peft_model(base_model, peft_config)
+            peft_model.save_pretrained(tmp_path)


### PR DESCRIPTION
The auto-tagging code assumed that every `PeftConfig.peft_type` value is an Enum value but when adding custom types without modifying the enum it is possible to have strings as well (and the interface supports that).

This change allows for string values of `PeftConfig.peft_type` in the auto-tagging code.