### PR TITLE
Fix various test errors in the single GPU case

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -209,6 +209,7 @@ class LoraModel(BaseTuner):
             "target_name": current_key,
             "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
             "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
+            "ephemeral_gpu_offload": lora_config.runtime_config.ephemeral_gpu_offload,
             "parameter_name": parameter_name,
         }
 

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -64,6 +64,7 @@ from .testing_utils import (
     load_cat_image,
     require_bitsandbytes,
     require_deterministic_for_xpu,
+    require_gptqmodel,
     require_non_cpu,
     require_torch_multi_accelerator,
 )
@@ -519,6 +520,7 @@ class PeftGPUCommonTests(unittest.TestCase):
             assert "default" in model.base_model.model.model.decoder.layers[0].self_attn.q_proj.ia3_l
             assert "adapter2" in model.base_model.model.model.decoder.layers[0].self_attn.q_proj.ia3_l
 
+    @require_gptqmodel
     @pytest.mark.single_gpu_tests
     def test_lora_gptq_quantization_from_pretrained_safetensors(self):
         r"""

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1365,6 +1365,10 @@ class ModelEmbConv1D(nn.Module):
         super().__init__()
         self.emb = nn.Embedding(emb_size, 5)
         self.conv1d = Conv1D(1, 5)
+        # make sure that we have a good signal-to-noise ratio
+        # since apparently CUDA ReLU clips the gradient at a
+        # certain point.
+        self.conv1d.weight.data += 10
         self.relu = nn.ReLU()
         self.flat = nn.Flatten()
         self.lin0 = nn.Linear(10, 2)

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -592,7 +592,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 device_map={"": 0},
             )
 
-            assert set(model.hf_device_map.values()) == {0}
+            # note: transformers v5 doesn't set the device map if there's only one device
+            assert not hasattr(model.hf_device_map) or set(model.hf_device_map.values()) == {0}
 
             tokenizer = AutoTokenizer.from_pretrained(self.seq2seq_model_id)
             model = prepare_model_for_kbit_training(model)


### PR DESCRIPTION
This addresses some of the errors reported by running the tests on a single GPU machine.

I will list the error messages and a short explanation of the fix.

> `FAILED tests/test_common_gpu.py::PeftGPUCommonTests::test_lora_gptq_quantization_from_pretrained_safetensors - NameError: name 'BACKEND' is not defined`

The test was using GPTQModel without marking the test as requiring it leading to an error. This is fixed by marking the test with `requires_gptqmodel`.

> `FAILED tests/test_custom_models.py::TestPeftCustomModel::test_only_params_are_updated[Embedding + transformers Conv1D 1 trainable_tokens-EmbConv1D-TrainableTokensConfig-config_kwargs180] - AssertionError: assert not True`
> `FAILED tests/test_custom_models.py::TestPeftCustomModel::test_disable_adapters_with_merging[Embedding + transformers Conv1D 1 trainable_tokens-EmbConv1D-TrainableTokensConfig-config_kwargs180] - AssertionError: assert not True`

This test fails because sometimes the gradients of the trainable tokens delta is 0 but only when training on CUDA, CPU is fine.

This is a weird one and I'm not sure if this is a good fix or not. I encountered this error on two machines (1xL40S and 4xA10G) and I was not able to pinpoint this to something particular in the environment, i.e. PEFT version (tested v0.17 to main), transformers version (tested 4.5{5,6,7}, 5.0), CUDA version (tested 12.6, 12.8) or torch version (tested 2.7, 2.8, 2.9, 2.10). I also set `LD_LIBRARY_PATH=` before running pytest to exclude cuDNN libraries that come preinstalled on the EC2 instance.

Removing the ReLU in `EmbConv1DModel` as well as boosting the Conv1D weights will fix the error. Replacing the ReLU with `Threshold(0, 0)` has the same behavior. It depends on the seed, i.e. if the initialization of `Conv1D` is favorable the bug will not trigger.

I tried pinpointing it on `index_copy` but it is not `index_copy` by itself that is the problem. Maybe we will just have to live with this?

> `FAILED tests/test_common_gpu.py::PeftGPUCommonTests::test_dora_ephemeral_gpu_offload_multigpu - RuntimeError: Expected all tensors to be on the same device, but got mat2 is on cpu, different from other tensors on cuda:0 (when checking argument in method wrapper_CUDA_mm)`

This is caused by a bug introduced in #2960 - `ephemeral_gpu_offload` is not passed to the variant and therefore never utilized.

> `FAILED tests/test_gpu_examples.py::PeftBnbGPUExampleTests::test_seq2seq_lm_training_single_gpu - AttributeError: 'T5ForConditionalGeneration' object has no attribute 'hf_device_map'`
    
This is caused by transformers@315dcbe45cee1489a32fc228a80502b0a150936c which disables accelerate hooks if the
device map only contains one device. I confirmed that just specifying one value moves the model to that device even
without accelerate hook invocation. I also tested having two devices (cpu + cuda:0) and in that case a device map is
present. Therefore this only needs an added `hasattr` check to be compatible with transformers v5.

