### PR TITLE
Add local smoke test script

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Basic local smoke test for a PEFT development checkout."""
+
+import torch
+
+import peft
+from peft import LoraConfig, TaskType, get_peft_model
+
+
+def main() -> None:
+    base_model = torch.nn.Sequential(
+        torch.nn.Linear(8, 4),
+        torch.nn.ReLU(),
+        torch.nn.Linear(4, 2),
+    )
+
+    config = LoraConfig(
+        task_type=TaskType.FEATURE_EXTRACTION,
+        target_modules=["0", "2"],
+        r=4,
+        lora_alpha=8,
+    )
+
+    model = get_peft_model(base_model, config)
+    trainable = sum(param.numel() for param in model.parameters() if param.requires_grad)
+    total = sum(param.numel() for param in model.parameters())
+
+    print(f"peft version: {peft.__version__}")
+    print(f"loaded from: {peft.__file__}")
+    print(f"model class: {model.__class__.__name__}")
+    print(f"trainable params: {trainable}")
+    print(f"total params: {total}")
+    model.print_trainable_parameters()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small local smoke test script for PEFT development checkouts
- verify the editable install can wrap a tiny PyTorch model with LoRA
- print basic package and trainable-parameter information for quick local validation

## Verification
- `source .venv/bin/activate && python scripts/smoke_test.py`
- `source .venv/bin/activate && pytest tests/test_mapping.py tests/test_config.py -k 'not from_pretrained and not cache_dir_remote and not from_pretrained_cache_dir'`
