### PR TITLE
TST: Remove unnecessary prefix tuning dtype test

### DIFF
--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -606,11 +606,6 @@ class TestDecoderModels(PeftCommonTester):
 
     @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
-    def test_prefix_tuning_half_prec_conversion(self, model_id, config_cls, config_kwargs):
-        self._test_prefix_tuning_half_prec_conversion(model_id, config_cls, config_kwargs.copy())
-
-    @pytest.mark.parametrize("model_id", PEFT_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_training_decoders(self, model_id, config_cls, config_kwargs):
         _skip_if_not_conv1d_supported(model_id, config_cls)
         self._test_training(model_id, config_cls, config_kwargs.copy())

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -343,11 +343,6 @@ class TestEncoderDecoderModels(PeftCommonTester):
 
     @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
-    def test_prefix_tuning_half_prec_conversion(self, model_id, config_cls, config_kwargs):
-        self._test_prefix_tuning_half_prec_conversion(model_id, config_cls, config_kwargs)
-
-    @pytest.mark.parametrize("model_id", PEFT_ENCODER_DECODER_MODELS_TO_TEST)
-    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
     def test_training_encoder_decoders(self, model_id, config_cls, config_kwargs):
         self._test_training(model_id, config_cls, config_kwargs)
 

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -1004,22 +1004,6 @@ class PeftCommonTester:
             # check if `generate` works
             _ = model.generate(input_ids=input_ids, attention_mask=attention_mask)
 
-    def _test_prefix_tuning_half_prec_conversion(self, model_id, config_cls, config_kwargs):
-        if config_cls not in (PrefixTuningConfig,):
-            pytest.skip(f"Test not applicable for {config_cls}")
-
-        config = config_cls(
-            base_model_name_or_path=model_id,
-            **config_kwargs,
-        )
-
-        with hub_online_once(model_id):
-            model = self.transformers_class.from_pretrained(model_id)
-            model = get_peft_model(model, config)
-            model = model.half()
-
-            assert model.base_model_torch_dtype == torch.float16
-
     def _test_training(self, model_id, config_cls, config_kwargs):
         if (config_cls == AdaLoraConfig) and ("roberta" in model_id.lower()):
             # TODO: no gradients on the "dense" layer, other layers work, not sure why


### PR DESCRIPTION
There are already better tests that check that the model works at half precision.