### PR TITLE
FIX Move further models to safetensors

### DIFF
--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -897,7 +897,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         EXPECTED_ALL_PARAMS = 125534208
 
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
 
@@ -917,7 +917,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         )
 
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=bnb_config,
         )
 
@@ -972,7 +972,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_8bit_merge_lora(self):
         torch.manual_seed(1000)
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
         random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
@@ -1005,7 +1005,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_8bit_merge_and_disable_lora(self):
         torch.manual_seed(1000)
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
         random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
@@ -1042,7 +1042,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         # same as test_8bit_merge_lora but with lora_bias=True
         torch.manual_seed(0)
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
         random_input = torch.LongTensor([[1, 0, 1, 0, 1, 0]]).to(model.device)
@@ -1078,7 +1078,7 @@ class PeftGPUCommonTests(unittest.TestCase):
             bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=bnb_config,
             dtype=torch.float32,
         )
@@ -1120,7 +1120,7 @@ class PeftGPUCommonTests(unittest.TestCase):
             bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=bnb_config,
             dtype=torch.float32,
         )
@@ -1163,7 +1163,7 @@ class PeftGPUCommonTests(unittest.TestCase):
             bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=bnb_config,
             dtype=torch.float32,
         )
@@ -1204,11 +1204,11 @@ class PeftGPUCommonTests(unittest.TestCase):
             bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=bnb_config,
             dtype=torch.float32,
         ).eval()
-        tokenizer = AutoTokenizer.from_pretrained("facebook/opt-125m")
+        tokenizer = AutoTokenizer.from_pretrained("peft-internal-testing/opt-125m")
         # input with 9 samples
         inputs = tokenizer(
             [
@@ -1272,11 +1272,11 @@ class PeftGPUCommonTests(unittest.TestCase):
         torch.manual_seed(3000)
         bnb_config = BitsAndBytesConfig(load_in_8bit=True)
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=bnb_config,
             dtype=torch.float32,
         ).eval()
-        tokenizer = AutoTokenizer.from_pretrained("facebook/opt-125m")
+        tokenizer = AutoTokenizer.from_pretrained("peft-internal-testing/opt-125m")
         # input with 9 samples
         inputs = tokenizer(
             [
@@ -1357,7 +1357,7 @@ class PeftGPUCommonTests(unittest.TestCase):
             bnb_4bit_compute_dtype=torch.float32,
         )
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=bnb_config,
             dtype=torch.float32,
         )
@@ -1370,7 +1370,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         logits_lora = model(random_input).logits
 
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=bnb_config,
             dtype=torch.float32,
         )
@@ -1392,7 +1392,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_8bit_dora_inference(self):
         # check for same result with and without DoRA when initializing with init_lora_weights=False
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             dtype=torch.float32,
         ).eval()
@@ -1405,7 +1405,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         logits_lora = model(random_input).logits
 
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             dtype=torch.float32,
         )
@@ -1483,7 +1483,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         # Check results for merging, unmerging, unloading
         torch.manual_seed(0)
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             dtype=torch.float32,
         ).eval()
@@ -1533,7 +1533,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         torch.manual_seed(0)
 
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             dtype=torch.float32,
         ).eval()
 
@@ -1585,7 +1585,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         torch.manual_seed(0)
 
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             dtype=torch.float32,
         ).eval()
 
@@ -1616,7 +1616,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         # Check results for merging, unmerging, unloading
         torch.manual_seed(0)
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             dtype=torch.float32,
         ).eval()
@@ -1704,7 +1704,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     def test_apply_GS_hra_inference(self):
         # check for different result with and without apply_GS
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             dtype=torch.float32,
         ).eval()
 
@@ -1716,7 +1716,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         logits_hra = model(random_input).logits
 
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             dtype=torch.float32,
         )
         torch.manual_seed(0)
@@ -1758,7 +1758,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         # check that an untrained HRA adapter can't be initialized as an identity tranformation
         # when r is an odd number
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             dtype=torch.float32,
         ).eval()
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -3424,7 +3424,7 @@ class TestPeftCustomModel(PeftCommonTester):
         # Here we test the refactor of DoRA which changed lora_magnitude_vector from a ParameterDict to a ModuleDict
         # with a DoraLayer instance. The old parameter is now the "weight" attribute of that layer. Since we want the
         # state_dict format not to change, we ensure that the ".weight" part of the key is removed.
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
         config = LoraConfig(task_type="CAUSAL_LM", use_dora=True)
         model = get_peft_model(model, config)
         state_dict = model.state_dict()
