### PR TITLE
CI: Dependabot PRs don't trigger unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
 
   tests:
     needs: check_code_quality
+    # dependabot updates (which don't require approval for CI to run) shouldn't trigger unit tests
+    if: !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
As Dependabot PRs don't require approval to start the CI, they will immediately trigger it, including the expensive unit tests. This PR should prevent unit tests to be run when Dependabot creates PRs, as this is generally unnecessary.

See #3040 for context.