### PR TITLE
FIX Deprecated key_cache attribute on Cache pt 2

### DIFF
--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -179,8 +179,16 @@ def map_cache_to_layer_device_map(model, cache) -> None:
     layer_device_map = get_layer_device_map(model)
     for idx in range(model.config.num_hidden_layers):
         layer_device = layer_device_map[idx]
-        cache.key_cache[idx] = cache.key_cache[idx].to(layer_device)
-        cache.value_cache[idx] = cache.value_cache[idx].to(layer_device)
+        if hasattr(cache, "layers"):
+            # new transformers uses cache.layers (>v4.55)
+            layer = cache.layers[idx]
+            layer.keys = layer.keys.to(layer_device)
+            layer.values = layer.values.to(layer_device)
+        else:
+            # old transformers uses cache.{key,value}_cache (<=v4.55)
+            # TODO: remove if we drop support for transformers <= 4.55
+            cache.key_cache[idx] = cache.key_cache[idx].to(layer_device)
+            cache.value_cache[idx] = cache.value_cache[idx].to(layer_device)
 
 
 ##################################


### PR DESCRIPTION
In #2737, we fixed some code that relied on the deprecated attribute but some was being missed, as it only runs on the nightly CI with multiple GPUs. This PR fixes this.

Note that the original transformers code that this solution was based on no longer exists, as transformers now initializes the cache lazily, so pre-allocating the keys and values to the correct device is not necessary. But since prefix tuning inserts "virtual" keys/values, we still have to ensure the correct device in PEFT.

I have tested the [failing tests](https://github.com/huggingface/peft/actions/runs/17255625337/job/48966700621#step:7:673) locally and they pass.