### PR TITLE
Fix OFT Conv2d weight reshaping for non-square kernels

### DIFF
--- a/src/peft/tuners/oft/layer.py
+++ b/src/peft/tuners/oft/layer.py
@@ -771,7 +771,7 @@ class Conv2d(nn.Module, OFTLayer):
         if base_layer.dilation[0] > 1:
             raise ValueError("Conv2d with dilation > 1 is not supported by OFT.")
 
-        conv_filter_dim = self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0]
+        conv_filter_dim = self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[1]
 
         if r == 0 and oft_block_size != 0:
             if conv_filter_dim % oft_block_size != 0 or oft_block_size > conv_filter_dim:
@@ -847,13 +847,13 @@ class Conv2d(nn.Module, OFTLayer):
                     oft_mat = self.get_delta_weight(active_adapter)
 
                     orig_weights = orig_weights.view(
-                        self.out_features, self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0]
+                        self.out_features, self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[1]
                     )
                     orig_weights = torch.transpose(orig_weights, 0, 1)
                     orig_weights = torch.mm(oft_mat, orig_weights.to(oft_mat.dtype))
                     orig_weights = torch.transpose(orig_weights, 0, 1)
                     orig_weights = orig_weights.view(
-                        self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[0]
+                        self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[1]
                     )
 
                     base_layer.weight.data = orig_weights.contiguous().to(orig_dtype)
@@ -862,13 +862,13 @@ class Conv2d(nn.Module, OFTLayer):
 
                     orig_weights = base_layer.weight.data.clone()
                     orig_weights = orig_weights.view(
-                        self.out_features, self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0]
+                        self.out_features, self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[1]
                     )
                     orig_weights = torch.transpose(orig_weights, 0, 1)
                     orig_weights = torch.mm(oft_mat, orig_weights.to(oft_mat.dtype))
                     orig_weights = torch.transpose(orig_weights, 0, 1)
                     orig_weights = orig_weights.view(
-                        self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[0]
+                        self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[1]
                     )
 
                     base_layer.weight.data = orig_weights.contiguous().to(orig_dtype)

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -5019,6 +5019,31 @@ class TestRequiresGrad:
             "base_model.model.lin0.oft_R.adapter1.weight",
         )
 
+    def test_oft_conv2d_non_square_kernel(self):
+        # OFT on a Conv2d with non-square kernel used to crash because the adapter
+        # filter dimension was computed as kernel_size[0] ** 2 instead of
+        # kernel_size[0] * kernel_size[1]; the forward pass then hit a shape
+        # mismatch and `merge_and_unload` failed to reshape the weights.
+        class NonSquareKernelConv2D(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv2d = nn.Conv2d(5, 10, kernel_size=(3, 5))
+
+            def forward(self, X):
+                X = X.float().reshape(-1, 5, 3, 5)
+                return self.conv2d(X)
+
+        torch.manual_seed(0)
+        model = NonSquareKernelConv2D().to(self.torch_device)
+        config = OFTConfig(r=5, oft_block_size=0, target_modules=["conv2d"], init_weights=False)
+        peft_model = get_peft_model(model, config)
+
+        X = torch.arange(5 * 5 * 3 * 5, dtype=torch.float, device=self.torch_device).reshape(5, 5, 3, 5)
+        output = peft_model(X)
+        merged = peft_model.merge_and_unload()
+        output_merged = merged(X)
+        assert torch.allclose(output, output_merged, atol=1e-5, rtol=1e-5)
+
     def test_requires_grad_hra_different_targets(self):
         # test two different HRA adapters that target different modules
         config0 = HRAConfig(target_modules=["lin0"])


### PR DESCRIPTION
## Summary

The OFT `Conv2d` layer computes the filter dimension and reshapes weights using `kernel_size[0] * kernel_size[0]`, squaring the kernel height instead of computing height × width (`kernel_size[0] * kernel_size[1]`). Similarly, the 4D reshape uses `kernel_size[0], kernel_size[0]` instead of `kernel_size[0], kernel_size[1]`.

This works by accident for square kernels (3×3, 5×5, etc.) but produces wrong dimensions for any asymmetric kernel (e.g., 3×1, 1×7, 3×5), causing `RuntimeError: shape mismatch` during forward/merge/unmerge.

**Fix:** Replace all 5 occurrences of the second `kernel_size[0]` with `kernel_size[1]` in `oft/layer.py`.

**Note:** The same pattern exists in `boft/layer.py` and `hra/layer.py`. Happy to extend this fix to those files if desired.

## Test plan

- [ ] Existing OFT tests with square kernels should continue to pass
- [ ] OFT with a non-square Conv2d kernel (e.g., `nn.Conv2d(3, 16, (3, 1))`) should now work

🤖 Generated with [Claude Code](https://claude.ai/claude-code)