### PR TITLE
Fix docker GPU build for gptqmodel

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -20,7 +20,7 @@ RUN conda create --name peft python=${PYTHON_VERSION} ipython jupyter pip
 # Below is copied from https://github.com/huggingface/accelerate/blob/main/docker/accelerate-gpu/Dockerfile
 # We don't install pytorch here yet since CUDA isn't available
 # instead we use the direct torch wheel
-ENV PATH /opt/conda/envs/peft/bin:$PATH
+ENV PATH=/opt/conda/envs/peft/bin:$PATH
 # Activate our bash shell
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
@@ -28,7 +28,7 @@ SHELL ["/bin/bash", "-c"]
 # Stage 2
 FROM nvidia/cuda:12.8.1-devel-ubuntu22.04 AS build-image
 COPY --from=compile-image /opt/conda /opt/conda
-ENV PATH /opt/conda/bin:$PATH
+ENV PATH=/opt/conda/bin:$PATH
 
 # Install apt libs
 RUN apt-get update && \


### PR DESCRIPTION
gptqmodel requires information about the compute capability of the system. The default is to look at the output of `nvidia-smi` but since there is no compute hardware on the docker image builder instance we have to hard-code the compute capability.

Since our CI runners use NVIDIA L4 which have a compute capability of 8.9 (according to https://developer.nvidia.com/cuda/gpus) we're using that.

In the future it might be worth extending this so that people using this docker image are using a gptqmodel version that supports higher compute cap. as well.