### PR TITLE
FIX Prefix tuning after transformers PR 38635

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -776,9 +776,12 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 # Dont' apply this to encoder-decoder models and not to models requiring special processing.
                 # local import in case users use a very old transformers version
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
-            elif peft_config.num_transformer_submodules == 2 and self.base_model._supports_cache_class:
+            elif (peft_config.num_transformer_submodules == 2) and getattr(
+                self.base_model, "_supports_cache_class", True
+            ):
                 # Dont' apply this to encoder-decoder models that don't support new Cachc format yet
                 # If we don't apply this, prefix-tuning fails to update cross-attn cache
+                # TODO: remove check for _supports_cache_class once transformers 4.53 is no longer supported
                 past_key_values = EncoderDecoderCache.from_legacy_cache(past_key_values)
                 past_key_values.cross_attention_cache = DynamicCache()
                 past_key_values.is_updated = {

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import packaging.version
 import torch
+import transformers
 from transformers import BloomPreTrainedModel
 
 
@@ -41,9 +43,14 @@ def starcoder_model_postprocess_past_key_value(past_key_values):
     return tuple(result)
 
 
-TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING = {
-    "gpt_bigcode": starcoder_model_postprocess_past_key_value,
-}
+# TODO: remove this once transformers 4.53 is no longer supported
+TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING = {}
+transformers_le_4_53 = packaging.version.parse(transformers.__version__) < packaging.version.parse("4.54.0.dev0")
+if transformers_le_4_53:
+    TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING["gpt_bigcode"] = (
+        starcoder_model_postprocess_past_key_value,
+    )
+
 
 if hasattr(BloomPreTrainedModel, "_convert_to_standard_cache"):
     # special handling for bloom architecture was fixed in:

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -48,7 +48,7 @@ TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING = {}
 transformers_le_4_53 = packaging.version.parse(transformers.__version__) < packaging.version.parse("4.54.0.dev0")
 if transformers_le_4_53:
     TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING["gpt_bigcode"] = (
-        starcoder_model_postprocess_past_key_value,
+        starcoder_model_postprocess_past_key_value
     )
 
 


### PR DESCRIPTION
Due to https://github.com/huggingface/transformers/pull/38635, [several tests involving prefix tuning broke](https://github.com/huggingface/peft/actions/runs/16417140904/job/46385751329).

This PR fixes this by resolving two issues:

1. The `_supports_cache_class` attribute was removed, we can now assume that it is True if the attribute does not exist.

2. We had special handling of `past_key_values` for `GPTBigCodeForCausalLM` which is no longer required (nor valid) after that PR, so it is removed depending on the transformers version.