### PR TITLE
fix(security): add allowlist for importlib calls to prevent arbitrary module loading (#3085)

### DIFF
--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -18,6 +18,10 @@ import importlib
 import os
 from typing import Optional
 
+# Allowlist of known-safe parent library modules for auto_mapping loading.
+# Only these modules may be resolved via importlib when loading adapter configs.
+ALLOWED_PARENT_LIBRARIES = {"transformers", "diffusers"}
+
 from transformers import (
     AutoModel,
     AutoModelForCausalLM,
@@ -104,6 +108,13 @@ class _BaseAutoPeftModel:
             auto_mapping = getattr(peft_config, "auto_mapping", None)
             base_model_class = auto_mapping["base_model_class"]
             parent_library_name = auto_mapping["parent_library"]
+
+            if parent_library_name not in ALLOWED_PARENT_LIBRARIES:
+                raise ValueError(
+                    f"Invalid parent_library '{parent_library_name}' in auto_mapping. "
+                    f"Only modules from {sorted(ALLOWED_PARENT_LIBRARIES)} are allowed. "
+                    "If this is a legitimate use case, please open an issue to request adding it to the allowlist."
+                )
 
             parent_library = importlib.import_module(parent_library_name)
             target_class = getattr(parent_library, base_model_class)

--- a/src/peft/tuners/lora/tp_layer.py
+++ b/src/peft/tuners/lora/tp_layer.py
@@ -313,6 +313,11 @@ def dispatch_megatron(
         target_base_layer = target
 
     if config.megatron_config:
+        if not config.megatron_core or "." not in config.megatron_core:
+            raise ValueError(
+                f"Invalid megatron_core value '{config.megatron_core}'. "
+                "It must be a fully qualified module name (e.g., 'megatron.core')."
+            )
         megatron_core = importlib.import_module(config.megatron_core)
     else:
         megatron_core = None


### PR DESCRIPTION
## Fixes #3085

### Problem
PEFT's `AutoPeftModel.from_pretrained()` and `dispatch_megatron()` contain unsanitized `importlib.import_module()` calls that allow arbitrary Python module loading via malicious adapter configs (CWE-94).

### Changes

**`src/peft/auto.py`** — Added `ALLOWED_PARENT_LIBRARIES` allowlist (`transformers`, `diffusers`):
- Before resolving `auto_mapping.parent_library` via `importlib.import_module()`, we now validate it against the allowlist
- Unknown modules raise a clear `ValueError` with guidance to open an issue

**`src/peft/tuners/lora/tp_layer.py`** — Added validation for `megatron_core` config:
- Validates that `megatron_core` is a non-empty, fully qualified module name (contains a dot)
- Prevents loading of top-level modules like `os` or `subprocess`

### Security Impact
- Prevents supply-chain attacks where malicious adapter configs trigger arbitrary code execution
- Defense-in-depth: users loading untrusted adapters from HuggingFace Hub are now protected

### Testing
- Existing tests should continue to pass since legitimate values (`transformers`, `diffusers`, `megatron.core`) remain allowed
- The `megatron_core` check only applies when `megatron_config` is set
