### PR TITLE
FIX: Warn when using LoRA bias w/o base layer bias

### DIFF
--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -109,6 +109,7 @@ from .tuners import (
 from .utils import (
     TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING,
     PeftType,
+    PeftWarning,
     TaskType,
     bloom_model_postprocess_past_key_value,
     cast_mixed_precision_params,
@@ -179,6 +180,7 @@ __all__ = [
     "PeftModelForSequenceClassification",
     "PeftModelForTokenClassification",
     "PeftType",
+    "PeftWarning",
     "PolyConfig",
     "PolyModel",
     "PrefixEncoder",

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -58,6 +58,7 @@ from .other import (
 )
 from .peft_types import PeftType, TaskType, register_peft_method
 from .save_and_load import get_peft_model_state_dict, load_peft_weights, set_peft_model_state_dict
+from .warning import PeftWarning
 
 
 __all__ = [
@@ -82,6 +83,7 @@ __all__ = [
     "AuxiliaryTrainingWrapper",
     "ModulesToSaveWrapper",
     "PeftType",
+    "PeftWarning",
     "TaskType",
     "TrainableTokensWrapper",
     "_freeze_adapter",

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -46,6 +46,7 @@ from peft import (
     MissConfig,
     OFTConfig,
     PeftModel,
+    PeftWarning,
     RandLoraConfig,
     ShiraConfig,
     TaskType,
@@ -1126,9 +1127,9 @@ class ModelConv1D(nn.Module):
 
 
 class ModelConv2D(nn.Module):
-    def __init__(self):
+    def __init__(self, bias=True):
         super().__init__()
-        self.conv2d = nn.Conv2d(5, 10, 3)
+        self.conv2d = nn.Conv2d(5, 10, 3, bias=bias)
         self.relu = nn.ReLU()
         self.flat = nn.Flatten()
         self.lin0 = nn.Linear(10, 2)
@@ -1476,6 +1477,28 @@ class TestPeftCustomModel(PeftCommonTester):
         else:
             config_kwargs["init_weights"] = False
         self._test_safe_merge(model_id, config_cls, config_kwargs)
+
+    @pytest.mark.parametrize("safe_merge", [False, True])
+    @pytest.mark.parametrize("module_type", ["linear", "conv2d"])
+    def test_merge_with_lora_bias_when_base_layer_has_no_bias_warns_and_raises(self, safe_merge, module_type):
+        # It is not possible to merge the lora_B bias if the base layer doesn't have a bias itself.
+        if module_type == "linear":
+            model = MLP(bias=False)
+            config = LoraConfig(target_modules=["lin0", "lin1"], lora_bias=True)
+            warn_msg = re.escape("`lora_bias=True` was passed but the targeted layer of type Linear has no bias")
+        elif module_type == "conv2d":
+            model = ModelConv2D(bias=False)
+            config = LoraConfig(target_modules=["conv2d"], lora_bias=True)
+            warn_msg = re.escape("`lora_bias=True` was passed but the targeted layer of type Conv2d has no bias")
+        else:
+            raise ValueError(f"Wrong module_type passed, expected 'linear' or 'conv2d', got {module_type}")
+
+        with pytest.warns(PeftWarning, match=warn_msg):
+            model = get_peft_model(model, config)
+
+        err_msg = "Impossible to merge LoRA with `lora_bias=True` because the base layer has no bias"
+        with pytest.raises(RuntimeError, match=err_msg):
+            model.merge_adapter(safe_merge=safe_merge)
 
     @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
     def test_generate(self, test_name, model_id, config_cls, config_kwargs):


### PR DESCRIPTION
When setting `lora_bias=True`, a bias term is added to `lora_B` (#2237). However, to merge this LoRA adapter, we need the base layer to also have a bias. This has not been checked so far.

With this PR, we will now warn the user when we detect this situation. Thus they can decide if they want to continue with this setting or not. If they don't intend to merge, they're fine.

On top of this, when trying to merge in this situation, we now raise an appropriate error that clearly explains why merging failed.

## About `PeftWarning`

This PR adds a new warning class, `PeftWarning`. This makes it easier for users to add PEFT specific warning filters (say, to ignore them or to raise an error).

There are many more warnings in PEFT that could be migrated to this new warning class (or a subclass where appropriate). This is outside the scope of this PR.

## Alternatives

1. We considered raising an error instead of warning when encountering said situation. Many users miss warnings, so an error would be a stronger signal. This would, however, be too harsh, as it could break existing user code that is working perfectly fine.

2. We considered adding a bias term to the base layer when it is missing during the merge. However, this requires careful bookkeeping (e.g. when unmerging all adapters, the bias needs to be removed again). Moreover, when calling `merge_and_unload()`, users expect the original model architecture to be returned. Suddenly adding a bias term would be unexpected and could lead to errors down the line.