### PR TITLE
ENH: Option for gradient checkpointing in MetaMath

### DIFF
--- a/method_comparison/MetaMathQA/default_training_params.json
+++ b/method_comparison/MetaMathQA/default_training_params.json
@@ -7,6 +7,7 @@
   "max_steps": 5000,
   "eval_steps": 250,
   "compile": false,
+  "use_gc": false,
   "seed": 0,
   "grad_norm_clip": 1.0,
   "optimizer_type": "AdamW",

--- a/method_comparison/MetaMathQA/run.py
+++ b/method_comparison/MetaMathQA/run.py
@@ -438,6 +438,7 @@ def main(*, path_experiment: str, experiment_name: str, clean: bool) -> None:
         model_id=train_config.model_id,
         dtype=train_config.dtype,
         compile=train_config.compile,
+        use_gc=train_config.use_gc,
         attn_implementation=train_config.attn_implementation,
         peft_config=peft_config,
         autocast_adapter_dtype=train_config.autocast_adapter_dtype,

--- a/method_comparison/MetaMathQA/utils.py
+++ b/method_comparison/MetaMathQA/utils.py
@@ -44,7 +44,7 @@ from transformers import (
 )
 
 import peft
-from peft import PeftConfig, get_peft_model, prepare_model_for_kbit_training
+from peft import PeftConfig, get_peft_model
 from peft.optimizers import create_lorafa_optimizer, create_loraplus_optimizer
 from peft.utils import SAFETENSORS_WEIGHTS_NAME, infer_device
 
@@ -80,6 +80,7 @@ class TrainConfig:
         max_steps: The maximum number of steps to train for
         eval_steps: The number of steps between evaluations
         compile: Whether to compile the model
+        use_gc: Whether to use gradient checkpointing.
         query_template: The template for the query
         seed: The random seed
         grad_norm_clip: The gradient norm clipping value (set to 0 to skip)
@@ -100,6 +101,7 @@ class TrainConfig:
     max_steps: int
     eval_steps: int
     compile: bool
+    use_gc: bool
     query_template: str
     seed: int
     grad_norm_clip: float  # set to 0 to skip
@@ -210,6 +212,7 @@ def get_base_model(
     model_id: str,
     dtype: Literal["float32", "float16", "bfloat16", "int8", "int4"],
     attn_implementation: Optional[str],
+    use_gc: bool,
 ) -> PreTrainedModel:
     kwargs: dict[str, Any] = {
         "pretrained_model_name_or_path": model_id,
@@ -230,9 +233,9 @@ def get_base_model(
         raise ValueError(f"Invalid dtype: {dtype}")
 
     model = AutoModelForCausalLM.from_pretrained(**kwargs)
-
-    if dtype in ["int8", "int4"]:
-        model = prepare_model_for_kbit_training(model)
+    if use_gc:
+        model.enable_input_require_grads()
+        model.gradient_checkpointing_enable()
 
     return model
 
@@ -242,11 +245,12 @@ def get_model(
     model_id: str,
     dtype: Literal["float32", "float16", "bfloat16", "int8", "int4"],
     compile: bool,
+    use_gc: bool,
     attn_implementation: Optional[str],
     peft_config: Optional[PeftConfig],
     autocast_adapter_dtype: bool,
 ) -> nn.Module:
-    base_model = get_base_model(model_id=model_id, dtype=dtype, attn_implementation=attn_implementation)
+    base_model = get_base_model(model_id=model_id, dtype=dtype, attn_implementation=attn_implementation, use_gc=use_gc)
     if peft_config is None:
         model = base_model
     else:


### PR DESCRIPTION
Add a new training parameter, `use_gc`, to the MetaMathQA benchmark. By default, this is off, but if enabled, the model will use gradient checkpointing (GC).

In my local testing, this reduces peak reserved memory for LoRA rank 32 from 18.4 GB to 11.3 GB. Train time for 250 steps increases from 29 sec to 38 sec. These findings are in line with what we would expect from gradient checkpointing.

Note that this option should not generally be used when adding new experiments for PEFT methods, as it makes it difficult to compare results when one experiments runs with and one without GC. Instead, it can be used in a pinch to check if GC works and how big of a difference it makes. In a pinch, it may also allow to run an experiment that would otherwise OOM.

Moreover, I removed the usage of `prepare_model_for_kbit_training`. This function wasn't really being used, as the existing experiments all run without quantization. But I think it's still better to remove it because it seriously hurt memory efficiency. E.g. for the smaller Gemma models, the embeddings take a huge part of the total parameter count, upcasting them to float32 requires a lot of extra memory.