@@ -3442,7 +3442,9 @@ class TestPeftCustomModel(PeftCommonTester):
             assert not any("lora_magnitude_vector.weight" in k for k in state_dict_adapter)
 
             del model
-            loaded = PeftModel.from_pretrained(AutoModelForCausalLM.from_pretrained("facebook/opt-125m"), tmp_dirname)
+            loaded = PeftModel.from_pretrained(
+                AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m"), tmp_dirname
+            )
         finally:
             try:
                 shutil.rmtree(tmp_dirname)
@@ -6052,7 +6054,9 @@ class TestMixedAdapterBatches:
             toc = time.perf_counter()
             logs.append(toc - tic)
 
-        base_model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m").to(self.torch_device).eval()
+        base_model = (
+            AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m").to(self.torch_device).eval()
+        )
         inputs = {"input_ids": torch.randint(0, 1000, (16, 64)).to(self.torch_device)}
         with timed():
             output_base = base_model(**inputs).logits
@@ -6250,7 +6254,7 @@ class TestDynamicDispatch:
     def test_override_lora_linear(self, custom_lora_cls):
         # in this test, we check if users can override default PEFT behavior by supplying a custom lora class that is
         # being used instead of lora.Linear
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
         config = LoraConfig(task_type=TaskType.CAUSAL_LM)
         config._register_custom_module({nn.Linear: custom_lora_cls})
         peft_model = get_peft_model(model, config)

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -153,7 +153,7 @@ DEVICE_MAP_MAP: dict[str, dict[str, int]] = {
         "model.decoder.layers.31": 1,
         "lm_head": 0,  # tied with embed_tokens
     },
-    "facebook/opt-125m": {
+    "peft-internal-testing/opt-125m": {
         "model.decoder.embed_tokens": 0,
         "model.decoder.embed_positions": 0,
         "model.decoder.final_layer_norm": 1,
@@ -899,7 +899,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
 
         # default adapter name
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             device_map="auto",
             quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
@@ -909,7 +909,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
 
         # other adapter name
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             device_map="auto",
             quantization_config=BitsAndBytesConfig(load_in_4bit=True),
         )
@@ -934,7 +934,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
 
         # default adapter name
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             device_map="auto",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
@@ -944,7 +944,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
 
         # other adapter name
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             device_map="auto",
             quantization_config=BitsAndBytesConfig(load_in_8bit=True),
         )
@@ -1249,7 +1249,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
         # 1674
         # The issue is that to initialize DoRA, we need to dequantize the weights. That only works on GPU for bnb.
         # Therefore, initializing DoRA with bnb on CPU used to fail.
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         if kbit == "4bit":
             bnb_config = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type="nf4")
         elif kbit == "8bit":
@@ -2498,7 +2498,7 @@ class TestPiSSA:
         tmp_path,
         bits=4,
         device="cuda",
-        model_id="hf-internal-testing/tiny-random-BloomForCausalLM",
+        model_id="peft-internal-testing/tiny-random-BloomForCausalLM",
     ):
         # Comparing the quantized LoRA model to the base model, vs the PiSSA quantized model to the base model.
         # We expect the PiSSA quantized model to have less error than the normal LoRA quantized model.
@@ -2710,7 +2710,7 @@ class TestOLoRA:
         tmp_path,
         bits=4,
         device="cuda",
-        model_id="hf-internal-testing/tiny-random-BloomForCausalLM",
+        model_id="peft-internal-testing/tiny-random-BloomForCausalLM",
     ):
         # Comparing the quantized LoRA model to the base model, vs the OLoRA quantized model to the base model.
         # We expect the OLoRA quantized model to have less error than the normal LoRA quantized model.
@@ -2859,7 +2859,7 @@ class TestLoftQ:
         bits=4,
         loftq_iter=1,
         device="cuda",
-        model_id="hf-internal-testing/tiny-random-BloomForCausalLM",
+        model_id="peft-internal-testing/tiny-random-BloomForCausalLM",
         use_dora=False,
     ):
         # Helper function that returns the quantization errors (MAE and MSE) when comparing the quantized LoRA model
