### PR TITLE
CI: Install fbgemm package needed by torchao, update test

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -53,6 +53,7 @@ RUN source activate peft && \
     "soundfile>=0.12.1" \
     scipy \
     torchao \
+    fbgemm-gpu-genai>=1.2.0 \
     git+https://github.com/huggingface/transformers \
     git+https://github.com/huggingface/accelerate \
     peft[test]@git+https://github.com/huggingface/peft \


### PR DESCRIPTION
Newer torchao versions [require](https://github.com/huggingface/peft/actions/runs/19022204234/job/54319145351#step:6:648) `fbgemm-gpu-genai>=1.2.0`. This PR installs it into the GPU Dockerfile used for nightly testing.

I had initially hoped that this would also allow us to train `int4_weight_only` quantized torchao models, as explored in #2848. However, there is a new error when trying to use this. The test has been updated to reflect this.