### PR TITLE
CHORE: Upgrade ruff to ~0.12.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.12.8
     hooks:
       - id: ruff
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ ignore = [
     "F841", # unused variable
     "UP007", # X | Y style Unions
     "C420", # dict.fromkeys
+    "UP045", # don't force replacing Optional[X] with X | None
 ]
 
 [tool.ruff.lint.isort]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras = {}
 extras["quality"] = [
     "black",  # doc-builder has an implicit dependency on Black, see huggingface/doc-builder#434
     "hf-doc-builder",
-    "ruff~=0.9.2",
+    "ruff~=0.12.8",
 ]
 extras["docs_specific"] = [
     "black",  # doc-builder has an implicit dependency on Black, see huggingface/doc-builder#434


### PR DESCRIPTION
Subjectively, there have been more issues recently with contributor PRs being rejected by ruff. This could possibly be caused by them using a different ruff version (presumably: more recent). This PR upgrades ruff to the latest version to hopefully reduce these issues.

The only change needed to make this ruff version pass was to disable UP045. This rule requires changing code like:

`x: Optional[int]`

into

`x: int | None`

in 220 places. Personally, I don't think it's crucial. Moreover, ruff won't fix this automatically, except with `--unsafe-fixes`. Note that Python 3.9 needs a `__future__` import for this, so that could be the reason why it's not done automatically. Perhaps, once Python 3.9 is dropped, we can revisit this. For now, my preference is thus just to disable the rule, but LMK if you disagree.