### PR TITLE
fix: replace deprecated financial_phrasebank in conditional generation notebooks

### DIFF
--- a/examples/conditional_generation/peft_ia3_seq2seq.ipynb
+++ b/examples/conditional_generation/peft_ia3_seq2seq.ipynb
@@ -28,7 +28,7 @@
     "tokenizer_name_or_path = \"bigscience/mt0-large\"\n",
     "\n",
     "checkpoint_name = \"financial_sentiment_analysis_ia3_v1.pt\"\n",
-    "text_column = \"sentence\"\n",
+    "text_column = \"text\"\n",
     "label_column = \"text_label\"\n",
     "max_length = 128\n",
     "lr = 8e-3\n",
@@ -572,7 +572,7 @@
    ],
    "source": [
     "# loading dataset\n",
-    "dataset = load_dataset(\"financial_phrasebank\", \"sentences_allagree\")\n",
+    "dataset = load_dataset(\"zeroshot/twitter-financial-news-sentiment\")\n",
     "dataset = dataset[\"train\"].train_test_split(test_size=0.1)\n",
     "dataset[\"validation\"] = dataset[\"test\"]\n",
     "del dataset[\"test\"]\n",

--- a/examples/conditional_generation/peft_lora_seq2seq.ipynb
+++ b/examples/conditional_generation/peft_lora_seq2seq.ipynb
@@ -25,7 +25,7 @@
     "tokenizer_name_or_path = \"bigscience/mt0-large\"\n",
     "\n",
     "checkpoint_name = \"financial_sentiment_analysis_lora_v1.pt\"\n",
-    "text_column = \"sentence\"\n",
+    "text_column = \"text\"\n",
     "label_column = \"text_label\"\n",
     "max_length = 128\n",
     "lr = 1e-3\n",
@@ -106,7 +106,7 @@
    ],
    "source": [
     "# loading dataset\n",
-    "dataset = load_dataset(\"financial_phrasebank\", \"sentences_allagree\")\n",
+    "dataset = load_dataset(\"zeroshot/twitter-financial-news-sentiment\")\n",
     "dataset = dataset[\"train\"].train_test_split(test_size=0.1)\n",
     "dataset[\"validation\"] = dataset[\"test\"]\n",
     "del dataset[\"test\"]\n",

--- a/examples/conditional_generation/peft_prefix_tuning_seq2seq.ipynb
+++ b/examples/conditional_generation/peft_prefix_tuning_seq2seq.ipynb
@@ -25,7 +25,7 @@
     "tokenizer_name_or_path = \"t5-large\"\n",
     "\n",
     "checkpoint_name = \"financial_sentiment_analysis_prefix_tuning_v1.pt\"\n",
-    "text_column = \"sentence\"\n",
+    "text_column = \"text\"\n",
     "label_column = \"text_label\"\n",
     "max_length = 128\n",
     "lr = 1e-2\n",
@@ -106,7 +106,7 @@
    ],
    "source": [
     "# loading dataset\n",
-    "dataset = load_dataset(\"financial_phrasebank\", \"sentences_allagree\")\n",
+    "dataset = load_dataset(\"zeroshot/twitter-financial-news-sentiment\")\n",
     "dataset = dataset[\"train\"].train_test_split(test_size=0.1)\n",
     "dataset[\"validation\"] = dataset[\"test\"]\n",
     "del dataset[\"test\"]\n",

--- a/examples/conditional_generation/peft_prompt_tuning_seq2seq.ipynb
+++ b/examples/conditional_generation/peft_prompt_tuning_seq2seq.ipynb
@@ -28,7 +28,7 @@
     "tokenizer_name_or_path = \"t5-large\"\n",
     "\n",
     "checkpoint_name = \"financial_sentiment_analysis_prompt_tuning_v1.pt\"\n",
-    "text_column = \"sentence\"\n",
+    "text_column = \"text\"\n",
     "label_column = \"text_label\"\n",
     "max_length = 128\n",
     "lr = 1\n",
@@ -287,7 +287,7 @@
    ],
    "source": [
     "# loading dataset\n",
-    "dataset = load_dataset(\"financial_phrasebank\", \"sentences_allagree\")\n",
+    "dataset = load_dataset(\"zeroshot/twitter-financial-news-sentiment\")\n",
     "dataset = dataset[\"train\"].train_test_split(test_size=0.1)\n",
     "dataset[\"validation\"] = dataset[\"test\"]\n",
     "del dataset[\"test\"]\n",


### PR DESCRIPTION
Continues #2998 (see also #3058 which fixed the IA3 doc and adalora script).

Updates the remaining conditional generation notebooks that reference the deprecated `financial_phrasebank` dataset, replacing it with `zeroshot/twitter-financial-news-sentiment`.

Affected files:
- `examples/conditional_generation/peft_ia3_seq2seq.ipynb`
- `examples/conditional_generation/peft_lora_seq2seq.ipynb`
- `examples/conditional_generation/peft_prompt_tuning_seq2seq.ipynb`
- `examples/conditional_generation/peft_prefix_tuning_seq2seq.ipynb`