### PR TITLE
Replace from_legacy_cache method with constructors 

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -786,14 +786,30 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 past_key_values = new_cache
             elif peft_config.num_transformer_submodules == 1:
                 # Dont' apply this to encoder-decoder models and not to models requiring special processing.
-                past_key_values = DynamicCache(past_key_values)
+                # TODO: remove from_legacy_cache once transformers < 4.56 is dropped
+                transformers_lt_4_56 = packaging.version.parse(transformers.__version__) < packaging.version.parse(
+                    "4.56.0.dev0"
+                )
+                if transformers_lt_4_56:
+                    past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+                else:
+                    past_key_values = DynamicCache(past_key_values)
+
             elif (peft_config.num_transformer_submodules == 2) and getattr(
                 self.base_model, "_supports_cache_class", True
             ):
                 # Dont' apply this to encoder-decoder models that don't support new Cache format yet
                 # If we don't apply this, prefix-tuning fails to update cross-attn cache
                 # TODO: remove check for _supports_cache_class once transformers 4.53 is no longer supported
-                past_key_values = EncoderDecoderCache(past_key_values)
+                # TODO: remove from_legacy_cache once transformers < 4.56 is dropped
+                transformers_lt_4_56 = packaging.version.parse(transformers.__version__) < packaging.version.parse(
+                    "4.56.0.dev0"
+                )
+                if transformers_lt_4_56:
+                    past_key_values = EncoderDecoderCache.from_legacy_cache(past_key_values)
+                else:
+                    past_key_values = EncoderDecoderCache(past_key_values)
+
                 past_key_values.cross_attention_cache = DynamicCache()
                 # invalidate the cross attention cache, since we add virtual tokens to the encoder
                 for key in past_key_values.is_updated.keys():

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -786,14 +786,14 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 past_key_values = new_cache
             elif peft_config.num_transformer_submodules == 1:
                 # Dont' apply this to encoder-decoder models and not to models requiring special processing.
-                past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+                past_key_values = DynamicCache(past_key_values)
             elif (peft_config.num_transformer_submodules == 2) and getattr(
                 self.base_model, "_supports_cache_class", True
             ):
                 # Dont' apply this to encoder-decoder models that don't support new Cache format yet
                 # If we don't apply this, prefix-tuning fails to update cross-attn cache
                 # TODO: remove check for _supports_cache_class once transformers 4.53 is no longer supported
-                past_key_values = EncoderDecoderCache.from_legacy_cache(past_key_values)
+                past_key_values = EncoderDecoderCache(past_key_values)
                 past_key_values.cross_attention_cache = DynamicCache()
                 # invalidate the cross attention cache, since we add virtual tokens to the encoder
                 for key in past_key_values.is_updated.keys():


### PR DESCRIPTION
Issue #2757 is about replacing the `from_legacy_cache` method of `transformers` `Cache` classes in `peft` due to their removal from transformers in v4.58.0. The `from_legacy_cache` method is used to convert data in the form of iterables to Cache objects. 

The issue is addressed by replacing the method with the corresponding constructors of the Cache classes since they also deal with the data in a similar way.