### PR TITLE
FIX Flaky X-LoRA test after adding caching

### DIFF
--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -364,6 +364,7 @@ class TestXlora:
         model_id = "peft-internal-testing/opt-125m"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
+            # note: exit the caching context to allow download of the LoRA adapters below
         model.config.use_cache = False
 
         adapters = [


### PR DESCRIPTION
For some reason, adding the caching context for the base model in the X-LoRA test (#3046) makes loading the PEFT adapters flaky, even though they are not cached. This PR attempts to fix this by moving the adapter loading code out of the caching context.

To review, disable showing whitespace.

**Edit**: All tests passed on first try. That's not proof that this fix worked but a strong indicator.