### PR TITLE
fix: layers_to_transform now correctly matches layer index on MoE models

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1722,7 +1722,10 @@ def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
             # TODO: It's still unclear how empty layers_pattern (None, [], or "") should behave
             # For now, empty layers_pattern means any layer pattern is ok
             if layers_pattern is None or len(layers_pattern) == 0:
-                layer_index = re.match(r".*\.[^.]*\.(\d+)\.", key)
+                # Use non-greedy .*? to match the FIRST digit group, not the last
+                # This prevents MoE expert indices from being matched instead of layer indices
+                # e.g., for "model.layers.1.mlp.experts.0.up_proj", we want to match "1" not "0"
+                layer_index = re.match(r".*?\.[^.]*\.(\d+)\.", key)
             else:
                 layers_pattern = [layers_pattern] if isinstance(layers_pattern, str) else layers_pattern
                 for pattern in layers_pattern:

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -128,6 +128,16 @@ REGEX_TEST_CASES = [
     ("blocks.1.bias", ["weight"], [1], ["blocks"], False),
     ("mlp.blocks.1.weight", ["weight"], [1], ["blocks"], True),
     ("mlp.blocks.1.bias", ["weight"], [1], ["blocks"], False),
+    # MoE models: layers_to_transform should match layer index, not expert index
+    # For "model.layers.1.mlp.experts.0.up_proj", should match layer 1, not expert 0
+    ("model.layers.1.mlp.experts.0.up_proj", ["up_proj"], [1], ["layers"], True),
+    ("model.layers.1.mlp.experts.0.up_proj", ["up_proj"], [0], ["layers"], False),  # expert 0, but layer 1
+    ("model.layers.1.mlp.experts.1.up_proj", ["up_proj"], [1], ["layers"], True),  # expert 1, layer 1
+    ("model.layers.2.mlp.experts.1.up_proj", ["up_proj"], [1], ["layers"], False),  # layer 2, not 1
+    # MoE without explicit layers_pattern - should still match layer index, not expert index
+    ("model.layers.1.mlp.experts.0.up_proj", ["up_proj"], [1], None, True),
+    ("model.layers.1.mlp.experts.0.up_proj", ["up_proj"], [0], None, False),  # must not match expert 0
+    ("model.layers.2.mlp.experts.1.up_proj", ["up_proj"], [1], None, False),  # must not match expert 1
 ]
 
 MAYBE_INCLUDE_ALL_LINEAR_LAYERS_TEST_CASES = [


### PR DESCRIPTION
## Summary
Fix `layers_to_transform` incorrectly matching MoE expert indices instead of layer indices.

## Problem
When using `layers_to_transform` on MoE (Mixture of Experts) models, modules under paths like `model.layers.<L>.mlp.experts.<E>.*` were incorrectly filtered based on the expert index `<E>` instead of the layer index `<L>`.

**Example:**
For key `model.layers.1.mlp.experts.0.up_proj`:
- **Expected:** Match layer index `1`
- **Actual (before fix):** Matched expert index `0`

This caused `layers_to_transform=[1]` to incorrectly exclude `model.layers.1.mlp.experts.0.up_proj` (because `0 != 1`) and incorrectly include `model.layers.2.mlp.experts.1.up_proj` (because `1 == 1`).

## Root Cause
The regex in `check_target_module_exists()` used greedy `.*` which matched as much as possible, leaving only the LAST digit in the path (the expert index) for the capture group:

```python
layer_index = re.match(r".*\.[^.]*\.(\d+)\.", key)  # Greedy
```

## Solution
Changed to non-greedy `.*?` which matches as little as possible, capturing the FIRST digit in the path (the layer index):

```python
layer_index = re.match(r".*?\.[^.]*\.(\d+)\.", key)  # Non-greedy
```

## Test Cases Added
Added 7 test cases covering MoE scenarios:
- With explicit `layers_pattern`
- Without `layers_pattern` (default behavior)

Fixes #3016