### PR TITLE
Support dataclass model configs

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
 import os
 import re
 import textwrap
@@ -879,6 +880,8 @@ class BaseTuner(nn.Module, ABC):
         model_config = getattr(model, "config", DUMMY_MODEL_CONFIG)
         if hasattr(model_config, "to_dict"):
             model_config = model_config.to_dict()
+        elif dataclasses.is_dataclass(model_config):
+            model_config = dataclasses.asdict(model_config)
         return model_config
 
     def _get_tied_target_modules(self, model: nn.Module) -> list[str]:

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import dataclasses
 import re
 import unittest
 from copy import deepcopy
@@ -1312,6 +1313,11 @@ class MockModelConfig:
         return self.config
 
 
+@dataclasses.dataclass
+class MockModelDataclassConfig:
+    mock_key: str
+
+
 class ModelWithConfig(nn.Module):
     def __init__(self):
         self.config = MockModelConfig()
@@ -1320,6 +1326,11 @@ class ModelWithConfig(nn.Module):
 class ModelWithDictConfig(nn.Module):
     def __init__(self):
         self.config = MockModelConfig.config
+
+
+class ModelWithDataclassConfig(nn.Module):
+    def __init__(self):
+        self.config = MockModelDataclassConfig(**MockModelConfig().to_dict())
 
 
 class ModelWithNoConfig(nn.Module):
@@ -1338,6 +1349,10 @@ class TestBaseTunerGetModelConfig(unittest.TestCase):
     def test_get_model_config_with_no_config(self):
         config = BaseTuner.get_model_config(ModelWithNoConfig())
         assert config == DUMMY_MODEL_CONFIG
+
+    def test_get_model_config_with_dataclass(self):
+        config = BaseTuner.get_model_config(ModelWithDataclassConfig())
+        assert config == MockModelConfig.config
 
 
 class TestBaseTunerWarnForTiedEmbeddings:


### PR DESCRIPTION
LeRobot uses dataclasses to manage policy configs. If we want to support LeRobot policy fine-tuning it'd be easiest to support these configs in `get_model_config`.

While it is possible to fix this on LeRobot's side (add a `to_dict` implementation to the config classes) I think it'd be cleaner to support it on our side since the cost is relatively low and dataclasses are getting more popular anyway.

Thanks @xliu0105 for raising this issue and proposing a fix (supersedes #2641).