### PR TITLE
Release 0.19.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import find_packages, setup
 
 
-VERSION = "0.18.2.dev0"
+VERSION = "0.19.0"
 
 extras = {}
 extras["quality"] = [

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.18.2.dev0"
+__version__ = "0.19.0"
 
 from .auto import (
     MODEL_TYPE_TO_PEFT_MODEL_MAPPING,

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -3439,19 +3439,3 @@ def get_model_status(model: torch.nn.Module) -> TunerModelStatus:
         devices=devices,
     )
     return adapter_model_status
-
-
-def __getattr__(name):
-    if name == "PEFT_TYPE_TO_MODEL_MAPPING":
-        # This is for backwards compatibility: In #2282, PEFT_TYPE_TO_MODEL_MAPPING was removed as it was redundant with
-        # PEFT_TYPE_TO_TUNER_MAPPING. However, third party code could still use this mapping, e.g.:
-        # https://github.com/AutoGPTQ/AutoGPTQ/blob/6689349625de973b9ee3016c28c11f32acf7f02c/auto_gptq/utils/peft_utils.py#L8
-        # TODO: Remove after 2026-01
-        msg = (
-            "PEFT_TYPE_TO_MODEL_MAPPING is deprecated, please use `from peft import PEFT_TYPE_TO_TUNER_MAPPING` instead. "
-            "The deprecated variable will be removed in 2026."
-        )
-        warnings.warn(msg, category=DeprecationWarning)
-        return PEFT_TYPE_TO_TUNER_MAPPING
-
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/peft/tuners/adaption_prompt/layer.py
+++ b/src/peft/tuners/adaption_prompt/layer.py
@@ -49,17 +49,8 @@ class _BaseAdaptedAttention(nn.Module):
         # https://github.com/ZrrSkywalker/LLaMA-Adapter/blob/41c3546fe1997ab8a65809dc8d8f9252b19d9faf/llama/model.py#L234
         # (bsz, adapter_len, hidden_size)
 
-        if hasattr(self.model, "hidden_size"):
-            # TODO: remove this clause after 2026-01-01
-            hidden_size = self.model.hidden_size
-        else:  # changed in https://github.com/huggingface/transformers/pull/35235
-            hidden_size = self.model.config.hidden_size
-
-        if hasattr(self.model, "num_heads"):
-            # TODO: remove this clause after 2026-01-01
-            self.num_heads = self.model.num_heads
-        else:  # changed in https://github.com/huggingface/transformers/pull/35235
-            self.num_heads = self.model.config.num_attention_heads
+        hidden_size = self.model.config.hidden_size
+        self.num_heads = self.model.config.num_attention_heads
 
         self.adaption_prompt = nn.Parameter(
             torch.empty(1, adapter_len, hidden_size, device=device, dtype=target_dtype).normal_()
@@ -187,11 +178,7 @@ class AdaptedAttention(_BaseAdaptedAttention):
             key = getattr(self.model, k_proj_layer)(self.adaption_prompt)
             value = getattr(self.model, v_proj_layer)(self.adaption_prompt)
 
-        if hasattr(self.model, "num_heads"):
-            # TODO: remove this clause after 2026-01-01
-            num_heads = self.model.num_heads
-        else:  # changed in https://github.com/huggingface/transformers/pull/35235
-            num_heads = self.model.config.num_attention_heads
+        num_heads = self.model.config.num_attention_heads
         # (bsz, num_key_value_heads, adapter_len, head_dim)
         adapter_k = (
             key.view(1, self.adapter_len, (num_heads // factor), self.model.head_dim)

--- a/src/peft/tuners/adaption_prompt/utils.py
+++ b/src/peft/tuners/adaption_prompt/utils.py
@@ -68,11 +68,7 @@ def llama_compute_query_states(model: nn.Module, **kwargs) -> torch.Tensor:
     position_ids = kwargs.get("position_ids")
     past_key_value = kwargs.get("past_key_value")
     bsz, q_len, _ = hidden_states.size()
-    if hasattr(model, "num_heads"):
-        # TODO: remove this clause after 2026-01-01
-        num_heads = model.num_heads
-    else:  # changed in https://github.com/huggingface/transformers/pull/35235
-        num_heads = model.config.num_attention_heads
+    num_heads = model.config.num_attention_heads
     query_states = model.q_proj(hidden_states).view(bsz, q_len, num_heads, model.head_dim).transpose(1, 2)
 
     factor = model.k_proj.in_features // model.k_proj.out_features

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -4357,28 +4357,6 @@ class TestHotSwapping:
                 assert param.shape[0] == 10  # output shape of conv layer
 
 
-def test_import_peft_type_to_model_mapping_deprecation_warning(recwarn):
-    # This is for backwards compatibility: In #2282, PEFT_TYPE_TO_MODEL_MAPPING was removed as it was redundant with
-    # PEFT_TYPE_TO_TUNER_MAPPING. However, third party code could still use this mapping, e.g.:
-    # https://github.com/AutoGPTQ/AutoGPTQ/blob/6689349625de973b9ee3016c28c11f32acf7f02c/auto_gptq/utils/peft_utils.py#L8
-    # TODO: Remove after 2026-01
-
-    # first check that there is no warning under normal circumstances
-    from peft.peft_model import PeftModel  # noqa
-
-    expected = (
-        "PEFT_TYPE_TO_MODEL_MAPPING is deprecated, please use `from peft import PEFT_TYPE_TO_TUNER_MAPPING` instead"
-    )
-    warnings = (w.message.args[0] for w in recwarn.list)
-    assert not any(w.startswith(expected) for w in warnings)
-
-    from peft.peft_model import PEFT_TYPE_TO_MODEL_MAPPING  # noqa
-
-    # check that there is a warning with this message after importing the variable
-    warnings = (w.message.args[0] for w in recwarn.list)
-    assert any(w.startswith(expected) for w in warnings)
-
-
 class TestScaling:
     """Tests for scaling and unscaling
 


### PR DESCRIPTION
- bump version to 0.19.0
- handle `PEFT_TYPE_TO_MODEL_MAPPING` deprecation
- handle attribute deprecation in adaption prompt