### PR TITLE
ENH: Store PEFT version in PEFT config file

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -543,11 +543,11 @@ class TestPeftConfig:
         monkeypatch.setattr(config, "_get_commit_hash", fake_commit_hash)
 
         peft_config = config_class(**mandatory_kwargs)
-        assert peft_config.peft_version == version
+        assert peft_config.peft_version == version + "@UNKNOWN"
 
         peft_config.save_pretrained(tmp_path)
         config_loaded = PeftConfig.from_pretrained(tmp_path)
-        assert config_loaded.peft_version == version
+        assert config_loaded.peft_version == version + "@UNKNOWN"
 
     @pytest.mark.parametrize("config_class, mandatory_kwargs", ALL_CONFIG_CLASSES)
     def test_peft_version_warn_when_commit_hash_errors(self, config_class, mandatory_kwargs, monkeypatch, tmp_path):
@@ -560,11 +560,11 @@ class TestPeftConfig:
         monkeypatch.setattr(config, "__version__", version)
 
         def fake_commit_hash_raises(pkg_name):
-            1 / 0
+            raise Exception("Error for testing purpose")
 
         monkeypatch.setattr(config, "_get_commit_hash", fake_commit_hash_raises)
 
         msg = "A dev version of PEFT is used but there was an error while trying to determine the commit hash"
         with pytest.warns(UserWarning, match=msg):
             peft_config = config_class(**mandatory_kwargs)
-        assert peft_config.peft_version == version
+        assert peft_config.peft_version == version + "@UNKNOWN"


### PR DESCRIPTION
This PR adds the PEFT version to the `adapter_config.json`. This can be useful in the future -- for instance when we change the state dict format of a PEFT method, we can convert it in a backwards compatible way based on the PEFT version being used. It can also be useful for debugging by providing an easy way to see the PEFT version that was used to train a PEFT adapter.

## Notes

In #2038, we made a change to PEFT configs to make it so that even if new arguments are added to a config, it can still be loaded with older PEFT versions (forward compatibility). Before that change, adding the PEFT version would have been quite disruptive, as it would make all PEFT configs incompatible with older PEFT versions. Said PR was included in the 0.14.0 release from Dec 2024, so we can expect the vast majority of PEFT users to use this version or a more recent one.

If the PEFT version is a dev version, the version tag is ambiguous. Therefore, I added some code to try to determine the commit hash. This works if users installed PEFT with `git+...@<HASH>`. Unit testing that the function to determine the hash works with these types of installs is not trivial. Therefore, I just patched the function to return a fixed hash. I did, however, test it locally and it works:

```sh
python -m pip install git+https://github.com/huggingface/diffusers.git@5e181eddfe7e44c1444a2511b0d8e21d177850a0
python -c "from peft.config import _get_commit_hash; print(_get_commit_hash('diffusers'))"
```

Also note that I tried to make the retrieval of the hash super robust by adding a broad `try ... except Exception`. If there is an error there, e.g. due to a busted install path, we never want this to fail, but rather just accept that the hash cannot be determined.

If users installed a dev version of PEFT in different way, e.g. using `git clone && pip install .`, the commit hash will not be detected. I think this is fine, I really don't want to start shelling out with git just for this purpose.