### PR TITLE
FIX Distributed training tests and extend them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,12 @@ tests_torch_compile:
 	python -m pytest tests/test_torch_compile.py $(if $(IS_GITHUB_CI),--report-log "compile_tests.log",)
 
 tests_training:
-	accelerate launch --config_file tests/training/deepspeed_config.yaml tests/training/training.py $(if $(IS_GITHUB_CI),--report-log "training_deepspeed.log",)
-	accelerate launch --config_file tests/training/deepspeed_config.yaml tests/training/training.py --quant 4bit $(if $(IS_GITHUB_CI),--report-log "training_deepspeed_4bit.log",)
-	accelerate launch --config_file tests/training/deepspeed_config.yaml tests/training/training.py --quant 8bit $(if $(IS_GITHUB_CI),--report-log "training_deepspeed_8bit.log",)
-	accelerate launch --config_file tests/training/fsdp_config.yaml tests/training/training.py $(if $(IS_GITHUB_CI),--report-log "training_fsdp.log",)
-	accelerate launch --config_file tests/training/fsdp_config.yaml tests/training/training.py --quant 4bit $(if $(IS_GITHUB_CI),--report-log "training_fsdp_4bit.log",)
-	accelerate launch --config_file tests/training/fsdp_config.yaml tests/training/adapters.py $(if $(IS_GITHUB_CI),--report-log "training_fsdp_adapters.log",)
+	accelerate launch --config_file tests/training/deepspeed_config.yaml tests/training/training.py -- $(if $(IS_GITHUB_CI),--report-log "training_deepspeed.log",)
+	accelerate launch --config_file tests/training/deepspeed_config.yaml tests/training/training.py --quant 4bit -- $(if $(IS_GITHUB_CI),--report-log "training_deepspeed_4bit.log",)
+	accelerate launch --config_file tests/training/deepspeed_config.yaml tests/training/training.py --quant 8bit -- $(if $(IS_GITHUB_CI),--report-log "training_deepspeed_8bit.log",)
+	accelerate launch --config_file tests/training/fsdp_config.yaml tests/training/training.py -- $(if $(IS_GITHUB_CI),--report-log "training_fsdp.log",)
+	accelerate launch --config_file tests/training/fsdp_config.yaml tests/training/training.py --quant 4bit -- $(if $(IS_GITHUB_CI),--report-log "training_fsdp_4bit.log",)
+	accelerate launch --config_file tests/training/fsdp2_config.yaml tests/training/training.py -- $(if $(IS_GITHUB_CI),--report-log "training_fsdp2.log",)
+	accelerate launch --config_file tests/training/fsdp2_config.yaml tests/training/training.py --quant 4bit -- $(if $(IS_GITHUB_CI),--report-log "training_fsdp2_4bit.log",)
+	accelerate launch --config_file tests/training/fsdp2_config.yaml tests/training/training.py --quant 4bit --target_modules q_proj --target_parameters v_proj.weight -- $(if $(IS_GITHUB_CI),--report-log "training_fsdp2_target_params.log",)
+	accelerate launch --config_file tests/training/fsdp_config.yaml tests/training/adapters.py -- $(if $(IS_GITHUB_CI),--report-log "training_fsdp_adapters.log",)

--- a/tests/training/fsdp2_config.yaml
+++ b/tests/training/fsdp2_config.yaml
@@ -1,0 +1,22 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+distributed_type: FSDP
+downcast_bf16: 'no'
+fsdp_config:
+  fsdp_version: 2
+  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  fsdp_cpu_ram_efficient_loading: false
+  fsdp_offload_params: false
+  fsdp_reshard_after_forward: true
+  fsdp_state_dict_type: SHARDED_STATE_DICT
+machine_rank: 0
+main_training_function: main
+mixed_precision: bf16
+num_machines: 1
+num_processes: 2
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false

--- a/tests/training/training.py
+++ b/tests/training/training.py
@@ -40,12 +40,17 @@ def print_if_process_zero(*args, **kwargs):
     PartialState().print(*args, **kwargs)
 
 
-def main(model_id: str, quant: Literal["4bit", "8bit"] | None, target_modules: list[str] | None):
+def main(
+    model_id: str,
+    quant: Literal["4bit", "8bit"] | None,
+    target_modules: list[str] | None,
+    target_parameters: list[str] | None,
+):
     if target_modules == ["all-linear"]:
         target_modules = "all-linear"
 
     print_if_process_zero("=" * 50)
-    print_if_process_zero(f"{model_id=}, {quant=}, {target_modules=}")
+    print_if_process_zero(f"{model_id=}, {quant=}, {target_modules=} {target_parameters=}")
     print_if_process_zero("=" * 50)
 
     data = load_dataset("ybelkada/english_quotes_copy")
@@ -80,6 +85,7 @@ def main(model_id: str, quant: Literal["4bit", "8bit"] | None, target_modules: l
         r=16,
         lora_alpha=32,
         target_modules=target_modules,
+        target_parameters=target_parameters,
         lora_dropout=0.05,
         bias="none",
         task_type="CAUSAL_LM",
@@ -138,5 +144,18 @@ if __name__ == "__main__":
         default=None,
         help="List of target modules for LoRA adaptation",
     )
+    parser.add_argument(
+        "--target_parameters",
+        type=str,
+        nargs="+",
+        required=False,
+        default=None,
+        help="List of target modules for LoRA adaptation",
+    )
     args = parser.parse_args()
-    main(model_id=args.model_id, quant=args.quant, target_modules=args.target_modules)
+    main(
+        model_id=args.model_id,
+        quant=args.quant,
+        target_modules=args.target_modules,
+        target_parameters=args.target_parameters,
+    )


### PR DESCRIPTION
There was an [error](https://github.com/huggingface/peft/actions/runs/22984495119/job/66731313046#step:8:23) with how the arguments are passed in the Makefile, this should now be fixed.

Also, tests for FSDP2 are added:

- normal FSDP2
- FSDP2 with 4bit quant (bnb)
- FSDP2 with target parameters

To enable the latter, the training script was extended to take the target_parameters argument.

Running these scripts locally passes.