### PR TITLE
fix: Handle FSDP-sharded parameters in LoRA ParamWrapper get_delta_weight

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -28,6 +28,7 @@ from peft.tuners._buffer_dict import BufferDict
 from peft.tuners.tuners_utils import BaseTunerLayer, _get_in_out_features, check_adapters_to_merge
 from peft.utils.integrations import (
     dequantize_module_weight,
+    fsdp_summon_full_params_ctx,
     gather_params_ctx,
     get_bnb_param_type,
     skip_init_on_device,
@@ -2169,17 +2170,20 @@ class ParamWrapper(nn.Module, LoraLayer):
         return param
 
     def get_delta_weight(self, adapter_name, *args, **kwargs):
-        if self.num_experts == 1:
-            delta_weight = Linear.get_delta_weight(self, adapter_name, *args, **kwargs)
-        else:
-            weight_A = self.lora_A[adapter_name].weight
-            weight_B = self.lora_B[adapter_name].weight
-            # shape: experts x rank x in_features
-            weight_A = weight_A.reshape(self.num_experts, -1, weight_A.shape[-1])
-            # shape: out_features x rank x experts
-            weight_B = weight_B.reshape(weight_B.shape[0], -1, self.num_experts)
-            # fan_in_fan_out must be False, so no transpose call here
-            delta_weight = torch.einsum("o r e, e r i -> e i o", weight_B, weight_A) * self.scaling[adapter_name]
+        # For MoE layers with FSDP, we need to summon full params to get the complete weight tensors
+        # since they may be sharded across GPUs
+        with fsdp_summon_full_params_ctx(self.lora_A[adapter_name]), fsdp_summon_full_params_ctx(self.lora_B[adapter_name]):
+            if self.num_experts == 1:
+                delta_weight = Linear.get_delta_weight(self, adapter_name, *args, **kwargs)
+            else:
+                weight_A = self.lora_A[adapter_name].weight
+                weight_B = self.lora_B[adapter_name].weight
+                # shape: experts x rank x in_features
+                weight_A = weight_A.reshape(self.num_experts, -1, weight_A.shape[-1])
+                # shape: out_features x rank x experts
+                weight_B = weight_B.reshape(weight_B.shape[0], -1, self.num_experts)
+                # fan_in_fan_out must be False, so no transpose call here
+                delta_weight = torch.einsum("o r e, e r i -> e i o", weight_B, weight_A) * self.scaling[adapter_name]
 
         base_layer = self.get_base_layer()
         param = self.get_param()

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2172,7 +2172,7 @@ class ParamWrapper(nn.Module, LoraLayer):
     def get_delta_weight(self, adapter_name, *args, **kwargs):
         # For MoE layers with FSDP, we need to summon full params to get the complete weight tensors
         # since they may be sharded across GPUs
-        with fsdp_summon_full_params_ctx(self.lora_A[adapter_name]), fsdp_summon_full_params_ctx(self.lora_B[adapter_name]):
+        with fsdp_summon_full_params_ctx(self.lora_A[adapter_name], self.lora_B[adapter_name]):
             if self.num_experts == 1:
                 delta_weight = Linear.get_delta_weight(self, adapter_name, *args, **kwargs)
             else:

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import functools
 from contextlib import contextmanager
 from typing import Literal, Optional
@@ -48,24 +49,34 @@ def gather_params_ctx(param, modifier_rank: Optional[int] = 0, fwd_module: torch
 
 
 @contextmanager
-def fsdp_summon_full_params_ctx(module: torch.nn.Module):
+def fsdp_summon_full_params_ctx(*modules: torch.nn.Module):
     """
     Context manager to gather full parameters for FSDP-wrapped modules.
     If the module is not FSDP-wrapped, this is a no-op.
+    
+    Accepts multiple modules (variadic) for consistency with gather_params_ctx.
+    Uses ExitStack to chain contexts since FSDP.summon_full_params only accepts
+    a single module.
     """
-    # Check if module is FSDP-wrapped by looking for FSDP-specific attributes
-    is_fsdp_wrapped = (
-        hasattr(module, "_is_fsdp_managed_module")
-        or module.__class__.__name__ == "FullyShardedDataParallel"
-    )
+    # Collect all FSDP-wrapped modules
+    fsdp_modules = []
+    for module in modules:
+        is_fsdp_wrapped = (
+            hasattr(module, "_is_fsdp_managed_module")
+            or module.__class__.__name__ == "FullyShardedDataParallel"
+        )
+        if is_fsdp_wrapped:
+            fsdp_modules.append(module)
 
-    if not is_fsdp_wrapped:
+    if not fsdp_modules:
         yield
         return
 
     from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-    with FSDP.summon_full_params(module):
+    with contextlib.ExitStack() as exit_stack:
+        for module in fsdp_modules:
+            exit_stack.enter_context(FSDP.summon_full_params(module))
         yield
     return
 

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -47,6 +47,29 @@ def gather_params_ctx(param, modifier_rank: Optional[int] = 0, fwd_module: torch
     return
 
 
+@contextmanager
+def fsdp_summon_full_params_ctx(module: torch.nn.Module):
+    """
+    Context manager to gather full parameters for FSDP-wrapped modules.
+    If the module is not FSDP-wrapped, this is a no-op.
+    """
+    # Check if module is FSDP-wrapped by looking for FSDP-specific attributes
+    is_fsdp_wrapped = (
+        hasattr(module, "_is_fsdp_managed_module")
+        or module.__class__.__name__ == "FullyShardedDataParallel"
+    )
+
+    if not is_fsdp_wrapped:
+        yield
+        return
+
+    from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+    with FSDP.summon_full_params(module):
+        yield
+    return
+
+
 def dequantize_module_weight(module: torch.nn.Module) -> torch.nn.Parameter:
     """
     Helper function to dequantize a quantized weight.

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4810,6 +4810,60 @@ class TestFSDPWrap:
         # Avoid raising on custom models since Trainer uses fsdp_auto_wrap_policy automatically for PEFT + FSDP
         fsdp_auto_wrap_policy(SimpleModel())  # does not raise
 
+    @pytest.mark.multi_gpu_tests
+    @require_torch_multi_gpu
+    def test_fsdp_paramwrapper_get_delta_weight(self):
+        """
+        Test that ParamWrapper.get_delta_weight works with FSDP wrapping.
+        
+        This test ensures that FSDP + ParamWrapper works correctly for MoE layers
+        with multiple experts. The get_delta_weight method uses fsdp_summon_full_params_ctx
+        to gather full parameters across GPUs before computing delta weights.
+        
+        See https://github.com/huggingface/peft/issues/3080
+        """
+        from peft.tuners.lora.layer import ParamWrapper
+        from peft.utils.integrations import fsdp_summon_full_params_ctx
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "29502"
+
+        # Initialize process group
+        init_process_group(world_size=1, rank=0)
+
+        # Create a simple model with ParamWrapper (simulating MoE with num_experts > 1)
+        base_model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/opt-125m")
+        
+        # Configure LoRA with MoE (num_experts > 1)
+        config = LoraConfig(
+            target_modules=["q_proj"],
+            task_type="CAUSAL_LM",
+            r=8,
+            num_experts=4,  # MoE configuration
+        )
+        model = get_peft_model(base_model, config)
+
+        # Verify that the model has ParamWrapper instances
+        param_wrappers = [m for m in model.modules() if isinstance(m, ParamWrapper)]
+        assert len(param_wrappers) > 0, "Model should have ParamWrapper instances"
+
+        # Wrap with FSDP
+        fsdp_model = FSDP(
+            model,
+            auto_wrap_policy=fsdp_auto_wrap_policy(model),
+            use_orig_params=True,
+            sync_module_states=True,
+        )
+
+        # Test that get_delta_weight works with FSDP wrapping
+        # This should not raise an error when accessing sharded parameters
+        for wrapper in param_wrappers:
+            if "default" in wrapper.lora_A:
+                # This should work without errors due to fsdp_summon_full_params_ctx
+                delta_weight = wrapper.get_delta_weight("default")
+                assert delta_weight is not None
+                break
+
 
 class TestBOFT:
     """


### PR DESCRIPTION
## Problem

When using FSDP (FullyShardedDataParallel) with MoE layers (`num_experts > 1`) via `target_parameters`, the LoRA weights (lora_A, lora_B) are sharded across GPUs. The `ParamWrapper.get_delta_weight` method was failing with a `RuntimeError` during the reshape operation because it expected the full tensor shape but only received the sharded portion.

Error from issue #3080:


## Solution

Added `fsdp_summon_full_params_ctx` context manager in `integrations.py` that:
1. Detects if a module is FSDP-wrapped by checking for `_is_fsdp_managed_module` attribute or `FullyShardedDataParallel` class name
2. Uses `FSDP.summon_full_params()` to gather full parameters when needed
3. Is a no-op for non-FSDP modules

Modified `ParamWrapper.get_delta_weight` to wrap the weight access in this context manager, ensuring full parameters are available for the reshape and einsum operations.

## Changes

- `src/peft/utils/integrations.py`: Added `fsdp_summon_full_params_ctx` context manager
- `src/peft/tuners/lora/layer.py`: Updated `ParamWrapper.get_delta_weight` to use the new context manager for both `lora_A` and `lora_B` modules

## Testing

- All existing `test_target_parameters` tests pass
- `test_gpu_examples.py::TestFSDPWrap::test_fsdp_auto_wrap_policy_does_not_raise_on_custom_model` passes
- Basic LoRA custom model tests pass

Fixes #3080

---

I have read the CLA Document and I hereby sign the CLA