### PR TITLE
MetaMath: Add forgetting metric

### DIFF
--- a/method_comparison/MetaMathQA/data.py
+++ b/method_comparison/MetaMathQA/data.py
@@ -107,3 +107,11 @@ def tokenize_wo_answer(samples, tokenizer, template):
         input_ids[: tokenizer.model_max_length] for input_ids in tokenized["attention_mask"]
     ]
     return tokenized
+
+
+def get_wiki_small(num_samples: int = 100) -> list[str]:
+    # This way of loading the dataset avoid having to download whole shards
+    ds = load_dataset("HuggingFaceFW/finewiki", split="train", streaming=True)
+    dataset_head = ds.take(num_samples)
+    rows = [row["text"] for row in dataset_head]
+    return rows

--- a/method_comparison/MetaMathQA/run.py
+++ b/method_comparison/MetaMathQA/run.py
@@ -29,7 +29,7 @@ from functools import partial
 from typing import Any, Callable, Literal, Optional
 
 import torch
-from data import get_train_valid_test_datasets
+from data import get_train_valid_test_datasets, get_wiki_small
 from torch import nn
 from torch.amp import GradScaler, autocast
 from tqdm import tqdm
@@ -92,6 +92,30 @@ def evaluate(model, tokenizer, ds, batch_size, generate_kwargs, use_tqdm: bool =
             outputs = model.generate(**batch, generation_config=generation_config, pad_token_id=tokenizer.eos_token_id)
             predictions += tokenizer.batch_decode(outputs, skip_special_tokens=True)
     return predictions, responses
+
+
+@torch.inference_mode  # type: ignore
+def calculate_mean_per_token_loss(model, tokenizer, rows: list[str], batch_size: int, max_length: int) -> float:
+    """Calculate the mean loss per token on the given dataset.
+
+    Useful to determine general model performance before and after training to get an estimate of the magnitude of
+    'forgetting'. Note that for Wikipedia data, since the information density is quite high, the loss can be
+    surprisingly large.
+
+    """
+    losses: list[float] = []
+    for j in range(0, len(rows), batch_size):
+        sliced = rows[j : j + batch_size]
+        batch = tokenizer(sliced, truncation=True, max_length=max_length)
+        batch = tokenizer.pad(batch, return_tensors="pt", padding_side="left").to(model.device)
+        outputs = model(**batch, pad_token_id=tokenizer.eos_token_id)
+        logits = outputs.logits
+        for logit, target, mask in zip(logits, batch["input_ids"], batch["attention_mask"]):
+            # calculate loss per token so that the mean is not skewed by sequence length of sample
+            num_tokens = mask.sum()
+            token_losses = torch.nn.functional.cross_entropy(logit[:num_tokens], target[:num_tokens], reduction="none")
+            losses.extend(loss.item() for loss in token_losses)
+    return torch.tensor(losses).mean().item()
 
 
 class DummyGradScaler:
@@ -167,6 +191,14 @@ def train(
     tic_train = time.perf_counter()
     eval_time = 0.0
     error_msg = ""
+
+    rows_wiki = get_wiki_small()
+    model.eval()
+    # use small batch_size, not batch_size_eval, to prevent this from taking too much memory and affecting the max memory metric
+    wiki_loss_before = calculate_mean_per_token_loss(
+        model=model, tokenizer=tokenizer, rows=rows_wiki, batch_size=batch_size, max_length=768
+    )
+    model.train()
 
     ds_train, ds_valid, ds_test = get_train_valid_test_datasets(
         tokenizer=tokenizer, query_template=query_template, print_fn=print_verbose
@@ -310,6 +342,11 @@ def train(
             use_tqdm=len(ds_test) > 100,
         )
         accuracy = get_accuracy(predictions=predictions, responses=responses)
+        # use small batch_size, not batch_size_eval, to prevent this from taking too much memory and affecting the max memory metric
+        wiki_loss_after = calculate_mean_per_token_loss(
+            model=model, tokenizer=tokenizer, rows=rows_wiki, batch_size=batch_size, max_length=768
+        )
+        forgetting = wiki_loss_after - wiki_loss_before
         metrics.append(
             {
                 "step": step,
@@ -317,6 +354,7 @@ def train(
                 "train loss": sum(losses[-eval_steps:]) / eval_steps,
                 "train samples": total_samples,
                 "train total tokens": sum(total_tokens),
+                "forgetting": forgetting,
             }
         )
         print_verbose(f"Test accuracy: {accuracy:.3f}")

--- a/method_comparison/app.py
+++ b/method_comparison/app.py
@@ -34,6 +34,7 @@ metric_preferences = {
     "test_accuracy": "higher",
     "train_loss": "lower",
     "num_trainable_params": "lower",
+    "forgetting*": "lower",
 }
 
 
@@ -230,6 +231,11 @@ def build_app(df):
             )
             apply_filter_button = gr.Button("Apply Filter")
             reset_filter_button = gr.Button("Reset Filter")
+
+        gr.Markdown(
+            "*forgetting: This is the reduction in CE loss on a sample of Wikipedia data and reflects how much the "
+            "model 'forgot' during training. The lower the number, the better."
+        )
 
         gr.Markdown("## Pareto plot")
         gr.Markdown(

--- a/method_comparison/processing.py
+++ b/method_comparison/processing.py
@@ -56,6 +56,7 @@ def preprocess(rows, task_name: str, print_fn=print):
             "train_loss": train_metrics["train loss"],
             "train_samples": train_metrics["train samples"],
             "train_total_tokens": train_metrics["train total tokens"],
+            "forgetting*": train_metrics.get("forgetting", 123),
             "peft_version": meta_info["package_info"]["peft-version"],
             "peft_branch": run_info["peft_branch"],
             "transformers_version": meta_info["package_info"]["transformers-version"],
@@ -104,6 +105,7 @@ def load_df(path, task_name, print_fn=print):
         "train_loss": float,
         "train_samples": int,
         "train_total_tokens": int,
+        "forgetting*": float,
         "num_trainable_params": int,
         "peft_version": "string",
         "peft_branch": "string",
@@ -137,6 +139,7 @@ def load_df(path, task_name, print_fn=print):
         "file_size",
         "created_at",
         "task_name",
+        "forgetting*",
     ]
     other_columns = [col for col in df if col not in important_columns]
     df = df[important_columns + other_columns]


### PR DESCRIPTION
This PR adds a new test metric to the MetaMathQA benchmark, 'forgetting'. This can be valid concern when fine-tuning models and some PEFT methods have reduced forgetting as a stated goal. Also, general wisdom is that PEFT forgets less than full fine-tuning.

The methodology to measure forgetting is pretty simple: Load a small subset of [finewiki](https://huggingface.co/datasets/HuggingFaceFW/finewiki) and calculate the cross entropy loss on it before and after fine-tuning. This is different from how some papers measure it, e.g. https://arxiv.org/abs/2405.09673. But we want to get a quick result and running full evals involving generations would slow down testing considerably for a non-essential metric. Metrics based on generations also have higher variance, so we cannot rely on small subsamples to get quick results.

We log the difference in loss after vs before training, i.e. a smaller value is better.

The implementation takes care of:

1. not downloading the whole finewiki dataset, as we only need a tiny sample
2. ensuring that the loss calculation is not stretching memory requirements to avoid OOM or affecting the max memory reserved calculation

I also tried some other sources than Wikipedia, like books. There, the loss can be much smaller than what we see here, probably because the Wiki samples are quite information dense. I don't think it makes much sense to mix sources when they have widely different losses, so I stuck with only Wiki for this PR.

Locally, I get a forgetting score of 0.28393 for LoRA rank 32. Re-running training multiple times shows that the initial loss is deterministic, but after training there can be small variations (~0.01).

Once this gets merged, all experiments should be re-run.