### PR TITLE
Test cleaning pytest caches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Make space for cache + models
+        # Ubuntu runner have less space free which is problematic since the model
+        # cache + dependencies fill up the disk, leaving no space for execution.
+        # So we remove some of the stuff we don't need (Java, .NET, etc.)
+        #
+        # Idea: https://dev.to/mathio/squeezing-disk-space-from-github-actions-runners-an-engineers-guide-3pjg
+        if: matrix.os != 'windows-latest'
         run: |
           df -h
 


### PR DESCRIPTION
Currently we run out of disk space when packing the model cache update on ubuntu 3.10 runs so in an effort to make space, we'll delete the temp dir pytest uses after the testing has finished.

Also set the CI flag so that test summaries are not truncated which might be better for inspection of errors.