### PR TITLE
TST: fix `to` issue for 8-bit model

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -2838,7 +2838,8 @@ class TestLoftQ:
     def get_base_model(self, model_id, device, **kwargs):
         cls = AutoModelForSeq2SeqLM if "t5" in str(model_id) else AutoModelForCausalLM
         model = cls.from_pretrained(model_id, **kwargs).eval()
-        model = model.to(self.device)
+        if not getattr(model, "is_loaded_in_8bit", False):
+            model = model.to(self.device)
         return model
 
     def get_logits(self, model, inputs):


### PR DESCRIPTION
## Issue
4 cases fail 
```
pytest -rA tests/test_gpu_examples.py::TestLoftQ::test_bloomz_loftq_8bit
pytest -rA tests/test_gpu_examples.py::TestLoftQ::test_bloomz_loftq_8bit_dora
pytest -rA tests/test_gpu_examples.py::TestLoftQ::test_bloomz_loftq_8bit_iter_5
pytest -rA tests/test_gpu_examples.py::TestLoftQ::test_t5_loftq_8bit
```
w/ log

> >               raise ValueError(
>                     "`.to` is not supported for `8-bit` bitsandbytes models. Please use the model as it is, since the"
>                     " model has already been set to the correct devices and casted to the correct `dtype`."
> E                   ValueError: `.to` is not supported for `8-bit` bitsandbytes models. Please use the model as it is, since the model has already been set to the correct devices and casted to the correct `dtype`.

## Root Cause
8-bit models don't support `to` and `cuda` according [transformers logic](https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L4353)

## Fix
check whether model is loaded in 8 bit, and skip `to` if so.

## Results:
Pass

@BenjaminBossan , pls help review, thx very much.