### PR TITLE
fix bug for feature_extraction example

### DIFF
--- a/examples/feature_extraction/peft_lora_embedding_semantic_search.py
+++ b/examples/feature_extraction/peft_lora_embedding_semantic_search.py
@@ -416,8 +416,7 @@ def main():
 
     for epoch in range(starting_epoch, args.num_train_epochs):
         model.train()
-        if args.with_tracking:
-            total_loss = 0
+        total_loss = 0
         if args.resume_from_checkpoint and epoch == starting_epoch and resume_step is not None:
             # We skip the first `n` batches in the dataloader when resuming from a checkpoint
             active_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)

--- a/examples/feature_extraction/requirements.txt
+++ b/examples/feature_extraction/requirements.txt
@@ -1,7 +1,7 @@
-git+https://github.com/huggingface/peft
-git+https://github.com/huggingface/accelerate
-git+https://github.com/huggingface/transformers
-datasets
+peft
+accelerate
+transformers
+datasets==2.18.0
 evaluate
 hnswlib
 pandas


### PR DESCRIPTION
Here we need to pin datasets to an old version to load the datasets in example. Otherwise it will crash in [L267](https://github.com/huggingface/peft/blob/main/examples/feature_extraction/peft_lora_embedding_semantic_search.py#L267)