### PR TITLE
FIX: Prompt learning methods modules_to_save issue

### DIFF
--- a/src/peft/config.py
+++ b/src/peft/config.py
@@ -335,6 +335,15 @@ class PromptLearningConfig(PeftConfig):
     )
     num_attention_heads: Optional[int] = field(default=None, metadata={"help": "Number of attention heads"})
     num_layers: Optional[int] = field(default=None, metadata={"help": "Number of transformer layers"})
+    modules_to_save: Optional[list[str]] = field(
+        default=None,
+        metadata={
+            "help": "List of extra modules to be set as trainable and saved in the final checkpoint. "
+            "For example, in Sequence Classification or Token Classification tasks, "
+            "the final layer `classifier/score` are randomly initialized and as such need to be trainable and saved. "
+            "The module(s) will be fully fine-tuned."
+        },
+    )
 
     @property
     def is_prompt_learning(self) -> bool:

--- a/tests/test_seq_classifier.py
+++ b/tests/test_seq_classifier.py
@@ -31,9 +31,11 @@ from peft import (
     PromptTuningInit,
     VBLoRAConfig,
     VeraConfig,
+    get_peft_model,
 )
+from peft.utils.other import ModulesToSaveWrapper
 
-from .testing_common import PeftCommonTester
+from .testing_common import PeftCommonTester, hub_online_once
 
 
 PEFT_SEQ_CLS_MODELS_TO_TEST = [
@@ -246,3 +248,21 @@ class TestSequenceClassificationModels(PeftCommonTester):
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_from_pretrained_config_construction(self, model_id, config_cls, config_kwargs):
         self._test_from_pretrained_config_construction(model_id, config_cls, config_kwargs.copy())
+
+    @pytest.mark.parametrize("model_id", PEFT_SEQ_CLS_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_modules_to_save_correctly_set(self, model_id, config_cls, config_kwargs):
+        # tests for a regression, introduced via #2220, where modules_to_save was not applied to prompt learning methods
+        with hub_online_once(model_id):
+            model = self.transformers_class.from_pretrained(model_id)
+            config = config_cls(
+                base_model_name_or_path=model_id,
+                **config_kwargs,
+            )
+            model = get_peft_model(model, config)
+            base_model = model.get_base_model()
+            # classifier layer is called either "classifier" or "score"
+            classifier = getattr(base_model, "classifier", getattr(base_model, "score", None))
+            if classifier is None:
+                raise ValueError(f"Could not determine classifier layer name for {model_id}, please fix the test")
+            assert isinstance(classifier, ModulesToSaveWrapper)


### PR DESCRIPTION
This PR relates to #2642 but is probably not the cause of the reported issue there.

When using prompt learning methods, `modules_to_save` is not correctly set automatically. This is really bad when using, for instance, sequence classification tasks, which require the classifier layer to be added to `modules_to_save`.

The issue was introduced in #2220 where it is wrongly assumed that the PEFT config always has a `modules_to_save` attribute, which is not true for prompt learning. In #2481, this was partly fixed by using `getattr` to avoid an error. However, this did not resolve the fundamental issue that for prompt learning, there is no such attribute, resulting in `module_to_save` not being applied.

This PR proposes to fix this by adding `modules_to_save` to the prompt learning configs.