### PR TITLE
fix(lora): use non-greedy regex to capture layer index in check_target_module_exists

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1812,7 +1812,12 @@ def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
             # TODO: It's still unclear how empty layers_pattern (None, [], or "") should behave
             # For now, empty layers_pattern means any layer pattern is ok
             if layers_pattern is None or len(layers_pattern) == 0:
-                layer_index = re.match(r".*\.[^.]*\.(\d+)\.", key)
+                # Use a non-greedy `.*?` so the regex captures the *first* numeric segment in the key
+                # (i.e. the transformer layer index) rather than a later numeric segment such as an
+                # MoE expert index.  For example, in `model.layers.1.mlp.experts.0.up_proj` the
+                # greedy `.*` would backtrack and capture `0` (the expert index), whereas `.*?` stops
+                # at the first match and correctly captures `1` (the layer index).
+                layer_index = re.match(r".*?\.[^.]*\.(\d+)\.", key)
             else:
                 layers_pattern = [layers_pattern] if isinstance(layers_pattern, str) else layers_pattern
                 for pattern in layers_pattern:


### PR DESCRIPTION
## Problem

When `layers_to_transform` is set and `layers_pattern` is `None` (the default), `check_target_module_exists` falls back to the regex:

```python
layer_index = re.match(r".*\.[^.]*\.(\d+)\.", key)
```

The greedy `.*` causes the regex engine to backtrack and capture the **last** digit-group in the key path rather than the **first** (which represents the actual transformer layer index).

For a MoE model key like `model.layers.1.mlp.experts.0.up_proj`:
- **Greedy match** → captures `0` (the expert index) ❌
- **Non-greedy match** → captures `1` (the layer index) ✅

This means `layers_to_transform=[1]` would **not** target the above module even though layer 1 is in the transform list. Instead it might incorrectly target/skip modules based on the expert index.

Reported in #3016.

## Fix

Change `.*` → `.*?` (non-greedy) so the regex stops at the first digit-segment it encounters:

```python
layer_index = re.match(r".*?\.[^.]*\.(\d+)\.", key)
```

For standard non-MoE keys like `model.layers.5.self_attn.q_proj`, both regexes produce the same result (capturing `5`). The change only affects keys that contain multiple digit-groups (i.e., MoE expert paths).

Fixes #3016