### PR TITLE
[WIP] ENH Cache DoRA weight norm for inference

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -103,7 +103,7 @@ class LoraLayer(BaseTunerLayer):
         self.use_dora: dict[str, bool] = {}  # not actively used anymore after #2443, keep it for BC
         self.lora_bias: dict[str, bool] = {}
         self.lora_magnitude_vector = torch.nn.ModuleDict()  # for DoRA
-        self._caches: dict[str, Any] = {}
+        self._caches: dict[str, Any] = {}  # small ad hoc cache; values are not part of the state_dict
         self.ephemeral_gpu_offload: bool = ephemeral_gpu_offload
         # flag to enable/disable casting of input to weight dtype during forward call
         self.cast_input_dtype_enabled: bool = True
@@ -471,9 +471,11 @@ class LoraLayer(BaseTunerLayer):
         self.lora_B[adapter_name].weight = nn.Parameter(lora_B.contiguous().to(dtype))
 
     def _cache_store(self, key: str, value: Any) -> None:
+        # cache intermediate values, e.g. weight norm of DoRA
         self._caches[key] = value
 
     def _cache_pop(self, key: str) -> Any:
+        # retrieve and remove from ad hoc cache
         value = self._caches.pop(key)
         return value
 


### PR DESCRIPTION
Resolves #2651

This is an experimental branch that caches the weight norm from DoRA for faster inference. Since, during inference, the weights don't change, there is no need to recalculate the weight norm of a DoRA module each time.

During training, recalculation is needed, thus there is no caching when the module has `training=True`.

The cache does not prevent each and every possible duplicate calculation. For instance, the weight norm is calculated during module initialization and then again during the first forward pass when performing inference. Only starting from the second forward pass on will the weight norms be cached.

The reason why this is just a draft PR is that before finishing it, I want to ensure that the addition of cache is worth it. Caches can often be a tricky business and lead to subtle bugs. Just as an example here, we detect if users put the model into training mode when calling `model.train()` and clear the cache. However, we would not detect it if the user directly sets `module.training=True`.

Some preliminary testing with a small model, meta-llama/Llama-3.2-1B, and some dummy data didn't show huge improvements, with an average of 10 runs showing:

- with caching: 1.3555 sec
- w/o caching: 1.4071 sec

Thus, before continuing, I'd like to see some more real world measurements. If the change is considered to be worth it, tests should be added to the PR before it's ready.