### PR TITLE
Fixed 4bit compare UT on XPU

### DIFF
--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -48,6 +48,8 @@
 # tests/regression/<TEST_NAME>/ will be loaded and compared to the current output.
 #
 # When implementing new tests, check the existing ones as well as the description in the docstring of RegressionTester.
+#
+# Note: For 4-bit tests using XPU (regardless of REGRESSION_CREATION_MODE), set `PEFT_USE_XPU=True` to enable the correct XPU path.
 
 import os
 import shutil


### PR DESCRIPTION
Similar to [#2473 ](https://github.com/huggingface/peft/pull/2473). Our internal CI testing for **XPU** found that current test results for cases like `test_bnb_regression.py::test_opt_350m_4bit_quant_storage` and `test_regression.py::TestOpt4bitBnb::test_lora_4bit` are similar to `test_bnb_regression.py::test_opt_350m_4bit`, vary due to the `bitsandbytes` version and **hardware platform**. 

**XPU** currently can pass all UT files in the latest `bitsandbytes` version. Therefore, can we temporarily disable these specific examples on XPU to prevent CI errors?