### PR TITLE
FIX OPT regression test after dtype change from v5

### DIFF
--- a/tests/regression/test_regression.py
+++ b/tests/regression/test_regression.py
@@ -549,7 +549,10 @@ class TestOpt(RegressionTester):
 
     def load_base_model(self):
         self.fix_seed()
-        return AutoModelForCausalLM.from_pretrained("facebook/opt-350m").to(self.torch_device)
+        # Note: Since transformers v5, the default dtype for opt has changed from float32 to float16. This causes the
+        # regression test to fail. Therefore, ensure that a float32 model is being used.
+        dtype = torch.float32
+        return AutoModelForCausalLM.from_pretrained("facebook/opt-350m", dtype=dtype).to(self.torch_device)
 
     def test_lora(self):
         base_model = self.load_base_model()


### PR DESCRIPTION
This PR fixes the failing OPT regression tests:

https://github.com/huggingface/peft/actions/runs/22048598786/job/63701885059#step:8:8255

Since transformers v5, the default `dtype` for OPT has changed from `float32` to `float16`. This causes the regression tests to fail. This PR hard-codes the `dtype` in the tests to `float32`.

Another solution could have been to accept `float16` and to create new regression artifacts for this `dtype`. This is what I originally went with: I deleted the old regression artifacts and created new ones with `float16`. However, for AdaLoRA, the output contained `nan` (thankfully the tests report that). It turns out that with the default setting, AdaLoRA causes an overflow. Therefore, I decided to hard-code `float32` and to recreate the `float32` regression artifacts.

For the record, here are part of the logs I used to debug this. Note that in layer 6, at the start the values are quite close but then they exceed 65k, at which point float16 overflows.

