### PR TITLE
add a asdict for dataclass model_config

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -21,6 +21,7 @@ import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager, nullcontext
 from typing import Any, Optional, Union, overload
+from dataclasses import asdict, is_dataclass
 
 import torch
 from accelerate.hooks import AlignDevicesHook
@@ -662,6 +663,8 @@ class BaseTuner(nn.Module, ABC):
         model_config = getattr(model, "config", DUMMY_MODEL_CONFIG)
         if hasattr(model_config, "to_dict"):
             model_config = model_config.to_dict()
+        elif is_dataclass(model_config):
+            model_config = asdict(model_config)
         return model_config
 
     def _get_tied_target_modules(self, model: nn.Module) -> list[str]:


### PR DESCRIPTION
The `get_model_config` function in `tuners_utils.py` does not handle model_config of dataclass data type, because some models (such as the lerobot model) have `config` attributes, but the dataclass type cannot be converted into a dictionary in the `get_model_config function`, resulting in an error when using `.get` in the `_get_tied_target_modules` function.

I fixed this problem. Make peft adapt to a wider range of model types.