### PR TITLE
Release: 0.17.1 changes

### DIFF
--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -276,7 +276,10 @@ The same logic applies to `alpha_pattern`. If you're in doubt, don't try to get 
 
 Generally, you should use `target_modules` to target the module (e.g. `nn.Linear`). However, in some circumstances, this is not possible. E.g., in many mixture of expert (MoE) layers in HF Transformers, instead of using `nn.Linear`, an `nn.Parameter` is used. PEFT normally overwrites the `forward` method for LoRA, but for `nn.Parameter`, there is none. Therefore, to apply LoRA to that parameter, it needs to be targeted with `target_parameters`. As an example, for [Llama4](https://huggingface.co/collections/meta-llama/llama-4-67f0c30d9fe03840bc9d0164), you can pass: `target_parameters=['feed_forward.experts.gate_up_proj', 'feed_forward.experts.down_proj]`.
 
-At the moment, this argument allows to target 2-dim or 3-dim `nn.Parameter`s. It is assumed that in the case of a 3-dim parameter, the 0th dimension is the expert dimension.
+#### Caveats
+
+- At the moment, this argument allows to target 2-dim or 3-dim `nn.Parameter`s. It is assumed that in the case of a 3-dim parameter, the 0th dimension is the expert dimension.
+- It is currently not possible to add multiple LoRA adapters (via `model.add_adapter` or `model.load_adapter`) that use `target_parameters` at the same time.
 
 ## Optimizers
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.17.0"
+VERSION = "0.17.1"
 
 extras = {}
 extras["quality"] = [

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 from .auto import (
     MODEL_TYPE_TO_PEFT_MODEL_MAPPING,

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2015,14 +2015,28 @@ class ParamWrapper(nn.Module, LoraLayer):
                 "Something went wrong, please report this issue on PEFT: https://github.com/huggingface/peft/issues"
             )
 
-        if len(base_layer.parametrizations[parameter_name]) == 1:
+        param_list = base_layer.parametrizations[parameter_name]
+        if len(param_list) == 1:
             # last parametrization, we can safely remove it completely
             nn.utils.parametrize.remove_parametrizations(base_layer, parameter_name, leave_parametrized=False)
-        else:
-            # TODO: If there are multiple parametrizations for the same parameter_name, we currently remove all of them,
-            # which is not desired. Unfortunately, PyTorch does not support this directly, so we need to take care.
-            # For now, remove all parametrizations.
-            nn.utils.parametrize.remove_parametrizations(base_layer, parameter_name, leave_parametrized=False)
+            return
+
+        # If there are multiple parametrizations for the same parameter_name, we only want to remove the LoRA proxy.
+        # Unfortunately, PyTorch does not support this directly, so we need to take care of it manually. To achieve
+        # this, we check the ParameterList from the back until we find the _LoraParameterProxy instance and then remove
+        # it.
+        reversed_indices = reversed(range(len(param_list)))
+        for i in reversed_indices:
+            module = param_list[i]
+            if isinstance(module, _LoraParameterProxy):
+                del param_list[i]
+                break
+        else:  # no break encountered
+            # this should not happen, but raising an error is probably not necessary
+            warnings.warn(
+                f"Could not find any LoRA parametrization on {self}, please open an issue on "
+                "https://github.com/huggingface/peft/issues and report this warning."
+            )
 
     def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         # same as lora.Linear.merge but not hard-coding base_layer.weight and without special cases like variants removed
@@ -2106,6 +2120,10 @@ class ParamWrapper(nn.Module, LoraLayer):
 
     def __repr__(self) -> str:
         rep = super().__repr__()
+        idx = rep.find("(") + 1
+        # insert the name of the parameter to allow the repr to be disambiguous when multiple parameters on the same
+        # module are being targeted
+        rep = f"{rep[:idx]}\n  parameter_name='{self.parameter_name}',{rep[idx:]}"
         return "lora." + rep
 
 

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -185,6 +185,18 @@ class LoraModel(BaseTuner):
         if current_key is None:
             raise ValueError("Current Key shouldn't be `None`")
 
+        if lora_config.target_parameters:
+            # Right now, unfortunately, we don't support multiple adapters with target_parameters on the same model.
+            other_configs_use_target_params = any(
+                conf.target_parameters for key, conf in self.peft_config.items() if key != adapter_name
+            )
+            if other_configs_use_target_params:
+                raise ValueError(
+                    f"Adding a LoRA config with `target_parameters={lora_config.target_parameters}` but there are "
+                    "already other LoRA adapters on this model that use `target_parameters`. At the moment, only "
+                    "one LoRA adapter per model with `target_parameters` is allowed."
+                )
+
         # Regexp matching - Find key which matches current target_name in patterns provided
         r_key = get_pattern_key(lora_config.rank_pattern.keys(), current_key)
         alpha_key = get_pattern_key(lora_config.alpha_pattern.keys(), current_key)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1406,7 +1406,7 @@ class TestLoraInitialization:
                 self.linear = nn.Linear(10, 10)
 
         base_model = MyModule()
-        config = LoraConfig(target_modules=["linear"], target_parameters=["weight"])
+        config = LoraConfig(target_modules=["linear"], target_parameters=["linear.weight"])
         msg = "Trying to wrap an `nn.Parameter` of layer 'linear' of type Linear, which is not a valid target."
         with pytest.raises(ValueError, match=msg):
             get_peft_model(base_model, config)
@@ -1444,6 +1444,26 @@ class TestLoraInitialization:
         msg = re.escape("target_parameters=['foobar.weight'] were set but no parameter was matched.")
         with pytest.warns(RuntimeWarning, match=msg):
             get_peft_model(model, config)
+
+    def test_adding_multiple_adapters_with_target_parameters_raises(self):
+        model = self.get_model()
+        config = LoraConfig(target_modules=[], target_parameters=["linear.weight"])
+        model = get_peft_model(model, config)
+        msg = re.escape("only one LoRA adapter per model with `target_parameters` is allowed")
+        with pytest.raises(ValueError, match=msg):
+            model.add_adapter(adapter_name="other", peft_config=config)
+
+    def test_loading_loading_adapters_with_target_parameters_raises(self, tmp_path):
+        model = self.get_model()
+        config = LoraConfig(target_modules=[], target_parameters=["linear.weight"])
+        model = get_peft_model(model, config)
+        model.save_pretrained(tmp_path)
+
+        model = self.get_model()
+        model = PeftModel.from_pretrained(model, tmp_path)
+        msg = re.escape("only one LoRA adapter per model with `target_parameters` is allowed")
+        with pytest.raises(ValueError, match=msg):
+            model.load_adapter(tmp_path, adapter_name="other")
 
 
 class TestLokrInitialization:

--- a/tests/test_target_parameters.py
+++ b/tests/test_target_parameters.py
@@ -14,6 +14,7 @@
 
 import pytest
 import torch
+from torch import nn
 from transformers import AutoModelForCausalLM
 
 from peft import LoraConfig, TaskType, get_peft_model
@@ -22,13 +23,13 @@ from .testing_common import PeftCommonTester, hub_online_once
 from .testing_utils import set_init_weights_false
 
 
-PEFT_DECODER_MODELS_TO_TEST = [
-    "trl-internal-testing/tiny-Llama4ForCausalLM",
-]
-
 ALL_CONFIGS = [
+    ##########
+    # Llama4 #
+    ##########
     # target down_proj
     (
+        "trl-internal-testing/tiny-Llama4ForCausalLM",
         LoraConfig,
         {
             "task_type": TaskType.CAUSAL_LM,
@@ -39,8 +40,9 @@ ALL_CONFIGS = [
             ],
         },
     ),
-    # target gate_up_proj and down_proj (but not on the same module!)
+    # target gate_up_proj and down_proj, but not on the same module
     (
+        "trl-internal-testing/tiny-Llama4ForCausalLM",
         LoraConfig,
         {
             "task_type": TaskType.CAUSAL_LM,
@@ -54,6 +56,7 @@ ALL_CONFIGS = [
     ),
     # target down_proj and gate_up_proj on the same module
     (
+        "trl-internal-testing/tiny-Llama4ForCausalLM",
         LoraConfig,
         {
             "task_type": "CAUSAL_LM",
@@ -70,6 +73,7 @@ ALL_CONFIGS = [
     ),
     # target q_proj, v_proj as modules, and down_proj as parameter
     (
+        "trl-internal-testing/tiny-Llama4ForCausalLM",
         LoraConfig,
         {
             "task_type": TaskType.CAUSAL_LM,
@@ -77,6 +81,66 @@ ALL_CONFIGS = [
             "lora_dropout": 0.0,
             "target_parameters": [
                 "feed_forward.experts.down_proj",
+            ],
+        },
+    ),
+    ###########
+    # gpt-oss #
+    ###########
+    # target down_proj
+    (
+        "trl-internal-testing/tiny-GptOssForCausalLM",
+        LoraConfig,
+        {
+            "task_type": TaskType.CAUSAL_LM,
+            "target_modules": [],
+            "lora_dropout": 0.0,
+            "target_parameters": [
+                "mlp.experts.down_proj",
+            ],
+        },
+    ),
+    # target gate_up_proj and down_proj, but not on the same module
+    (
+        "trl-internal-testing/tiny-GptOssForCausalLM",
+        LoraConfig,
+        {
+            "task_type": TaskType.CAUSAL_LM,
+            "target_modules": [],
+            "lora_dropout": 0.0,
+            "target_parameters": [
+                "0.mlp.experts.gate_up_proj",
+                "1.mlp.experts.down_proj",
+            ],
+        },
+    ),
+    # target down_proj and gate_up_proj on the same module
+    (
+        "trl-internal-testing/tiny-GptOssForCausalLM",
+        LoraConfig,
+        {
+            "task_type": "CAUSAL_LM",
+            "r": 8,
+            "lora_alpha": 32,
+            "target_modules": None,
+            "lora_dropout": 0.0,
+            "bias": "none",
+            "target_parameters": [
+                "mlp.experts.down_proj",
+                "mlp.experts.gate_up_proj",
+            ],
+        },
+    ),
+    # target q_proj, v_proj as modules, and down_proj as parameter
+    (
+        "trl-internal-testing/tiny-GptOssForCausalLM",
+        LoraConfig,
+        {
+            "task_type": TaskType.CAUSAL_LM,
+            "target_modules": ["q_proj", "v_proj"],
+            "lora_dropout": 0.0,
+            "target_parameters": [
+                "mlp.experts.down_proj",
             ],
         },
     ),
@@ -114,170 +178,151 @@ class TestDecoderModelsTargetParameters(PeftCommonTester):
         attention_mask = torch.tensor([[1, 1, 1], [1, 0, 1]]).to(self.torch_device)
         return {"input_ids": input_ids, "attention_mask": attention_mask}
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_attributes_parametrized(self, model_id, config_cls, config_kwargs):
         self._test_model_attr(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_adapter_name(self, model_id, config_cls, config_kwargs):
         self._test_adapter_name(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_prepare_for_training_parametrized(self, model_id, config_cls, config_kwargs):
         self._test_prepare_for_training(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_save_pretrained(self, model_id, config_cls, config_kwargs):
         self._test_save_pretrained(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_save_pretrained_pickle(self, model_id, config_cls, config_kwargs):
         self._test_save_pretrained(model_id, config_cls, config_kwargs.copy(), safe_serialization=False)
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.skip(reason="Multiple adapters with target_parameters are not supported yet.")
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_save_pretrained_selected_adapters(self, model_id, config_cls, config_kwargs):
         self._test_save_pretrained_selected_adapters(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.skip(reason="Multiple adapters with target_parameters are not supported yet.")
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_save_pretrained_selected_adapters_pickle(self, model_id, config_cls, config_kwargs):
         self._test_save_pretrained_selected_adapters(
             model_id, config_cls, config_kwargs.copy(), safe_serialization=False
         )
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_from_pretrained_config_construction(self, model_id, config_cls, config_kwargs):
         self._test_from_pretrained_config_construction(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_merge_layers(self, model_id, config_cls, config_kwargs):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_merge_layers(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.skip(reason="Multiple adapters with target_parameters are not supported yet.")
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_merge_layers_multi(self, model_id, config_cls, config_kwargs):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_merge_layers_multi(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_merge_layers_nan(self, model_id, config_cls, config_kwargs):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_merge_layers_nan(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.skip(reason="Multiple adapters with target_parameters are not supported yet.")
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_mixed_adapter_batches(self, model_id, config_cls, config_kwargs):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         msg = "lora.ParamWrapper does not support mixed adapter batches yet."
         with pytest.raises(ValueError, match=msg):
             self._test_mixed_adapter_batches(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.skip(reason="Multiple adapters with target_parameters are not supported yet.")
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate_with_mixed_adapter_batches(self, model_id, config_cls, config_kwargs):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         msg = "lora.ParamWrapper does not support mixed adapter batches yet."
         with pytest.raises(ValueError, match=msg):
             self._test_generate_with_mixed_adapter_batches_and_beam_search(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate(self, model_id, config_cls, config_kwargs):
         self._test_generate(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate_pos_args(self, model_id, config_cls, config_kwargs):
         self._test_generate_pos_args(model_id, config_cls, config_kwargs.copy(), raises_err=False)
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_merge_layers_fp16(self, model_id, config_cls, config_kwargs):
         self._test_merge_layers_fp16(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_generate_half_prec(self, model_id, config_cls, config_kwargs):
         self._test_generate_half_prec(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_training_decoders(self, model_id, config_cls, config_kwargs):
         self._test_training(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_training_decoders_gradient_checkpointing(self, model_id, config_cls, config_kwargs):
         self._test_training_gradient_checkpointing(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_inference_safetensors(self, model_id, config_cls, config_kwargs):
         self._test_inference_safetensors(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_peft_model_device_map(self, model_id, config_cls, config_kwargs):
         self._test_peft_model_device_map(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.skip(reason="Multiple adapters with target_parameters are not supported yet.")
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_delete_adapter(self, model_id, config_cls, config_kwargs):
         self._test_delete_adapter(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.skip(reason="Multiple adapters with target_parameters are not supported yet.")
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_delete_inactive_adapter(self, model_id, config_cls, config_kwargs):
         self._test_delete_inactive_adapter(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_adding_multiple_adapters_with_bias_raises(self, model_id, config_cls, config_kwargs):
         self._test_adding_multiple_adapters_with_bias_raises(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_unload_adapter(self, model_id, config_cls, config_kwargs):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_unload_adapter(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.skip(reason="Multiple adapters with target_parameters are not supported yet.")
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_weighted_combination_of_adapters(self, model_id, config_cls, config_kwargs):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         msg = "add_weighted_adapter does not support targeting nn.Parameter"
         with pytest.raises(ValueError, match=msg):
             self._test_weighted_combination_of_adapters(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_training_prompt_learning_tasks(self, model_id, config_cls, config_kwargs):
         self._test_training_prompt_learning_tasks(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_disable_adapter(self, model_id, config_cls, config_kwargs):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_disable_adapter(model_id, config_cls, config_kwargs.copy())
 
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    @pytest.mark.parametrize("model_id,config_cls,config_kwargs", ALL_CONFIGS)
     def test_passing_input_embeds_works(self, model_id, config_cls, config_kwargs):
         self._test_passing_input_embeds_works("", model_id, config_cls, config_kwargs.copy())
 
 
-class TestTargetParameter:
+class TestTargetParameters:
+    # Tests specifically designed for target_parameters
     def test_targeting_module_and_targeting_param_equivalent(self):
+        # Test that using LoRA with target_modules vs target_parameters yields identical results.
         # note: we purposely target the gate_proj because its weight is not square (unlike q_proj, ...), this makes it
         # easier to catch shape errors
         torch.manual_seed(0)
@@ -313,7 +358,6 @@ class TestTargetParameter:
                 out_lora_1 = model1(x, output_hidden_states=True).hidden_states[-1]
 
             # sanity check: basemodel outputs should be different
-
             atol, rtol = 1e-6, 1e-6
             assert not torch.allclose(out_base, out_lora_0, atol=atol, rtol=rtol)
 
@@ -392,3 +436,72 @@ class TestTargetParameter:
             atol, rtol = 0.1, 0.1
             for key in lora_weights_before.keys():
                 assert not torch.allclose(lora_weights_before[key], lora_weights_after[key], atol=atol, rtol=rtol)
+
+    def test_target_parameters_works_with_existing_parametrization(self):
+        # When a parameter is already parametrized, we want the LoRA parametrization to work with it correctly.
+        class MyLinear(nn.Linear):
+            # For testing purposes, define a linear layer with 2 parameters: weight and other_weight.
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                nn.init.ones_(self.weight)
+                self.other_weight = nn.Parameter(torch.ones(self.weight.shape))
+
+        class MyModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = MyLinear(2, 2, bias=False)
+
+            def forward(self, x):
+                return self.lin(x)
+
+        class MyParametrization(nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, x):
+                return x + 1
+
+        # base model
+        model = MyModule()
+        x = torch.ones((2, 2))
+
+        # sanity check: result should be 1*1 + 1*1 == 2
+        output_base = model(x)
+        assert torch.all(output_base == 2)
+
+        # add parametrization to the weight
+        nn.utils.parametrize.register_parametrization(model.lin, "weight", MyParametrization())
+
+        # result should be (1+1)*1 + (1+1)*1 == 4
+        output_parametrized = model(x)
+        assert torch.all(output_parametrized == 4)
+
+        # add LoRA parametrization to the weight
+        config = LoraConfig(r=2, lora_alpha=6, target_parameters=["lin.weight"], init_lora_weights=False)
+        model = get_peft_model(model, config)
+        # manually set LoRA weights to ones
+        nn.init.ones_(model.base_model.model.lin.lora_A["default"].weight)
+        nn.init.ones_(model.base_model.model.lin.lora_B["default"].weight)
+
+        output_lora = model(x)
+        # delta_weight should be: (1+1) * lora_scale = (1+1) * (alpha / rank) = 2 * (6 / 2) = 6
+        # result should be: (1+1+6)*1 + (1+1+6)*1 == 8 + 8 == 16
+        assert torch.all(output_lora == 16)
+
+        # calling twice should yield the same result
+        output_lora2 = model(x)
+        assert torch.allclose(output_lora, output_lora2)
+
+        # add another LoRA parametrization to other_weight, should have no effect on the output
+        config = LoraConfig(r=2, lora_alpha=6, target_parameters=["lin.other_weight"], init_lora_weights=False)
+        model.add_adapter("other", config)
+
+        output_other_lora = model(x)
+        # delta_weight should be: (1+1) * lora_scale = (1+1) * (alpha / rank) = 2 * (6 / 2) = 6
+        # result should be: (1+1+6)*1 + (1+1+6)*1 == 8 + 8 == 16
+        assert torch.all(output_other_lora == output_lora)
+
+        # after unloading, the output should be the same as before LoRA was applied
+        unloaded = model.unload()
+        output_unloaded = unloaded(x)
+        assert torch.all(output_unloaded == output_parametrized)

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -59,6 +59,7 @@ from peft import (
     inject_adapter_in_model,
     prepare_model_for_kbit_training,
 )
+from peft.tuners._buffer_dict import BufferDict
 from peft.tuners.lora import LoraLayer
 from peft.tuners.tuners_utils import BaseTunerLayer
 from peft.utils import _get_submodules, infer_device
@@ -873,6 +874,13 @@ class PeftCommonTester:
             model.add_adapter("adapter-2", config)
             model.set_adapter("adapter-2")
             model.eval()
+
+            # sanity check: each adapter layer with a 'default' adapter should also have 'adapter-2'
+            containers = (torch.nn.ModuleDict, torch.nn.ParameterDict, BufferDict)
+            num_default = len([m for m in model.modules() if isinstance(m, containers) and "default" in m])
+            num_adapter2 = len([m for m in model.modules() if isinstance(m, containers) and "adapter-2" in m])
+            assert num_default > 0
+            assert num_default == num_adapter2
 
             with torch.inference_mode():
                 logits_adapter_2 = model(**dummy_input)[0]


### PR DESCRIPTION
This PR contains the changes require for the 0.17.1 patch release:

- The commit with the fixes to `target_parameters` (#2710)
- Version bumps

Note: Windows tests are failing because #2724 is not included, but since this is only affecting tests, I see no reason to cherry-pick that commit into the release.