### PR TITLE
Resolves #2944: make enusre_weight_tying respect the model config tie_word_embeddings flag

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -24,19 +24,19 @@ jobs:
       group: aws-general-8-plus
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Login to DockerHub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and Push CPU
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
         with:
           context: ./docker/peft-cpu
           push: true
@@ -59,19 +59,19 @@ jobs:
       group: aws-general-8-plus
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Login to DockerHub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and Push GPU
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
         with:
           context: ./docker/peft-gpu
           push: true

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@607843a35ee10949e5bea9ca2f206831b0305b4c  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@98154fc40f6896c500b4b4aaf7f2757b4f9cb2ad  # main
     with:
       commit_sha: ${{ github.sha }}
       package: peft

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@607843a35ee10949e5bea9ca2f206831b0305b4c  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@98154fc40f6896c500b4b4aaf7f2757b4f9cb2ad  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a  # v47.0.4
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323  # v47.0.5
         with:
           files: docker/*/Dockerfile
           json: "true"
@@ -53,13 +53,13 @@ jobs:
           sudo du -sh /usr/local/lib/
           sudo du -sh /usr/share/
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Build Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
         with:
           file: ${{ matrix.docker-file }}
           context: .

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -15,4 +15,4 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Secret Scanning
-      uses: trufflesecurity/trufflehog@041f07e9df901a1038a528e5525b0226d04dd5ea  # v3.93.6
+      uses: trufflesecurity/trufflehog@586f66d7886cd0b037c7c245d4a6e34ef357ab10  # v3.94.1

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@607843a35ee10949e5bea9ca2f206831b0305b4c  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
     with:
       package_name: peft
     secrets:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.18.2.dev0"
+VERSION = "0.19.0"
 
 extras = {}
 extras["quality"] = [

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.2.dev0"
+__version__ = "0.19.0"
 
 from .auto import (
     MODEL_TYPE_TO_PEFT_MODEL_MAPPING,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -3439,19 +3439,3 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
         devices=devices,
     )
     return adapter_model_status
-
-
-def __getattr__(name):
-    if name == "PEFT_TYPE_TO_MODEL_MAPPING":
-        # This is for backwards compatibility: In #2282, PEFT_TYPE_TO_MODEL_MAPPING was removed as it was redundant with
-        # PEFT_TYPE_TO_TUNER_MAPPING. However, third party code could still use this mapping, e.g.:
-        # https://github.com/AutoGPTQ/AutoGPTQ/blob/6689349625de973b9ee3016c28c11f32acf7f02c/auto_gptq/utils/peft_utils.py#L8
-        # TODO: Remove after 2026-01
-        msg = (
-            "PEFT_TYPE_TO_MODEL_MAPPING is deprecated, please use `from peft import PEFT_TYPE_TO_TUNER_MAPPING` instead. "
-            "The deprecated variable will be removed in 2026."
-        )
-        warnings.warn(msg, category=DeprecationWarning)
-        return PEFT_TYPE_TO_TUNER_MAPPING
-
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/peft/tuners/adaption_prompt/layer.py
+++ b/src/peft/tuners/adaption_prompt/layer.py
@@ -49,17 +49,8 @@ class _BaseAdaptedAttention(nn.Module):
         # https://github.com/ZrrSkywalker/LLaMA-Adapter/blob/41c3546fe1997ab8a65809dc8d8f9252b19d9faf/llama/model.py#L234
         # (bsz, adapter_len, hidden_size)
 
-        if hasattr(self.model, "hidden_size"):
-            # TODO: remove this clause after 2026-01-01
-            hidden_size = self.model.hidden_size
-        else:  # changed in https://github.com/huggingface/transformers/pull/35235
-            hidden_size = self.model.config.hidden_size
-
-        if hasattr(self.model, "num_heads"):
-            # TODO: remove this clause after 2026-01-01
-            self.num_heads = self.model.num_heads
-        else:  # changed in https://github.com/huggingface/transformers/pull/35235
-            self.num_heads = self.model.config.num_attention_heads
+        hidden_size = self.model.config.hidden_size
+        self.num_heads = self.model.config.num_attention_heads
 
         self.adaption_prompt = nn.Parameter(
             torch.empty(1, adapter_len, hidden_size, device=device, dtype=target_dtype).normal_()
@@ -187,11 +178,7 @@ class AdaptedAttention(_BaseAdaptedAttention):
             key = getattr(self.model, k_proj_layer)(self.adaption_prompt)
             value = getattr(self.model, v_proj_layer)(self.adaption_prompt)
 
-        if hasattr(self.model, "num_heads"):
-            # TODO: remove this clause after 2026-01-01
-            num_heads = self.model.num_heads
-        else:  # changed in https://github.com/huggingface/transformers/pull/35235
-            num_heads = self.model.config.num_attention_heads
+        num_heads = self.model.config.num_attention_heads
         # (bsz, num_key_value_heads, adapter_len, head_dim)
         adapter_k = (
             key.view(1, self.adapter_len, (num_heads // factor), self.model.head_dim)

--- a/src/peft/tuners/adaption_prompt/utils.py
+++ b/src/peft/tuners/adaption_prompt/utils.py
@@ -68,11 +68,7 @@ def llama_compute_query_states(model: nn.Module, **kwargs) -> torch.Tensor:
     position_ids = kwargs.get("position_ids")
     past_key_value = kwargs.get("past_key_value")
     bsz, q_len, _ = hidden_states.size()
-    if hasattr(model, "num_heads"):
-        # TODO: remove this clause after 2026-01-01
-        num_heads = model.num_heads
-    else:  # changed in https://github.com/huggingface/transformers/pull/35235
-        num_heads = model.config.num_attention_heads
+    num_heads = model.config.num_attention_heads
     query_states = model.q_proj(hidden_states).view(bsz, q_len, num_heads, model.head_dim).transpose(1, 2)
 
     factor = model.k_proj.in_features // model.k_proj.out_features

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -30,6 +30,7 @@ from transformers.pytorch_utils import Conv1D
 from peft.import_utils import is_transformers_ge_v5_4_0
 from peft.tuners._buffer_dict import BufferDict
 from peft.tuners.tuners_utils import BaseTunerLayer, _get_in_out_features, check_adapters_to_merge
+from peft.utils import ALLOWED_COMPUTE_DTYPES, UPCAST_DTYPES
 from peft.utils.integrations import (
     dequantize_module_weight,
     gather_params_ctx,
@@ -2075,7 +2076,28 @@ class _LoraParameterProxy(nn.Module):
         super().__init__()
         self.delta_weight = delta_weight
 
+    @staticmethod
+    def _low_prec_add(x, y):
+        # addition in fp8 is not directly supported, need to use a higher precision
+        orig_dtype = x.dtype
+        upcast_dtype = y.dtype
+        if upcast_dtype not in ALLOWED_COMPUTE_DTYPES:
+            raise RuntimeError(
+                f"There is an attempt to upcast the targeted parameter to {upcast_dtype} "
+                f"but the only supported are: {ALLOWED_COMPUTE_DTYPES}."
+            )
+
+        # this operation can be quite costly
+        x = x.to(upcast_dtype)
+        z = x + y
+        # clamp to valid range before casting down, as this is *not* performed automatically and can thus result in NANs
+        info = torch.finfo(orig_dtype)
+        z = z.clamp(min=info.min, max=info.max)
+        return z.to(orig_dtype)
+
     def forward(self, W):
+        if any(getattr(torch, dtype_name, None) == W.dtype for dtype_name in UPCAST_DTYPES):
+            return self._low_prec_add(W, self.delta_weight)
         return W + self.delta_weight
 
 
@@ -2284,7 +2306,12 @@ class ParamWrapper(nn.Module, LoraLayer):
                 delta_weight = torch.einsum("o r e, e r i -> e o i", weight_B, weight_A) * self.scaling[adapter_name]
 
         param = self.get_param()
-        delta_weight = delta_weight.to(param.device, param.dtype)
+        if param.dtype in ALLOWED_COMPUTE_DTYPES:
+            delta_weight = delta_weight.to(param.device, param.dtype)
+        else:
+            # don't cast dW to weight dtype if it is in torch.float8_e4m3fn etc. as these low precision dtypes because
+            # we want to perform the W+dW addition in high precision before downcasting, see _low_prec_add.
+            delta_weight = delta_weight.to(param.device)
         return delta_weight
 
     @contextmanager

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -35,7 +35,7 @@ from transformers.pytorch_utils import Conv1D
 
 from peft.import_utils import is_transformers_ge_v5
 from peft.mapping import PEFT_TYPE_TO_PREFIX_MAPPING
-from peft.utils import INCLUDE_LINEAR_LAYERS_SHORTHAND
+from peft.utils import INCLUDE_LINEAR_LAYERS_SHORTHAND, UPCAST_DTYPES
 from peft.utils.constants import (
     DUMMY_MODEL_CONFIG,
     DUMMY_TARGET_MODULES,
@@ -2152,7 +2152,7 @@ def cast_adapter_dtype(model: nn.Module, adapter_name: str, autocast_adapter_dty
     """
     A helper method to cast the adapter weights to the correct dtype.
 
-    Currently, this only upcasts float16 and bfloat16 to float32.
+    Currently, this only upcasts float dtypes to float32.
 
     Args:
         adapter_name (`str`):
@@ -2164,6 +2164,11 @@ def cast_adapter_dtype(model: nn.Module, adapter_name: str, autocast_adapter_dty
         return
 
     dtypes_to_convert_to_fp32 = {torch.float16, torch.bfloat16}
+    # Upcast lower precision floats like float8_e4m3fn; defensively only include dtypes that are actually found, as this
+    # could depend on torch version and platform
+    for name in UPCAST_DTYPES:
+        torch_dtype = getattr(torch, name)
+        dtypes_to_convert_to_fp32.add(torch_dtype)
 
     for module in model.modules():
         if not isinstance(module, BaseTunerLayer):

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .constants import ALLOWED_COMPUTE_DTYPES, UPCAST_DTYPES
 from .integrations import map_cache_to_layer_device_map
 from .loftq_utils import replace_lora_weights_loftq
 from .other import (
@@ -76,6 +77,7 @@ from .warning import PeftWarning
 
 
 __all__ = [
+    "ALLOWED_COMPUTE_DTYPES",
     "CONFIG_NAME",
     "INCLUDE_LINEAR_LAYERS_SHORTHAND",
     "SAFETENSORS_WEIGHTS_NAME",
@@ -108,6 +110,7 @@ __all__ = [
     "TRANSFORMERS_MODELS_TO_VBLORA_TARGET_MODULES_MAPPING",
     "TRANSFORMERS_MODELS_TO_VERA_TARGET_MODULES_MAPPING",
     "TRANSFORMERS_MODELS_TO_WAVEFT_TARGET_MODULES_MAPPING",
+    "UPCAST_DTYPES",
     "WEIGHTS_NAME",
     "AuxiliaryTrainingWrapper",
     "ModulesToSaveWrapper",

--- a/src/peft/utils/constants.py
+++ b/src/peft/utils/constants.py
@@ -372,3 +372,7 @@ DUMMY_MODEL_CONFIG = {"model_type": "custom"}
 # otherwise there is no point in optimizing and there is a small chance of bugs in the optimization algorithm, so no
 # point in taking unnecessary risks. See #2045 for more context.
 MIN_TARGET_MODULES_FOR_OPTIMIZATION = 20
+# dtypes that are allowed to be used for adapter computation
+ALLOWED_COMPUTE_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+# float dtypes that should be upcast in the adapter for computation
+UPCAST_DTYPES = ("float8_e4m3fn", "float8_e4m3fnuz", "float8_e5m2", "float8_e5m2fnuz", "float8_e8m0fnu")

--- a/src/peft/utils/merge_utils.py
+++ b/src/peft/utils/merge_utils.py
@@ -68,7 +68,7 @@ def random_pruning(tensor: torch.Tensor, density: float, rescale: bool) -> torch
     mask = torch.bernoulli(torch.full_like(input=tensor, fill_value=density))
     pruned_tensor = tensor * mask
     if rescale:
-        torch.div(input=pruned_tensor, other=density)
+        pruned_tensor = pruned_tensor / density
     return pruned_tensor
 
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1657,9 +1657,8 @@ def _get_module_names_tied_with_embedding(model) -> list[str]:
     to the base model anyway. Non-transformer models have to provide a `_tied_weights_keys` attribute for this function
     to work.
 
-    Note that this function will not check if weight tying is disabled by the model's config. There can be the case
-    that the weight tying definition is present but the tying is disabled via `model_config.tie_word_embeddings=False`.
-    You have to check that yourself.
+    If the model's config has `tie_word_embeddings` set to `False`, this function returns an empty list, as weight
+    tying is explicitly disabled for that model checkpoint.
     """
     tied_weights: list[str] = []
 
@@ -1670,6 +1669,16 @@ def _get_module_names_tied_with_embedding(model) -> list[str]:
     if hasattr(model, "tuner_layer_cls"):
         # unpack BaseTuner
         model = model.model
+
+    # `_tied_weights_keys` is architectural capability; `tie_word_embeddings=False` means tying is
+    # explicitly disabled for this checkpoint and must be respected.
+    model_config = getattr(model, "config", None)
+    if (
+        model_config is not None
+        and hasattr(model_config, "tie_word_embeddings")
+        and not model_config.tie_word_embeddings
+    ):
+        return []
 
     if not hasattr(model, "_tied_weights_keys"):
         return []

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1676,7 +1676,7 @@ def _get_module_names_tied_with_embedding(model) -> list[str]:
     if (
         model_config is not None
         and hasattr(model_config, "tie_word_embeddings")
-        and not model_config.tie_word_embeddings
+        and getattr(model_config, "tie_word_embeddings") is False
     ):
         return []
 

--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -37,6 +37,11 @@ from transformers.core_model_loading import (
 from peft import PeftType
 
 
+# https://github.com/huggingface/transformers/pull/45340#issuecomment-4222734042
+_MODEL_TO_CONVERSION_PATTERN = _MODEL_TO_CONVERSION_PATTERN.copy()
+_MODEL_TO_CONVERSION_PATTERN["mixtral"] = "mixtral"
+
+
 def _block_diag_3d(tensors: list[torch.Tensor]) -> torch.Tensor:
     if len(tensors) < 2:
         raise ValueError(f"_block_diag_3d expects at least 2 tensors, got {len(tensors)}")

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -51,6 +51,7 @@ from transformers import (
     AutoTokenizer,
     BitsAndBytesConfig,
     DataCollatorForLanguageModeling,
+    FineGrainedFP8Config,
     Seq2SeqTrainer,
     Seq2SeqTrainingArguments,
     Trainer,
@@ -6148,6 +6149,147 @@ class TestTransformerEngine:
         assert torch.isfinite(loss), f"Loss is not finite: {loss.item()}"
         loss.backward()
         optimizer.step()
+
+
+@pytest.mark.skipif(not hasattr(torch, "float8_e4m3fn"), reason="Platform does not support torch.float8_e4m3fn")
+@require_torch_gpu
+@pytest.mark.single_gpu_tests
+class TestDtypeFp8:
+    """Tests that float8 models work.
+
+    Note that at this time, these lower dtypes require a GPU, so these tests cannot be added to the standard CPU test
+    suite.
+    """
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_cleanup(self):
+        yield
+        clear_device_cache(garbage_collection=True)
+
+    @pytest.fixture
+    def model_high_prec(self):
+        model_id = "facebook/opt-125m"
+        model = AutoModelForCausalLM.from_pretrained(model_id, device_map=0)
+        return model
+
+    @pytest.fixture
+    def model_low_prec(self):
+        model_id = "facebook/opt-125m"
+        # only convert q_proj to fp8, otherwise we get nan results
+        modules_not_to_convert = ["embed_tokens", "lm_head", "v_proj", "k_proj", "out_proj", "fc1", "fc2"]
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id,
+            device_map=0,
+            quantization_config=FineGrainedFP8Config(
+                modules_to_not_convert=modules_not_to_convert,
+            ),
+        )
+        # sanity check
+        assert model.model.decoder.layers[0].self_attn.q_proj.weight.dtype == torch.float8_e4m3fn
+        return model
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            LoraConfig(target_modules=["q_proj", "v_proj"], init_lora_weights=False),
+            VeraConfig(target_modules=["q_proj", "v_proj"], init_weights=False),
+            RoadConfig(target_modules=["q_proj", "v_proj"], init_weights=False),
+        ],
+        ids=lambda c: c.__class__.__name__,
+    )
+    def test_target_modules_float8_e4m3fn(self, model_high_prec, model_low_prec, config):
+        # Test should work with all adapters, but only testing a few here to save time and resources.
+        inputs = torch.arange(10).view(1, -1).to(model_low_prec.device)
+
+        # high precision
+        torch.manual_seed(0)
+        model_high_prec = get_peft_model(model_high_prec, config)
+        with torch.inference_mode():
+            # check that there are no errors
+            output_high_prec = model_high_prec(inputs).logits
+
+        # low precision
+        torch.manual_seed(0)
+        model_low_prec = get_peft_model(model_low_prec, config)
+        with torch.inference_mode():
+            # check that there are no errors
+            output_low_prec = model_low_prec(inputs).logits
+        # sanity check
+        assert torch.isfinite(output_low_prec).all()
+
+        # use relatively high tolerances because of low precision dtype
+        mse = ((output_low_prec - output_high_prec) ** 2).mean()
+        assert mse < 0.05
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            LoraConfig(target_modules=["q_proj", "v_proj"], init_lora_weights=False),
+            VeraConfig(target_modules=["q_proj", "v_proj"], init_weights=False),
+            RoadConfig(target_modules=["q_proj", "v_proj"], init_weights=False),
+        ],
+        ids=lambda c: c.__class__.__name__,
+    )
+    @pytest.mark.xfail(reason="Merging with float8 not supported (yet)", strict=True)
+    def test_merge_with_float8_e4m3fn(self, model_high_prec, model_low_prec, config):
+        # Test should work with all adapters, but only testing a few here to save time and resources.
+        inputs = torch.arange(10).view(1, -1).to(model_low_prec.device)
+
+        # high precision
+        torch.manual_seed(0)
+        model_high_prec = get_peft_model(model_high_prec, config).merge_and_unload()
+        with torch.inference_mode():
+            # check that there are no errors
+            output_high_prec = model_high_prec(inputs).logits
+
+        # low precision
+        torch.manual_seed(0)
+        model_low_prec = get_peft_model(model_low_prec, config).merge_and_unload()
+        with torch.inference_mode():
+            # check that there are no errors
+            output_low_prec = model_low_prec(inputs).logits
+        # sanity check
+        assert torch.isfinite(output_low_prec).all()
+
+        # use relatively high tolerances because of low precision dtype
+        mse = ((output_low_prec - output_high_prec) ** 2).mean()
+        assert mse < 0.05
+
+    def test_lora_target_parameters_float8_e4m3fn(self, model_high_prec, model_low_prec):
+        inputs = torch.arange(10).view(1, -1).to(model_low_prec.device)
+
+        # high precision
+        torch.manual_seed(0)
+        config = LoraConfig(
+            target_modules=["k_proj", "v_proj"], target_parameters=["q_proj.weight"], init_lora_weights=False
+        )
+        model_high_prec = get_peft_model(model_high_prec, config)
+        with torch.inference_mode():
+            # check that there are no errors
+            output_high_prec = model_high_prec(inputs).logits
+
+        # low precision
+        torch.manual_seed(0)
+        model_low_prec = get_peft_model(model_low_prec, config)
+        with torch.inference_mode():
+            # check that there are no errors
+            output_low_prec = model_low_prec(inputs).logits
+        # sanity check
+        assert torch.isfinite(output_low_prec).all()
+
+        # use relatively high tolerances because of low precision dtype
+        mse = ((output_low_prec - output_high_prec) ** 2).mean()
+        assert mse < 0.05
+
+    def test_target_modules_no_autocast_prevserves_e4m3fn(self, model_low_prec):
+        # ensure that users can choose to keep the adapter weights in the same dtype as the original weights by passing
+        # autocast_adapter_dtype=False, even though the resulting model is not usable (no inference or training
+        # possible)
+        config = LoraConfig(target_modules=["q_proj", "v_proj"], init_lora_weights=False)
+        model = get_peft_model(model_low_prec, config, autocast_adapter_dtype=False)
+        q_proj = model.base_model.model.model.decoder.layers[0].self_attn.q_proj
+        assert q_proj.lora_A.default.weight.dtype == torch.float8_e4m3fn
+        assert q_proj.lora_B.default.weight.dtype == torch.float8_e4m3fn
 
 
 ### LoRA and Tensor Parallelism tests ###

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -5027,14 +5027,23 @@ class TestWeightTying:
                 self.embed_tokens = nn.Embedding(1000, 1000)
                 self.linear = nn.Linear(1000, 1000, bias=False)
 
+        # Config object
+        class ModelConfig:
+            def __init__(self, tie_word_embeddings):
+                self.tie_word_embeddings = tie_word_embeddings
+
+            def to_dict(self):
+                return {"tie_word_embeddings": self.tie_word_embeddings}
+
         class CausalLM(nn.Module):
-            if tie_weights:
-                _tied_weights_keys = ["lm_head.weight"]
+            # _tied_weights_keys on class-level architectural
+            # so it exists regardless of whether tying is actually enabled
+            _tied_weights_keys = ["lm_head.weight"]
 
             def __init__(self):
                 super().__init__()
                 self.model = MyModule()
-                self.config = {"tie_word_embeddings": tie_weights}
+                self.config = ModelConfig(tie_word_embeddings=tie_weights)  # Updated Config Object!
                 self.lm_head = nn.Linear(1000, 1000, bias=False)
 
                 if tie_weights:
@@ -5063,18 +5072,26 @@ class TestWeightTying:
                 self.encoder = Seq2SeqStack()
                 self.decoder = Seq2SeqStack()
 
+        class ModelConfig:
+            def __init__(self, tie_word_embeddings):
+                self.tie_word_embeddings = tie_word_embeddings
+
+            def to_dict(self):
+                return {"tie_word_embeddings": self.tie_word_embeddings}
+
         class Seq2SeqLM(nn.Module):
-            if tie_weights:
-                _tied_weights_keys = {
-                    "model.encoder.embed_tokens.weight": "model.shared.weight",
-                    "model.decoder.embed_tokens.weight": "model.shared.weight",
-                    "lm_head.weight": "model.shared.weight",
-                }
+            # _tied_weights_keys on class-level architectural
+            # so it exists regardless of whether tying is actually enabled
+            _tied_weights_keys = {
+                "model.encoder.embed_tokens.weight": "model.shared.weight",
+                "model.decoder.embed_tokens.weight": "model.shared.weight",
+                "lm_head.weight": "model.shared.weight",
+            }
 
             def __init__(self):
                 super().__init__()
                 self.model = MySeq2SeqModule()
-                self.config = {"tie_word_embeddings": tie_weights}
+                self.config = ModelConfig(tie_word_embeddings=tie_weights)
                 self.lm_head = nn.Linear(1000, 1000, bias=False)
 
                 if tie_weights:
@@ -5417,6 +5434,34 @@ class TestWeightTying:
 
         if "lm_head" in modules_to_save:
             assert isinstance(model.base_model.model.lm_head, ModulesToSaveWrapper)
+        else:
+            assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
+
+        # weights must NOT share memory (they should be separate)
+        embed_ptr = model.base_model.model.model.embed_tokens.weight.data_ptr()
+        lm_head_ptr = model.base_model.model.lm_head.weight.data_ptr()
+        assert embed_ptr != lm_head_ptr
+
+    @pytest.mark.parametrize("target_modules", [["lm_head"], ["embed_tokens"], ["lm_head", "embed_tokens"]])
+    def test_ensure_weight_tying_not_tying_when_model_config_tie_false_target_modules(self, target_modules):
+        # When tie_word_embeddings=False, ensure_weight_tying=True should not tie weights.
+        # Regression test for issue #2944 targeting target_modules flow
+        model = self.get_lm_model(tie_weights=False)
+        config = LoraConfig(
+            target_modules=["linear"] + target_modules,  # Passing to target_module
+            ensure_weight_tying=True,
+        )
+
+        with pytest.warns(UserWarning, match="no tied modules were found in the model"):
+            model = get_peft_model(model, config)
+
+        if "embed_tokens" in target_modules:
+            assert isinstance(model.base_model.model.model.embed_tokens, LoraLayer)
+        else:
+            assert isinstance(model.base_model.model.model.embed_tokens, torch.nn.modules.Embedding)
+
+        if "lm_head" in target_modules:
+            assert isinstance(model.base_model.model.lm_head, LoraLayer)
         else:
             assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -4357,28 +4357,6 @@ class TestHotSwapping:
                 assert param.shape[0] == 10  # output shape of conv layer
 
 
-def test_import_peft_type_to_model_mapping_deprecation_warning(recwarn):
-    # This is for backwards compatibility: In #2282, PEFT_TYPE_TO_MODEL_MAPPING was removed as it was redundant with
-    # PEFT_TYPE_TO_TUNER_MAPPING. However, third party code could still use this mapping, e.g.:
-    # https://github.com/AutoGPTQ/AutoGPTQ/blob/6689349625de973b9ee3016c28c11f32acf7f02c/auto_gptq/utils/peft_utils.py#L8
-    # TODO: Remove after 2026-01
-
-    # first check that there is no warning under normal circumstances
-    from peft.peft_model import PeftModel  # noqa
-
-    expected = (
-        "PEFT_TYPE_TO_MODEL_MAPPING is deprecated, please use `from peft import PEFT_TYPE_TO_TUNER_MAPPING` instead"
-    )
-    warnings = (w.message.args[0] for w in recwarn.list)
-    assert not any(w.startswith(expected) for w in warnings)
-
-    from peft.peft_model import PEFT_TYPE_TO_MODEL_MAPPING  # noqa
-
-    # check that there is a warning with this message after importing the variable
-    warnings = (w.message.args[0] for w in recwarn.list)
-    assert any(w.startswith(expected) for w in warnings)
-
-
 class TestScaling:
     """Tests for scaling and unscaling
 
@@ -5417,3 +5395,32 @@ class TestWeightTying:
         assert isinstance(model.base_model.model.model.encoder.embed_tokens, torch.nn.modules.sparse.Embedding)
         assert isinstance(model.base_model.model.model.decoder.embed_tokens, torch.nn.modules.sparse.Embedding)
         assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
+
+    @pytest.mark.parametrize("modules_to_save", [["lm_head"], ["embed_tokens"], ["lm_head", "embed_tokens"]])
+    def test_ensure_weight_tying_not_tying_when_model_config_tie_false(self, modules_to_save):
+        # When tie_word_embeddings=False, ensure_weight_tying=True should not tie weights.
+        # Regression test for issue #2944
+        model = self.get_lm_model(tie_weights=False)
+        config = LoraConfig(
+            modules_to_save=modules_to_save,
+            target_modules=["linear"],
+            ensure_weight_tying=True,
+        )
+
+        with pytest.warns(UserWarning, match="no tied modules were found in the model"):
+            model = get_peft_model(model, config)
+
+        if "embed_tokens" in modules_to_save:
+            assert isinstance(model.base_model.model.model.embed_tokens, ModulesToSaveWrapper)
+        else:
+            assert isinstance(model.base_model.model.model.embed_tokens, torch.nn.modules.Embedding)
+
+        if "lm_head" in modules_to_save:
+            assert isinstance(model.base_model.model.lm_head, ModulesToSaveWrapper)
+        else:
+            assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
+
+        # weights must NOT share memory (they should be separate)
+        embed_ptr = model.base_model.model.model.embed_tokens.weight.data_ptr()
+        lm_head_ptr = model.base_model.model.lm_head.weight.data_ptr()
+        assert embed_ptr != lm_head_ptr

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -634,6 +634,17 @@ class TestGetModuleNamesTiedWithEmbedding:
 
             assert expected == modules
 
+    @pytest.mark.parametrize("tied_weights_type", ["list", "mapping"])
+    @pytest.mark.parametrize("model_id", model_ids)
+    def test_get_modules_tied_returns_empty_when_tying_disabled(self, model_id, tied_weights_type):
+        """When tie_word_embeddings=False, no tied modules should be reported even if _tied_weights_keys exists."""
+        with self.patch_model(model_id, tied_weights_type) as (model, _expected):
+            # Model has _tied_weights_keys (architectural capability) but tying is disabled
+            model.config.tie_word_embeddings = False
+
+            modules = _get_module_names_tied_with_embedding(model)
+            assert modules == []
+
 
 # TODO for PEFT 0.20 remove this
 class TestLoftQDeprecation:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -637,8 +637,9 @@ class TestGetModuleNamesTiedWithEmbedding:
     @pytest.mark.parametrize("tied_weights_type", ["list", "mapping"])
     @pytest.mark.parametrize("model_id", model_ids)
     def test_get_modules_tied_returns_empty_when_tying_disabled(self, model_id, tied_weights_type):
-        """When tie_word_embeddings=False, no tied modules should be reported even if _tied_weights_keys exists."""
-        with self.patch_model(model_id, tied_weights_type) as (model, _expected):
+        # When tie_word_embeddings=False, no tied modules should be reported even if _tied_weights_keys exists
+        # Linked to origin issue #2944
+        with self.patch_model(model_id, tied_weights_type) as (model, _):
             # Model has _tied_weights_keys (architectural capability) but tying is disabled
             model.config.tie_word_embeddings = False
 


### PR DESCRIPTION
## Fix: `_get_module_names_tied_with_embedding` ignores `tie_word_embeddings=False`

Resolves #2944

Updated _get_module_names_tied_with_embedding() in `src/peft/utils/other.py` to respect `model.config.tie_word_embeddings`. Previously, the function read` _tied_weights_key`s a class-level architectural attribute  without checking the instance-level config flag, causing embeddings to be incorrectly tied even when `tie_word_embeddings=False`

### Problem

When `ensure_weight_tying=True` in `LoraConfig`, PEFT ties `embed_tokens` and `lm_head` weights 
even when the model's config has `tie_word_embeddings=False`. This happens because 
`_get_module_names_tied_with_embedding()` returns tied module names based on the class-level 
`_tied_weights_keys` attribute (architectural capability) without checking the instance-level 
`tie_word_embeddings` config (actual tying state).

### Fix
Added a guard in `_get_module_names_tied_with_embedding()` in `src/peft/utils/other.py` that 
returns an empty list when `model.config.tie_word_embeddings` is explicitly `False`. This is 
the correct layer to fix because:
- The function has multiple callers; fixing it here protects all of them
- `_tied_weights_keys` is a class-level declaration of capability, not configuration
- Other callers already had their own `tie_word_embeddings` guards, but `_check_tied_modules()` 
  in `tuners_utils.py` did not — this fix makes the utility function self-consistent

### Test

Added `test_get_modules_tied_returns_empty_when_tying_disabled` in `tests/test_other.py` that 
verifies the function returns `[]` when `tie_word_embeddings=False`, even with `_tied_weights_keys` present.

---

### Output of reproduction script from issue #2944:
```python
from peft import LoraConfig, get_peft_model
from transformers import AutoModelForCausalLM

model_name = "Isotonic/TinyMixtral-4x248M-MoE"
device = "cuda:0"

model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device)
print(f"Is weight tying enabled?: {model.config.tie_word_embeddings}")

if not model.config.tie_word_embeddings:
    emb = model.get_input_embeddings()
    lm = model.get_output_embeddings()
    assert emb.weight.data_ptr() != lm.weight.data_ptr()
    print("Loaded model does not have tied embeddings")

modules_to_save = ["embed_tokens"]
target_modules = ["q_proj"]

lora_cfg = LoraConfig(
    modules_to_save=modules_to_save,
    target_modules=target_modules,
    task_type="CAUSAL_LM",
    ensure_weight_tying=True
)

model = get_peft_model(model, lora_cfg)

if not model.config.tie_word_embeddings:
    emb = model.get_input_embeddings()
    lm = model.get_output_embeddings()
    assert emb.weight.data_ptr() != lm.weight.data_ptr(), "PEFT model has tied embeddings"
    print("PEFT model does not have tied embeddings")
```
output before updation
```bash
Is weight tying enabled?: False
Loaded model does not have tied embeddings
ModulesToSaveWrapper(
  (original_module): Embedding(32003, 1024)
  (modules_to_save): ModuleDict(
    (default): Embedding(32003, 1024)
  )
...
Traceback (most recent call last):
  File "D:\peft\peft_bug_testing\test.py", line 32, in <module>
    assert emb.weight.data_ptr() != lm.weight.data_ptr(), "PEFT model has tied embeddings"
AssertionError: PEFT model has tied embeddings
```

output after updation:
```
Is weight tying enabled?: False
Loaded model does not have tied embeddings
D:\peft\src\peft\tuners\tuners_utils.py:1337: UserWarning: You have requested `ensure_weight_tying`, but no tied modules were found in the model
  warnings.warn("You have requested `ensure_weight_tying`, but no tied modules were found in the model")
ModulesToSaveWrapper(
  (original_module): Embedding(32003, 1024)
  (modules_to_save): ModuleDict(
    (default): Embedding(32003, 1024)
  )
) Linear(in_features=1024, out_features=32003, bias=False)
PEFT model does not have tied embeddings
```

---
### Tests logs if needed
```
(.venv) PS :\peft> ruff check --fix src tests
Found 1 error (1 fixed, 0 remaining).
(.venv) PS :\peft> ruff format src tests
1 file reformatted, 274 files left unchanged
(.venv) PS :\peft> ruff check --fix src tests
All checks passed!
(.venv) PS :\peft> ruff check src tests
All checks passed!
(.venv) PS :\peft> python -m pytest tests/test_other.py -k "TestGetModuleNamesTiedWithEmbedding" -v
=========================== test session starts ===============================
platform win32 -- Python 3.12.0, pytest-9.0.2, pluggy-1.6.0 -- :\peft\.venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: :\peft
configfile: pyproject.toml
plugins: anyio-4.13.0, cov-7.1.0, xdist-3.8.0
collected 43 items / 25 deselected / 18 selected                                                                                                   

tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/opt-125m-list] PASSED [  5%]    
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/opt-125m-mapping] PASSED [ 11%] 
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/tiny-random-BertModel-list] PASSED [ 16%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/tiny-random-BertModel-mapping] PASSED [ 22%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/tiny-random-t5-list] PASSED [ 27%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/tiny-random-t5-mapping] PASSED [ 33%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding_peft[peft-internal-testing/opt-125m-list] PASSED [ 38%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding_peft[peft-internal-testing/opt-125m-mapping] PASSED [ 44%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding_peft[peft-internal-testing/tiny-random-BertModel-list]
 PASSED [ 50%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding_peft[peft-internal-testing/tiny-random-BertModel-mapping] PASSED [ 55%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding_peft[peft-internal-testing/tiny-random-t5-list] PASSED [ 61%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding_peft[peft-internal-testing/tiny-random-t5-mapping] PASSED [ 66%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/opt-125m-list] PASSED [ 72%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/opt-125m-mapping] PASSED [ 77%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/tiny-random-BertModel-list] PASSED [ 83%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/tiny-random-BertModel-mapping] PASSED [ 88%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/tiny-random-t5-list] PASSED [ 94%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/tiny-random-t5-mapping] PASSED [100%]
```
