### PR TITLE
FIX Migrate method comparison space to Gradio 6

### DIFF
--- a/method_comparison/app.py
+++ b/method_comparison/app.py
@@ -188,7 +188,7 @@ def format_df(df):
 
 
 def build_app(df):
-    with gr.Blocks(theme=gr.themes.Soft()) as demo:
+    with gr.Blocks() as demo:
         gr.Markdown("# PEFT method comparison")
         gr.Markdown(
             "Find more information [on the PEFT GitHub repo](https://github.com/huggingface/peft/tree/main/method_comparison)"
@@ -382,4 +382,4 @@ def build_app(df):
 path = os.path.join(os.path.dirname(__file__), "MetaMathQA", "results")
 df = load_df(path, task_name="MetaMathQA")
 demo = build_app(df)
-demo.launch()
+demo.launch(theme=gr.themes.Soft())

--- a/method_comparison/requirements-app.txt
+++ b/method_comparison/requirements-app.txt
@@ -1,3 +1,3 @@
 dash
-gradio>=5.38.0
+gradio>=6.0.2
 pandas


### PR DESCRIPTION
There was a breaking change in the API of Gradio 6, this has been taken care off. Locally, the app works again with this change.