### PR TITLE
MNT: Clean up unused method set_auxiliary_adapters

### DIFF
--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -28,6 +28,7 @@ from peft.utils import (
     _get_submodules,
     get_auto_gptq_quant_linear,
 )
+from peft.utils.other import _set_adapter
 
 
 # Collection of constants used for all tuners
@@ -188,7 +189,7 @@ class MixedModel(BaseTuner):
         return new_module
 
     def set_adapter(self, adapter_name: Union[str, list[str]], inference_mode: bool = False) -> None:
-        self.set_auxiliary_adapters(adapter_name, inference_mode=inference_mode)
+        _set_adapter(self, adapter_name, inference_mode=inference_mode)  # handle auxiliary modules
         for module in self.model.modules():
             if isinstance(module, Layers):
                 if module.merged:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1110,21 +1110,6 @@ class BaseTuner(nn.Module, ABC):
                 with onload_layer(module):
                     module.unmerge()
 
-    def set_auxiliary_adapters(self, adapter_name: str | list[str], inference_mode: bool) -> None:
-        """
-        Sets the active adapter(s) on auxiliary modules.
-
-        If the subclass (e.g. `LoraModel`) supports auxiliary modules like `modules_to_save`, it should call this
-        method in `set_adapter` to ensure that those auxiliary modules are being set correctly.
-
-        Args:
-            adapter_name (`str` or `list[str]`):
-                The name(s) of the adapter(s) to be set as active. The adapters must be loaded first.
-            inference_mode (bool, optional):
-                 Whether the activated adapter should be frozen (i.e. `requires_grad=False`). Default is False.
-        """
-        _set_adapter(self, adapter_name, inference_mode=inference_mode)
-
     def set_adapter(self, adapter_name: str | list[str], inference_mode: bool = False) -> None:
         """Set the active adapter(s).
 


### PR DESCRIPTION
During work on #2771, the usage of `set_auxiliary_adapters` became obsolete, expect in one place, which was missed. This has now been cleaned up and the obsolete method is removed.