### PR TITLE
Add Marian to author list

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To use 🤗 PEFT in your publication, please cite it by using the following BibT
 ```bibtex
 @Misc{peft,
   title =        {{PEFT}: State-of-the-art Parameter-Efficient Fine-Tuning methods},
-  author =       {Sourab Mangrulkar and Sylvain Gugger and Lysandre Debut and Younes Belkada and Sayak Paul and Benjamin Bossan},
+  author =       {Sourab Mangrulkar and Sylvain Gugger and Lysandre Debut and Younes Belkada and Sayak Paul and Benjamin Bossan and Marian Tietz},
   howpublished = {\url{https://github.com/huggingface/peft}},
   year =         {2022}
 }


### PR DESCRIPTION
I also saw that other PEFT repos have a CITATION.cff, which is also picked up by GH. Not sure how useful it is, it looks like a common standard but would be one more place to keep up-to-date.