### PR TITLE
Update LoRA developer guides: non-in-place operations

### DIFF
--- a/docs/source/developer_guides/lora.md
+++ b/docs/source/developer_guides/lora.md
@@ -511,7 +511,7 @@ from peft import PeftModel
 base_model = AutoModelForCausalLM.from_pretrained("mistralai/Mistral-7B-v0.1")
 peft_model_id = "alignment-handbook/zephyr-7b-sft-lora"
 model = PeftModel.from_pretrained(base_model, peft_model_id)
-merged_model = model.merge_and_unload()
+model = model.merge_and_unload()
 ```
 
 It is important to assign the returned model to a variable and use it, [`~LoraModel.merge_and_unload`] is not an in-place operation. If you need to keep a copy of the weights so you can unmerge the adapter later or delete and load different ones, you should use the [`~LoraModel.merge_adapter`] function instead. Now you have the option to use [`~LoraModel.unmerge_adapter`] to return the base model.


### PR DESCRIPTION
The documentation of the [merge_and_unload()](https://huggingface.co/docs/peft/main/en/package_reference/tuners#peft.tuners.tuners_utils.BaseTuner.merge_and_unload) function clarifies that this is not an in-place operation. However, the [developer guides code snippets](https://huggingface.co/docs/peft/main/en/developer_guides/lora#merge-lora-weights-into-the-base-model) shows
``` py
from transformers import AutoModelForCausalLM
from peft import PeftModel

base_model = AutoModelForCausalLM.from_pretrained("mistralai/Mistral-7B-v0.1")
peft_model_id = "alignment-handbook/zephyr-7b-sft-lora"
model = PeftModel.from_pretrained(base_model, peft_model_id)
model.merge_and_unload()
```
which do not match the function documentation. The same happens with the [unload()](https://huggingface.co/docs/peft/main/en/package_reference/tuners#peft.tuners.tuners_utils.BaseTuner.unload) function.

This PR just changes it to be consistent and minimize silent mistakes when using the guides! 