### PR TITLE
FIX: Error in workflow file to deploy method comparison app

### DIFF
--- a/.github/workflows/deploy_method_comparison_app.yml
+++ b/.github/workflows/deploy_method_comparison_app.yml
@@ -7,8 +7,7 @@ on:
       - "method_comparison/**"
   workflow_dispatch:
 
-permissions:
-  contents: {}
+permissions: {}
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixing the [error](https://github.com/huggingface/peft/actions/runs/16262915745):

```
permissions:
  contents: {}
 Check failure on line 11 in .github/workflows/deploy_method_comparison_app.yml

GitHub Actions
/ Deploy "method_comparison" Gradio to Spaces
Invalid workflow file

The workflow is not valid.
.github/workflows/deploy_method_comparison_app.yml (Line: 11, Col: 13): A mapping was not expected
```