### PR TITLE
LoRA dispatch: surface inner-`.linear` hint for wrapper modules (fixes #3129 UX)

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -421,10 +421,42 @@ class LoraModel(BaseTuner):
 
         if new_module is None:
             # no module could be matched
-            raise ValueError(
-                f"Target module {target} is not supported. Currently, only the following modules are supported: "
+            supported_msg = (
+                "Currently, only the following modules are supported: "
                 "`torch.nn.Linear`, `torch.nn.Embedding`, `torch.nn.Conv1d`, `torch.nn.Conv2d`, `torch.nn.Conv3d`, "
                 "`transformers.pytorch_utils.Conv1D`, `torch.nn.MultiheadAttention.`."
+            )
+            # Check for a common failure mode: the target is a wrapper module that
+            # contains a single `nn.Linear` in a submodule (typically named `.linear`).
+            # Examples include `transformers.models.gemma4.modeling_gemma4.Gemma4ClippableLinear`,
+            # which inherits from `nn.Module` rather than `nn.Linear`. In these cases
+            # the user can target the inner linear directly by appending its attribute
+            # name to their `target_modules` regex. Surface this hint in the error so
+            # users do not have to guess.
+            wrapper_hint = ""
+            if isinstance(target, torch.nn.Module):
+                inner_linear_attrs = [
+                    attr_name
+                    for attr_name, child in target.named_children()
+                    if isinstance(child, torch.nn.Linear)
+                ]
+                # Only offer the hint when the wrapper contains exactly one inner
+                # `nn.Linear`. Multiple inner linears would be ambiguous and are
+                # out of scope for this error message.
+                if len(inner_linear_attrs) == 1:
+                    inner_attr = inner_linear_attrs[0]
+                    target_cls_name = type(target).__name__
+                    wrapper_hint = (
+                        f"\n\nHint: `{target_cls_name}` appears to be a wrapper module that contains a "
+                        f"single `nn.Linear` in its `.{inner_attr}` attribute. You can target the inner "
+                        f"linear by appending `\\.{inner_attr}` to your `target_modules` regex, for example "
+                        f"`target_modules=r\".*\\.{inner_attr}\"` or a more specific pattern like "
+                        f"`target_modules=r\".*(q_proj|v_proj)\\.{inner_attr}\"`. See "
+                        f"https://github.com/huggingface/peft/issues/3129 for a worked example with "
+                        f"`Gemma4ClippableLinear`."
+                    )
+            raise ValueError(
+                f"Target module {target} is not supported. {supported_msg}{wrapper_hint}"
             )
 
         return new_module

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1613,6 +1613,58 @@ class TestLoraInitialization:
         config2 = LoraConfig(target_modules=["linear"], bias="none")
         model.add_adapter("other", config2)  # does not raise
 
+    def test_dispatch_error_hints_inner_linear_attribute(self):
+        # When a target module is an unsupported wrapper that contains a single
+        # nn.Linear in a submodule attribute (e.g. the `.linear` in Gemma 4's
+        # Gemma4ClippableLinear), the error message should explicitly suggest
+        # targeting the inner attribute. Regression test for issue #3129.
+        class ClippableLinearWrapper(nn.Module):
+            """Minimal reproduction of transformers.Gemma4ClippableLinear."""
+
+            def __init__(self, in_features: int, out_features: int):
+                super().__init__()
+                self.linear = nn.Linear(in_features, out_features, bias=False)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class WrapperModel(nn.Module):
+            def __init__(self, dim: int = 16):
+                super().__init__()
+                self.q_proj = ClippableLinearWrapper(dim, dim)
+
+            def forward(self, x):
+                return self.q_proj(x)
+
+        model = WrapperModel()
+        config = LoraConfig(target_modules=["q_proj"], r=4)
+        with pytest.raises(ValueError) as exc_info:
+            get_peft_model(model, config)
+
+        msg = str(exc_info.value)
+        # Preserves the original "not supported" message so existing string matches still work.
+        assert "is not supported" in msg
+        # Surfaces the wrapper class name so the user knows which module triggered the hint.
+        assert "ClippableLinearWrapper" in msg
+        # Surfaces the inner attribute name (`.linear`) and the suggested regex.
+        assert "`.linear`" in msg
+        assert "target_modules" in msg
+        # Points users at the worked example issue for more context.
+        assert "3129" in msg
+
+        # The .linear regex workaround should succeed: targeting the inner nn.Linear
+        # drills past the wrapper and produces a valid LoRA adapter.
+        model = WrapperModel()
+        config = LoraConfig(target_modules=r".*q_proj\.linear", r=4)
+        peft_model = get_peft_model(model, config)
+        # Verify the inner linear was actually wrapped as a LoRA layer.
+        inner = peft_model.base_model.model.q_proj.linear
+        assert hasattr(inner, "lora_A")
+        # And the forward pass still runs through the wrapper's forward method.
+        x = torch.randn(2, 16)
+        out = peft_model(x)
+        assert out.shape == (2, 16)
+
 
 class TestLokrInitialization:
     torch_device = infer_device()


### PR DESCRIPTION
## Summary

Addresses #3129. When a user's `target_modules` regex matches a wrapper module that contains a single `nn.Linear` child, the current dispatch error gives no guidance on how to recover. This is a real footgun on Gemma 4, whose `Gemma4ClippableLinear` inherits from `nn.Module` (not `nn.Linear`) and wraps a plain `nn.Linear` in its `.linear` attribute. It is used in the audio and vision towers. A user attempting `LoraConfig(target_modules=["q_proj", "k_proj", "v_proj"])` to LoRA-ify the language model hits this wrapper in the audio tower and gets stuck.

@BenjaminBossan already identified the right workaround in the issue thread: target the inner `.linear` attribute with a more specific regex like `target_modules=r".*\.audio_tower.*\.(q_proj|v_proj)\.linear"`. This works correctly. The PEFT dispatch sees the inner `nn.Linear`, wraps it with a LoRA layer, and the wrapper's forward still applies its clipping around the LoRA-augmented linear operation.

This PR surfaces that workaround in the error message so future users do not have to find the issue thread to discover it.

## What Changed

**`src/peft/tuners/lora/model.py`** - When the existing "Target module ... is not supported" error fires, inspect the target. If it has exactly one `nn.Linear` child, append a hint paragraph with:

- The wrapper class name
- The attribute name that contains the inner linear
- A sample regex the user can adapt
- A link back to #3129 for context

The original error text is preserved so existing string matches (e.g. in `test_initialization.py::test_road_with_conv2d_layer`) continue to work. The hint is additive.

**`tests/test_initialization.py`** - Regression test in `TestLoraInitialization` that:
1. Asserts the new hint fires with the expected content (wrapper class name, `.linear` attribute name, sample regex, issue link)
2. Confirms the `.linear` regex workaround actually produces a valid LoRA adapter and supports forward pass through the wrapper

The test uses a minimal `ClippableLinearWrapper` class that reproduces the exact structure of `Gemma4ClippableLinear` without requiring transformers or a downloaded model.

## Verification

Built and tested on NVIDIA DGX Spark GB10 (torch 2.11.0+cu130, transformers 5.5.4, peft 0.18.2.dev0 from this branch).

Repro before fix (stock peft 0.18.1):

```
ValueError: Target module Gemma4ClippableLinear(
  (linear): Linear(in_features=64, out_features=64, bias=False)
) is not supported. Currently, only the following modules are supported: ...
```

After fix, same invocation:

```
ValueError: Target module Gemma4ClippableLinear(
  (linear): Linear(in_features=64, out_features=64, bias=False)
) is not supported. Currently, only the following modules are supported: `torch.nn.Linear`, `torch.nn.Embedding`, `torch.nn.Conv1d`, `torch.nn.Conv2d`, `torch.nn.Conv3d`, `transformers.pytorch_utils.Conv1D`, `torch.nn.MultiheadAttention.`.

Hint: `Gemma4ClippableLinear` appears to be a wrapper module that contains a single `nn.Linear` in its `.linear` attribute. You can target the inner linear by appending `\.linear` to your `target_modules` regex, for example `target_modules=r".*\.linear"` or a more specific pattern like `target_modules=r".*(q_proj|v_proj)\.linear"`. See https://github.com/huggingface/peft/issues/3129 for a worked example with `Gemma4ClippableLinear`.
```

Full `TestLoraInitialization` suite: **114 passed, 0 regressions** (including the new test).

## Why This Approach

I considered a more invasive fix that would automatically drill into `.linear` submodules and replace them in place. It would be cleaner from the user's perspective (no regex change needed) but would require restructuring `_create_and_replace` to operate on nested parents, which risks side effects in the other tuner types that share the dispatch path. The hint-only fix is minimal, targeted, backward-compatible, and resolves the UX problem without changing dispatch semantics. If you would prefer the auto-drilling approach, happy to rework.

## Related

- Issue: #3129
- Workaround originally suggested by @BenjaminBossan in the issue thread
- Verified on Gemma 4 `Gemma4ClippableLinear` from transformers 5.5.4