### PR TITLE
DOC Prefix tuning for encoder-decoder models

### DIFF
--- a/docs/source/package_reference/prefix_tuning.md
+++ b/docs/source/package_reference/prefix_tuning.md
@@ -18,6 +18,8 @@ rendered properly in your Markdown viewer.
 
 [Prefix tuning](https://hf.co/papers/2101.00190) prefixes a series of task-specific vectors to the input sequence that can be learned while keeping the pretrained model frozen. The prefix parameters are inserted in all of the model layers.
 
+**Note** For encoder-decoder models (seq2seq), the prefix is only applied to the decoder, which does not correspond to the paper specification (see e.g. Figure 2). Prefix tuning can still be fine-tuned on these model architectures but the performance could be sub-par; consider using other PEFT methods for encoder-decoder models.
+
 ## Initialize from a KV cache prefix
 
 By default, prefix tuning is randomly initialized.


### PR DESCRIPTION
See discussiopn #2974.

## Description

Prefix tuning is implemented by inserting prefix embeddings into the KV cache (`past_key_values`). However, in encoder-decoder models (seq2seq) from transformers, the encoder does not make use of the KV cache, given that it's not causal. Therefore, injecting the prefixes does not work for the encoder, which does not correspond to the paper description ([paper figure 2](https://hf.co/papers/2101.00190)). This is now documented.

Prefix tuning can still be applied to encoder-decoder models and can still learn something useful, but it's not working the way the paper describes it.

## Notes

We discussed internally if encoder-decoder architectures could be updated to allow injection via `past_key_values` but it would be a non-trivial change. Given that prefix tuning of encoder-decoder models is rather niche, we decided not to proceed with this.

I did consider giving a warning when we detect prefix tuning being used with encoder-decoder models, but I considered this to be too obtrusive for something that technically works and hasn't changed in recent releases. However, I'm open to the idea to make this information salient in other ways than just in the docs.

It's possible that injection via `past_key_values` used to work before it was refactored in transformers to take the role of KV cache, but I haven't checked (it wouldn't help now either way).