### PR TITLE
Update prompt_based_methods.md - remove eval_preds

### DIFF
--- a/docs/source/task_guides/prompt_based_methods.md
+++ b/docs/source/task_guides/prompt_based_methods.md
@@ -241,17 +241,14 @@ for epoch in range(num_epochs):
 
     model.eval()
     eval_loss = 0
-    eval_preds = []
+
     for step, batch in enumerate(tqdm(eval_dataloader)):
         batch = {k: v.to(device) for k, v in batch.items()}
         with torch.no_grad():
             outputs = model(**batch)
         loss = outputs.loss
         eval_loss += loss.detach().float()
-        eval_preds.extend(
-            tokenizer.batch_decode(torch.argmax(outputs.logits, -1).detach().cpu().numpy(), skip_special_tokens=True)
-        )
-
+    
     eval_epoch_loss = eval_loss / len(eval_dataloader)
     eval_ppl = torch.exp(eval_epoch_loss)
     train_epoch_loss = total_loss / len(train_dataloader)


### PR DESCRIPTION
## Description
Removes unused `eval_preds` collection from prompt tuning tutorial evaluation loop.

## Changes
- Removed `eval_preds` initialization
- Removed `torch.argmax(outputs.logits, -1)` code block
- Cleaned up unused variable for speed 

## Rationale
As noted in #2988 , the eval_preds were using argmax instead of 
proper generation, producing gibberish outputs. Since these predictions 
are never used in the tutorial, removing them simplifies the code and 
avoids confusion.

## Testing
- [x] Documentation builds without errors
- [x] Code runs successfully
- [x] No functionality is lost (variable was unused)