### PR TITLE
TST Fix tolerance issue with GPT-OSS and transformers v5

### DIFF
--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -609,6 +609,9 @@ class PeftCommonTester:
             atol, rtol = 1e-4, 1e-4
             if self.torch_device in ["mlu"]:
                 atol, rtol = 1e-3, 1e-3  # MLU
+            if model_id == "trl-internal-testing/tiny-GptOssForCausalLM":
+                # this tolerance issue with the target_parameters test only occurrs on CI with transformers v5
+                atol, rtol = 1e-3, 1e-3
             if config.peft_type in ("ADALORA", "OFT"):
                 # these methods require a bit higher tolerance
                 atol, rtol = 1e-2, 1e-2


### PR DESCRIPTION
## Description

For some reason, the merging test with `target_parameters` on GPT-OSS fails with transformers v5. Reducing the tolerances slightly from 1e-4 to 1e-3 fixes the issue.

Example:

https://github.com/huggingface/peft/actions/runs/20788094489/job/59703106956#step:6:3345

## Notes

The current CI won't reveal the bug as it installs transformers v4.57.3. I could, however, confirm that this fix works here:

https://github.com/huggingface/peft/pull/2981

I could not reproduce the error locally, neither on GPU nor CPU, it seems to be CI specific. Otherwise, I would have tried to investigate further what the source of the bug is. Since the very same test already loosens tolerances for other conditions too, I think it's fine to do the same here.