```
float16
base_model.model.model.decoder.layers.6.self_attn.q_proj.base_layer: mean finite values: 1.00, min value: -4.71, max value: 4.24
base_model.model.model.decoder.layers.6.self_attn.q_proj.lora_dropout.default: mean finite values: 1.00, min value: -3.08, max value: 3.10
base_model.model.model.decoder.layers.6.self_attn.q_proj: mean finite values: 1.00, min value: -378.00, max value: 398.75
base_model.model.model.decoder.layers.6.self_attn.k_proj.base_layer: mean finite values: 1.00, min value: -3.82, max value: 4.21
base_model.model.model.decoder.layers.6.self_attn.k_proj.lora_dropout.default: mean finite values: 1.00, min value: -3.08, max value: 3.10
base_model.model.model.decoder.layers.6.self_attn.k_proj: mean finite values: 1.00, min value: -458.50, max value: 421.25
base_model.model.model.decoder.layers.6.self_attn.v_proj.base_layer: mean finite values: 1.00, min value: -2.53, max value: 2.61
base_model.model.model.decoder.layers.6.self_attn.v_proj.lora_dropout.default: mean finite values: 1.00, min value: -3.08, max value: 3.10
base_model.model.model.decoder.layers.6.self_attn.v_proj: mean finite values: 1.00, min value: -91.62, max value: 95.31
base_model.model.model.decoder.layers.6.self_attn.out_proj.base_layer: mean finite values: 1.00, min value: -153.50, max value: 52.25
base_model.model.model.decoder.layers.6.self_attn.out_proj.lora_dropout.default: mean finite values: 1.00, min value: -91.62, max value: 95.31
base_model.model.model.decoder.layers.6.self_attn.out_proj: mean finite values: 1.00, min value: -3732.00, max value: 3788.00
base_model.model.model.decoder.layers.6.self_attn: mean finite values: 1.00, min value: -3732.00, max value: 3788.00
base_model.model.model.decoder.layers.6.self_attn_layer_norm: mean finite values: 1.00, min value: -3.31, max value: 3.41
base_model.model.model.decoder.layers.6.fc1.base_layer: mean finite values: 1.00, min value: -4.55, max value: 4.12
base_model.model.model.decoder.layers.6.fc1.lora_dropout.default: mean finite values: 1.00, min value: -3.31, max value: 3.41
base_model.model.model.decoder.layers.6.fc1: mean finite values: 1.00, min value: -421.00, max value: 397.00
base_model.model.model.decoder.layers.6.activation_fn: mean finite values: 1.00, min value: 0.00, max value: 397.00
base_model.model.model.decoder.layers.6.fc2.base_layer: mean finite values: 1.00, min value: -580.50, max value: 717.00
base_model.model.model.decoder.layers.6.fc2.lora_dropout.default: mean finite values: 1.00, min value: 0.00, max value: 397.00
# vvv values start to overflow with fp16 vvv
base_model.model.model.decoder.layers.6.fc2: mean finite values: 1.00, min value: -inf, max value: inf
base_model.model.model.decoder.layers.6.final_layer_norm: mean finite values: 0.00, min value: nan, max value: nan
base_model.model.model.decoder.layers.6: mean finite values: 0.00, min value: nan, max value: nan

float32
base_model.model.model.decoder.layers.6.self_attn.q_proj.base_layer: mean finite values: 1.00, min value: -4.71, max value: 4.24
base_model.model.model.decoder.layers.6.self_attn.q_proj.lora_dropout.default: mean finite values: 1.00, min value: -3.08, max value: 3.10
base_model.model.model.decoder.layers.6.self_attn.q_proj: mean finite values: 1.00, min value: -377.79, max value: 398.66
base_model.model.model.decoder.layers.6.self_attn.k_proj.base_layer: mean finite values: 1.00, min value: -3.82, max value: 4.21
base_model.model.model.decoder.layers.6.self_attn.k_proj.lora_dropout.default: mean finite values: 1.00, min value: -3.08, max value: 3.10
base_model.model.model.decoder.layers.6.self_attn.k_proj: mean finite values: 1.00, min value: -458.59, max value: 421.02
base_model.model.model.decoder.layers.6.self_attn.v_proj.base_layer: mean finite values: 1.00, min value: -2.53, max value: 2.61
base_model.model.model.decoder.layers.6.self_attn.v_proj.lora_dropout.default: mean finite values: 1.00, min value: -3.08, max value: 3.10
base_model.model.model.decoder.layers.6.self_attn.v_proj: mean finite values: 1.00, min value: -91.73, max value: 95.37
base_model.model.model.decoder.layers.6.self_attn.out_proj.base_layer: mean finite values: 1.00, min value: -153.53, max value: 52.30
base_model.model.model.decoder.layers.6.self_attn.out_proj.lora_dropout.default: mean finite values: 1.00, min value: -91.73, max value: 95.37
base_model.model.model.decoder.layers.6.self_attn.out_proj: mean finite values: 1.00, min value: -3733.77, max value: 3791.08
base_model.model.model.decoder.layers.6.self_attn: mean finite values: 1.00, min value: -3733.77, max value: 3791.08
base_model.model.model.decoder.layers.6.self_attn_layer_norm: mean finite values: 1.00, min value: -3.31, max value: 3.41
base_model.model.model.decoder.layers.6.fc1.base_layer: mean finite values: 1.00, min value: -4.55, max value: 4.12
base_model.model.model.decoder.layers.6.fc1.lora_dropout.default: mean finite values: 1.00, min value: -3.31, max value: 3.41
base_model.model.model.decoder.layers.6.fc1: mean finite values: 1.00, min value: -420.86, max value: 396.98
base_model.model.model.decoder.layers.6.activation_fn: mean finite values: 1.00, min value: 0.00, max value: 396.98
base_model.model.model.decoder.layers.6.fc2.base_layer: mean finite values: 1.00, min value: -580.74, max value: 717.98
base_model.model.model.decoder.layers.6.fc2.lora_dropout.default: mean finite values: 1.00, min value: 0.00, max value: 396.98
# vvv values are fine with fp32 vvv
base_model.model.model.decoder.layers.6.fc2: mean finite values: 1.00, min value: -67593.91, max value: 66406.52
base_model.model.model.decoder.layers.6.final_layer_norm: mean finite values: 1.00, min value: -3.15, max value: 3.07
base_model.model.model.decoder.layers.6: mean finite values: 1.00, min value: -3.15, max value: 3.07
```
