### PR TITLE
Ignore BPE errors in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,9 +33,18 @@ def pytest_configure(config):
         def emit(self, record):
             msg = record.getMessage().lower()
             if "deprecat" in msg or "future" in msg:
-                if "torch_dtype" not in msg:
-                    # let's ignore the torch_dtype => dtype deprecation for now
-                    raise AssertionError(f"**Transformers Deprecation**: {msg}")
+                # let's ignore the torch_dtype => dtype deprecation for now
+                if "torch_dtype" in msg:
+                    return
+
+                # BPE warning comes from transformers and we cannot do anything about it, transformers has to fix it
+                bpe_warning = (
+                    "Deprecated in 0.9.0: BPE.__init__ will not create from files anymore, try `BPE.from_file` instead"
+                )
+                if bpe_warning in msg:
+                    return
+
+                raise AssertionError(f"**Transformers Deprecation**: {msg}")
 
     # Add our handler
     handler = ErrorOnDeprecation()


### PR DESCRIPTION
We're seeing deprecation warnings from BPE, used by transformers:

    FAILED tests/test_gpu_examples.py::PeftBnbGPUExampleTests::test_causal_lm_training_4bit_vera - DeprecationWarning: Deprecated in 0.9.0: BPE.__init__ will not create from files anymore, try `BPE.from_file` instead
    FAILED tests/test_gpu_examples.py::PeftBnbGPUExampleTests::test_causal_lm_training_8bit_dora - DeprecationWarning: Deprecated in 0.9.0: BPE.__init__ will not create from files anymore, try `BPE.from_file` instead

Since we can't do anything about it and it is not a direct transformers deprecation, we can ignore it.

This should fix the nightly CI in part as well :)