### PR TITLE
WIP: Support tranformers weight conversion

### DIFF
--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .integrations import map_cache_to_layer_device_map
+from .integrations import (
+    build_peft_weight_mapping_for_transformers,
+    convert_peft_config_for_transformers,
+    map_cache_to_layer_device_map,
+)
 from .loftq_utils import replace_lora_weights_loftq
 from .other import (
     CONFIG_NAME,
@@ -112,7 +116,9 @@ __all__ = [
     "_set_adapter",
     "_set_trainable",
     "bloom_model_postprocess_past_key_value",
+    "build_peft_weight_mapping_for_transformers",
     "cast_mixed_precision_params",
+    "convert_peft_config_for_transformers",
     "get_gptqmodel_quant_linear",
     "get_peft_model_state_dict",
     "get_quantization_config",


### PR DESCRIPTION
Continuation of PR #2995.
Background: huggingface/transformers#42491 and huggingface/transformers#43261.

This change implements conversion operations for converting some existing PEFT checkpoints, mainly dealing with the fusing of MoE layers in transformers v5.

The code added here is currently a copy from the code that exists in transformers which is supposed to be gated as soon PEFT v0.19 is released and use the code in this PR.

The copying makes testing a bit difficult since there's currently no routing depending on the PEFT version in transformers. Older transformers versions, therefore, need patching to forcefully use the PEFT implementation of the conversion. As soon as the routing is implemented in transformers we can conditionally disable the patching.