### PR TITLE
FIX Add guard when detecting the optimum version

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -43,7 +43,16 @@ def is_gptqmodel_available():
         version_gptqmodel = packaging.version.parse(importlib_metadata.version("gptqmodel"))
         if GPTQMODEL_MINIMUM_VERSION <= version_gptqmodel:
             if is_optimum_available():
-                version_optimum = packaging.version.parse(importlib_metadata.version("optimum"))
+                try:
+                    version_optimum = packaging.version.parse(importlib_metadata.version("optimum"))
+                except importlib_metadata.PackageNotFoundError:
+                    # Same idea as in diffusers:
+                    # https://github.com/huggingface/diffusers/blob/9f06a0d1a4a998ac6a463c5be728c892f95320a8/src/diffusers/utils/import_utils.py#L351-L357
+                    # It's not clear under what circumstances `importlib_metadata.version("optimum")` can raise an error
+                    # even though `importlib.util.find_spec("optimum") is not None` but it has been observed, so adding
+                    # this for precaution. If we cannot detect it, we just optimistically assume it's high enough.
+                    return True
+
                 if OPTIMUM_MINIMUM_VERSION <= version_optimum:
                     return True
                 else:


### PR DESCRIPTION
Reported by @SunMarc 

Apparently, it's possible that there is an error when the optimum version is being determined, even if optimum is installed. To prevent this from throwing an error, a `try...catch` is now added. If we can't detect the version, we optimistically assume it's high enough and continue. Otherwise, users with otherwise working environments could get an error here with no avenue to resolve it.