### PR TITLE
Add support for LoRA with Transformer Engine

### DIFF
--- a/docs/source/developer_guides/quantization.md
+++ b/docs/source/developer_guides/quantization.md
@@ -322,6 +322,31 @@ Besides LoRA, the following PEFT methods also support quantization:
 - **AdaLoRA** (supports both bitsandbytes and GPTQ quantization)
 - **(IA)³** (supports bitsandbytes quantization)
 
+## Transformer Engine (TE) LoRA
+
+PEFT supports LoRA adapters on top of [NVIDIA Transformer Engine](https://docs.nvidia.com/deeplearning/transformer-engine/) layers (`te.pytorch.Linear`, `te.pytorch.LayerNormLinear`, and `te.pytorch.LayerNormMLP`). TE layers use FP8 and fused kernels to accelerate transformer training, and attaching LoRA adapters lets you parameter-efficiently fine-tune TE-accelerated models.
+
+```python
+from peft import LoraConfig, get_peft_model
+
+config = LoraConfig(
+    r=8,
+    lora_alpha=16,
+    target_modules=["q_proj", "v_proj"],
+    task_type="TOKEN_CLS",
+)
+model = get_peft_model(te_model, config)
+```
+
+When Transformer Engine is installed, PEFT automatically dispatches matching layers to the `TeLinear` adapter — no extra configuration is needed.
+
+### Caveats
+
+- `merge()` and `unmerge()` are not yet supported for TE layers.
+- DoRA is not supported with TE layers.
+
+A complete ESM2 token-classification example is available under `examples/lora_finetuning_transformer_engine/`.
+
 ## Next steps
 
 If you're interested in learning more about quantization, the following may be helpful:

--- a/examples/lora_finetuning_transformer_engine/Dockerfile
+++ b/examples/lora_finetuning_transformer_engine/Dockerfile
@@ -1,0 +1,8 @@
+FROM nvcr.io/nvidia/pytorch:26.01-py3
+
+WORKDIR /workspace/lora_finetuning
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY lora_finetuning_te.py .

--- a/examples/lora_finetuning_transformer_engine/README.md
+++ b/examples/lora_finetuning_transformer_engine/README.md
@@ -1,0 +1,119 @@
+# Transformer Engine ESM2 LoRA Fine-Tuning
+
+This example demonstrates LoRA fine-tuning for Transformer Engine ESM2 token classification.
+
+## Setup
+
+Choose one of the two options below.
+
+### Option A: Docker (recommended)
+
+Build a self-contained image based on the publicly available NVIDIA PyTorch container
+(`nvcr.io/nvidia/pytorch:26.01-py3`), which already ships CUDA, cuDNN, and Transformer Engine:
+
+```bash
+docker build -t lora-te examples/lora_finetuning_transformer_engine
+```
+
+Run the training inside the container:
+
+```bash
+docker run --gpus all --rm lora-te \
+  python lora_finetuning_te.py \
+    --base_model nvidia/esm2_t6_8M_UR50D \
+    --output_dir ./esm2_lora_output \
+    --num_train_samples 256 \
+    --num_eval_samples 64 \
+    --num_epochs 1
+```
+
+Or start an interactive session to experiment:
+
+```bash
+docker run --gpus all --rm -it lora-te bash
+```
+
+### Option B: Virtual environment
+
+Create and activate a virtual environment, then install the Python dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r examples/lora_finetuning_transformer_engine/requirements.txt
+```
+
+**Transformer Engine** must be installed separately and must match the system CUDA toolkit version.
+See the [TE installation guide](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html)
+for details.
+
+## What this example does
+
+- Loads a Transformer Engine ESM2 model for token classification
+- Applies LoRA adapters via PEFT
+- Generates random protein-like sequences
+- Assigns randomly generated secondary structure labels (`H`, `E`, `C`)
+- Trains/evaluates with `Trainer`
+
+## Run
+
+```bash
+python examples/lora_finetuning_transformer_engine/lora_finetuning_te.py \
+  --base_model nvidia/esm2_t6_8M_UR50D \
+  --output_dir ./esm2_lora_output \
+  --num_train_samples 256 \
+  --num_eval_samples 64 \
+  --num_epochs 1
+```
+
+> **Note:** The default ESM2 models on Hugging Face Hub ship custom modeling code.
+> You must pass `--trust_remote_code` to allow loading that code.
+
+## Customize
+
+```bash
+python examples/lora_finetuning_transformer_engine/lora_finetuning_te.py \
+  --base_model nvidia/esm2_t6_8M_UR50D \
+  --trust_remote_code \
+  --output_dir ./esm2_lora_output \
+  --max_length 256 \
+  --batch_size 4 \
+  --learning_rate 3e-4 \
+  --lora_r 16 \
+  --lora_alpha 32 \
+  --lora_dropout 0.1
+```
+
+## Dataset
+
+By default the script generates a **synthetic dataset** at runtime — random protein-like sequences
+with randomly generated secondary structure labels (`H`, `E`, `C`). This is useful for quick sanity checks and testing.
+
+For a more realistic evaluation, you can use the **Porter6** secondary-structure dataset.
+A download-and-convert script is available in the BioNeMo repository:
+
+[prepare_porter6_dataset.py](https://github.com/NVIDIA/bionemo-framework/blob/bd72d882bca458d9438e05661c41163949713d1f/bionemo-recipes/recipes/esm2_peft_te/data/prepare_porter6_dataset.py)
+
+Run it to produce train and validation parquet files, then pass them to the training script
+with `--train_parquet` and `--val_parquet`:
+
+```bash
+python examples/lora_finetuning_transformer_engine/lora_finetuning_te.py \
+  --base_model nvidia/esm2_t6_8M_UR50D \
+  --train_parquet porter6_train_dataset_55k.parquet \
+  --val_parquet porter6_val_dataset_2024_692.parquet \
+  --output_dir ./esm2_lora_output \
+  --num_epochs 3
+```
+
+## Outputs
+
+After training, the script saves:
+
+- PEFT adapter weights/config in `--output_dir`
+- Tokenizer files in `--output_dir`
+
+## More examples
+
+For additional examples of TransformerEngine-accelerated transformers, visit
+`https://github.com/NVIDIA/bionemo-framework/bionemo-recipes`.

--- a/examples/lora_finetuning_transformer_engine/lora_finetuning_te.py
+++ b/examples/lora_finetuning_transformer_engine/lora_finetuning_te.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+Transformer Engine ESM2 LoRA fine-tuning example using Hugging Face Trainer.
+
+This script demonstrates:
+1. Loading a Transformer Engine-based ESM2 token classification model
+2. Applying LoRA adapters with PEFT
+3. Building a synthetic protein token-classification dataset in code
+4. Training with the Hugging Face Trainer (no DDP setup required)
+"""
+
+import os
+
+
+# TE-backed models are incompatible with Trainer's DataParallel wrapping.
+# Pin to a single GPU before torch is imported so torch.cuda.device_count() == 1.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "0")
+
+import argparse
+import random
+
+import numpy as np
+import pandas as pd
+import torch
+from datasets import Dataset
+from transformers import (
+    AutoConfig,
+    AutoModelForTokenClassification,
+    AutoTokenizer,
+    DataCollatorForTokenClassification,
+    Trainer,
+    TrainingArguments,
+)
+
+from peft import LoraConfig, TaskType, get_peft_model
+
+
+SS3_ID2LABEL = {0: "H", 1: "E", 2: "C"}
+SS3_LABEL2ID = {label: idx for idx, label in SS3_ID2LABEL.items()}
+
+AMINO_ACIDS = "ACDEFGHIKLMNPQRSTVWY"
+HELIX_AA = set("AELMQKRH")
+BETA_AA = set("VIFYWT")
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Transformer Engine ESM2 LoRA fine-tuning with Hugging Face Trainer")
+
+    parser.add_argument(
+        "--base_model",
+        type=str,
+        default="nvidia/esm2_t6_8M_UR50D",
+        help="Transformer Engine ESM2 model name or path",
+    )
+    parser.add_argument("--output_dir", type=str, default="./esm2_lora_output", help="Output directory")
+    parser.add_argument("--max_length", type=int, default=128, help="Maximum sequence length")
+    parser.add_argument("--num_train_samples", type=int, default=256, help="Number of synthetic training samples")
+    parser.add_argument("--num_eval_samples", type=int, default=64, help="Number of synthetic evaluation samples")
+    parser.add_argument("--min_seq_len", type=int, default=32, help="Minimum sequence length")
+    parser.add_argument("--max_seq_len", type=int, default=96, help="Maximum sequence length")
+    parser.add_argument("--batch_size", type=int, default=8, help="Per-device batch size")
+    parser.add_argument("--num_epochs", type=int, default=1, help="Number of training epochs")
+    parser.add_argument("--learning_rate", type=float, default=5e-4, help="Learning rate")
+    parser.add_argument("--weight_decay", type=float, default=0.01, help="Weight decay")
+    parser.add_argument("--logging_steps", type=int, default=10, help="Logging frequency (steps)")
+    parser.add_argument("--eval_steps", type=int, default=25, help="Evaluation frequency (steps)")
+    parser.add_argument("--save_steps", type=int, default=25, help="Save frequency (steps)")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument("--lora_r", type=int, default=8, help="LoRA rank")
+    parser.add_argument("--lora_alpha", type=int, default=16, help="LoRA alpha")
+    parser.add_argument("--lora_dropout", type=float, default=0.05, help="LoRA dropout")
+    parser.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        default=False,
+        help="Allow loading model code from the Hub. Required for models like nvidia/esm2_*.",
+    )
+    parser.add_argument(
+        "--train_parquet",
+        type=str,
+        default=None,
+        help="Path to a training parquet file with Sequence and Secondary_structure columns. "
+        "When provided, the synthetic dataset is not generated.",
+    )
+    parser.add_argument(
+        "--val_parquet",
+        type=str,
+        default=None,
+        help="Path to a validation parquet file with the same schema as --train_parquet.",
+    )
+
+    args = parser.parse_args()
+
+    if bool(args.train_parquet) != bool(args.val_parquet):
+        parser.error("--train_parquet and --val_parquet must both be provided or both omitted.")
+
+    return args
+
+
+def set_seed(seed: int):
+    """Set random seeds for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def build_synthetic_sequences(num_samples: int, min_len: int, max_len: int):
+    """Generate random amino-acid sequences."""
+    sequences = []
+    for _ in range(num_samples):
+        length = random.randint(min_len, max_len)
+        sequences.append("".join(random.choices(AMINO_ACIDS, k=length)))
+    return sequences
+
+
+def ss_char_to_label(char: str) -> int:
+    """Map a single secondary structure character to a label id (H/E/C)."""
+    return SS3_LABEL2ID.get(char, SS3_LABEL2ID["C"])
+
+
+def tokenize_and_align_labels(sequences, label_strings, tokenizer, max_length: int):
+    """Tokenize protein sequences and align per-residue label strings to token positions."""
+    batch_input_ids = []
+    batch_attention_mask = []
+    batch_labels = []
+
+    for sequence, label_str in zip(sequences, label_strings):
+        encoded = tokenizer(
+            sequence,
+            truncation=True,
+            max_length=max_length,
+            add_special_tokens=True,
+        )
+        input_ids = encoded["input_ids"]
+        attention_mask = encoded["attention_mask"]
+
+        labels = [-100] * len(input_ids)
+        usable_len = min(len(sequence), len(label_str), len(input_ids) - 2)
+        for idx in range(usable_len):
+            labels[idx + 1] = ss_char_to_label(label_str[idx])
+
+        batch_input_ids.append(input_ids)
+        batch_attention_mask.append(attention_mask)
+        batch_labels.append(labels)
+
+    return {
+        "input_ids": batch_input_ids,
+        "attention_mask": batch_attention_mask,
+        "labels": batch_labels,
+    }
+
+
+def load_parquet_dataset(train_path: str, val_path: str, tokenizer, max_length: int):
+    """Load train/val parquet files and return tokenized Datasets."""
+    train_df = pd.read_parquet(train_path)
+    val_df = pd.read_parquet(val_path)
+
+    train_dataset = Dataset.from_pandas(train_df).map(
+        lambda ex: tokenize_and_align_labels(ex["Sequence"], ex["Secondary_structure"], tokenizer, max_length),
+        batched=True,
+        remove_columns=train_df.columns.tolist(),
+    )
+    val_dataset = Dataset.from_pandas(val_df).map(
+        lambda ex: tokenize_and_align_labels(ex["Sequence"], ex["Secondary_structure"], tokenizer, max_length),
+        batched=True,
+        remove_columns=val_df.columns.tolist(),
+    )
+    return train_dataset, val_dataset
+
+
+def compute_metrics(eval_pred):
+    """Compute token accuracy while ignoring -100 labels."""
+    logits, labels = eval_pred
+    predictions = np.argmax(logits, axis=-1)
+    mask = labels != -100
+    correct = (predictions == labels) & mask
+    total_tokens = mask.sum()
+    accuracy = float(correct.sum() / total_tokens) if total_tokens > 0 else 0.0
+    return {"token_accuracy": accuracy}
+
+
+def residue_to_ss_char(aa: str) -> str:
+    """Map an amino acid to a synthetic secondary structure character (H/E/C)."""
+    if aa in HELIX_AA:
+        return "H"
+    if aa in BETA_AA:
+        return "E"
+    return "C"
+
+
+def sequence_to_synthetic_labels(sequence: str) -> str:
+    """Derive a synthetic per-residue label string from an amino acid sequence."""
+    return "".join(residue_to_ss_char(aa) for aa in sequence)
+
+
+def make_synthetic_dataset(
+    tokenizer,
+    num_train_samples: int,
+    num_eval_samples: int,
+    min_seq_len: int,
+    max_seq_len: int,
+    max_length: int,
+):
+    """Create a synthetic train/eval dataset for token classification."""
+    train_sequences = build_synthetic_sequences(num_train_samples, min_seq_len, max_seq_len)
+    eval_sequences = build_synthetic_sequences(num_eval_samples, min_seq_len, max_seq_len)
+
+    train_labels = [sequence_to_synthetic_labels(s) for s in train_sequences]
+    eval_labels = [sequence_to_synthetic_labels(s) for s in eval_sequences]
+
+    train_dataset = Dataset.from_dict({"sequence": train_sequences, "labels_str": train_labels}).map(
+        lambda ex: tokenize_and_align_labels(ex["sequence"], ex["labels_str"], tokenizer, max_length),
+        batched=True,
+        remove_columns=["sequence", "labels_str"],
+    )
+    eval_dataset = Dataset.from_dict({"sequence": eval_sequences, "labels_str": eval_labels}).map(
+        lambda ex: tokenize_and_align_labels(ex["sequence"], ex["labels_str"], tokenizer, max_length),
+        batched=True,
+        remove_columns=["sequence", "labels_str"],
+    )
+    return train_dataset, eval_dataset
+
+
+def main():
+    args = parse_args()
+    set_seed(args.seed)
+
+    if not args.trust_remote_code and "esm2" in args.base_model.lower():
+        raise ValueError(
+            f"Model '{args.base_model}' requires remote code execution. "
+            "Re-run with --trust_remote_code to confirm you trust this model's code."
+        )
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    use_bf16 = torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+    model_dtype = torch.bfloat16 if use_bf16 else torch.float32
+
+    print(f"Loading tokenizer and model from: {args.base_model}")
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model, trust_remote_code=args.trust_remote_code)
+
+    config = AutoConfig.from_pretrained(args.base_model, trust_remote_code=args.trust_remote_code)
+    config.num_labels = 3
+    config.id2label = SS3_ID2LABEL
+    config.label2id = SS3_LABEL2ID
+
+    model = AutoModelForTokenClassification.from_pretrained(
+        args.base_model,
+        config=config,
+        trust_remote_code=args.trust_remote_code,
+        dtype=model_dtype,
+    )
+
+    lora_config = LoraConfig(
+        task_type=TaskType.TOKEN_CLS,
+        r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
+        target_modules=["layernorm_qkv"],
+        bias="none",
+        inference_mode=False,
+    )
+    model = get_peft_model(model, lora_config)
+    model.print_trainable_parameters()
+
+    if args.train_parquet and args.val_parquet:
+        print(f"Loading parquet datasets: train={args.train_parquet}, val={args.val_parquet}")
+        train_dataset, eval_dataset = load_parquet_dataset(
+            train_path=args.train_parquet,
+            val_path=args.val_parquet,
+            tokenizer=tokenizer,
+            max_length=args.max_length,
+        )
+    else:
+        print("Building synthetic dataset...")
+        train_dataset, eval_dataset = make_synthetic_dataset(
+            tokenizer=tokenizer,
+            num_train_samples=args.num_train_samples,
+            num_eval_samples=args.num_eval_samples,
+            min_seq_len=args.min_seq_len,
+            max_seq_len=args.max_seq_len,
+            max_length=args.max_length,
+        )
+
+    data_collator = DataCollatorForTokenClassification(tokenizer=tokenizer)
+
+    training_args = TrainingArguments(
+        output_dir=args.output_dir,
+        num_train_epochs=args.num_epochs,
+        per_device_train_batch_size=args.batch_size,
+        per_device_eval_batch_size=args.batch_size,
+        learning_rate=args.learning_rate,
+        weight_decay=args.weight_decay,
+        logging_steps=args.logging_steps,
+        eval_steps=args.eval_steps,
+        save_steps=args.save_steps,
+        eval_strategy="steps",
+        save_strategy="steps",
+        save_total_limit=2,
+        load_best_model_at_end=True,
+        metric_for_best_model="token_accuracy",
+        greater_is_better=True,
+        report_to="none",
+        remove_unused_columns=False,
+        bf16=use_bf16,
+        seed=args.seed,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        data_collator=data_collator,
+        compute_metrics=compute_metrics,
+    )
+
+    trainer.train()
+    final_metrics = trainer.evaluate()
+    print(f"Final evaluation metrics: {final_metrics}")
+
+    model.save_pretrained(args.output_dir)
+    tokenizer.save_pretrained(args.output_dir)
+    print(f"Saved LoRA adapter and tokenizer to: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/lora_finetuning_transformer_engine/requirements.txt
+++ b/examples/lora_finetuning_transformer_engine/requirements.txt
@@ -1,0 +1,12 @@
+torch
+transformers
+datasets
+peft
+accelerate
+numpy
+pandas
+pyarrow
+safetensors
+# transformer-engine must match the system CUDA toolkit version.
+# Install it separately or use the system-provided package.
+# See: https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -159,3 +159,8 @@ def is_xpu_available(check_device=False):
 @lru_cache
 def is_diffusers_available():
     return importlib.util.find_spec("diffusers") is not None
+
+
+@lru_cache
+def is_te_available():
+    return importlib.util.find_spec("transformer_engine") is not None

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -55,6 +55,7 @@ from .gptq import dispatch_gptq
 from .hqq import dispatch_hqq
 from .inc import dispatch_inc
 from .layer import Conv2d, LoraLayer, ParamWrapper, dispatch_default
+from .te import dispatch_transformer_engine
 from .torchao import dispatch_torchao
 from .tp_layer import dispatch_megatron
 
@@ -342,6 +343,7 @@ class LoraModel(BaseTuner):
                 dispatch_inc,
                 dispatch_torchao,
                 dispatch_megatron,
+                dispatch_transformer_engine,
                 dispatch_default,
             ]
         )

