### PR TITLE
ENH: Targeting multiple parameters on the same module

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -53,7 +53,7 @@ from .eetq import dispatch_eetq
 from .gptq import dispatch_gptq
 from .hqq import dispatch_hqq
 from .inc import dispatch_inc
-from .layer import Conv2d, LoraLayer, dispatch_default
+from .layer import Conv2d, LoraLayer, ParamWrapper, dispatch_default
 from .torchao import dispatch_torchao
 from .tp_layer import dispatch_megatron
 
@@ -227,7 +227,9 @@ class LoraModel(BaseTuner):
         # note: AdaLoraLayer is a subclass of LoraLayer, we need to exclude it
         from peft.tuners.adalora import AdaLoraLayer
 
-        if isinstance(target, LoraLayer) and not isinstance(target, AdaLoraLayer):
+        # if the target is a ParamWrapper, we nest it to allow targeting multiple nn.Parameter on the same module
+        wrap_target_param = isinstance(target, ParamWrapper) and (adapter_name in target.lora_A)
+        if isinstance(target, LoraLayer) and not isinstance(target, AdaLoraLayer) and not wrap_target_param:
             target.update_layer(
                 adapter_name,
                 r,
@@ -239,6 +241,11 @@ class LoraModel(BaseTuner):
                 lora_bias=lora_config.lora_bias,
             )
         else:
+            if isinstance(target, ParamWrapper) and (parameter_name == target.parameter_name):
+                raise ValueError(
+                    "Trying to target the same nn.Parameter twice, this should not happen. Please open an issue on the "
+                    "PEFT repo: https://github.com/huggingface/peft/issues"
+                )
             device_map = self.model.hf_device_map if hasattr(self.model, "hf_device_map") else None
             new_module = self._create_new_module(lora_config, adapter_name, target, device_map=device_map, **kwargs)
             if adapter_name not in self.active_adapters:

--- a/tests/test_target_parameters.py
+++ b/tests/test_target_parameters.py
@@ -354,11 +354,11 @@ class TestTargetParameter:
 
             def mock_forward(self, W):
                 weights.append(W)
-                with torch.nn.utils.parametrize.cached():
-                    return W + self.delta_weight
+                return orig_forward(self, W)
 
             from peft.tuners.lora.layer import _LoraParameterProxy
 
+            orig_forward = _LoraParameterProxy.forward
             monkeypatch.setattr(_LoraParameterProxy, "forward", mock_forward)
 
             num_steps = 3

--- a/tests/test_target_parameters.py
+++ b/tests/test_target_parameters.py
@@ -59,6 +59,22 @@ ALL_CONFIGS = [
             ],
         },
     ),
