### PR TITLE
CHORE: Ensure PEFT works with huggingface_hub 1.0.0

### DIFF
--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -422,15 +422,17 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
 
         # load the config
         if config is None:
-            config = PEFT_TYPE_TO_CONFIG_MAPPING[
-                PeftConfig._get_peft_type(
-                    model_id,
-                    subfolder=kwargs.get("subfolder", None),
-                    revision=kwargs.get("revision", None),
-                    cache_dir=kwargs.get("cache_dir", None),
-                    use_auth_token=kwargs.get("use_auth_token", None),
-                )
-            ].from_pretrained(model_id, **kwargs)
+            kwargs = {
+                "subfolder": kwargs.get("subfolder", None),
+                "revision": kwargs.get("revision", None),
+                "cache_dir": kwargs.get("cache_dir", None),
+                "token": kwargs.get("token", None),
+            }
+            if use_auth_token := kwargs.get("use_auth_token", None):
+                kwargs["use_auth_token"] = use_auth_token
+            config = PEFT_TYPE_TO_CONFIG_MAPPING[PeftConfig._get_peft_type(model_id, **kwargs)].from_pretrained(
+                model_id, **kwargs
+            )
         elif isinstance(config, PeftConfig):
             config.inference_mode = not is_trainable
         else:

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -422,15 +422,15 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
 
         # load the config
         if config is None:
