### PR TITLE
Fix issue #2786: Store xlora scaling and fix per token normalization

### DIFF
--- a/src/peft/tuners/xlora/layer.py
+++ b/src/peft/tuners/xlora/layer.py
@@ -73,11 +73,6 @@ class XLoraLayer:
 
             xlora_scalings = xlora_scalings * mask.to(xlora_scalings.dtype)
 
-        if self.config.enable_softmax_topk:
-            nonzero_mask = xlora_scalings != 0
-            softmax_res_nonzero = torch.softmax(xlora_scalings[nonzero_mask], dim=-1)
-            xlora_scalings[nonzero_mask] = softmax_res_nonzero
-
         # Apply per-token normalization to the xLoRA scaling factors using a softmax
         if self.config.enable_softmax_topk:
             nonzero_mask = xlora_scalings != 0

--- a/src/peft/tuners/xlora/layer.py
+++ b/src/peft/tuners/xlora/layer.py
@@ -78,6 +78,13 @@ class XLoraLayer:
             softmax_res_nonzero = torch.softmax(xlora_scalings[nonzero_mask], dim=-1)
             xlora_scalings[nonzero_mask] = softmax_res_nonzero
 
+        # Apply per-token normalization to the xLoRA scaling factors using a softmax
+        if self.config.enable_softmax_topk:
+            nonzero_mask = xlora_scalings != 0
+            full = xlora_scalings.masked_fill(~nonzero_mask, float("-inf"))
+            new_scalings = torch.softmax(full, dim=-1)
+            xlora_scalings = new_scalings.masked_fill(~nonzero_mask, 0.0)
+
         return xlora_scalings
 
 

--- a/src/peft/tuners/xlora/model.py
+++ b/src/peft/tuners/xlora/model.py
@@ -368,6 +368,8 @@ class XLoraModel(BaseTuner):
                     self.lora_model.enable_adapter_layers()
 
             xlora_scalings = self.internal_xlora_classifier(result=base_output, *args_real, **kwargs_real)
+            # Store computed scalings to fix get_latest_scalings() returning None
+            self.internal_xlora_scalings = xlora_scalings
 
             # =========================== Real forward pass with calculated scalings ==================
 


### PR DESCRIPTION
Resolves [#2786](https://github.com/huggingface/peft/issues/2786)

## Description

This PR addresses two issues identified while using X-LoRA with the Qwen2-VL-7B model.

### Issue 1: Internal Scaling Storage Problem

**Location:** `_enable_peft_forward_hooks()` in `src/peft/tuners/xlora/model.py`
**Problem:** After calling `enable_scalings_logging()`, the subsequent call to `get_latest_scalings()` returned `None` because computed `xlora_scalings` were not properly stored for later retrieval.

### Issue 2: Incorrect Probability Normalization
**Location:** `get_maybe_topk_scalings()` in `src/peft/tuners/xlora/layer.py`
**Problem:** The current implementation incorrectly normalized expert probabilities such that the sum over all tokens was 1, rather than summing to 1 per token.


## Implementation

- src/peft/tuners/xlora/model.py: Added storage of computed scalings in `_enable_peft_forward_hooks()`
```
xlora_scalings = self.internal_xlora_classifier(result=base_output, *args_real, **kwargs_real)
# Store computed scalings to fix get_latest_scalings() returning None
self.internal_xlora_scalings = xlora_scalings
```
- src/peft/tuners/xlora/layer.py: Fixed normalization logic in `get_maybe_topk_scalings()`
```
# Apply per-token normalization to the xLoRA scaling factors using a softmax
if self.config.enable_softmax_topk:
    nonzero_mask = xlora_scalings != 0
    full = xlora_scalings.masked_fill(~nonzero_mask, float("-inf"))
    new_scalings = torch.softmax(full, dim=-1)
    xlora_scalings = new_scalings.masked_fill(~nonzero_mask, 0.0)
```