+    # target down_proj and gate_up_proj on the same module
+    (
+        LoraConfig,
+        {
+            "task_type": "CAUSAL_LM",
+            "r": 8,
+            "lora_alpha": 32,
+            "target_modules": None,
+            "lora_dropout": 0.0,
+            "bias": "none",
+            "target_parameters": [
+                "feed_forward.experts.down_proj",
+                "feed_forward.experts.gate_up_proj",
+            ],
+        },
+    ),
     # target q_proj, v_proj as modules, and down_proj as parameter
     (
         LoraConfig,
@@ -314,38 +330,75 @@ class TestTargetParameter:
             # LoRA outputs should be the same
             assert torch.allclose(out_lora_0, out_lora_1, atol=atol, rtol=rtol)
 
-    def test_target_multiple_parameters_on_same_module(self):
-        # for now, it is not supported to target multiple parameters from the same module with the same adapter,
-        # however, it is possible to target multiple parameters from same module with different adapters
+    def test_target_multiple_parameters_on_same_module(self, monkeypatch):
+        # test that if we target multiple nn.Parameters on the same module, all of them are being used during the
+        # forward pass
         torch.manual_seed(0)
-        model_id = "hf-internal-testing/tiny-random-LlamaForCausalLM"
+        model_id = "trl-internal-testing/tiny-Llama4ForCausalLM"
         with hub_online_once(model_id):
-            model = AutoModelForCausalLM.from_pretrained(model_id)
             x = torch.arange(10).view(2, 5)
-            with torch.inference_mode():
-                out_base = model(x, output_hidden_states=True).hidden_states[-1]
+            model = MyAutoModelForCausalLM.from_pretrained(model_id)
+            shape_gate_up_proj = model.model.layers[0].feed_forward.experts.gate_up_proj.shape
+            shape_down_proj = model.model.layers[0].feed_forward.experts.down_proj.shape
+            num_layers = len(model.model.layers)
 
-            # targeting gate_up_proj
-            config0 = LoraConfig(target_parameters=["feed_forward.experts.gate_up_proj"], init_lora_weights=False)
-            model = get_peft_model(model, config0)
-            with torch.inference_mode():
-                out_lora_0 = model(x, output_hidden_states=True).hidden_states[-1]
-            atol, rtol = 1e-6, 1e-6
-            assert not torch.allclose(out_base, out_lora_0, atol=atol, rtol=rtol)
+            target_parameters = ["feed_forward.experts.gate_up_proj", "feed_forward.experts.down_proj"]
+            num_params = len(target_parameters)
+            config = LoraConfig(target_parameters=target_parameters, init_lora_weights=False)
+            model = get_peft_model(model, config)
 
-            # targeting down_proj
-            config1 = LoraConfig(target_parameters=["feed_forward.experts.down_proj"], init_lora_weights=False)
-            model.add_adapter("other", config1)
-            model.set_adapter("other")
-            with torch.inference_mode():
-                out_lora_1 = model(x, output_hidden_states=True).hidden_states[-1]
-            assert not torch.allclose(out_base, out_lora_1, atol=atol, rtol=rtol)
-            assert not torch.allclose(out_lora_0, out_lora_1, atol=atol, rtol=rtol)
+            # CHECK FORWARD CALLS
 
-            # targeting both gate_up_proj and down_proj
-            model.base_model.set_adapter(["default", "other"])
+            # log the weights seen during the forward call
+            weights = []
+
+            def mock_forward(self, W):
+                weights.append(W)
+                with torch.nn.utils.parametrize.cached():
+                    return W + self.delta_weight
+
+            from peft.tuners.lora.layer import _LoraParameterProxy
+
+            monkeypatch.setattr(_LoraParameterProxy, "forward", mock_forward)
+
+            num_steps = 3
             with torch.inference_mode():
-                out_lora_01 = model(x, output_hidden_states=True).hidden_states[-1]
-            assert not torch.allclose(out_base, out_lora_01, atol=atol, rtol=rtol)
-            assert not torch.allclose(out_lora_0, out_lora_01, atol=atol, rtol=rtol)
-            assert not torch.allclose(out_lora_1, out_lora_01, atol=atol, rtol=rtol)
+                for _ in range(num_steps):
+                    out_base = model(x, output_hidden_states=True).hidden_states[-1]
+
+            actual_call_count = len(weights)
+            # Note: We call forward twice per step, once to create the parametrization and once for the actual forward
+            # step. This may be a bit wasteful but it's not clear how to prevent this and overall is probably negligible
+            num_forward_per_step = 2
+            expected_call_count = num_steps * num_layers * num_params * num_forward_per_step
+            assert actual_call_count == expected_call_count
+
+            actual_shapes = {W.shape for W in weights}
+            expected_shapes = {shape_gate_up_proj, shape_down_proj}
+            assert actual_shapes == expected_shapes
+
+            # CHECK WEIGHT UPDATES
+
+            lora_weights_before = {
+                k: v.clone() for k, v in model.named_parameters() if "lora_A.default" in k or "lora_B.default" in k
+            }
+            print(lora_weights_before)
+            # sanity check:
+            assert len(lora_weights_before) == 2 * num_layers * num_params
+            # train
+            optim = torch.optim.SGD(model.parameters(), lr=0.01)
+            for _ in range(10):
+                optim.zero_grad()
+                out = model(x)
+                loss = out.logits.sum()
+                loss.backward()
+                optim.step()
+
+            print(lora_weights_before)
+            lora_weights_after = {
+                k: v for k, v in model.named_parameters() if "lora_A.default" in k or "lora_B.default" in k
+            }
+            assert lora_weights_before.keys() == lora_weights_after.keys()
+            atol, rtol = 0.1, 0.1
+            for key in lora_weights_before.keys():
+                assert not torch.allclose(lora_weights_before[key], lora_weights_after[key], atol=atol, rtol=rtol)


### PR DESCRIPTION
When the `target_parameters` feature for LoRA was introduced in #2638, there was one gap, namely the possibility to target multiple `nn.Parameter`s on the same module (there was only a workaround involving multiple adapters, but that is not user friendly). With this PR, it is now possible to achieve this.

The mechanism to enable this is a bit crude, namely allowing to nest multiple `ParamWrapper`s. This should generally be fine as long as there are only a couple of `nn.Parameter`s being targeted on the same module. When there are dozens or hundreds, this approach could load to slow downs or other issues.

A side effect of this implementation is that the `ParamWrapper`, when it removes the parametrization, now only removes its own parametrization. When using `nn.utils.parametrize.remove_parametrization`, it removes all parametrizations, which is bad when we have nested parametrizations.

## Alternative approaches

Some alternative approaches were discussed internally but the chosen one was considered most practical.

1. Allow to have more than one adapted parameter per LoRA layer. This would require to have nested dicts for the LoRA parameters, something like `self.lora_A[adapter_name][parameter_name]`. We don't have this anywhere so far and it would probably break implicit assumptions about PEFT layers in many places (like, parsing of `state_dict` keys), requiring many adjustments.
2. Have an auxiliary module that contains the individual LoRA layers that target the individual parameters. This could be the cleanest solution and would probably be more efficient if there are a huge number of targeted parameters per module. However, this also brings extra complexity, as it requires implementing the logic of how to route the information to the right parameter, and it may be a solution to a problem that is irrelevant in practice (large number of targets per module).