### PR TITLE
ENH Small speedups to adapter injection

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -530,10 +530,9 @@ class BaseTuner(nn.Module, ABC):
             and (len(peft_config.target_modules) >= MIN_TARGET_MODULES_FOR_OPTIMIZATION)
             and (peft_config.peft_type != PeftType.IA3)
         ):
+            suffixes = tuple("." + suffix for suffix in peft_config.target_modules)
             names_no_target = [
-                name
-                for name in key_list
-                if not any((name == suffix) or name.endswith("." + suffix) for suffix in peft_config.target_modules)
+                name for name in key_list if (name not in peft_config.target_modules) and not name.endswith(suffixes)
             ]
             new_target_modules = _find_minimal_target_modules(peft_config.target_modules, names_no_target)
             if len(new_target_modules) < len(peft_config.target_modules):
@@ -543,10 +542,10 @@ class BaseTuner(nn.Module, ABC):
         # MATCHING & CREATING MODULES #
         ###############################
 
-        existing_adapter_map = {}
+        existing_adapter_prefixes = []
         for key, module in named_modules:
             if isinstance(module, BaseTunerLayer):
-                existing_adapter_map[key] = module
+                existing_adapter_prefixes.append(key + ".")
 
         # TODO: check if this the most robust way
         module_names: set[str] = set()
@@ -560,8 +559,8 @@ class BaseTuner(nn.Module, ABC):
 
             # It is possible that we're adding an additional adapter, so if we encounter a key that clearly belongs to a
             # previous adapter we can skip here since we don't want to interfere with adapter internals.
-            for adapter_key in existing_adapter_map:
-                if key.startswith(adapter_key + "."):
+            for adapter_key in existing_adapter_prefixes:
+                if key.startswith(adapter_key):
                     excluded_modules.append(key)
                     break
 


### PR DESCRIPTION
See https://github.com/huggingface/diffusers/issues/11816#issuecomment-3281290153

## Description

This PR implements two small improvements to the speed of adapter injection. On a benchmark based on the linked issue, the first change leads to a speedup of 21% and the second change of another 3%. It's not that much, but as the changes don't make the code more complicated, there is really no reason not to take them.

The optimizations don't add any functional change but are simply based on not recomputing the same values multiple times. Therefore, unless I'm missing something, they should strictly improve runtime.

## Note

Be careful when profiling this: Each operation is very quick but can be perfomed millions of times. If the profiler adds overhead, it can completely skew the results. E.g. with pyinstrument, just enabling the profiler increases execution time (after optimization) from ~15 sec to ~21 sec.

## Script

This was the script I used to profile (profiler commented out for aforementioned reason):

```python
import time

import torch
from diffusers import StableDiffusionXLPipeline
from huggingface_hub import hf_hub_download
# from pyinstrument import Profiler

pipeline = StableDiffusionXLPipeline.from_pretrained(
    "stabilityai/stable-diffusion-xl-base-1.0",
    torch_dtype=torch.float16,
    #controlnet=controlnet,
    variant="fp16",
    use_safetensors=True,
).to("cuda")

hf_hub_download("johass/lr", "k1.safetensors")

loras = [
    "k1.safetensors",
] * 6

# profiler = Profiler(interval=0.01)
# profiler.start()

for i, lora in enumerate(loras):
    adapter_name = lora.replace(".", "_")
    adapter_name = f"{i}_{adapter_name}"
    ti = time.time()
    pipeline.load_lora_weights(
        "johass/lr", weight_name=lora, adapter_name=adapter_name, low_cpu_mem_usage=True
    )
    dt = time.time() - ti
    pipeline.set_adapters(adapter_name, adapter_weights=0.7)
    print(f"Loaded adapter {i} in {dt:.3f} s")

# profiler.stop()
# profiler.write_html("profile.html")
```
