### PR TITLE
fix dequantize bnb weight on CPU

### DIFF
--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -23,8 +23,6 @@ import torch
 import transformers
 from torch import nn
 
-from peft.import_utils import is_xpu_available
-
 
 def check_deepspeed_zero3_enabled() -> bool:
     if packaging.version.parse(transformers.__version__) >= packaging.version.parse("4.33.0"):


### PR DESCRIPTION
There has no need to check cpu specifically as CPU support dequantize bnb weights.

Hi @BenjaminBossan . Could you please review this PR? Thanks!

cc @yao-matrix 