### PR TITLE
[WIP] Testing transformers deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-        os: ["ubuntu-latest", "macos-13", "windows-latest"]
+        python-version: ["3.13"]
+        os: ["ubuntu-latest"]
         exclude:
           - os: macos-13
             python-version: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,8 @@ markers = [
     "regression: whether to run regression suite test",
     "bitsandbytes: select bitsandbytes integration tests"
 ]
+
+filterwarnings = [
+    "error::DeprecationWarning:transformers",
+    "error::FutureWarning:transformers",
+]


### PR DESCRIPTION
DON'T MERGE

Check if/how often PEFT triggers transformers FutureWarning or DeprecationWarning by converting these warnings into failures. Note that there will be many false negatives, as transformers uses logger.warning frequently, which will not trigger a failure.