### PR TITLE
Add tooling to bump action version

### DIFF
--- a/scripts/bump_action_versions.py
+++ b/scripts/bump_action_versions.py
@@ -135,6 +135,7 @@ def process_workflow_file(workflow_file):
             release_data, error = get_latest_release(repo)
             if error is not None:
                 log(f"Error {step_name=} release fetch {repo=}: {error}")
+                update_summary[(repo, version)] = {"old_version": version, "error": f"Fetching release failed: {error}"}
                 continue
 
             new_version = release_data['commit_sha']
@@ -159,17 +160,19 @@ def print_summary(update_summaries):
         summaries_merged.update(summary)
 
     for (repo, version), summary in summaries_merged.items():
-        release_data = summary['release']
-
         tag_current = get_tag_for_hash(repo, version)
         if not tag_current:
             tag_current = "UNKNOWN TAG"
 
         print(f"* Repository: {repo}, current version: {version} (tag: {tag_current})")
-        print(f"  This was updated to version {summary['new_version']}")
-        print(f"  This corresponds to release {release_data['tag_name']}")
-        print(f"  Release information: {release_data['release_url']}")
-        print(f"  See what changed: {build_compare_url(repo, version, summary['new_version'])}")
+        if "error" in summary:
+            print(f"  Was not updated. Error: {summary['error']}")
+        else:
+            release_data = summary['release']
+            print(f"  This was updated to version {summary['new_version']}")
+            print(f"  This corresponds to release {release_data['tag_name']}")
+            print(f"  Release information: {release_data['release_url']}")
+            print(f"  See what changed: {build_compare_url(repo, version, summary['new_version'])}")
         print()
 
 


### PR DESCRIPTION
Add a CLI tool for bumping workflow actions to their newest release. 
Requirements were:

- modify the workflow files as little as possible for easy review
- make it low friction to review the changes from old to new version
- keep the version comments in the YAML files

GitHub limits the number of API calls so for repeated execution it is recommended to create a `.github_bearer_token` file containing an API token for the user's account (no permissions are needed) to increase the rate limit significantly (60/h to 1000+/h).

Here's an example of a summary at the end of the update run:

```
Summary of combined updates:
----------------------------

The summary will include repos more than once if their current version differs.

* Repository: docker/setup-buildx-action, current version: 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f (tag: v3)
  This was updated to version 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
  This corresponds to release v3.12.0
  Release information: https://github.com/docker/setup-buildx-action/releases/tag/v3.12.0
  See what changed: https://github.com/docker/setup-buildx-action/compare/8d2750c68a42422c14e847fe6c8ac0403b4cbd6f...8d2750c68a42422c14e847fe6c8ac0403b4cbd6f

* Repository: tj-actions/changed-files, current version: 1c8e6069583811afb28f97afeaf8e7da80c6be5c (tag: UNKNOWN TAG)
  This was updated to version e0021407031f5be11a464abee9a0776171c79891
  This corresponds to release v47.0.1
  Release information: https://github.com/tj-actions/changed-files/releases/tag/v47.0.1
  See what changed: https://github.com/tj-actions/changed-files/compare/1c8e6069583811afb28f97afeaf8e7da80c6be5c...e0021407031f5be11a464abee9a0776171c79891

* Repository: huggingface/hf-workflows, current version: 3f88d63d3761558a32e8e46fc2a8536e04bb2aea (tag: UNKNOWN TAG)
  Was not updated. Error: Fetching release failed: Error: 404
```

Note that there's currently a lot of inconsistent formatting in the workflow files which the YAML formatter will rectify, `git diff -w` makes review rather simple, though.