@@ -3206,7 +3206,7 @@ class MultiprocessTester(unittest.TestCase):
 @require_non_cpu
 class MixedPrecisionTests(unittest.TestCase):
     def setUp(self):
-        self.causal_lm_model_id = "facebook/opt-125m"
+        self.causal_lm_model_id = "peft-internal-testing/opt-125m"
         self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
         self.config = LoraConfig(
             r=16,
@@ -3910,7 +3910,7 @@ class PeftEetqGPUTests(unittest.TestCase):
     """
 
     def setUp(self):
-        self.causal_lm_model_id = "facebook/opt-125m"
+        self.causal_lm_model_id = "peft-internal-testing/opt-125m"
         self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
 
     def tearDown(self):
@@ -4065,7 +4065,7 @@ class PeftTorchaoGPUTests(unittest.TestCase):
     ]
 
     def setUp(self):
-        self.causal_lm_model_id = "facebook/opt-125m"
+        self.causal_lm_model_id = "peft-internal-testing/opt-125m"
         self.tokenizer = AutoTokenizer.from_pretrained(self.causal_lm_model_id)
         # torchao breaks with fp16 and if a previous test uses fp16, transformers will set this env var, which affects
         # subsequent tests, therefore the env var needs to be cleared explicitly
@@ -4597,7 +4597,7 @@ class TestFSDPWrap:
             bnb_4bit_use_double_quant=True,
         )
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=quant_config,
             dtype=torch.float32,
         )
@@ -4649,7 +4649,7 @@ class TestBOFT:
 
 class TestPTuningReproducibility:
     device = infer_device()
-    causal_lm_model_id = "facebook/opt-125m"
+    causal_lm_model_id = "peft-internal-testing/opt-125m"
 
     @require_non_cpu
     @require_deterministic_for_xpu
@@ -4660,7 +4660,7 @@ class TestPTuningReproducibility:
 
         # The model must be sufficiently large for the effect to be measurable, which is why this test requires is not
         # run on CPU.
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         inputs = torch.arange(10).view(-1, 1).to(self.device)
 
         torch.manual_seed(0)
@@ -4936,13 +4936,13 @@ class TestALoRAInferenceGPU:
 
     @pytest.fixture
     def tokenizer(self):
-        tokenizer = AutoTokenizer.from_pretrained("facebook/opt-125m")
+        tokenizer = AutoTokenizer.from_pretrained("peft-internal-testing/opt-125m")
         tokenizer.pad_token = tokenizer.eos_token
         return tokenizer
 
     @pytest.fixture
     def model(self):
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
         model.model.decoder.layers = model.model.decoder.layers[:2]  # truncate to 2 layers
         return model.to(self.DEVICE)
 
@@ -4950,7 +4950,7 @@ class TestALoRAInferenceGPU:
     def model_bnb(self):
         bnb_config = BitsAndBytesConfig(load_in_4bit=True)
         model = AutoModelForCausalLM.from_pretrained(
-            "facebook/opt-125m",
+            "peft-internal-testing/opt-125m",
             quantization_config=bnb_config,
         )
         model.model.decoder.layers = model.model.decoder.layers[:2]  # truncate to 2 layers
@@ -5001,7 +5001,7 @@ class TestALoRAInferenceGPU:
 @pytest.mark.multi_gpu_tests
 class TestPrefixTuning:
     device = infer_device()
-    causal_lm_model_id = "facebook/opt-125m"
+    causal_lm_model_id = "peft-internal-testing/opt-125m"
 
     @require_torch_multi_accelerator
     def test_prefix_tuning_multiple_devices_decoder_model(self):
@@ -5031,7 +5031,7 @@ class TestPrefixTuning:
     @require_torch_multi_accelerator
     def test_prefix_tuning_multiple_devices_encoder_decoder_model(self):
         # See issue 2134
-        model_id = "hf-internal-testing/tiny-random-T5Model"
+        model_id = "peft-internal-testing/tiny-random-T5Model"
         tokenizer = AutoTokenizer.from_pretrained(model_id, padding="left")
         inputs = tokenizer(["A list of colors: red, blue"], return_tensors="pt").to(self.device)
         device_map = {
@@ -5394,7 +5394,7 @@ class TestArrowQuantized:
         Build a randomly initialized LoRA adapter for OPT-125M and save into `out_dir`. We construct a model from
         CONFIG (no pretrained weights) to avoid slow downloads here.
         """
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         # Target all linear layers so the adapter matches whatever we later quantize/load.
         lora_cfg = LoraConfig(
             r=rank,
@@ -5427,7 +5427,7 @@ class TestArrowQuantized:
         if not torch.cuda.is_available():
             pytest.skip("CUDA required for 4-bit bitsandbytes test.")
 
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
 
         # Quantization config (nf4, bf16 compute)
         bnb_config = BitsAndBytesConfig(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -77,7 +77,7 @@ class TestCheckIsPeftModel:
 class TestScalingAdapters:
     @pytest.fixture(scope="class")
     def tokenizer(self):
-        return AutoTokenizer.from_pretrained("facebook/opt-125m")
+        return AutoTokenizer.from_pretrained("peft-internal-testing/opt-125m")
 
     def get_scale_from_modules(self, model):
         layer_to_scale_map = {}
@@ -88,7 +88,7 @@ class TestScalingAdapters:
         return layer_to_scale_map
 
     def test_rescale_adapter_scale(self, tokenizer):
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
         lora_config = LoraConfig(
             r=4,
             lora_alpha=4,
@@ -127,7 +127,7 @@ class TestScalingAdapters:
         assert torch.allclose(logits_before_scaling, logits_after_scaling)
 
     def test_wrong_scaling_datatype(self):
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
         lora_config = LoraConfig(
             r=4,
             lora_alpha=4,
@@ -146,7 +146,7 @@ class TestScalingAdapters:
                 pass
 
     def test_not_lora_model(self):
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
 
         # we expect a value error here because the model
         # does not have lora layers
@@ -155,7 +155,7 @@ class TestScalingAdapters:
                 pass
 
     def test_scaling_set_to_zero(self, tokenizer):
-        base_model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        base_model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
         inputs = tokenizer("hello world", return_tensors="pt")
 
         base_model.eval()
@@ -230,7 +230,7 @@ class TestScalingAdapters:
 
     def test_transformers_pipeline(self, tmp_path, tokenizer):
         # this uses a transformers model that loads the adapter directly
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         model = AutoModelForCausalLM.from_pretrained(model_id)
         config = LoraConfig(init_lora_weights=False)
         model = get_peft_model(model, config)
@@ -267,7 +267,7 @@ class TestScalingAdapters:
         assert torch.allclose(logits_before_scaling, logits_after_scaling)
 
     def test_multi_adapters(self, tokenizer):
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
         lora_config = LoraConfig(
             r=4,
             lora_alpha=4,
@@ -308,7 +308,7 @@ class TestScalingAdapters:
         assert torch.allclose(logits_before, logits_after)
 
     def test_rank_alpha_pattern(self, tokenizer):
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
         lora_config = LoraConfig(
             r=4,
             lora_alpha=4,
@@ -349,7 +349,7 @@ class TestScalingAdapters:
         assert torch.allclose(logits_before_scaling, logits_after_scaling)
 
     def test_merging_adapter(self, tokenizer):
-        model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+        model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
         lora_config = LoraConfig(
             r=4,
             lora_alpha=4,

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -51,7 +51,7 @@ class TestLocalModel:
         # However, previously, those checks only covered huggingface hub models.
         # This test makes sure that the local `config.json` is checked as well.
         # If `save_pretrained` could not find the file, it will issue a warning.
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         model = AutoModelForCausalLM.from_pretrained(model_id)
         local_dir = tmp_path / model_id
         model.save_pretrained(local_dir)

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -171,7 +171,7 @@ class TestInjectAdapterFromStateDict:
                 assert sd_before[key].shape == sd_after[key].shape
 
     def test_inject_from_state_dict_transformers(self):
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         config = LoraConfig()
 
         with hub_online_once(model_id):
@@ -193,7 +193,7 @@ class TestInjectAdapterFromStateDict:
 
     def test_inject_from_state_dict_transformers_irregular_targets(self):
         # ensure that this works even if an "irregular" pattern is used, i.e. only targeting some modules on some layers
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         config = LoraConfig(
             target_modules=r".*\.[0-5]\.self_attn\.v_proj|.*\.[4-7]\.self_attn\.k_proj",
         )
@@ -220,7 +220,7 @@ class TestInjectAdapterFromStateDict:
         # the state_dict, we cannot tell if the user intends to use target_modules or target_parameters. Currently, we
         # just assume the former, thus applying normal lora.Linear etc. layers instead of lora.ParamWrapper. When we
         # detect that the user tries to do this, we raise an error.
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         config = LoraConfig(target_modules=[], target_parameters=["q_proj.weight", "v_proj.weight"])
 
         with hub_online_once(model_id):
@@ -242,7 +242,7 @@ class TestInjectAdapterFromStateDict:
         # the state_dict, we cannot tell if the user intends to use target_modules or target_parameters. Currently, we
         # just assume the former, thus applying normal lora.Linear etc. layers instead of lora.ParamWrapper. When we
         # don't detect that the user tries to do this, there is nothing that can be done.
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         config = LoraConfig(target_modules=[], target_parameters=["q_proj.weight", "v_proj.weight"])
 
         with hub_online_once(model_id):
@@ -311,7 +311,7 @@ class TestInjectAdapterFromStateDict:
                 assert sd_unet_before[key].shape == sd_unet_after[key].shape
 
     def test_inject_from_state_dict_low_cpu_mem_usage(self):
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         config = LoraConfig()
 
         with hub_online_once(model_id):
@@ -328,7 +328,7 @@ class TestInjectAdapterFromStateDict:
 
     def test_inject_from_state_dict_missing_keys_warning(self):
         # check that if the PEFT config specifies **more** taget modules than the state_dict, we get a warning for that
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         config = LoraConfig()
 
         with hub_online_once(model_id):
@@ -362,7 +362,7 @@ class TestInjectAdapterFromStateDict:
 
     def test_inject_from_state_dict_extra_keys_warning(self):
         # check that if the PEFT config specifies **fewer** taget modules than the state_dict, we get a warning for that
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         config = LoraConfig()
 
         with hub_online_once(model_id):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -524,7 +524,7 @@ class TestGetNoSplitModules:
 
     def test_get_no_split_modules_simple(self):
         # choose a model where recursively visiting children is *not* required
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         model = AutoModelForCausalLM.from_pretrained(model_id)
         assert model._no_split_modules == ["OPTDecoderLayer"]
         no_split_modules = _get_no_split_modules(model)
@@ -549,10 +549,10 @@ class TestGetModuleNamesTiedWithEmbedding:
             "cls.predictions.decoder.weight": "bert.embeddings.word_embeddings.weight",
             "cls.predictions.decoder.bias": "bert.embeddings.word_embeddings.bias",
         },
-        "facebook/opt-125m": {
+        "peft-internal-testing/opt-125m": {
             "lm_head.weight": "model.decoder.embed_tokens.weight",
         },
-        "hf-internal-testing/tiny-random-t5": {
+        "peft-internal-testing/tiny-random-t5": {
             "lm_head.weight": "shared.weight",
             "encoder.embed_tokens.weight": "shared.weight",
             "decoder.embed_tokens.weight": "shared.weight",
@@ -560,9 +560,9 @@ class TestGetModuleNamesTiedWithEmbedding:
     }
 
     model_ids = [
-        "facebook/opt-125m",
+        "peft-internal-testing/opt-125m",
         "peft-internal-testing/tiny-random-BertModel",
-        "hf-internal-testing/tiny-random-t5",
+        "peft-internal-testing/tiny-random-t5",
     ]
 
     @contextmanager

--- a/tests/test_trainable_tokens.py
+++ b/tests/test_trainable_tokens.py
@@ -579,7 +579,7 @@ class TestTrainableTokens:
 
     @pytest.fixture()
     def model_id_weight_tied(self):
-        return "facebook/opt-125m"
+        return "peft-internal-testing/opt-125m"
 
     @pytest.fixture()
     def model_weight_tied(self, request, model_id_weight_tied):
@@ -757,7 +757,7 @@ class TestTrainableTokens:
         ],
     )
     def test_weight_tying_applied_when_model_is_tied_encoder_decoder(self, peft_config):
-        model_id = "hf-internal-testing/tiny-random-t5"
+        model_id = "peft-internal-testing/tiny-random-t5"
         base_model = AutoModelForSeq2SeqLM.from_pretrained(model_id)
 
         peft_model = get_peft_model(base_model, peft_config)

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -134,14 +134,14 @@ MAYBE_INCLUDE_ALL_LINEAR_LAYERS_TEST_CASES = [
     # model_name, model_type, initial_target_modules, expected_target_modules
     # test for a causal Llama model
     (
-        "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+        "peft-internal-testing/tiny-random-LlamaForCausalLM",
         "causal",
         INCLUDE_LINEAR_LAYERS_SHORTHAND,
         ["k_proj", "v_proj", "q_proj", "o_proj", "down_proj", "up_proj", "gate_proj"],
     ),
     # test for a Llama model without the LM head
     (
-        "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+        "peft-internal-testing/tiny-random-LlamaForCausalLM",
         "base",
         INCLUDE_LINEAR_LAYERS_SHORTHAND,
         ["k_proj", "v_proj", "q_proj", "o_proj", "down_proj", "up_proj", "gate_proj"],
@@ -150,14 +150,15 @@ MAYBE_INCLUDE_ALL_LINEAR_LAYERS_TEST_CASES = [
     ("hf-internal-testing/tiny-random-gpt2", "causal", INCLUDE_LINEAR_LAYERS_SHORTHAND, ["c_attn", "c_proj", "c_fc"]),
     # test for T5 model
     (
-        "hf-internal-testing/tiny-random-t5",
+        "peft-internal-testing/tiny-random-t5",
         "seq2seq",
         INCLUDE_LINEAR_LAYERS_SHORTHAND,
         ["k", "q", "v", "o", "wi", "wo"],
     ),
-    # test for GPTNeoX. output module list should exclude classification head - which is named as "embed_out" instead of the usual "lm_head" for GPTNeoX
+    # test for GPTNeoX. output module list should exclude classification head - which is named as "embed_out" instead of
+    # the usual "lm_head" for GPTNeoX
     (
-        "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
+        "peft-internal-testing/tiny-random-GPTNeoXForCausalLM",
         "causal",
         INCLUDE_LINEAR_LAYERS_SHORTHAND,
         ["query_key_value", "dense", "dense_h_to_4h", "dense_4h_to_h"],
@@ -178,7 +179,7 @@ BNB_QUANTIZATIONS = [("4bit",), ("8bit",)]
 BNB_TEST_CASES = [(x + y) for x in MAYBE_INCLUDE_ALL_LINEAR_LAYERS_TEST_CASES for y in BNB_QUANTIZATIONS]
 
 
-class PeftCustomKwargsTester:
+class TestPeftCustomKwargs:
     r"""
     Test if the PeftModel is instantiated with correct behaviour for custom kwargs. This includes:
     - test if regex matching works correctly
@@ -207,7 +208,7 @@ class PeftCustomKwargsTester:
         # users to easily debug their configuration. Here we only test a single case, not all possible combinations of
         # configs that could exist. This is okay as the method calls `check_target_module_exists` internally, which
         # has been extensively tested above.
-        model_id = "hf-internal-testing/tiny-random-BloomForCausalLM"
+        model_id = "peft-internal-testing/tiny-random-BloomForCausalLM"
         with hub_online_once(model_id):
             model = AutoModel.from_pretrained(model_id)
         # by default, this model matches query_key_value
@@ -231,7 +232,7 @@ class PeftCustomKwargsTester:
             assert key not in unmatched
 
     def test_feedforward_matching_ia3(self):
-        model_id = "hf-internal-testing/tiny-random-T5ForConditionalGeneration"
+        model_id = "peft-internal-testing/tiny-random-T5ForConditionalGeneration"
         with hub_online_once(model_id):
             model = AutoModelForSeq2SeqLM.from_pretrained(model_id)
         # simple example for just one t5 block for testing
@@ -313,7 +314,7 @@ class PeftCustomKwargsTester:
 
     def test_maybe_include_all_linear_layers_ia3_loha(self):
         model_id, initial_target_modules, expected_target_modules = (
-            "HuggingFaceH4/tiny-random-LlamaForCausalLM",
+            "peft-internal-testing/tiny-random-LlamaForCausalLM",
             INCLUDE_LINEAR_LAYERS_SHORTHAND,
             ["k_proj", "v_proj", "q_proj", "o_proj", "down_proj", "up_proj", "gate_proj"],
         )
@@ -329,7 +330,7 @@ class PeftCustomKwargsTester:
 
     @parameterized.expand(MAYBE_INCLUDE_ALL_LINEAR_LAYERS_TEST_INTERNALS)
     def test_maybe_include_all_linear_layers_internals(self, initial_target_modules, expected_target_modules):
-        model_id = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
+        model_id = "peft-internal-testing/tiny-random-LlamaForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
         config = LoraConfig(base_model_name_or_path=model_id, target_modules=initial_target_modules)
@@ -356,7 +357,7 @@ class PeftCustomKwargsTester:
         # See issue 2027
         # Ensure that if a SEQ_CLS model is being used with target_modules="all-linear", the classification head is not
         # targeted by the adapter layer.
-        model_id = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
+        model_id = "peft-internal-testing/tiny-random-LlamaForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForSequenceClassification.from_pretrained(model_id, num_labels=10)
         # sanity check
@@ -397,7 +398,7 @@ class PeftCustomKwargsTester:
     def test_add_second_adapter_with_all_linear_works(self):
         # See 2390 Similar test to test_all_linear_nested_targets_correct_layers above, but using add_adapter instead of
         # calling get_peft_model in an already adapted model
-        model_id = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
+        model_id = "peft-internal-testing/tiny-random-LlamaForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
 
@@ -480,7 +481,7 @@ class TestTargetedModuleNames:
         assert model.targeted_module_names == ["lin0", "lin1"]
 
     def test_realistic_example(self):
-        model_id = "hf-internal-testing/tiny-random-BloomForCausalLM"
+        model_id = "peft-internal-testing/tiny-random-BloomForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
         config = LoraConfig(task_type="CAUSAL_LM")
@@ -581,7 +582,7 @@ class TestExcludedModuleNames:
             get_peft_model(model, LoraConfig(target_modules=["lin1"], exclude_modules=["non_existent_module"]))
 
     def test_realistic_example(self):
-        model_id = "hf-internal-testing/tiny-random-BloomForCausalLM"
+        model_id = "peft-internal-testing/tiny-random-BloomForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
         config = LoraConfig(task_type="CAUSAL_LM", exclude_modules="transformer.h.2.self_attention.query_key_value")
@@ -1451,7 +1452,7 @@ class TestModelAndLayerStatus:
             model.get_model_status()
 
     def test_adaption_prompt(self):
-        model_id = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
+        model_id = "peft-internal-testing/tiny-random-LlamaForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
         config = AdaptionPromptConfig(adapter_layers=1, adapter_len=4)
@@ -1545,7 +1546,7 @@ class TestBaseTunerGetModelConfig:
 
 
 class TestBaseTunerWarnForTiedEmbeddings:
-    model_id = "HuggingFaceH4/tiny-random-LlamaForCausalLM"
+    model_id = "peft-internal-testing/tiny-random-LlamaForCausalLM"
     warn_end_inject = "huggingface/peft/issues/2018."
     warn_end_merge = (
         "# Now use the original model but in untied format\n"
@@ -1686,7 +1687,7 @@ class TestFindMinimalTargetModules:
         # Check that when calling get_peft_model, the target_module optimization is indeed applied if the length of
         # target_modules is big enough. The resulting model itself should be unaffected.
         torch.manual_seed(0)
-        model_id = "facebook/opt-125m"  # must be big enough for optimization to trigger
+        model_id = "peft-internal-testing/opt-125m"  # must be big enough for optimization to trigger
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
 

--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -51,7 +51,7 @@ def flaky(num_tries: int):
 class TestXlora:
     torch_device = infer_device()
 
-    model_id = "facebook/opt-125m"
+    model_id = "peft-internal-testing/opt-125m"
     num_loras = 4
 
     @pytest.fixture(scope="class")
@@ -356,7 +356,7 @@ class TestXlora:
         # This test also simulatenously tests the loading-from-hub functionality!
         torch.manual_seed(123)
 
-        model_id = "facebook/opt-125m"
+        model_id = "peft-internal-testing/opt-125m"
         model = AutoModelForCausalLM.from_pretrained(model_id)
         model.config.use_cache = False
 


### PR DESCRIPTION
This is a continuation of #2913. Check that PR for explanation. Some models were missed, this should now hopefully cover all of them.