### PR TITLE
FIX: Small fixes to target_parameters

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -1767,10 +1767,9 @@ class _LoraParameterProxy(nn.Module):
     Intended to be used in conjunction with `nn.utils.parametrize`, see `ParamWrapper`.
     """
 
-    def __init__(self, delta_weight, num_experts):
+    def __init__(self, delta_weight):
         super().__init__()
         self.delta_weight = delta_weight
-        self.num_experts = num_experts
 
     def forward(self, W):
         with nn.utils.parametrize.cached():
@@ -1998,7 +1997,7 @@ class ParamWrapper(nn.Module, LoraLayer):
         base_layer = self.get_base_layer()
         requires_grad_before = self.get_param().requires_grad
         nn.utils.parametrize.register_parametrization(
-            base_layer, self.parameter_name, _LoraParameterProxy(delta_weight, num_experts=self.num_experts)
+            base_layer, self.parameter_name, _LoraParameterProxy(delta_weight)
         )
         # set requires_grad, as it defaults to False
         base_layer.parametrizations[self.parameter_name].original.requires_grad_(requires_grad_before)

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -656,7 +656,9 @@ class BaseTuner(nn.Module, ABC):
                     if isinstance(target, BaseTunerLayer) and target.__class__.__name__ != "ParamWrapper":
                         raise ValueError(
                             f"Trying to wrap an `nn.Parameter` of layer '{target_name}' of type "
-                            f"{type(target).__name__}, which is not a valid target."
+                            f"{type(target).__name__}, which is not a valid target. Make sure that this layer is not "
+                            "also targeted with `target_modules`. For some models, PEFT will do this automatically, "
+                            "try setting `target_modules=[]` to prevent it."
                         )
 
                     self._check_target_module_compatiblity(peft_config, model, target_name)


### PR DESCRIPTION
1. Better error message when same layer targeted twice
2. Remove unused attribute `num_experts` from `_LoraParameterProxy`

No functional changes.