### PR TITLE
FIX: Some GPU tests failing due to transformers v5

### DIFF
--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 import torch
+from accelerate.test_utils.testing import get_backend
 from safetensors.torch import load_file as safe_load_file
 from transformers import (
     AutoModelForCausalLM,
@@ -776,6 +777,10 @@ class TestDecoderModels(PeftCommonTester):
 
     def test_prefix_tuning_mistral(self):
         # See issue 869, 1962
+        _, device_count, _ = get_backend()
+        if device_count > 1:
+            pytest.skip("PEFT Mistral training with DP does not work, skipping")
+
         model_id = "hf-internal-testing/tiny-random-MistralForCausalLM"
         base_model = AutoModelForCausalLM.from_pretrained(model_id)
         peft_config = PrefixTuningConfig(num_virtual_tokens=10, task_type="CAUSAL_LM")


### PR DESCRIPTION
This PR works on some of the GPU tests that are now failing, but others are still open.

1. Mistral fine-tuning: Fails with `DataParallel` on two GPUs. This is actually not something we generally support, so just skipping this test.
2. Offload tests: Offloading now requires an `offload_folder` argument, previously the weights were just stored in the HF cache. This resolves one error in those tests but they still fail at a later step.
3. Offloat tests: Refactored for pytest style. Just boyscout rule.