### PR TITLE
FIX Load quantized weights with PEFT mixed model

### DIFF
--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import warnings
 from typing import Any, Optional, Union
 
+import torch
 from torch import nn
 from tqdm import tqdm
 
@@ -131,12 +132,23 @@ class MixedModel(BaseTuner):
                 new_module.state = child.state
             new_module.to(child.weight.device)
 
+        meta = torch.device("meta")
         # dispatch to correct device
         for name, module in new_module.named_modules():
             if any(prefix in name for prefix in PREFIXES):
-                module.to(child.weight.device)
-            if "ranknum" in name:
-                module.to(child.weight.device)
+                if hasattr(child, "qweight"):
+                    weight = child.qweight
+                elif hasattr(child, "W_q"):
+                    weight = child.W_q
+                elif hasattr(child, "weight"):
+                    weight = child.weight
+                elif getattr(child, "in_proj_weight", None) is not None:  # MHA
+                    weight = child.in_proj_weight
+                else:
+                    weight = next(child.parameters())
+
+                if not any(p.device == meta for p in module.parameters()):
+                    module.to(weight.device)
 
     def _mark_only_adapters_as_trainable(self, model: nn.Module) -> None:
         for n, p in model.named_parameters():


### PR DESCRIPTION
Resolves #2914

The handling of loading weights with quantized base models by PEFT mixed model has fallen a bit behind, which resulted in some quantization types not working. This PR brings it up to date with [the normal PEFT model](https://github.com/huggingface/peft/blob/5fbdd672f5591f69472b46f84b12ae443f9579e6/src/peft/tuners/tuners_utils.py#L1058-L1074).

As this is a very special case that requires GPU, I think it's overkill to add a test just for that. To test it with AWQ, you can run:

```python
from transformers import AutoModelForCausalLM
from peft import PeftMixedModel

model_id = "hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4"
model = AutoModelForCausalLM.from_pretrained(model_id)

model_name_lora = "Tfloow/Meta-Llama-3.1-8B-Instruct-AWQ-INT4_simulated_2-bits_lora_test_QKGateUp"
model = PeftMixedModel.from_pretrained(
    model,
    model_name_lora,
)
```