### PR TITLE
FIX DOC Add missing TOC entry for WaveFT

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -134,6 +134,8 @@
       title: MiSS
     - local: package_reference/road
       title: RoAd
+    - local: package_reference/waveft
+      title: WaveFT
 
     title: Adapters
   - sections:


### PR DESCRIPTION
I missed the failed doc build in the original PR.