### PR TITLE
Fix not detecting regex-targeted embedding layer

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -38,7 +38,7 @@ from peft.utils.constants import (
     SEQ_CLS_HEAD_NAMES,
 )
 from peft.utils.integrations import init_empty_weights
-from peft.utils.other import AuxiliaryTrainingWrapper, set_additional_trainable_modules
+from peft.utils.other import AuxiliaryTrainingWrapper, match_target_against_key, set_additional_trainable_modules
 from peft.utils.peft_types import PeftType, TaskType
 
 from ..config import PeftConfig
@@ -1050,7 +1050,7 @@ def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
             return _ExcludedModule()
 
     if isinstance(config.target_modules, str):
-        target_module_found = re.fullmatch(config.target_modules, key)
+        target_module_found = match_target_against_key(config.target_modules, key)
     elif key in config.target_modules:
         # this module is specified directly in target_modules
         target_module_found = True

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1229,6 +1229,14 @@ def check_file_exists_on_hf_hub(repo_id: str, filename: str, **kwargs) -> Option
     return exists
 
 
+def match_target_against_key(target_pattern: str, key: str):
+    """Backing function for `target_modules` config parameter.
+
+    Having this as its own function ensures that target key matching can be implemented in the same way everywhere.
+    """
+    return re.fullmatch(target_pattern, key)
+
+
 def get_pattern_key(pattern_keys: Sequence[str], key_to_match: str) -> str:
     """Match a substring of key_to_match in pattern keys"""
     for key in pattern_keys:

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -14,12 +14,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
-
+import pytest
 import torch
+from transformers import AutoModelForCausalLM
 
-from peft import LoraConfig, get_peft_model_state_dict, inject_adapter_in_model
+from peft import LoraConfig, get_peft_model, get_peft_model_state_dict, inject_adapter_in_model
 from peft.utils import ModulesToSaveWrapper
+
+from .testing_common import hub_online_once
 
 
 class DummyModel(torch.nn.Module):
@@ -37,61 +39,126 @@ class DummyModel(torch.nn.Module):
         return x
 
 
-class TestPeft(unittest.TestCase):
-    def setUp(self):
-        self.model = DummyModel()
+@pytest.fixture
+def dummy_peft_model():
+    """
+    Creates a DummyModel and injects a LoRA adapter into it. This fixture is used by tests that need a pre-configured
+    PEFT model.
+    """
+    model = DummyModel()
+    lora_config = LoraConfig(
+        lora_alpha=16,
+        lora_dropout=0.1,
+        r=64,
+        bias="none",
+        target_modules=["linear"],
+    )
+    return inject_adapter_in_model(lora_config, model)
 
-        lora_config = LoraConfig(
-            lora_alpha=16,
-            lora_dropout=0.1,
-            r=64,
-            bias="none",
-            target_modules=["linear"],
-        )
 
-        self.model = inject_adapter_in_model(lora_config, self.model)
+def test_inject_adapter_in_model(dummy_peft_model):
+    dummy_inputs = torch.LongTensor([[0, 1, 2, 3, 4, 5, 6, 7]])
+    _ = dummy_peft_model(dummy_inputs)
 
-    def test_inject_adapter_in_model(self):
-        dummy_inputs = torch.LongTensor([[0, 1, 2, 3, 4, 5, 6, 7]])
-        _ = self.model(dummy_inputs)
+    for name, module in dummy_peft_model.named_modules():
+        if name == "linear":
+            assert hasattr(module, "lora_A")
+            assert hasattr(module, "lora_B")
 
-        for name, module in self.model.named_modules():
-            if name == "linear":
-                assert hasattr(module, "lora_A")
-                assert hasattr(module, "lora_B")
 
-    def test_get_peft_model_state_dict(self):
-        peft_state_dict = get_peft_model_state_dict(self.model)
+def test_modules_to_save():
+    model = DummyModel()
 
+    lora_config = LoraConfig(
+        lora_alpha=16,
+        lora_dropout=0.1,
+        r=64,
+        bias="none",
+        target_modules=["linear"],
+        modules_to_save=["embedding", "linear2"],
+    )
+
+    model = inject_adapter_in_model(lora_config, model)
+
+    # Check for LoRA injection and module wrapping
+    for name, module in model.named_modules():
+        if name == "linear":
+            assert hasattr(module, "lora_A")
+            assert hasattr(module, "lora_B")
+        elif name in ["embedding", "linear2"]:
+            assert isinstance(module, ModulesToSaveWrapper)
+
+    # Check that the state dict includes the saved modules
+    state_dict = get_peft_model_state_dict(model)
+    assert "embedding.weight" in state_dict
+    assert "linear2.weight" in state_dict
+    assert "linear2.bias" in state_dict
+
+    # Check that original attributes are still accessible
+    assert hasattr(model.embedding, "weight")
+    assert hasattr(model.linear2, "weight")
+    assert hasattr(model.linear2, "bias")
+
+
+class TestGetStateDict:
+    def test_get_peft_model_state_dict(dummy_peft_model):
+        peft_state_dict = get_peft_model_state_dict(dummy_peft_model)
+
+        # Ensure all keys in the state dict are for LoRA parameters
         for key in peft_state_dict.keys():
             assert "lora" in key
 
