### PR TITLE
FIX: warmup_ratio deprecated (fixes #2949)

### DIFF
--- a/docs/source/accelerate/deepspeed.md
+++ b/docs/source/accelerate/deepspeed.md
@@ -104,7 +104,7 @@ accelerate launch --config_file "configs/deepspeed_config.yaml"  train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "llama-sft-lora-deepspeed" \
 --per_device_train_batch_size 8 \
@@ -220,7 +220,7 @@ accelerate launch --config_file "configs/deepspeed_config_z3_qlora.yaml"  train.
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "llama-sft-qlora-dsz3" \
 --per_device_train_batch_size 2 \

--- a/docs/source/accelerate/fsdp.md
+++ b/docs/source/accelerate/fsdp.md
@@ -84,7 +84,7 @@ accelerate launch --config_file "configs/fsdp_config.yaml"  train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "llama-sft-lora-fsdp" \
 --per_device_train_batch_size 8 \
@@ -221,7 +221,7 @@ accelerate launch --config_file "configs/fsdp_config_qlora.yaml"  train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "llama-sft-qlora-fsdp" \
 --per_device_train_batch_size 2 \

--- a/examples/bone_finetuning/README.md
+++ b/examples/bone_finetuning/README.md
@@ -76,7 +76,7 @@ python bone_finetuning.py \
     --logging_steps 1 \
     --learning_rate 2e-5 \
     --weight_decay 0. \
-    --warmup_ratio 0.03 \
+    --warmup_steps 0.03 \
     --tf32 True \
     --report_to none
 ```

--- a/examples/corda_finetuning/README.md
+++ b/examples/corda_finetuning/README.md
@@ -208,7 +208,7 @@ python corda_finetuning.py \
     --save_total_limit 1 \
     --learning_rate 2e-5 \
     --weight_decay 0. \
-    --warmup_ratio 0.03 \
+    --warmup_steps 0.03 \
     --lr_scheduler_type "cosine" \
     --logging_steps 1 \
     --bf16 True \

--- a/examples/miss_finetuning/README.md
+++ b/examples/miss_finetuning/README.md
@@ -84,7 +84,7 @@ python miss_finetuning.py \
     --logging_steps 1 \
     --learning_rate 2e-5 \
     --weight_decay 0. \
-    --warmup_ratio 0.03 \
+    --warmup_steps 0.03 \
     --tf32 True \
     --report_to none
 ```

--- a/examples/pissa_finetuning/README.md
+++ b/examples/pissa_finetuning/README.md
@@ -112,7 +112,7 @@ python pissa_finetuning.py \
     --logging_steps 1 \
     --learning_rate 2e-5 \
     --weight_decay 0. \
-    --warmup_ratio 0.03 \
+    --warmup_steps 0.03 \
     --tf32 True \
     --report_to none \
     --convert_pissa_to_lora

--- a/examples/sft/run_peft.sh
+++ b/examples/sft/run_peft.sh
@@ -21,7 +21,7 @@ python train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "mistral-sft-lora" \
 --per_device_train_batch_size 8 \

--- a/examples/sft/run_peft_deepspeed.sh
+++ b/examples/sft/run_peft_deepspeed.sh
@@ -21,7 +21,7 @@ accelerate launch --config_file "configs/deepspeed_config.yaml"  train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "mistral-sft-lora-deepspeed" \
 --per_device_train_batch_size 8 \

--- a/examples/sft/run_peft_fsdp.sh
+++ b/examples/sft/run_peft_fsdp.sh
@@ -21,7 +21,7 @@ accelerate launch --config_file "configs/fsdp_config.yaml"  train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "mistral-sft-lora-fsdp" \
 --per_device_train_batch_size 8 \

--- a/examples/sft/run_peft_fsdp_gptq.sh
+++ b/examples/sft/run_peft_fsdp_gptq.sh
@@ -18,7 +18,7 @@ accelerate launch --config_file "configs/fsdp_config.yaml"  train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "llama3-8B-gptq-sft-lora-fsdp" \
 --per_device_train_batch_size 8 \

--- a/examples/sft/run_peft_multigpu.sh
+++ b/examples/sft/run_peft_multigpu.sh
@@ -21,7 +21,7 @@ torchrun --nproc_per_node 8 --nnodes 1 train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "mistral-sft-lora-multigpu" \
 --per_device_train_batch_size 8 \

--- a/examples/sft/run_peft_qlora_deepspeed_stage3.sh
+++ b/examples/sft/run_peft_qlora_deepspeed_stage3.sh
@@ -21,7 +21,7 @@ accelerate launch --config_file "configs/deepspeed_config_z3_qlora.yaml"  train.
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "llama-sft-qlora-dsz3" \
 --per_device_train_batch_size 2 \

--- a/examples/sft/run_peft_qlora_fsdp.sh
+++ b/examples/sft/run_peft_qlora_fsdp.sh
@@ -21,7 +21,7 @@ accelerate launch --config_file "configs/fsdp_config_qlora.yaml"  train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "llama-sft-qlora-fsdp" \
 --per_device_train_batch_size 2 \

--- a/examples/sft/run_unsloth_peft.sh
+++ b/examples/sft/run_unsloth_peft.sh
@@ -21,7 +21,7 @@ python train.py \
 --learning_rate 1e-4 \
 --lr_scheduler_type "cosine" \
 --weight_decay 1e-4 \
---warmup_ratio 0.0 \
+--warmup_steps 0 \
 --max_grad_norm 1.0 \
 --output_dir "mistral-sft-lora-unsloth" \
 --per_device_train_batch_size 8 \


### PR DESCRIPTION
Fixes #2949 
This PR replaces all occurrences of the deprecated warmup_ratio argument with warmup_steps across the examples/directory and documentation.
Specific changes include:
   - Zero Warmup: Replaced --warmup_ratio 0.0 with --warmup_steps 0 in SFT example scripts and Accelerate documentation.
     Using an integer 0 is compatible with previous transformers versions and functionally equivalent.
   - Ratio Warmup: Replaced --warmup_ratio 0.03 with --warmup_steps 0.03 in various finetuning example READMEs (MiSS,
     PiSSA, Bone, CoRDA).