--- a/src/peft/tuners/lora/te.py
+++ b/src/peft/tuners/lora/te.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-Apache2
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Optional
+
+import torch
+
+from peft.import_utils import is_te_available
+from peft.tuners.lora.layer import LoraLayer
+from peft.tuners.tuners_utils import BaseTunerLayer
+
+from .config import LoraConfig
+
+
+if is_te_available():
+    import transformer_engine as te
+
+
+class TeLinear(torch.nn.Module, LoraLayer):
+    """LoRA layer for TransformerEngine linear modules.
+
+    Supports ``te.pytorch.Linear``, ``te.pytorch.LayerNormLinear``, and ``te.pytorch.LayerNormMLP`` as base layers.
+
+    Note:
+        Adapter weight merging (``merge`` / ``unmerge``) is **not supported** yet.
+    """
+
+    def __init__(
+        self,
+        base_layer,
+        adapter_name: str,
+        config: LoraConfig,
+        r: int = 0,
+        lora_alpha: int = 1,
+        **kwargs,
+    ):
+        if config.use_dora:
+            raise ValueError(f"{self.__class__.__name__} does not support DoRA yet, please set it to False")
+
+        super().__init__()
+        LoraLayer.__init__(self, base_layer=base_layer, **kwargs)
+
+        self._active_adapter = adapter_name
+        self.update_layer(
+            adapter_name,
+            r,
+            lora_alpha=lora_alpha,
+            config=config,
+        )
+
+    def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
+        """Not supported yet for TransformerEngine layers.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not support merge yet.")
+
+    def unmerge(self) -> None:
+        """Not supported yet for TransformerEngine layers.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not support unmerge yet.")
+
+    def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
+        self._check_forward_args(x, *args, **kwargs)
+        adapter_names = kwargs.pop("adapter_names", None)
+
+        if self.disable_adapters:
+            result = self.base_layer(x, *args, **kwargs)
+        elif adapter_names is not None:
+            raise ValueError(f"{self.__class__.__name__} does not support mixed_batch_forward yet.")
+        else:
+            result = self.base_layer(x, *args, **kwargs)
+            torch_result_dtype = result.dtype
+
+            lora_A_keys = self.lora_A.keys()
+            for active_adapter in self.active_adapters:
+                if active_adapter not in lora_A_keys:
+                    continue
+
+                lora_A = self.lora_A[active_adapter]
+                lora_B = self.lora_B[active_adapter]
+                dropout = self.lora_dropout[active_adapter]
+                scaling = self.scaling[active_adapter]
+                x = self._cast_input_dtype(x, lora_A.weight.dtype)
+                result = result + lora_B(lora_A(dropout(x))) * scaling
+
+            result = result.to(torch_result_dtype)
+
+        return result
+
+    def __repr__(self) -> str:
+        rep = super().__repr__()
+        return "lora." + rep
+
+
+def dispatch_transformer_engine(
+    target: torch.nn.Module,
+    adapter_name: str,
+    config: LoraConfig,
+    **kwargs: Any,
+) -> Optional[torch.nn.Module]:
+    new_module = None
+
+    if isinstance(target, BaseTunerLayer):
+        target_base_layer = target.get_base_layer()
+    else:
+        target_base_layer = target
+
+    if is_te_available() and isinstance(
+        target_base_layer, (te.pytorch.LayerNormLinear, te.pytorch.LayerNormMLP, te.pytorch.Linear)
+    ):
+        new_module = TeLinear(target, adapter_name, config=config, **kwargs)
+
+    return new_module

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -196,6 +196,14 @@ def _get_in_out_features(module: nn.Module) -> tuple[int, int] | tuple[None, Non
     elif hasattr(module, "input_size") and hasattr(module, "output_size"):
         # Megatron ColumnParallelLinear,RowParallelLinear
         in_features, out_features = module.input_size, module.output_size
+    elif module.__class__.__name__ == "Linear" or module.__class__.__name__ == "LayerNormLinear":
+        # TransformerEngine
+        in_features, out_features = module.in_features, module.out_features
+    elif module.__class__.__name__ == "LayerNormMLP":
+        # TransformerEngine
+        ln_weight = module.layer_norm_weight
+        ln_size = ln_weight.shape[0]
+        in_features, out_features = ln_size, ln_size
     elif hasattr(module, "codebooks") and module.__class__.__name__ == "QuantizedLinear":
         # AQLM QuantLinear
         in_features, out_features = module.in_features, module.out_features

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -78,7 +78,7 @@ from peft import (
     replace_lora_weights_loftq,
     set_peft_model_state_dict,
 )
-from peft.import_utils import is_diffusers_available, is_transformers_ge_v5, is_xpu_available
+from peft.import_utils import is_diffusers_available, is_te_available, is_transformers_ge_v5, is_xpu_available
 from peft.tuners import boft
 from peft.tuners.tuners_utils import BaseTunerLayer
 from peft.utils import SAFETENSORS_WEIGHTS_NAME, infer_device
@@ -5838,3 +5838,116 @@ class TestDtypeAutocastBnb:
             peft_type=peft_type,
             tmp_path=tmp_path,
         )