-            kwargs = {
+            hf_kwargs = {
                 "subfolder": kwargs.get("subfolder", None),
                 "revision": kwargs.get("revision", None),
                 "cache_dir": kwargs.get("cache_dir", None),
                 "token": kwargs.get("token", None),
             }
             if use_auth_token := kwargs.get("use_auth_token", None):
-                kwargs["use_auth_token"] = use_auth_token
-            config = PEFT_TYPE_TO_CONFIG_MAPPING[PeftConfig._get_peft_type(model_id, **kwargs)].from_pretrained(
+                hf_kwargs["use_auth_token"] = use_auth_token
+            config = PEFT_TYPE_TO_CONFIG_MAPPING[PeftConfig._get_peft_type(model_id, **hf_kwargs)].from_pretrained(
                 model_id, **kwargs
             )
         elif isinstance(config, PeftConfig):

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -434,16 +434,17 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         # load the config
         if config is None:
-            config = PEFT_TYPE_TO_CONFIG_MAPPING[
-                PeftConfig._get_peft_type(
-                    model_id,
-                    subfolder=kwargs.get("subfolder", None),
-                    revision=kwargs.get("revision", None),
-                    cache_dir=kwargs.get("cache_dir", None),
-                    use_auth_token=kwargs.get("use_auth_token", None),
-                    token=kwargs.get("token", None),
-                )
-            ].from_pretrained(model_id, **kwargs)
+            kwargs = {
+                "subfolder": kwargs.get("subfolder", None),
+                "revision": kwargs.get("revision", None),
+                "cache_dir": kwargs.get("cache_dir", None),
+                "token": kwargs.get("token", None),
+            }
+            if use_auth_token := kwargs.get("use_auth_token", None):
+                kwargs["use_auth_token"] = use_auth_token
+            config = PEFT_TYPE_TO_CONFIG_MAPPING[PeftConfig._get_peft_type(model_id, **kwargs)].from_pretrained(
+                model_id, **kwargs
+            )
         elif isinstance(config, PeftConfig):
             config.inference_mode = not is_trainable
         else:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -434,15 +434,15 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         # load the config
         if config is None:
-            kwargs = {
+            hf_kwargs = {
                 "subfolder": kwargs.get("subfolder", None),
                 "revision": kwargs.get("revision", None),
                 "cache_dir": kwargs.get("cache_dir", None),
                 "token": kwargs.get("token", None),
             }
             if use_auth_token := kwargs.get("use_auth_token", None):
-                kwargs["use_auth_token"] = use_auth_token
-            config = PEFT_TYPE_TO_CONFIG_MAPPING[PeftConfig._get_peft_type(model_id, **kwargs)].from_pretrained(
+                hf_kwargs["use_auth_token"] = use_auth_token
+            config = PEFT_TYPE_TO_CONFIG_MAPPING[PeftConfig._get_peft_type(model_id, **hf_kwargs)].from_pretrained(
                 model_id, **kwargs
             )
         elif isinstance(config, PeftConfig):

--- a/src/peft/utils/hotswap.py
+++ b/src/peft/utils/hotswap.py
@@ -597,15 +597,15 @@ def hotswap_adapter(model, model_name_or_path, adapter_name, torch_device=None, 
     ############################
     # LOAD CONFIG AND VALIDATE #
     ############################
-    kwargs = {
+    hf_kwargs = {
         "subfolder": kwargs.get("subfolder", None),
         "revision": kwargs.get("revision", None),
         "cache_dir": kwargs.get("cache_dir", None),
         "token": kwargs.get("token", None),
     }
     if use_auth_token := kwargs.get("use_auth_token", None):
-        kwargs["use_auth_token"] = use_auth_token
-    config_cls = PEFT_TYPE_TO_CONFIG_MAPPING[PeftConfig._get_peft_type(model_name_or_path, **kwargs)]
+        hf_kwargs["use_auth_token"] = use_auth_token
+    config_cls = PEFT_TYPE_TO_CONFIG_MAPPING[PeftConfig._get_peft_type(model_name_or_path, **hf_kwargs)]
     config = config_cls.from_pretrained(model_name_or_path, **kwargs)
     # config keys that could affect the model output besides what is determined by the state_dict
     check_hotswap_configs_compatible(model.active_peft_config, config)

--- a/src/peft/utils/hotswap.py
+++ b/src/peft/utils/hotswap.py
@@ -597,17 +597,15 @@ def hotswap_adapter(model, model_name_or_path, adapter_name, torch_device=None, 
     ############################
     # LOAD CONFIG AND VALIDATE #
     ############################
-
-    config_cls = PEFT_TYPE_TO_CONFIG_MAPPING[
-        PeftConfig._get_peft_type(
-            model_name_or_path,
-            subfolder=kwargs.get("subfolder", None),
-            revision=kwargs.get("revision", None),
-            cache_dir=kwargs.get("cache_dir", None),
-            use_auth_token=kwargs.get("use_auth_token", None),
-            token=kwargs.get("token", None),
-        )
-    ]
+    kwargs = {
+        "subfolder": kwargs.get("subfolder", None),
+        "revision": kwargs.get("revision", None),
+        "cache_dir": kwargs.get("cache_dir", None),
+        "token": kwargs.get("token", None),
+    }
+    if use_auth_token := kwargs.get("use_auth_token", None):
+        kwargs["use_auth_token"] = use_auth_token
+    config_cls = PEFT_TYPE_TO_CONFIG_MAPPING[PeftConfig._get_peft_type(model_name_or_path, **kwargs)]
     config = config_cls.from_pretrained(model_name_or_path, **kwargs)
     # config keys that could affect the model output besides what is determined by the state_dict
     check_hotswap_configs_compatible(model.active_peft_config, config)

--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -95,13 +95,7 @@ def setup_tearndown():
     # provide such a feature
 
     # download regression artifacts from Hugging Face Hub at the start
-    snapshot_download(
-        repo_id=HF_REPO,
-        local_dir=REGRESSION_DIR,
-        # Don't use symlink, because this prevents us from properly cleaning up the files once finished
-        local_dir_use_symlinks=False,
-    )
-
+    snapshot_download(repo_id=HF_REPO, local_dir=REGRESSION_DIR)
     yield
 
     # delete regression artifacts at the end of the test session; optionally, upload them first if in creation mode


### PR DESCRIPTION
The `reset_sessions` function is removed but it's also no longer necessary to call it for the purpose we used it.

Moreover, the deprecated `use_auth_token` argument is fully removed now, so everywhere we used to pass it, it is now removed, unless a user passes it explicitly.