### PR TITLE
Fix DARE rescaling no-op in random_pruning

### DIFF
--- a/src/peft/utils/merge_utils.py
+++ b/src/peft/utils/merge_utils.py
@@ -68,7 +68,7 @@ def random_pruning(tensor: torch.Tensor, density: float, rescale: bool) -> torch
     mask = torch.bernoulli(torch.full_like(input=tensor, fill_value=density))
     pruned_tensor = tensor * mask
     if rescale:
-        torch.div(input=pruned_tensor, other=density)
+        pruned_tensor = pruned_tensor / density
     return pruned_tensor
 
 


### PR DESCRIPTION
## Bug

`random_pruning` in `src/peft/utils/merge_utils.py` calls `torch.div(input=pruned_tensor, other=density)` but discards the return value. `torch.div` is not in-place — it returns a new tensor without modifying the input. The rescale step therefore has no effect.

## Root cause

Line 71 treats `torch.div` as if it were an in-place operation:

```python
torch.div(input=pruned_tensor, other=density)  # result discarded
```

## Impact

Both `dare_linear` and `dare_ties` adapter merging call `prune(..., rescale=True)`, which delegates to `random_pruning`. Without rescaling, merged adapter weights are systematically smaller than intended by a factor of `density`, silently producing incorrect merged models.

## Fix

Assign the division result back:

```python
pruned_tensor = pruned_tensor / density
```

One-line change, no new dependencies.