### PR TITLE
Fix module target edge cases

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -315,8 +315,26 @@ def get_peft_model_state_dict(
     elif save_embedding_layers:
         warnings.warn("Could not identify embedding layer(s) because the model is not a 🤗 transformers model.")
 
+    foobar = {k.replace(f".{adapter_name}", ""): v for k, v in to_return.items()}
     # REMOVE ADAPTER NAME
-    to_return = {k.replace(f".{adapter_name}", ""): v for k, v in to_return.items()}
+    # Ensure not to replace in the middle of the key because a module happens to have the same name as the adapter.
+    pattern = re.compile(re.escape(f".{adapter_name}") + r"$")
+
+    def remove_adapter_name(key):
+        if "." not in key:
+            # nothing to do
+            return key
+
+        if key.endswith(f".{adapter_name}"):
+            # comes from an nn.Parameter, so no .weight suffix, the adapter name is directly at the end
+            return key.removesuffix(f".{adapter_name}")
+
+        # comes from an nn.Module, i.e. the adapter name is the 2nd to last element, e.g. v_proj.lora_A.default.weight
+        key, _, suffix = key.rpartition(".")  # split, e.g. v_proj.lora_A.default + weight
+        key = pattern.sub("", key)  # remove adapter name, e.g. v_proj.lora_A
+        return f"{key}.{suffix}"  # stitch the suffix back, e.g, v_proj.lora_A.weight
+
+    to_return = {remove_adapter_name(k): v for k, v in to_return.items()}
     return to_return
 
 
@@ -355,10 +373,12 @@ def _insert_adapter_name_into_state_dict(
     peft_model_state_dict = {}
     for key, val in state_dict.items():
         if parameter_prefix in key:
-            suffix = key.split(parameter_prefix)[1]
+            _, _, suffix = key.rpartition(parameter_prefix)
             if "." in suffix:
                 suffix_to_replace = ".".join(suffix.split(".")[1:])
-                key = key.replace(suffix_to_replace, f"{adapter_name}.{suffix_to_replace}")
+                # only replace the substring if the key ends on the substring to avoid accidental replacement inside of
+                # the key if a module happens to have a name that contains the substring
+                key = re.sub(re.escape(suffix_to_replace) + r"$", f"{adapter_name}.{suffix_to_replace}", key)
             else:
                 key = f"{key}.{adapter_name}"
             peft_model_state_dict[key] = val

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -315,7 +315,6 @@ def get_peft_model_state_dict(
     elif save_embedding_layers:
         warnings.warn("Could not identify embedding layer(s) because the model is not a 🤗 transformers model.")
 
-    foobar = {k.replace(f".{adapter_name}", ""): v for k, v in to_return.items()}
     # REMOVE ADAPTER NAME
     # Ensure not to replace in the middle of the key because a module happens to have the same name as the adapter.
     pattern = re.compile(re.escape(f".{adapter_name}") + r"$")

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1110,7 +1110,6 @@ class TestLoraInitialization:
         # path is the same for all of them, so only testing LoRA.
         model = self.get_model()
 
-        # check scaling factor use_rslora=True with rank and alpha pattern
         config = LoraConfig(
             target_modules=["linear"],
             modules_to_save=["foobar"],

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -396,7 +396,7 @@ class TestInjectAdapterFromStateDict:
 
 class TestPeftStateDict:
     # Test some edge cases around getting and setting the PEFT state_dict. There are potential sources of errors there
-    # because the adapter_name is removed from/added to the state_dict key.
+    # because the adapter_name is removed from/added to the state_dict keys.
     def test_get_peft_model_state_dict_removes_adapter_name(self):
         # ensure that the adapter name, "default", is removed from the state_dict
         model_id = "hf-internal-testing/tiny-random-OPTForCausalLM"
@@ -492,8 +492,8 @@ class TestPeftStateDict:
 
     @pytest.mark.parametrize("nested", [False, True])
     def test_get_and_set_peft_model_state_dict_normal_names(self, nested):
-        # In this test, neither the module names, runs in any type of edge case. Therefore, this test is basically the
-        # "control group" for the subsequent tests (if this test failed, it means the test itself is wrong).
+        # In this test, there is no edge case. Therefore, this test is basically the "control group" for the subsequent
+        # tests (if this test were to fail, it means the testing code itself is wrong).
         class MyModel(nn.Module):
             def __init__(self):
                 super().__init__()

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -20,6 +20,7 @@ import re
 import pytest
 import torch
 from diffusers import StableDiffusionPipeline
+from torch import nn
 from transformers import AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoModelForSequenceClassification
 
 from peft import (
@@ -28,8 +29,10 @@ from peft import (
     LoKrConfig,
     LoraConfig,
     RandLoraConfig,
+    get_peft_model,
     get_peft_model_state_dict,
     inject_adapter_in_model,
+    set_peft_model_state_dict,
 )
 from peft.tuners import lora
 from peft.utils import ModulesToSaveWrapper
@@ -389,3 +392,231 @@ class TestInjectAdapterFromStateDict:
             assert sd_before.keys() == sd_after.keys()
             for key in sd_before.keys():
                 assert sd_before[key].shape == sd_after[key].shape
+
+
+class TestPeftStateDict:
+    # Test some edge cases around getting and setting the PEFT state_dict. There are potential sources of errors there
+    # because the adapter_name is removed from/added to the state_dict key.
+    def test_get_peft_model_state_dict_removes_adapter_name(self):
+        # ensure that the adapter name, "default", is removed from the state_dict
+        model_id = "hf-internal-testing/tiny-random-OPTForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+
+        # note: lora targets q_proj and v_proj; add in an auxiliary module for good measure
+        model = get_peft_model(model, LoraConfig(modules_to_save=["lm_head"]))
+        sd = get_peft_model_state_dict(model)
+        assert len(sd) > 1  # sanity check
+        assert not any("default" in key for key in sd)
+
+    def test_get_peft_model_state_dict_removes_non_defaul_adapter_name(self):
+        # ensure that the adapter name is removed from the state_dict, even if it's not "default"
+        model_id = "hf-internal-testing/tiny-random-OPTForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+
+        model = get_peft_model(model, LoraConfig(modules_to_save=["lm_head"]), adapter_name="other")
+        sd = get_peft_model_state_dict(model, adapter_name="other")
+        assert len(sd) > 1  # sanity check
+        assert not any("other" in key for key in sd)
+
+    def test_get_peft_model_state_dict_removes_adapter_name_when_same_as_module_name(self):
+        # here the adapter is named "v_proj", which is the same name as some modules targeted with lora in the model,
+        # which is nefarious
+        model_id = "hf-internal-testing/tiny-random-OPTForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+
+        model = get_peft_model(model, LoraConfig(modules_to_save=["lm_head"]), adapter_name="v_proj")
+        sd = get_peft_model_state_dict(model, adapter_name="v_proj")
+        assert len(sd) > 1  # sanity check
+        for key in sd:
+            # assert that the adapter_name was indeed removed
+            assert not key.endswith("lora_A.v_proj.weight")
+            assert not key.endswith("lora_B.v_proj.weight")
+            assert not key.endswith("modules_to_save.v_proj.weight")
+            # assert that the module name was not stripped completely from the key
+            assert ("v_proj" in key) or ("q_proj" in key) or ("lm_head") in key
+
+    def check_peft_model_weights_loaded_correctly(self, inner_model_cls, config, nested, adapter_name="default"):
+        # Runs checks that a roundtrip of get_peft_model_state_dict and set_peft_model_state_dict results in the same
+        # model (same outputs and same weights).
+        class Outer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.inner = inner_model_cls()
+
+            def forward(self, x):
+                return self.inner(x)
+
+        if nested:
+            # add another layer of nesting
+            model_cls = Outer
+        else:
+            model_cls = inner_model_cls
+
+        x = torch.randn(1, 5)
+
+        torch.manual_seed(0)
+        base_model = model_cls()
+        with torch.inference_mode():
+            base_out = base_model(x)
+
+        torch.manual_seed(42)
+        model = get_peft_model(base_model, config, adapter_name=adapter_name)
+        with torch.inference_mode():
+            peft_out = model(x)
+        # sanity check: peft adapter has an effect
+        assert not torch.allclose(base_out, peft_out, atol=1e-6)
+
+        sd = get_peft_model_state_dict(model, adapter_name=adapter_name)
+
+        torch.manual_seed(0)
+        base_model = model_cls()
+        torch.manual_seed(42 + 1)  # ensure we start with a different, randomly initialized PEFT model
+        model_new = get_peft_model(base_model, config, adapter_name=adapter_name)
+        with torch.inference_mode():
+            peft_new = model_new(x)
+        assert not torch.allclose(peft_out, peft_new, atol=1e-6)
+
+        set_peft_model_state_dict(model_new, sd, adapter_name=adapter_name)
+        with torch.inference_mode():
+            peft_out_loaded = model_new(x)
+        assert torch.allclose(peft_out, peft_out_loaded, atol=1e-6)
+
+        sd_new = get_peft_model_state_dict(model, adapter_name=adapter_name)
+        assert sd.keys() == sd_new.keys()
+        for key, val in sd.items():
+            val_new = sd_new[key]
+            torch.allclose(val, val_new)
+
+    @pytest.mark.parametrize("nested", [False, True])
+    def test_get_and_set_peft_model_state_dict_normal_names(self, nested):
+        # In this test, neither the module names, runs in any type of edge case. Therefore, this test is basically the
+        # "control group" for the subsequent tests (if this test failed, it means the test itself is wrong).
+        class MyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.foo_linear = nn.Linear(5, 5)
+                self.foo_baz = nn.Linear(5, 5)
+                self.baz_foo = nn.Linear(5, 5)
+                self.foo_baz_foo = nn.Linear(5, 5)
+                self.baz_foo_baz = nn.Linear(5, 5)
+
+            def forward(self, x):
+                x = self.foo_linear(x)
+                x = self.foo_baz(x)
+                x = self.baz_foo(x)
+                x = self.foo_baz_foo(x)
+                x = self.baz_foo_baz(x)
+                return x
+
+        config = LoraConfig(
+            target_modules=["foo_linear", "foo_baz", "baz_foo", "foo_baz_foo", "baz_foo_baz"], init_lora_weights=False
+        )
+        self.check_peft_model_weights_loaded_correctly(MyModel, config, nested=nested)
+
+    @pytest.mark.parametrize("nested", [False, True])
+    def test_get_and_set_peft_model_state_dict_peft_prefix_in_module_name(self, nested):
+        # Here we have a model with some modules containing "lora" in their name.
+        class MyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.foo_linear = nn.Linear(5, 5)
+                self.foo_lora = nn.Linear(5, 5)
+                self.lora_foo = nn.Linear(5, 5)
+                self.foo_lora_foo = nn.Linear(5, 5)
+                self.lora_foo_lora = nn.Linear(5, 5)
+
+            def forward(self, x):
+                x = self.foo_linear(x)
+                x = self.foo_lora(x)
+                x = self.lora_foo(x)
+                x = self.foo_lora_foo(x)
+                x = self.lora_foo_lora(x)
+                return x
+
+        config = LoraConfig(
+            target_modules=["foo_linear", "foo_lora", "lora_foo", "foo_lora_foo", "lora_foo_lora"],
+            init_lora_weights=False,
+        )
+        self.check_peft_model_weights_loaded_correctly(MyModel, config, nested=nested)
+
+    @pytest.mark.parametrize("nested", [False, True])
+    def test_get_and_set_peft_model_state_dict_weight_in_module_name(self, nested):
+        # Here we have a model with some modules containing "weight" in their name.
+        # See #2772
+        class MyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.foo_linear = nn.Linear(5, 5)
+                self.foo_weight = nn.Linear(5, 5)
+                self.weight_foo = nn.Linear(5, 5)
+                self.foo_weight_foo = nn.Linear(5, 5)
+                self.weight_foo_weight = nn.Linear(5, 5)
+
+            def forward(self, x):
+                x = self.foo_linear(x)
+                x = self.foo_weight(x)
+                x = self.weight_foo(x)
+                x = self.foo_weight_foo(x)
+                x = self.weight_foo_weight(x)
+                return x
+
+        config = LoraConfig(
+            target_modules=["foo_linear", "foo_weight", "weight_foo", "foo_weight_foo", "weight_foo_weight"],
+            init_lora_weights=False,
+        )
+        self.check_peft_model_weights_loaded_correctly(MyModel, config, nested=nested)
+
+    @pytest.mark.parametrize("nested", [False, True])
+    def test_get_and_set_peft_model_state_dict_bias_in_module_name(self, nested):
+        # Here we have a model with some modules containing "bias" in their name.
+        class MyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.foo_linear = nn.Linear(5, 5)
+                self.foo_bias = nn.Linear(5, 5)
+                self.bias_foo = nn.Linear(5, 5)
+                self.foo_bias_foo = nn.Linear(5, 5)
+                self.bias_foo_bias = nn.Linear(5, 5)
+
+            def forward(self, x):
+                x = self.foo_linear(x)
+                x = self.foo_bias(x)
+                x = self.bias_foo(x)
+                x = self.foo_bias_foo(x)
+                x = self.bias_foo_bias(x)
+                return x
+
+        config = LoraConfig(
+            target_modules=["foo_linear", "foo_bias", "bias_foo", "foo_bias_foo", "bias_foo_bias"],
+            init_lora_weights=False,
+            bias="lora_only",
+        )
+        self.check_peft_model_weights_loaded_correctly(MyModel, config, nested=nested)
+
+    @pytest.mark.parametrize("nested", [False, True])
+    def test_get_and_set_peft_model_state_dict_adapter_name_same_as_module_name(self, nested):
+        # Here we choose a module name that is identical to the name of one of the adapters.
+        class MyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.foo = nn.Linear(5, 5)
+                self.foo_baz = nn.Linear(5, 5)
+                self.baz_foo = nn.Linear(5, 5)
+                self.foo_baz_foo = nn.Linear(5, 5)
+                self.baz_foo_baz = nn.Linear(5, 5)
+
+            def forward(self, x):
+                x = self.foo(x)
+                x = self.foo_baz(x)
+                x = self.baz_foo(x)
+                x = self.foo_baz_foo(x)
+                x = self.baz_foo_baz(x)
+                return x
+
+        config = LoraConfig(
+            target_modules=["foo", "foo_baz", "baz_foo", "foo_baz_foo", "baz_foo_baz"], init_lora_weights=False
+        )
+        self.check_peft_model_weights_loaded_correctly(MyModel, config, nested=nested, adapter_name="foo")


### PR DESCRIPTION
Resolves #2772

Fixes several edge cases with unusual layer names or target modules.

1. As #2772 stated, if `"weight"` is part of a layer name, it would be treated incorrectly when creating the PEFT `state_dict`.
2. Similarly, when the adapter name itself is part of a layer name.

Some of these errors would pass silently, which is especially bad (e.g. a weight not being loaded but no error raised).

I also added some tests that were not failing before, but to cover some yet uncovered cases or to lay out some basic functionality.

While working on this, I also noticed that it was possible to target a `BaseTunerLayer` with `modules_to_save` and `trainable_token_indices` (e.g. the `lora_A` and `lora_B` `nn.Linear` would be wrapped with `ModulesToSaveWrapper`). I don't think this is ever desired, so we now raise an error if this is detected.

Note to reviewers: Please be super diligent in reviewing this and don't hesitate to suggest more tests if you have ideas. It is easy to add a (silent) breaking change here if not careful.