### PR TITLE
Resolve #2431: Remove macos-13 from tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,10 +84,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           TRANSFORMERS_IS_CI: 1
         run: |
-          set +e
           make test
-          status=$?
-          exit $status
       - name: Dump cache content and diff
         # This is just debug info so that we can monitor if the model cache diverges substantially
         # over time and what the diverging model is.


### PR DESCRIPTION
As discussed in #2431 since there are no better macos runners available and the intel macos runners are failing for quite some time now we now have little choice other than to stop using macos in the CI.