### PR TITLE
FIX Bug when dequantizing 4bit bnb weights

### DIFF
--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -88,15 +88,22 @@ def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
     """Helper function to dequantize 4bit or 8bit bnb weights."""
     import bitsandbytes as bnb
 
-    if state.SCB is None:
-        state.SCB = weight.SCB
-
     device = weight.device
 
     cls_name = weight.__class__.__name__
     if cls_name == "Params4bit":
         dequantized = bnb.functional.dequantize_4bit(weight.data, weight.quant_state)
         return dequantized
+
+    # 8bit case
+    if state is None:
+        raise ValueError(
+            "No `state` was passed for bnb 8bit quantized weights. Please open an issue on the PEFT repository and "
+            "report the error: https://github.com/huggingface/peft/issues"
+        )
+
+    if state.SCB is None:
+        state.SCB = weight.SCB
 
     if hasattr(bnb.functional, "int8_vectorwise_dequant"):
         # Use bitsandbytes API if available (requires v0.45.0+)


### PR DESCRIPTION
Fixes some [failing GPU tests in CI](https://github.com/huggingface/peft/actions/runs/18580534896/job/52974274686#step:6:743).

A bug was introduced in #2797 where `state.SCB` was accessed while dequantizing 4bit bnb weights even though state is `None`. This would occur, for instance, when using DoRA, which needs to dequantize the weight. The attribute access is now restricted to 8bit bnb weights.