### PR TITLE
Some more TIP migration

### DIFF
--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -71,12 +71,9 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
     This class does not support loading/saving, and it shouldn't usually be initialized directly. Instead, use
     `get_peft_model` with the argument `mixed=True`.
 
-    <Tip>
-
-    Read the [Mixed adapter types](https://huggingface.co/docs/peft/en/developer_guides/mixed_models) guide to learn
-    more about using different adapter types.
-
-    </Tip>
+    > [!TIP]
+    > Read the [Mixed adapter types](https://huggingface.co/docs/peft/en/developer_guides/mixed_models) guide to learn
+    > more about using different adapter types.
 
     Example:
 
@@ -224,12 +221,9 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
                 Create empty adapter weights on meta device. Useful to speed up the process when loading saved
                 adapters.
 
-                <Tip>
-
-                Don't use `low_cpu_mem_usage=True` when creating a new PEFT adapter for training (training is untested
-                and discouraged for PeftMixedModel in general).
-
-                </Tip>
+                > [!TIP]
+                > Don't use `low_cpu_mem_usage=True` when creating a new PEFT adapter for training (training is untested
+                > and discouraged for PeftMixedModel in general).
         """
         _check_config_compatible(peft_config)
 

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -71,9 +71,8 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
     This class does not support loading/saving, and it shouldn't usually be initialized directly. Instead, use
     `get_peft_model` with the argument `mixed=True`.
 
-    > [!TIP]
-    > Read the [Mixed adapter types](https://huggingface.co/docs/peft/en/developer_guides/mixed_models) guide to learn
-    > more about using different adapter types.
+    > [!TIP] > Read the [Mixed adapter types](https://huggingface.co/docs/peft/en/developer_guides/mixed_models) guide
+    to learn > more about using different adapter types.
 
     Example:
 
@@ -221,9 +220,8 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
                 Create empty adapter weights on meta device. Useful to speed up the process when loading saved
                 adapters.
 
-                > [!TIP]
-                > Don't use `low_cpu_mem_usage=True` when creating a new PEFT adapter for training (training is untested
-                > and discouraged for PeftMixedModel in general).
+                > [!TIP] > Don't use `low_cpu_mem_usage=True` when creating a new PEFT adapter for training (training
+                is untested > and discouraged for PeftMixedModel in general).
         """
         _check_config_compatible(peft_config)
 

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -83,8 +83,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         low_cpu_mem_usage (`bool`, `optional`, defaults to `False`):
             Create empty adapter weights on meta device. Useful to speed up the loading loading process.
 
-            > [!TIP]
-            > Don't use `low_cpu_mem_usage=True` when creating a new PEFT adapter for training.
+            > [!TIP] > Don't use `low_cpu_mem_usage=True` when creating a new PEFT adapter for training.
 
     **Attributes**:
         - **base_model** ([`torch.nn.Module`]) -- The base transformer model used for Peft.

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -83,11 +83,8 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         low_cpu_mem_usage (`bool`, `optional`, defaults to `False`):
             Create empty adapter weights on meta device. Useful to speed up the loading loading process.
 
-            <Tip>
-
-            Don't use `low_cpu_mem_usage=True` when creating a new PEFT adapter for training.
-
-            </Tip>
+            > [!TIP]
+            > Don't use `low_cpu_mem_usage=True` when creating a new PEFT adapter for training.
 
     **Attributes**:
         - **base_model** ([`torch.nn.Module`]) -- The base transformer model used for Peft.


### PR DESCRIPTION
Either re-introduced or overlooked `<Tip>`s converted to new syntax.