### PR TITLE
CHORE: Bump 3rd party GH actions

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@f05501e212c51ca46626f95da79703182bcfdc6b  # main from 2025-09-05
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@607843a35ee10949e5bea9ca2f206831b0305b4c  # main
     with:
       commit_sha: ${{ github.sha }}
       package: peft

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@f05501e212c51ca46626f95da79703182bcfdc6b  # main from 2025-09-05
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@607843a35ee10949e5bea9ca2f206831b0305b4c  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@35dace0375d89e25e78db5f0a44127b61f4e5c20 #v42
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a  # v47.0.4
         with:
           files: docker/*/Dockerfile
           json: "true"

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -15,4 +15,4 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Secret Scanning
-      uses: trufflesecurity/trufflehog@7c0734f987ad0bb30ee8da210773b800ee2016d3  # v3.93.4
+      uses: trufflesecurity/trufflehog@041f07e9df901a1038a528e5525b0226d04dd5ea  # v3.93.6

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@f05501e212c51ca46626f95da79703182bcfdc6b  # main from 2025-09-05
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@607843a35ee10949e5bea9ca2f206831b0305b4c  # main
     with:
       package_name: peft
     secrets:


### PR DESCRIPTION
Supersedes #3072 by Dependabot, check that PRs to see the diffs of the 3rd party actions.

The reason to create this PR is that Dependabot seems to have struggle parsing some of the comments, not updating them or using main branch instead of the release branch for tj-actions. This PR normalizes the comments, so hopefully next time, Dependabot should parse them correctly.