+
+
+if is_te_available():
+    import transformer_engine as te
+
+    from peft.tuners.lora.te import TeLinear
+
+
+def _replace_with_te_linear(model, target_module_names):
+    """Replace nn.Linear modules whose short name is in target_module_names with te.pytorch.Linear.
+
+    Weights and biases are copied from the original module. The replacement is done *in-place* (via ``setattr`` on the
+    parent module).
+    """
+    replacements = []
+    for name, module in model.named_modules():
+        short_name = name.rsplit(".", 1)[-1] if "." in name else name
+        if short_name in target_module_names and isinstance(module, torch.nn.Linear):
+            replacements.append((name, short_name, module))
+
+    for name, short_name, module in replacements:
+        parent_name = name.rsplit(".", 1)[0] if "." in name else ""
+        parent = model.get_submodule(parent_name) if parent_name else model
+
+        te_linear = te.pytorch.Linear(
+            module.in_features,
+            module.out_features,
+            bias=module.bias is not None,
+            params_dtype=module.weight.dtype,
+            device=module.weight.device,
+        )
+        with torch.no_grad():
+            te_linear.weight.copy_(module.weight)
+            if module.bias is not None:
+                te_linear.bias.copy_(module.bias)
+
+        setattr(parent, short_name, te_linear)
+
+
+@pytest.mark.skipif(not is_te_available(), reason="transformer_engine is not available")
+class TestTransformerEngine:
+    """Tests for LoRA with TransformerEngine layers.
+
+    Uses a standard OPT model with selected nn.Linear layers manually replaced by te.pytorch.Linear.
+    """
+
+    model_id = "facebook/opt-125m"
+    te_target_modules = ["q_proj", "v_proj"]
+
+    @pytest.fixture
+    def model_with_te_layers(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_id, torch_dtype=torch.bfloat16)
+        _replace_with_te_linear(model, self.te_target_modules)
+        return model
+
+    @pytest.fixture
+    def tokenizer(self):
+        return AutoTokenizer.from_pretrained(self.model_id)
+
+    @pytest.fixture
+    def tokenized_inputs(self, tokenizer):
+        return tokenizer("Hello world", return_tensors="pt")
+
+    @require_torch_gpu
+    @pytest.mark.single_gpu_tests
+    def test_te_lora_wraps_te_linear_and_keeps_forward_working(self, model_with_te_layers, tokenized_inputs):
+        cfg = LoraConfig(target_modules=self.te_target_modules, r=2, lora_alpha=8)
+        lora_model = get_peft_model(model_with_te_layers, cfg).to("cuda")
+
+        wrapped_q_proj = lora_model.base_model.model.model.decoder.layers[0].self_attn.q_proj
+
+        assert isinstance(wrapped_q_proj, TeLinear)
+        assert "default" in wrapped_q_proj.lora_A and "default" in wrapped_q_proj.lora_B
+        assert wrapped_q_proj.get_base_layer().weight.requires_grad is False
+        assert wrapped_q_proj.lora_A["default"].weight.requires_grad is True
+        assert wrapped_q_proj.lora_B["default"].weight.requires_grad is True
+
+        inputs = {k: v.to("cuda") for k, v in tokenized_inputs.items()}
+        out = lora_model(**inputs)
+        assert out.logits.ndim == 3
+
+    @require_torch_gpu
+    @pytest.mark.single_gpu_tests
+    def test_te_lora_forward_matches_base_before_backward(self, model_with_te_layers, tokenized_inputs):
+        base_model = deepcopy(model_with_te_layers).to("cuda")
+        cfg = LoraConfig(target_modules=self.te_target_modules, r=4, lora_alpha=8)
+        lora_model = get_peft_model(model_with_te_layers, cfg).to("cuda")
+
+        inputs = {k: v.to("cuda") for k, v in tokenized_inputs.items()}
+        lora_model.eval()
+        base_model.eval()
+        with torch.no_grad():
+            lora_result = lora_model(**inputs).logits
+            base_result = base_model(**inputs).logits
+
+        assert torch.allclose(lora_result, base_result, rtol=1e-3, atol=1e-3)
+
+    @require_torch_gpu
+    @pytest.mark.single_gpu_tests
+    def test_te_lora_backward(self, model_with_te_layers, tokenized_inputs):
+        cfg = LoraConfig(target_modules=self.te_target_modules, r=4, lora_alpha=8)
+        lora_model = get_peft_model(model_with_te_layers, cfg).to("cuda")
+
+        optimizer = torch.optim.AdamW(lora_model.parameters())
+        loss_fn = torch.nn.CrossEntropyLoss()
+        inputs = {k: v.to("cuda") for k, v in tokenized_inputs.items()}
+        logits = lora_model(**inputs).logits
+        shift_logits = logits[:, :-1, :].contiguous()
+        shift_labels = inputs["input_ids"][:, 1:].contiguous()
+        loss = loss_fn(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+        assert torch.isfinite(loss), f"Loss is not finite: {loss.item()}"
+        loss.backward()
+        optimizer.step()


### PR DESCRIPTION
This PR adds support so that TransformerEngine layers (https://github.com/NVIDIA/TransformerEngine) are recognized as valid layers to which LoRA adapters can be added. 