### PR TITLE
ENH: Improve MetaMath training script runtime

### DIFF
--- a/method_comparison/MetaMathQA/run.py
+++ b/method_comparison/MetaMathQA/run.py
@@ -18,7 +18,6 @@ Main entry point to run the experiments. Contains general setup and the proper t
 
 import argparse
 import datetime as dt
-import gc
 import json
 import os
 import random
@@ -296,7 +295,6 @@ def train(
                 }
                 print_verbose(json.dumps(log_dict))
 
-            # # TODO is this needed?
             if step % ACCELERATOR_EMPTY_CACHE_SCHEDULE == 0:
                 torch_accelerator_module.empty_cache()
 


### PR DESCRIPTION
The training script of the MetaMathQA PEFT method comparison was calling `cuda.empty_cache()` and `gc.collect()` after each step. However, this is not really needed and it also slows down training considerably.

It turns out that `gc.collect()` is not needed at all when it comes to memory and thus it has been removed. This results in a big improvement in runtime. As for `empty_cache()`, not calling it at all leads to an increase in memory usage, but it's not necessary to call it every step. It is instead called every 10th step.

Improvement (tested locally, 250 steps):

- Removing `gc.collect()`
  - 108 sec => 65 sec
  - memory reserved max stays the same (19.3 GB)
  - memory reserved 99th percentile stays the same (18.0 GB)
  - memory reserved avg stays the same (12.0 GB)
- Also calling `empty_cache()` only every 10 steps
  - 65 sec => 50 sec
  - memory reserved max stays the same (19.3 GB)
  - memory reserved 99th percentile: 18.0 GB => 19.3 GB
  - memory reserved avg: 12.0 GB => 14.5 GB
- Not calling `empty_cache()` at all:
  - 65 sec => 45 sec
  - memory reserved max: 19.3 GB => 23.5 GB
  - memory reserved 99th percentile: 18.0 GB => 23.5 GB
  - memory reserved avg: 12.0 GB => 22.1 GB

Thus `gc.collect()` can be safely removed, but removing `empty_cache()` completely is not advisable. Calling `empty_cache()` only every 10th step does increase average memory usage, but the peak is unaffected, which is what's most important in this benchmark, so it is a worthwhile tradeoff for the 23% speed improvement we get.

I also tested how manually deleting certain torch variables (batch, output, loss) would affect training but could not see any difference.

While working on this PR, I also removed an obsolete comment and an unused variable.

Note to maintainers: If this is merged, **all MetaMathQA benchmarks should be re-run**.