### PR TITLE
Add Arrow + GenKnowSub to LoRA

### DIFF
--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -14,6 +14,7 @@
 
 __version__ = "0.17.1.dev0"
 
+
 from .auto import (
     MODEL_TYPE_TO_PEFT_MODEL_MAPPING,
     AutoPeftModel,
@@ -50,6 +51,7 @@ from .tuners import (
     AdaLoraModel,
     AdaptionPromptConfig,
     AdaptionPromptModel,
+    ArrowConfig,
     BOFTConfig,
     BOFTModel,
     BoneConfig,
@@ -75,8 +77,6 @@ from .tuners import (
     LoraConfig,
     LoraModel,
     LoraRuntimeConfig,
-    MissConfig,
-    MissModel,
     MultitaskPromptTuningConfig,
     MultitaskPromptTuningInit,
     OFTConfig,
@@ -93,8 +93,6 @@ from .tuners import (
     PromptTuningInit,
     RandLoraConfig,
     RandLoraModel,
-    ShiraConfig,
-    ShiraModel,
     TrainableTokensConfig,
     TrainableTokensModel,
     VBLoRAConfig,
@@ -103,6 +101,7 @@ from .tuners import (
     VeraModel,
     XLoraConfig,
     XLoraModel,
+    create_arrow_model,
     get_eva_state_dict,
     initialize_lora_eva_weights,
 )
@@ -132,6 +131,7 @@ __all__ = [
     "AdaLoraModel",
     "AdaptionPromptConfig",
     "AdaptionPromptModel",
+    "ArrowConfig",
     "AutoPeftModel",
     "AutoPeftModelForCausalLM",
     "AutoPeftModelForFeatureExtraction",
@@ -164,8 +164,6 @@ __all__ = [
     "LoraConfig",
     "LoraModel",
     "LoraRuntimeConfig",
-    "MissConfig",
-    "MissModel",
     "MultitaskPromptTuningConfig",
     "MultitaskPromptTuningInit",
     "OFTConfig",
@@ -194,8 +192,6 @@ __all__ = [
     "PromptTuningInit",
     "RandLoraConfig",
     "RandLoraModel",
-    "ShiraConfig",
-    "ShiraModel",
     "TaskType",
     "TrainableTokensConfig",
     "TrainableTokensModel",
@@ -208,6 +204,7 @@ __all__ = [
     "XLoraModel",
     "bloom_model_postprocess_past_key_value",
     "cast_mixed_precision_params",
+    "create_arrow_model",
     "get_eva_state_dict",
     "get_layer_status",
     "get_model_status",

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -45,11 +45,7 @@ def get_peft_config(config_dict: dict[str, Any]) -> PeftConfig:
 
 
 def inject_adapter_in_model(
-    peft_config: PeftConfig,
-    model: torch.nn.Module,
-    adapter_name: str = "default",
-    low_cpu_mem_usage: bool = False,
-    state_dict: Optional[dict[str, torch.Tensor]] = None,
+    peft_config: PeftConfig, model: torch.nn.Module, adapter_name: str = "default", low_cpu_mem_usage: bool = False
 ) -> torch.nn.Module:
     r"""
     A simple API to create and inject adapter in-place into a model. Currently the API does not support prompt learning
@@ -65,11 +61,6 @@ def inject_adapter_in_model(
             The name of the adapter to be injected, if not provided, the default adapter name is used ("default").
         low_cpu_mem_usage (`bool`, `optional`, defaults to `False`):
             Create empty adapter weights on meta device. Useful to speed up the loading process.
-        state_dict (`dict`, *optional*, defaults to `None`)
-            If a state_dict is passed here, the adapters will be injected based on the entries of the state_dict. This
-            can be useful when the exact `target_modules` of the PEFT method is unknown, for instance because the
-            checkpoint was created without meta data. Note that the values from the state_dict are not used, only the
-            keys are used to determine the correct layers that should be adapted.
     """
     if peft_config.is_prompt_learning or peft_config.is_adaption_prompt:
         raise ValueError("`create_and_replace` does not support prompt learning and adaption prompt yet.")
@@ -82,8 +73,6 @@ def inject_adapter_in_model(
     tuner_cls = PEFT_TYPE_TO_TUNER_MAPPING[peft_config.peft_type]
 
     # By instantiating a peft model we are injecting randomly initialized LoRA layers into the model's modules.
-    peft_model = tuner_cls(
-        model, peft_config, adapter_name=adapter_name, low_cpu_mem_usage=low_cpu_mem_usage, state_dict=state_dict
-    )
+    peft_model = tuner_cls(model, peft_config, adapter_name=adapter_name, low_cpu_mem_usage=low_cpu_mem_usage)
 
     return peft_model.model

--- a/src/peft/tuners/lora/__init__.py
+++ b/src/peft/tuners/lora/__init__.py
@@ -15,14 +15,16 @@
 from peft.import_utils import is_bnb_4bit_available, is_bnb_available, is_eetq_available
 from peft.utils import register_peft_method
 
-from .config import EvaConfig, LoftQConfig, LoraConfig, LoraRuntimeConfig
+from .config import ArrowConfig, EvaConfig, LoftQConfig, LoraConfig, LoraRuntimeConfig
 from .eva import get_eva_state_dict, initialize_lora_eva_weights
 from .gptq import GPTQLoraLinear
-from .layer import Conv2d, Conv3d, Embedding, Linear, LoraLayer, ParamWrapper
+from .layer import Conv2d, Conv3d, Embedding, Linear, LoraLayer
 from .model import LoraModel
+from .variants import create_arrow_model
 
 
 __all__ = [
+    "ArrowConfig",
     "Conv2d",
     "Conv3d",
     "Embedding",
@@ -34,7 +36,7 @@ __all__ = [
     "LoraLayer",
     "LoraModel",
     "LoraRuntimeConfig",
-    "ParamWrapper",
+    "create_arrow_model",
     "get_eva_state_dict",
     "initialize_lora_eva_weights",
 ]

--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -24,6 +24,7 @@ from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
 from peft.utils.integrations import dequantize_bnb_weight
 from peft.utils.other import transpose
 
+from .config import ArrowConfig
 from .layer import LoraLayer, LoraVariant
 
 
@@ -41,6 +42,7 @@ if is_bnb_available():
             init_lora_weights: bool = True,
             use_rslora: bool = False,
             use_dora: bool = False,
+            arrow_config: ArrowConfig = None,
             lora_bias: bool = False,
             **kwargs,
         ) -> None:
@@ -58,9 +60,17 @@ if is_bnb_available():
                 use_rslora=use_rslora,
                 use_dora=use_dora,
                 lora_bias=lora_bias,
+                arrow_config=arrow_config,
             )
 
-        def resolve_lora_variant(self, *, use_dora: bool, **kwargs) -> Optional[LoraVariant]:
+        def resolve_lora_variant(
+            self, *, arrow_config: ArrowConfig, use_dora: bool, **kwargs
+        ) -> Optional[LoraVariant]:
+            if arrow_config is not None:
+                from .variants import ArrowLinearVariant
+
+                return ArrowLinearVariant()
+
             if not use_dora:
                 return None
 
@@ -296,6 +306,7 @@ if is_bnb_4bit_available():
             init_lora_weights: bool = True,
             use_rslora: bool = False,
             use_dora: bool = False,
+            arrow_config: ArrowConfig = None,
             lora_bias: bool = False,
             **kwargs,
         ) -> None:
@@ -313,9 +324,17 @@ if is_bnb_4bit_available():
                 use_rslora=use_rslora,
                 use_dora=use_dora,
                 lora_bias=lora_bias,
+                arrow_config=arrow_config,
             )
 
-        def resolve_lora_variant(self, *, use_dora: bool, **kwargs) -> Optional[LoraVariant]:
+        def resolve_lora_variant(
+            self, *, arrow_config: ArrowConfig, use_dora: bool, **kwargs
+        ) -> Optional[LoraVariant]:
+            if arrow_config is not None:
+                from .variants import ArrowLinearVariant
+
+                return ArrowLinearVariant()
+
             if not use_dora:
                 return None
 

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -53,7 +53,7 @@ from .eetq import dispatch_eetq
 from .gptq import dispatch_gptq
 from .hqq import dispatch_hqq
 from .inc import dispatch_inc
-from .layer import Conv2d, LoraLayer, ParamWrapper, dispatch_default
+from .layer import Conv2d, LoraLayer, dispatch_default
 from .torchao import dispatch_torchao
 from .tp_layer import dispatch_megatron
 
@@ -139,6 +139,9 @@ class LoraModel(BaseTuner):
 
     prefix: str = "lora_"
 
+    def __init__(self, model, config, adapter_name, low_cpu_mem_usage: bool = False) -> None:
+        super().__init__(model, config, adapter_name, low_cpu_mem_usage=low_cpu_mem_usage)
+
     def _check_new_adapter_config(self, config: LoraConfig) -> None:
         """
         A helper method to check the config when a new adapter is being added.
@@ -179,23 +182,9 @@ class LoraModel(BaseTuner):
         target_name,
         parent,
         current_key,
-        *,
-        parameter_name: Optional[str] = None,
-    ) -> None:
+    ):
         if current_key is None:
             raise ValueError("Current Key shouldn't be `None`")
-
-        if lora_config.target_parameters:
-            # Right now, unfortunately, we don't support multiple adapters with target_parameters on the same model.
-            other_configs_use_target_params = any(
-                conf.target_parameters for key, conf in self.peft_config.items() if key != adapter_name
-            )
-            if other_configs_use_target_params:
-                raise ValueError(
-                    f"Adding a LoRA config with `target_parameters={lora_config.target_parameters}` but there are "
-                    "already other LoRA adapters on this model that use `target_parameters`. At the moment, only "
-                    "one LoRA adapter per model with `target_parameters` is allowed."
-                )
 
         # Regexp matching - Find key which matches current target_name in patterns provided
         r_key = get_pattern_key(lora_config.rank_pattern.keys(), current_key)
@@ -215,10 +204,11 @@ class LoraModel(BaseTuner):
             "qalora_group_size": lora_config.qalora_group_size,
             "ephemeral_gpu_offload": lora_config.runtime_config.ephemeral_gpu_offload,
             "lora_bias": lora_config.lora_bias,
+            "arrow_config": lora_config.arrow_config,
             "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
             "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
-            "parameter_name": parameter_name,
         }
+
         # for torchao merging, we need the get_apply_tensor_subclass from the quantization config
         try:
             kwargs["get_apply_tensor_subclass"] = operator.attrgetter(
@@ -236,9 +226,7 @@ class LoraModel(BaseTuner):
         # note: AdaLoraLayer is a subclass of LoraLayer, we need to exclude it
         from peft.tuners.adalora import AdaLoraLayer
 
-        # if the target is a ParamWrapper, we nest it to allow targeting multiple nn.Parameter on the same module
-        wrap_target_param = isinstance(target, ParamWrapper) and (adapter_name in target.lora_A)
-        if isinstance(target, LoraLayer) and not isinstance(target, AdaLoraLayer) and not wrap_target_param:
+        if isinstance(target, LoraLayer) and not isinstance(target, AdaLoraLayer):
             target.update_layer(
                 adapter_name,
                 r,
@@ -248,13 +236,9 @@ class LoraModel(BaseTuner):
                 use_rslora=lora_config.use_rslora,
                 use_dora=lora_config.use_dora,
                 lora_bias=lora_config.lora_bias,
+                arrow_config=lora_config.arrow_config,
             )
         else:
-            if isinstance(target, ParamWrapper) and (parameter_name == target.parameter_name):
-                raise ValueError(
-                    "Trying to target the same nn.Parameter twice, this should not happen. Please open an issue on the "
-                    "PEFT repo: https://github.com/huggingface/peft/issues"
-                )
             device_map = self.model.hf_device_map if hasattr(self.model, "hf_device_map") else None
             new_module = self._create_new_module(lora_config, adapter_name, target, device_map=device_map, **kwargs)
             if adapter_name not in self.active_adapters:
@@ -518,12 +502,11 @@ class LoraModel(BaseTuner):
     @staticmethod
     def _prepare_adapter_config(peft_config, model_config):
         if peft_config.target_modules is None:
-            if model_config["model_type"] in TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING:
-                peft_config.target_modules = set(
-                    TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING[model_config["model_type"]]
-                )
-            elif not peft_config.target_parameters:
-                raise ValueError("Please specify `target_modules` or `target_parameters`in `peft_config`")
+            if model_config["model_type"] not in TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING:
+                raise ValueError("Please specify `target_modules` in `peft_config`")
+            peft_config.target_modules = set(
+                TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING[model_config["model_type"]]
+            )
         return peft_config
 
     def _unload_and_optionally_merge(
@@ -567,12 +550,6 @@ class LoraModel(BaseTuner):
         for adapter in adapters:
             if adapter not in list(self.peft_config.keys()):
                 raise ValueError(f"Adapter {adapter} does not exist")
-
-        for adapter in adapters:
-            if self.peft_config[adapter].target_parameters:
-                raise ValueError(
-                    f"add_weighted_adapter does not support targeting nn.Parameter (problematic adapter '{adapter}')"
-                )
 
         # If more than one of the adapters targets the same module with modules_to_save, raise an error, as these
         # modules cannot be merged. First, find the ModulesToSaveWrapper instances in the model, then check if they

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1,0 +1,318 @@
+# Copyright 2025-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from transformers import AutoModelForCausalLM, AutoModelForImageClassification
+
+from peft import LoraConfig, get_peft_model
+from peft.tuners.lora import ArrowConfig, create_arrow_model
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def base_model():
+    """Tiny GPT-2 variant that ships with HF for unit tests."""
+    return AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+
+
+@pytest.fixture(scope="module")
+def workdir(tmp_path_factory):
+    """
+    Create a temp directory and chdir into it for the duration of the module. This lets us use *relative* adapter paths
+    like 'ts0' so split_repo_and_subfolder() recognises them as LOCAL repo-roots.
+    """
+    wd = tmp_path_factory.mktemp("arrow_workdir")
+    old_cwd = os.getcwd()
+    os.chdir(wd)
+    yield Path(wd)
+    os.chdir(old_cwd)
+    # (pytest will auto-delete wd)
+
+
+def _create_and_save_adapter(out_dir: Path, rank: int = 4):
+    """Helper: build a LoRA adapter around `model` and save into `out_dir`."""
+    # fan_in_fan_out is set to True because of GPT2 model that we use to avoid warning
+    cfg = LoraConfig(r=rank, target_modules=["c_attn"], fan_in_fan_out=True, init_lora_weights=False)
+    model = AutoModelForCausalLM.from_pretrained(  # FRESH each call
+        "hf-internal-testing/tiny-random-gpt2"
+    )
+    peft_model = get_peft_model(model, cfg)
+    peft_model.save_pretrained(out_dir)
+
+
+@pytest.fixture(scope="module")
+def ts_adapters(workdir: Path, base_model):
+    """
+    Build 3 task-specific adapters and return their absolute paths
+    """
+    abs_paths = []
+    for i in range(3):
+        sub = f"{workdir}/ts{i}"
+        _create_and_save_adapter(sub)
+        abs_paths.append(sub)
+    return abs_paths
+
+
+@pytest.fixture(scope="module")
+def gen_adapter(workdir: Path, base_model):
+    """Build 1 general-knowledge adapter and return its absolute path list."""
+    sub = f"{workdir}/gen0"
+    _create_and_save_adapter(sub)
+    return [sub]  # list because create_arrow_model expects list
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+class TestArrowRouting:
+    def test_arrow_differs_with_extra_expert(self, ts_adapters):
+        """
+        Arrow with 2 experts vs Arrow with 3 experts must produce different logits.
+        """
+        # Arrow over first 2 experts
+        cfg_small = ArrowConfig(top_k=2)
+        m_small = create_arrow_model(
+            base_model=AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2"),
+            task_specific_adapter_paths=ts_adapters[:2],
+            ts_repo_id="/".join(ts_adapters[0].split("/")[:2]),
+            arrow_config=cfg_small,
+        ).eval()
+
+        # Arrow over all 3 experts
+        cfg_big = ArrowConfig(top_k=2)
+        m_big = create_arrow_model(
+            base_model=AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2"),
+            task_specific_adapter_paths=ts_adapters,
+            ts_repo_id="/".join(ts_adapters[0].split("/")[:2]),
+            arrow_config=cfg_big,
+        ).eval()
+
+        x = torch.ones(1, 4, dtype=torch.long)
+        assert not torch.allclose(m_small(x).logits, m_big(x).logits)
+
+    def test_arrow_gks_with_load_adapter_later_with_forward(self, ts_adapters, gen_adapter):
+        """
+        Loading the last expert after creating the arrow model should produce the same result as loading all the
+        experts at once in create_arrow_model(), when forward path is called before adding the new adapter.
+        """
+        # Arrow over all three experts
+        cfg_big = ArrowConfig(top_k=2, use_gks=True)
+        m_big = create_arrow_model(
+            base_model=AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2"),
+            task_specific_adapter_paths=ts_adapters,
+            ts_repo_id="/".join(ts_adapters[0].split("/")[:2]),
+            general_adapter_paths=gen_adapter,
+            gen_repo_id="/".join(gen_adapter[0].split("/")[:2]),
+            arrow_config=cfg_big,
+        ).eval()
+
+        # Arrow over all 2 experts + loading the third expert later
+        cfg_small_later_big = ArrowConfig(top_k=2, use_gks=True)
+        m_small_later_big = create_arrow_model(
+            base_model=AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2"),
+            task_specific_adapter_paths=ts_adapters[:2],
+            ts_repo_id="/".join(ts_adapters[0].split("/")[:2]),
+            general_adapter_paths=gen_adapter,
+            gen_repo_id="/".join(gen_adapter[0].split("/")[:2]),
+            arrow_config=cfg_small_later_big,
+        )
+
+        # Ensuring that the prototypes and gks are done one time by running a forward path
+        x = torch.ones(1, 4, dtype=torch.long)
+        m_small_later_big(x)
+
+        # Now loading the third expert
+        parts = ts_adapters[-1].split("/")
+        repo_id = "/".join(parts[:2])
+        sub_folder = "/".join(parts[2:])
+        m_small_later_big.load_adapter(
+            model_id=repo_id,
+            adapter_name="new_added_ts_expert",
+            subfolder=sub_folder,
+        )
+        m_small_later_big.eval()
+
+        x = torch.ones(1, 4, dtype=torch.long)
+        assert torch.allclose(m_big(x).logits, m_small_later_big(x).logits)
+
+    def test_arrow_gks_with_load_adapter_later_without_forward(self, ts_adapters, gen_adapter):
+        """
+        Loading the last expert after creating the arrow model should produce the same result as loading all the
+        experts at once in create_arrow_model()
+        """
+        # Arrow over all three experts
+        cfg_big = ArrowConfig(top_k=2, use_gks=True)
+        m_big = create_arrow_model(
+            base_model=AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2"),
+            task_specific_adapter_paths=ts_adapters,
+            ts_repo_id="/".join(ts_adapters[0].split("/")[:2]),
+            general_adapter_paths=gen_adapter,
+            gen_repo_id="/".join(gen_adapter[0].split("/")[:2]),
+            arrow_config=cfg_big,
+        ).eval()
+
+        # Arrow over all 2 experts + loading the third expert later
+        cfg_small_later_big = ArrowConfig(top_k=2, use_gks=True)
+        m_small_later_big = create_arrow_model(
+            base_model=AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2"),
+            task_specific_adapter_paths=ts_adapters[:2],
+            ts_repo_id="/".join(ts_adapters[0].split("/")[:2]),
+            general_adapter_paths=gen_adapter,
+            gen_repo_id="/".join(gen_adapter[0].split("/")[:2]),
+            arrow_config=cfg_small_later_big,
+        )
+
+        # Now loading the third expert
+        parts = ts_adapters[-1].split("/")
+        repo_id = "/".join(parts[:2])
+        sub_folder = "/".join(parts[2:])
+        m_small_later_big.load_adapter(
+            model_id=repo_id,
+            adapter_name="new_added_ts_expert",
+            subfolder=sub_folder,
+        )
+        m_small_later_big.eval()
+
+        x = torch.ones(1, 4, dtype=torch.long)
+        assert torch.allclose(m_big(x).logits, m_small_later_big(x).logits)
+
+    def test_genknowsub_changes_output(self, ts_adapters, gen_adapter):
+        """
+        Arrow+GenKnowSub vs plain Arrow must change logits.
+        """
+        # Plain Arrow
+        cfg_plain = ArrowConfig(top_k=2)
+        m_plain = create_arrow_model(
+            base_model=AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2"),
+            task_specific_adapter_paths=ts_adapters,
+            ts_repo_id="/".join(ts_adapters[0].split("/")[:2]),
+            arrow_config=cfg_plain,
+        ).eval()
+
+        # Arrow + GenKnowSub
+        cfg_gks = ArrowConfig(top_k=2, use_gks=True)
+        m_gks = create_arrow_model(
+            base_model=AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2"),
+            task_specific_adapter_paths=ts_adapters,
+            ts_repo_id="/".join(ts_adapters[0].split("/")[:2]),
+            general_adapter_paths=gen_adapter,
+            gen_repo_id="/".join(gen_adapter[0].split("/")[:2]),
+            arrow_config=cfg_gks,
+        ).eval()
+
+        x = torch.ones(1, 4, dtype=torch.long)
+        assert not torch.allclose(m_plain(x).logits, m_gks(x).logits)
+
+    def test_merging_adapters_raise_typeerror_in_arrow(self, ts_adapters):
+        """
+        Merging/unmerging is not allowed while an ArrowLinearLayer is loaded on the model and active.
+        """
+        # Arrow over first 2 experts
+        cfg_small = ArrowConfig(top_k=2)
+        m_small = create_arrow_model(
+            base_model=AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2"),
+            task_specific_adapter_paths=ts_adapters[:2],
+            ts_repo_id="/".join(ts_adapters[0].split("/")[:2]),
+            arrow_config=cfg_small,
+        ).eval()
+
+        with pytest.raises(RuntimeError, match=r"Cannot merge an active Arrow router adapter"):
+            m_small.merge_and_unload()
+
+    def test_conv2d_targets_raise_typeerror_in_arrow(self, workdir):
+        """
+        Adapters applied to Conv2d must be rejected by create_arrow_model() which enforces Linear/Linear4bit-only
+        targets.
+        """
+
+        model_id = "hf-internal-testing/tiny-random-ResNetForImageClassification"
+
+        # Find a Conv2d module name in the ResNet test model
+        probe = AutoModelForImageClassification.from_pretrained(model_id)
+        conv_names = [n.split(".")[-1] for n, m in probe.named_modules() if isinstance(m, torch.nn.Conv2d)]
+        assert len(conv_names) > 0, "No Conv2d modules found in the ResNet test model."
+        target_name = conv_names[0]
+
+        # Build a LoRA adapter targeting a Conv2d
+        cfg = LoraConfig(r=4, target_modules=[target_name], init_lora_weights=False)
+        base = AutoModelForImageClassification.from_pretrained(model_id)
+        peft_model = get_peft_model(base, cfg)
+
+        conv_dir = workdir / "cv0"
+        peft_model.save_pretrained(conv_dir)
+
+        # Expect create_arrow_model to raise TypeError
+        with pytest.raises(TypeError, match=r"LoRA adapters must only target Linear"):
+            _ = create_arrow_model(
+                base_model=AutoModelForImageClassification.from_pretrained(model_id),
+                task_specific_adapter_paths=[str(conv_dir)],
+                ts_repo_id=str(workdir),
+                arrow_config=ArrowConfig(top_k=1),
+            )
+
+    def test_arrow_forward_float16_no_autocast_with_merging(self, ts_adapters):
+        """
+        Run Arrow in float16 with autocast disabled; forward should work, while merge/unmerge operations must raise for
+        Arrow models.
+        """
+        import platform
+
+        try:
+            _ = torch.zeros(1, dtype=torch.float16)
+        except Exception:
+            pytest.skip(reason="Test requires float16 support")
+
+        if platform.system() == "Darwin":
+            pytest.skip(reason="MacOS does not support multiple ops in float16")
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model_id = "hf-internal-testing/tiny-random-gpt2"
+
+        # Create base in fp16 (no manual assignment to .dtype)
+        base = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16).to(device)
+
+        cfg = ArrowConfig(top_k=2)
+        ts_repo_id = "/".join(ts_adapters[0].split("/")[:2])
+
+        # Build Arrow model and disable adapter dtype autocast
+        model = create_arrow_model(
+            base_model=base,
+            task_specific_adapter_paths=ts_adapters,
+            ts_repo_id=ts_repo_id,
+            arrow_config=cfg,
+            autocast_adapter_dtype=False,
+            torch_dtype=torch.float16,
+        ).eval()
+
+        X = {
+            "input_ids": torch.ones(1, 4, dtype=torch.long, device=device),
+            "attention_mask": torch.ones(1, 4, dtype=torch.long, device=device),
+        }
+
+        # Forward should work in fp16
+        _ = model(**X)
+
+        # Merge must fail on Arrow models
+        with pytest.raises(RuntimeError, match=r"Cannot merge an active Arrow router adapter"):
+            model.merge_adapter(safe_merge=False)
+
+        with pytest.raises(RuntimeError, match=r"Cannot merge an active Arrow router adapter"):
+            _ = model.merge_and_unload()


### PR DESCRIPTION
Hi there! 👋

This PR adds support for **Arrow**, a modular routing mechanism for LoRA experts introduced [here](https://arxiv.org/abs/2405.11157), as well as our refinement method **GenKnowSub**, proposed in our ACL 2025 Main Conference [paper](https://arxiv.org/abs/2505.10939). GenKnowSub enhances Arrow by subtracting a general-domain LoRA from task-specific ones prior to routing, leading to improved generalisation and modularity.

The integration is implemented through a new ArrowLoraLinearLayer, registered as a LoraVariant (similar to DoRA).

### 🔧 Code Changes

Modified files under peft/tuners/lora/:

- config.py, layer.py, model.py, variants.py
- bnb.py (adds support for Arrow with bitsandbytes quantisation)

Added a new file:

- arrow.py – contains the core logic for Arrow and GenKnowSub

### ✅ Testing & Quality
Confirmed that tests/test_lora_variants.py passes.

All formatting and style checks pass (make quality successful).

### 📚 Optional Follow-up
I’ve also developed a separate GitHub repository demonstrating how to use Arrow and GenKnowSub on benchmark datasets (e.g., BoolQ, PIQA, ARC-Challenge). I’d be happy to contribute this as an example under peft/examples/ if it’s of interest.

Thank you in advance for reviewing this PR!