### PR TITLE
fix: replace 2 bare except clauses with except Exception

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2118,7 +2118,7 @@ class PeftModelForCausalLM(PeftModel):
                     outputs = self.base_model.generate(*args, **kwargs)
             else:
                 outputs = self.base_model.generate(*args, **kwargs)
-        except:
+        except Exception:
             self.base_model.prepare_inputs_for_generation = self.base_model_prepare_inputs_for_generation
             raise
         else:
@@ -2506,7 +2506,7 @@ class PeftModelForSeq2SeqLM(PeftModel):
                     return self.base_model.generate(**kwargs)
                 else:
                     raise NotImplementedError
-        except:
+        except Exception:
             self.base_model.prepare_inputs_for_generation = self.base_model_prepare_inputs_for_generation
             self.base_model._prepare_encoder_decoder_kwargs_for_generation = (
                 self.base_model_prepare_encoder_decoder_kwargs_for_generation


### PR DESCRIPTION
## What
Replace 2 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.