### PR TITLE
[WIP] TST Enable int4 torchao tests

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -53,6 +53,7 @@ RUN source activate peft && \
     "soundfile>=0.12.1" \
     scipy \
     torchao \
+    fbgemm-gpu-genai>=1.2.0 \
     git+https://github.com/huggingface/transformers \
     git+https://github.com/huggingface/accelerate \
     peft[test]@git+https://github.com/huggingface/peft \


### PR DESCRIPTION
Trying to train LoRA with int4 torchao used to raise a RuntimeError. Lately, this error no longer being raised, suggesting that int4 training is unblocked.

For this to work, we need:

- fbgemm-gpu-genai package from PyTorch (added to Dockerfile)
- transformers has to allow int4 training

The latter is not yet implemented, so this PR is WIP for now.

Moreover, on my machine, I still get an error with int4, namely:

> RuntimeError: cutlass cannot initialize

This could be something specific to my setup and has to be investigated further.

Moreover, there was a warning that bfloat16 should be used with torchao, so I switched the dtype used in the tests to bfloat16. This required one test to increase the tolerances for comparing outputs.