-    def test_modules_to_save(self):
-        self.model = DummyModel()
+    # Testing save_embedding_layer="auto" needs to check the following logic:
+    #
+    # - when vocab size was NOT changed, embeddings should be saved only when targeted
+    # however
+    # - when vocab size was changed, embeddings should be saved automatically
+    # but not when
+    # - using PeftType.TRAINABLE_TOKENS
+    # - LoRA using trainable_token_indices (because trainable tokens's benefit is that we only store the diff)
+    @pytest.mark.parametrize(
+        "peft_config, embedding_changed, expect_embedding",
+        [
+            # embeddings are not changed, no auto-saving
+            (LoraConfig(target_modules="all-linear"), False, False),
+            (LoraConfig(target_modules=["q_proj", "embed_tokens"]), False, True),
+            (LoraConfig(target_modules=r".*\.embed_tokens"), False, True),
+            # embeddings are changed, auto-saving since we cannot know if the embedding modification
+            # was done using model.resize_token_embeddings or some other way and the adapter depends on it
+            (LoraConfig(target_modules="all-linear"), True, True),
+            (LoraConfig(target_modules=["q_proj", "embed_tokens"]), True, True),
+            (LoraConfig(target_modules=r".*\.embed_tokens"), True, True),
+            # embeddings are changed, trainable tokens is used -> no auto-saving since we expect trainable tokens
+            # to cover the diff.
+            (LoraConfig(target_modules="all-linear", trainable_token_indices=[1, 2, 3]), True, False),
+            (LoraConfig(target_modules="all-linear", trainable_token_indices=[1, 2, 3]), False, False),
+        ],
+    )
+    def test_save_embeddings_auto(self, peft_config, embedding_changed, expect_embedding):
+        model_id = "trl-internal-testing/tiny-random-LlamaForCausalLM"
+        with hub_online_once(model_id):
+            base_model = AutoModelForCausalLM.from_pretrained(model_id)
 
-        lora_config = LoraConfig(
-            lora_alpha=16,
-            lora_dropout=0.1,
-            r=64,
-            bias="none",
-            target_modules=["linear"],
-            modules_to_save=["embedding", "linear2"],
+            if embedding_changed:
+                # Make sure to modify the embeddings so that auto saving is activated. We need to do that beforehand
+                # since resizing a targeted layer doesn't work
+                base_model.resize_token_embeddings(base_model.config.vocab_size + 2)
+
+            peft_model = get_peft_model(base_model, peft_config)
+
+        # important not to cache this call with `hub_online_once` as it attempts to fetch a config in some cases and the
+        # caching is not aware of when that is, it will just cache once the call is completed.
+        state_dict = get_peft_model_state_dict(peft_model, save_embedding_layers="auto")
+
+        contains_embedding = (
+            # not adapted, only resized -> 'normal' module path
+            "base_model.model.model.embed_tokens.weight" in state_dict
+            or
+            # adapted (and possibly resized) -> base layer module path
+            "base_model.model.model.embed_tokens.base_layer.weight" in state_dict
         )
 
-        self.model = inject_adapter_in_model(lora_config, self.model)
-
-        for name, module in self.model.named_modules():
-            if name == "linear":
-                assert hasattr(module, "lora_A")
-                assert hasattr(module, "lora_B")
-            elif name in ["embedding", "linear2"]:
-                assert isinstance(module, ModulesToSaveWrapper)
-
-        state_dict = get_peft_model_state_dict(self.model)
-
-        assert "embedding.weight" in state_dict.keys()
-
-        assert hasattr(self.model.embedding, "weight")
-
-        assert hasattr(self.model.linear2, "weight")
-        assert hasattr(self.model.linear2, "bias")
+        if expect_embedding:
+            assert contains_embedding
+        else:
+            assert not contains_embedding


### PR DESCRIPTION
This issue was found in PR #2638 and is defined thusly:

> When calling `get_peft_model_state_dict(..., save_embedding_layers="auto")` we check if the
> embedding layer is targetted to determine if the embedding layers need saving. This is not
> done when `PeftConfig.target_modules` is a regex-string, potentially missing to save embeddings.

This is fixed by adding a check similar to the existing query of whether `EMBEDDING_LAYER_NAMES` is a subset of the defined target modules, only that the regex matching from `BaseTuner.inject_adapter` is used. To avoid code duplication, the matching was moved to its own utility function `match_target_against_key`.

The main complication was to define the test-cases as it was non-trivial to find what the meaning of `save_embedding_layers="auto"` entails. I've assembled a list of cases that I think are correct in the corresponding unit test.