### PR TITLE
Benchmark results for new methods

### DIFF
--- a/method_comparison/MetaMathQA/results/adamss--llama-3.2-3B-rank32.json
+++ b/method_comparison/MetaMathQA/results/adamss--llama-3.2-3B-rank32.json
@@ -1,0 +1,363 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T13:52:52+00:00",
+    "total_time": 5544.705792816996,
+    "experiment_name": "adamss/llama-3.2-3B-rank32",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.0001,
+        "weight_decay": 0.1
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": "CAUSAL_LM",
+      "peft_type": "ADAMSS",
+      "auto_mapping": null,
+      "peft_version": "0.19.0",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 100,
+      "num_subspaces": 32,
+      "subspace_rank": 1,
+      "target_modules": [
+        "q_proj",
+        "v_proj"
+      ],
+      "init_weights": "orthogonal",
+      "modules_to_save": null,
+      "layers_to_transform": null,
+      "layers_pattern": null,
+      "use_asa": false,
+      "asa_target_subspaces": 50,
+      "init_warmup": 50,
+      "final_warmup": 1000,
+      "mask_interval": 100,
+      "asa_importance_beta": 0.85,
+      "asa_uncertainty_beta": 0.85,
+      "asa_schedule_exponent": 3.0,
+      "use_dynamic_rank": false,
+      "svd_threshold": 0.1
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 13458967049,
+    "accelerator_memory_max": 20323500032,
+    "accelerator_memory_reserved_99th": 18486394880,
+    "train_time": 4596.08915475203,
+    "file_size": 70459192,
+    "num_trainable_params": 293888,
+    "num_total_params": 3213043712,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.0,
+        "train loss": 1.3170231812000275,
+        "train samples": 1000,
+        "train time": 164.87659186910605,
+        "eval time": 45.593037275990355,
+        "tokens / sec": 1284.1058733678926,
+        "mem allocated avg": 6859081226.24,
+        "mem reserved avg": 13558565830.656,
+        "elapsed time": 295.8943835730024
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.0,
+        "train loss": 1.1954840586185456,
+        "train samples": 2000,
+        "train time": 166.43435910790868,
+        "eval time": 44.427490632995614,
+        "tokens / sec": 1249.7119051309908,
+        "mem allocated avg": 6852174585.856,
+        "mem reserved avg": 13240302043.136,
+        "elapsed time": 509.59304542800237
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.24,
+        "train loss": 0.9188390662670135,
+        "train samples": 3000,
+        "train time": 165.89597663206223,
+        "eval time": 45.04990096799156,
+        "tokens / sec": 1292.3821562925316,
+        "mem allocated avg": 6861978892.288,
+        "mem reserved avg": 13438810062.848,
+        "elapsed time": 723.2884168320015
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.28,
+        "train loss": 0.8316707408428192,
+        "train samples": 4000,
+        "train time": 165.8942028221063,
+        "eval time": 44.705238544993335,
+        "tokens / sec": 1255.8365298840815,
+        "mem allocated avg": 6853364180.992,
+        "mem reserved avg": 13442173894.656,
+        "elapsed time": 936.7426501810114
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.34,
+        "train loss": 0.8031793196201324,
+        "train samples": 5000,
+        "train time": 166.34746922992053,
+        "eval time": 45.23661799800175,
+        "tokens / sec": 1253.628930848145,
+        "mem allocated avg": 6853527777.28,
+        "mem reserved avg": 13494325870.592,
+        "elapsed time": 1151.1076066460082
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.36,
+        "train loss": 0.7772162261009217,
+        "train samples": 6000,
+        "train time": 167.20215503200598,
+        "eval time": 45.08574113200302,
+        "tokens / sec": 1251.9635285796985,
+        "mem allocated avg": 6855708528.64,
+        "mem reserved avg": 13412318838.784,
+        "elapsed time": 1366.2412558400101
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.32,
+        "train loss": 0.7615521411895751,
+        "train samples": 7000,
+        "train time": 167.64521759089257,
+        "eval time": 45.147190629999386,
+        "tokens / sec": 1248.797925813145,
+        "mem allocated avg": 6856783118.336,
+        "mem reserved avg": 13761318486.016,
+        "elapsed time": 1581.863356398011
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.26,
+        "train loss": 0.7539848216772079,
+        "train samples": 8000,
+        "train time": 166.568618839985,
+        "eval time": 44.94827433799219,
+        "tokens / sec": 1246.9095406231604,
+        "mem allocated avg": 6852422844.416,
+        "mem reserved avg": 13454152826.88,
+        "elapsed time": 1796.2559075200115
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.38,
+        "train loss": 0.7444141312837601,
+        "train samples": 9000,
+        "train time": 166.63916836991848,
+        "eval time": 45.11883862000832,
+        "tokens / sec": 1289.9008204532192,
+        "mem allocated avg": 6863277742.08,
+        "mem reserved avg": 13692187967.488,
+        "elapsed time": 2010.7747859730007
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.34,
+        "train loss": 0.7402979242801666,
+        "train samples": 10000,
+        "train time": 167.3797131489846,
+        "eval time": 44.99307104799664,
+        "tokens / sec": 1230.53741773753,
+        "mem allocated avg": 6850039672.832,
+        "mem reserved avg": 13260275318.784,
+        "elapsed time": 2225.957470817011
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.3,
+        "train loss": 0.733423663854599,
+        "train samples": 11000,
+        "train time": 166.81764313385065,
+        "eval time": 45.51151215299615,
+        "tokens / sec": 1270.1354366335913,
+        "mem allocated avg": 6859437490.176,
+        "mem reserved avg": 13584763453.44,
+        "elapsed time": 2441.0304056930036
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.34,
+        "train loss": 0.7258533200025559,
+        "train samples": 12000,
+        "train time": 166.40352799696848,
+        "eval time": 45.112399252000614,
+        "tokens / sec": 1254.3664338883648,
+        "mem allocated avg": 6855105021.952,
+        "mem reserved avg": 13508292902.912,
+        "elapsed time": 2655.413832613005
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.28,
+        "train loss": 0.7344502800703049,
+        "train samples": 13000,
+        "train time": 167.75549283101282,
+        "eval time": 44.94758386199828,
+        "tokens / sec": 1257.1928134266784,
+        "mem allocated avg": 6858180347.904,
+        "mem reserved avg": 13389225000.96,
+        "elapsed time": 2870.820019774008
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.38,
+        "train loss": 0.7221226370334626,
+        "train samples": 14000,
+        "train time": 166.08321435720427,
+        "eval time": 45.384310558001744,
+        "tokens / sec": 1262.921125483995,
+        "mem allocated avg": 6854977140.736,
+        "mem reserved avg": 13403082981.376,
+        "elapsed time": 3085.1512631299993
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.36,
+        "train loss": 0.717872628569603,
+        "train samples": 15000,
+        "train time": 167.00246237695683,
+        "eval time": 45.29121434899571,
+        "tokens / sec": 1297.6036216212158,
+        "mem allocated avg": 6866502846.464,
+        "mem reserved avg": 13721313214.464,
+        "elapsed time": 3300.268306899001
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.36,
+        "train loss": 0.7365663632154464,
+        "train samples": 16000,
+        "train time": 167.08000112406444,
+        "eval time": 45.17965000300319,
+        "tokens / sec": 1223.2044447273126,
+        "mem allocated avg": 6847144562.688,
+        "mem reserved avg": 13416219541.504,
+        "elapsed time": 3515.3813499660027
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.44,
+        "train loss": 0.7155313398838044,
+        "train samples": 17000,
+        "train time": 167.22311856393935,
+        "eval time": 34.083910091008875,
+        "tokens / sec": 1264.1134899010594,
+        "mem allocated avg": 6859216920.576,
+        "mem reserved avg": 13421261094.912,
+        "elapsed time": 3719.3419795750087
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.28,
+        "train loss": 0.7270838797092438,
+        "train samples": 18000,
+        "train time": 167.84598211097182,
+        "eval time": 45.66838745299901,
+        "tokens / sec": 1238.1470046902914,
+        "mem allocated avg": 6853195386.88,
+        "mem reserved avg": 13379812982.784,
+        "elapsed time": 3935.711468303998
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.38,
+        "train loss": 0.7194143581390381,
+        "train samples": 19000,
+        "train time": 167.38743777899072,
+        "eval time": 45.20093128300505,
+        "tokens / sec": 1254.2100099363015,
+        "mem allocated avg": 6855967637.504,
+        "mem reserved avg": 13455318843.392,
+        "elapsed time": 4151.067342627008
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.38,
+        "train loss": 0.7252694470882416,
+        "train samples": 20000,
+        "train time": 167.5015109970991,
+        "eval time": 44.824427195999306,
+        "tokens / sec": 1243.4514695429054,
+        "mem allocated avg": 6852545486.848,
+        "mem reserved avg": 13145619824.64,
+        "elapsed time": 4366.147349254999
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.3366186504927976,
+        "train loss": 0.7252694470882416,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": 0.1917562484741211
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/lily--llama-3.2-3B-rank140-mlp-a2-b2-s8.0.json
+++ b/method_comparison/MetaMathQA/results/lily--llama-3.2-3B-rank140-mlp-a2-b2-s8.0.json
@@ -1,0 +1,356 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T15:25:22+00:00",
+    "total_time": 1508.5701706959953,
+    "experiment_name": "lily/llama-3.2-3B-rank140-mlp-a2-b2-s8.0",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.0001,
+        "weight_decay": 0.1
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": null,
+      "peft_type": "LILY",
+      "auto_mapping": null,
+      "peft_version": "0.18.2.dev0@UNKNOWN",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 140,
+      "stride_A": 14,
+      "num_B": 2,
+      "scaling": 8.0,
+      "target_modules": [
+        "gate_proj",
+        "up_proj",
+        "down_proj"
+      ],
+      "exclude_modules": null,
+      "modules_to_save": null,
+      "layers_to_transform": null,
+      "layers_pattern": null,
+      "init_weights": true
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 15918990517,
+    "accelerator_memory_max": 25620905984,
+    "accelerator_memory_reserved_99th": 22953328640,
+    "train_time": 1277.8012849430233,
+    "file_size": 835056616,
+    "num_trainable_params": 9485280,
+    "num_total_params": 3222235104,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.38,
+        "train loss": 0.8256735709905625,
+        "train samples": 1000,
+        "train time": 42.6443230760342,
+        "eval time": 14.504582415000186,
+        "tokens / sec": 4964.763999712415,
+        "mem allocated avg": 6936251998.208,
+        "mem reserved avg": 16089031376.896,
+        "elapsed time": 81.28787563399237
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.34,
+        "train loss": 0.6826477601528168,
+        "train samples": 2000,
+        "train time": 42.2773666617868,
+        "eval time": 14.315907434996916,
+        "tokens / sec": 4919.77188796861,
+        "mem allocated avg": 6928928501.76,
+        "mem reserved avg": 15588214702.08,
+        "elapsed time": 141.77711231099966
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.34,
+        "train loss": 0.6573149716854095,
+        "train samples": 3000,
+        "train time": 43.28126011911081,
+        "eval time": 8.37400708500354,
+        "tokens / sec": 4953.668155917008,
+        "mem allocated avg": 6939525292.032,
+        "mem reserved avg": 15782100598.784,
+        "elapsed time": 197.20532249999815
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.32,
+        "train loss": 0.639818743944168,
+        "train samples": 4000,
+        "train time": 42.61807771808526,
+        "eval time": 8.229445117991418,
+        "tokens / sec": 4888.441974744235,
+        "mem allocated avg": 6930499950.592,
+        "mem reserved avg": 15902594564.096,
+        "elapsed time": 251.91880162298912
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.34,
+        "train loss": 0.6363241444826127,
+        "train samples": 5000,
+        "train time": 42.06402060594701,
+        "eval time": 10.332513002998894,
+        "tokens / sec": 4957.633554661128,
+        "mem allocated avg": 6930508310.528,
+        "mem reserved avg": 15943648411.648,
+        "elapsed time": 308.05530174900196
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.4,
+        "train loss": 0.6253738467693328,
+        "train samples": 6000,
+        "train time": 41.91525867798191,
+        "eval time": 11.934035009995569,
+        "tokens / sec": 4994.147873646825,
+        "mem allocated avg": 6931955746.816,
+        "mem reserved avg": 15847707901.952,
+        "elapsed time": 365.7262236300012
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.38,
+        "train loss": 0.6155040527582168,
+        "train samples": 7000,
+        "train time": 42.188536402158206,
+        "eval time": 10.358341593004297,
+        "tokens / sec": 4962.366980554703,
+        "mem allocated avg": 6933686202.368,
+        "mem reserved avg": 16351930351.616,
+        "elapsed time": 422.08481220700196
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.48,
+        "train loss": 0.6137498723268509,
+        "train samples": 8000,
+        "train time": 42.357142422086326,
+        "eval time": 12.660346331991605,
+        "tokens / sec": 4903.446930633849,
+        "mem allocated avg": 6928296169.472,
+        "mem reserved avg": 15882461904.896,
+        "elapsed time": 480.95308933599154
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.44,
+        "train loss": 0.597766970872879,
+        "train samples": 9000,
+        "train time": 42.931307530001504,
+        "eval time": 14.416990344994701,
+        "tokens / sec": 5006.78903967201,
+        "mem allocated avg": 6940560240.64,
+        "mem reserved avg": 16288529252.352,
+        "elapsed time": 542.1166483720008
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.54,
+        "train loss": 0.5919559133052826,
+        "train samples": 10000,
+        "train time": 41.70843030480319,
+        "eval time": 9.76289252899005,
+        "tokens / sec": 4938.258248867271,
+        "mem allocated avg": 6926012788.736,
+        "mem reserved avg": 15607357505.536,
+        "elapsed time": 597.4219364019955
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.46,
+        "train loss": 0.5769172513484955,
+        "train samples": 11000,
+        "train time": 43.127307615985046,
+        "eval time": 9.960909426998114,
+        "tokens / sec": 4912.919718676497,
+        "mem allocated avg": 6936733149.184,
+        "mem reserved avg": 16094047764.48,
+        "elapsed time": 654.2756872559985
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.52,
+        "train loss": 0.5612472039461136,
+        "train samples": 12000,
+        "train time": 42.239655314959236,
+        "eval time": 11.954717915010406,
+        "tokens / sec": 4941.588619594573,
+        "mem allocated avg": 6931731558.4,
+        "mem reserved avg": 15963353251.84,
+        "elapsed time": 712.3074494850007
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.54,
+        "train loss": 0.5673659546375275,
+        "train samples": 13000,
+        "train time": 42.33562183519825,
+        "eval time": 12.707640161999734,
+        "tokens / sec": 4981.644082635272,
+        "mem allocated avg": 6934144847.872,
+        "mem reserved avg": 15901453713.408,
+        "elapsed time": 770.994042773993
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.66,
+        "train loss": 0.545010736823082,
+        "train samples": 14000,
+        "train time": 42.281060568013345,
+        "eval time": 8.43354035000084,
+        "tokens / sec": 4960.850016110547,
+        "mem allocated avg": 6932022097.92,
+        "mem reserved avg": 15900908453.888,
+        "elapsed time": 825.5365358699928
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.58,
+        "train loss": 0.5402257640361786,
+        "train samples": 15000,
+        "train time": 42.802468458903604,
+        "eval time": 9.628816233001999,
+        "tokens / sec": 5062.862208708018,
+        "mem allocated avg": 6943652876.288,
+        "mem reserved avg": 16252055584.768,
+        "elapsed time": 881.6665664929897
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.56,
+        "train loss": 0.5433241729736328,
+        "train samples": 16000,
+        "train time": 41.81887960090535,
+        "eval time": 14.174946258994169,
+        "tokens / sec": 4887.098888119793,
+        "mem allocated avg": 6923834982.4,
+        "mem reserved avg": 15850375479.296,
+        "elapsed time": 941.5388599899889
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.54,
+        "train loss": 0.5326699557304382,
+        "train samples": 17000,
+        "train time": 42.274479638945195,
+        "eval time": 10.527029891003622,
+        "tokens / sec": 5000.392714597928,
+        "mem allocated avg": 6935376879.616,
+        "mem reserved avg": 15868905914.368,
+        "elapsed time": 998.0180430210021
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.6,
+        "train loss": 0.5365609186887741,
+        "train samples": 18000,
+        "train time": 42.545722530951025,
+        "eval time": 14.54571558299358,
+        "tokens / sec": 4884.580344094926,
+        "mem allocated avg": 6930109265.92,
+        "mem reserved avg": 15868159328.256,
+        "elapsed time": 1058.9818301439955
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.54,
+        "train loss": 0.5245453017950058,
+        "train samples": 19000,
+        "train time": 42.411762549993,
+        "eval time": 9.394262889007223,
+        "tokens / sec": 4950.018282134201,
+        "mem allocated avg": 6932563480.576,
+        "mem reserved avg": 15933733076.992,
+        "elapsed time": 1114.546965069996
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.62,
+        "train loss": 0.5315924286842346,
+        "train samples": 20000,
+        "train time": 42.75402231501357,
+        "eval time": 8.965857996998238,
+        "tokens / sec": 4871.588419573333,
+        "mem allocated avg": 6929910355.968,
+        "mem reserved avg": 15463241220.096,
+        "elapsed time": 1170.1189909499954
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.5489006823351024,
+        "train loss": 0.5315924286842346,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": -0.09576702117919922
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/lily--llama-3.2-3B-rank896-a2-b2-s2.0.json
+++ b/method_comparison/MetaMathQA/results/lily--llama-3.2-3B-rank896-a2-b2-s2.0.json
@@ -1,0 +1,355 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T15:50:36+00:00",
+    "total_time": 1449.8400646160007,
+    "experiment_name": "lily/llama-3.2-3B-rank896-a2-b2-s2.0",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.0001,
+        "weight_decay": 0.1
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": null,
+      "peft_type": "LILY",
+      "auto_mapping": null,
+      "peft_version": "0.18.2.dev0@UNKNOWN",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 896,
+      "stride_A": 14,
+      "num_B": 2,
+      "scaling": 2.0,
+      "target_modules": [
+        "v_proj",
+        "q_proj"
+      ],
+      "exclude_modules": null,
+      "modules_to_save": null,
+      "layers_to_transform": null,
+      "layers_pattern": null,
+      "init_weights": true
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 15175244788,
+    "accelerator_memory_max": 23517462528,
+    "accelerator_memory_reserved_99th": 21133000704,
+    "train_time": 1232.5725108610059,
+    "file_size": 1439071096,
+    "num_trainable_params": 18450432,
+    "num_total_params": 3231200256,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.36,
+        "train loss": 0.8951853168010712,
+        "train samples": 1000,
+        "train time": 42.645143303932855,
+        "eval time": 13.483017150007072,
+        "tokens / sec": 4964.668508464707,
+        "mem allocated avg": 7077320843.264,
+        "mem reserved avg": 15294512758.784,
+        "elapsed time": 79.54473755300569
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.38,
+        "train loss": 0.7073598281145096,
+        "train samples": 2000,
+        "train time": 41.90585757285589,
+        "eval time": 9.058929259001161,
+        "tokens / sec": 4963.387269629025,
+        "mem allocated avg": 7069815642.112,
+        "mem reserved avg": 14891658248.192,
+        "elapsed time": 134.19524280399492
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.36,
+        "train loss": 0.6779004307985306,
+        "train samples": 3000,
+        "train time": 43.049693761058734,
+        "eval time": 13.401617012001225,
+        "tokens / sec": 4980.314173429492,
+        "mem allocated avg": 7080050778.112,
+        "mem reserved avg": 15128745476.096,
+        "elapsed time": 194.21879527899728
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.3,
+        "train loss": 0.6569800573587418,
+        "train samples": 4000,
+        "train time": 41.5335750940867,
+        "eval time": 8.7474542229902,
+        "tokens / sec": 5016.086371761954,
+        "mem allocated avg": 7071607871.488,
+        "mem reserved avg": 15185737678.848,
+        "elapsed time": 248.1806672149978
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.42,
+        "train loss": 0.6520011286735534,
+        "train samples": 5000,
+        "train time": 41.65768492598727,
+        "eval time": 8.170601553007145,
+        "tokens / sec": 5005.9911003337575,
+        "mem allocated avg": 7072201093.12,
+        "mem reserved avg": 15218872680.448,
+        "elapsed time": 301.5600879370031
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.48,
+        "train loss": 0.6425405044555664,
+        "train samples": 6000,
+        "train time": 42.43562909694447,
+        "eval time": 11.146407181993709,
+        "tokens / sec": 4932.906721419918,
+        "mem allocated avg": 7073242789.888,
+        "mem reserved avg": 15118368768.0,
+        "elapsed time": 358.84500950199435
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.4,
+        "train loss": 0.6329075671434402,
+        "train samples": 7000,
+        "train time": 42.10086405201582,
+        "eval time": 13.399562666003476,
+        "tokens / sec": 4972.700791635556,
+        "mem allocated avg": 7074987571.2,
+        "mem reserved avg": 15549182509.056,
+        "elapsed time": 417.97980555999675
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.38,
+        "train loss": 0.6324304534196854,
+        "train samples": 8000,
+        "train time": 42.159079158023815,
+        "eval time": 13.448914284992497,
+        "tokens / sec": 4926.483313866945,
+        "mem allocated avg": 7069927809.024,
+        "mem reserved avg": 15162618675.2,
+        "elapsed time": 477.34609732399986
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.46,
+        "train loss": 0.6206917855739593,
+        "train samples": 9000,
+        "train time": 43.05002522098948,
+        "eval time": 9.909368462991551,
+        "tokens / sec": 4992.981976122046,
+        "mem allocated avg": 7082264524.8,
+        "mem reserved avg": 15461999706.112,
+        "elapsed time": 533.9334219529992
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.48,
+        "train loss": 0.6139078584909439,
+        "train samples": 10000,
+        "train time": 41.60877637399244,
+        "eval time": 8.158329568002955,
+        "tokens / sec": 4950.085485540489,
+        "mem allocated avg": 7068237475.84,
+        "mem reserved avg": 14934607921.152,
+        "elapsed time": 587.3544365129928
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.44,
+        "train loss": 0.6042117999792099,
+        "train samples": 11000,
+        "train time": 41.9166208460083,
+        "eval time": 10.863204982000752,
+        "tokens / sec": 5054.820634955295,
+        "mem allocated avg": 7077648775.168,
+        "mem reserved avg": 15347738476.544,
+        "elapsed time": 643.6914956859982
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.44,
+        "train loss": 0.5922493088245392,
+        "train samples": 12000,
+        "train time": 41.62047092492867,
+        "eval time": 11.62051810999401,
+        "tokens / sec": 5015.104235040746,
+        "mem allocated avg": 7073923039.232,
+        "mem reserved avg": 15243795234.816,
+        "elapsed time": 700.6200896990049
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.52,
+        "train loss": 0.5992187641859055,
+        "train samples": 13000,
+        "train time": 42.223515122939716,
+        "eval time": 8.044301860005362,
+        "tokens / sec": 4994.870734611555,
+        "mem allocated avg": 7075892357.12,
+        "mem reserved avg": 15047904460.8,
+        "elapsed time": 754.4190594569955
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.54,
+        "train loss": 0.5811601771116257,
+        "train samples": 14000,
+        "train time": 42.35961454302014,
+        "eval time": 13.508444199003861,
+        "tokens / sec": 4951.650345802352,
+        "mem allocated avg": 7073715894.272,
+        "mem reserved avg": 15114635837.44,
+        "elapsed time": 813.9558513039956
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.66,
+        "train loss": 0.5768540184497833,
+        "train samples": 15000,
+        "train time": 43.349727582142805,
+        "eval time": 8.491797911003232,
+        "tokens / sec": 4998.947215743685,
+        "mem allocated avg": 7084721074.176,
+        "mem reserved avg": 15481847152.64,
+        "elapsed time": 869.4534589090035
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.46,
+        "train loss": 0.5858272787332535,
+        "train samples": 16000,
+        "train time": 42.0340883720346,
+        "eval time": 9.063182918995153,
+        "tokens / sec": 4862.077611655066,
+        "mem allocated avg": 7065572147.2,
+        "mem reserved avg": 15137905836.032,
+        "elapsed time": 924.2474565089942
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.54,
+        "train loss": 0.5711492766141891,
+        "train samples": 17000,
+        "train time": 42.32160690399178,
+        "eval time": 8.440006308010197,
+        "tokens / sec": 4994.8245226024665,
+        "mem allocated avg": 7076573898.752,
+        "mem reserved avg": 15096801656.832,
+        "elapsed time": 978.4909052750008
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.48,
+        "train loss": 0.5774585075378418,
+        "train samples": 18000,
+        "train time": 41.511545921996,
+        "eval time": 8.886905466002645,
+        "tokens / sec": 5006.269831302093,
+        "mem allocated avg": 7070892578.816,
+        "mem reserved avg": 15101390225.408,
+        "elapsed time": 1032.6312066489918
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.5,
+        "train loss": 0.5683148888349533,
+        "train samples": 19000,
+        "train time": 42.38187334500253,
+        "eval time": 13.407011750998208,
+        "tokens / sec": 4953.509211143802,
+        "mem allocated avg": 7074292113.408,
+        "mem reserved avg": 15185276305.408,
+        "elapsed time": 1092.0027905040042
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.5,
+        "train loss": 0.5755550808906555,
+        "train samples": 20000,
+        "train time": 41.60871007213427,
+        "eval time": 8.621644578990526,
+        "tokens / sec": 5005.682695736511,
+        "mem allocated avg": 7070758524.928,
+        "mem reserved avg": 14801296162.816,
+        "elapsed time": 1145.8259893009963
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.4973464746019712,
+        "train loss": 0.5755550808906555,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": 0.5971565246582031
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/peanut--llama-3.2-3B-rank1-relu-depth0-s32.0.json
+++ b/method_comparison/MetaMathQA/results/peanut--llama-3.2-3B-rank1-relu-depth0-s32.0.json
@@ -1,0 +1,355 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T16:14:51+00:00",
+    "total_time": 1532.0036416129878,
+    "experiment_name": "peanut/llama-3.2-3B-rank1-relu-depth0-s32.0",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.0001,
+        "weight_decay": 0.1
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": null,
+      "peft_type": "PEANUT",
+      "auto_mapping": null,
+      "peft_version": "0.18.2.dev0@UNKNOWN",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 1,
+      "depth": 0,
+      "act_fn": "relu",
+      "scaling": 32.0,
+      "target_modules": [
+        "v_proj",
+        "q_proj"
+      ],
+      "exclude_modules": null,
+      "modules_to_save": null,
+      "layers_to_transform": null,
+      "layers_pattern": null,
+      "init_weights": true
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 17181366550,
+    "accelerator_memory_max": 25142755328,
+    "accelerator_memory_reserved_99th": 22779265024,
+    "train_time": 1293.6483223879623,
+    "file_size": 932264,
+    "num_trainable_params": 229376,
+    "num_total_params": 3212979200,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.34,
+        "train loss": 1.0782873232364654,
+        "train samples": 1000,
+        "train time": 42.55134219395404,
+        "eval time": 13.958351688008406,
+        "tokens / sec": 4975.612732377743,
+        "mem allocated avg": 6785008205.824,
+        "mem reserved avg": 17304003805.184,
+        "elapsed time": 81.30933156199171
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.36,
+        "train loss": 0.755793830871582,
+        "train samples": 2000,
+        "train time": 41.34523496500333,
+        "eval time": 13.814105221012142,
+        "tokens / sec": 5030.688546722672,
+        "mem allocated avg": 6778270351.36,
+        "mem reserved avg": 16942278639.616,
+        "elapsed time": 141.31103577399335
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.34,
+        "train loss": 0.7086091032028198,
+        "train samples": 3000,
+        "train time": 42.28425140600302,
+        "eval time": 13.539051175990608,
+        "tokens / sec": 5070.469332456051,
+        "mem allocated avg": 6788110041.088,
+        "mem reserved avg": 17121434140.672,
+        "elapsed time": 201.85834894300206
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.42,
+        "train loss": 0.687263855099678,
+        "train samples": 4000,
+        "train time": 42.44843867281452,
+        "eval time": 11.434455522001372,
+        "tokens / sec": 4907.9779260155865,
+        "mem allocated avg": 6779349958.656,
+        "mem reserved avg": 17201360797.696,
+        "elapsed time": 260.675236547002
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.42,
+        "train loss": 0.6842224428653717,
+        "train samples": 5000,
+        "train time": 41.416183590044966,
+        "eval time": 12.598084267010563,
+        "tokens / sec": 5035.181465878121,
+        "mem allocated avg": 6779618480.128,
+        "mem reserved avg": 17183191072.768,
+        "elapsed time": 319.43940766299784
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.38,
+        "train loss": 0.6787137789726257,
+        "train samples": 6000,
+        "train time": 41.91785034920031,
+        "eval time": 9.889278128001024,
+        "tokens / sec": 4993.839098526042,
+        "mem allocated avg": 6781385140.224,
+        "mem reserved avg": 17173091188.736,
+        "elapsed time": 376.1354592169955
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.36,
+        "train loss": 0.6703564523458481,
+        "train samples": 7000,
+        "train time": 42.66953206398466,
+        "eval time": 13.807240802008891,
+        "tokens / sec": 4906.428307816074,
+        "mem allocated avg": 6782774999.04,
+        "mem reserved avg": 17526192865.28,
+        "elapsed time": 437.4318203169969
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.44,
+        "train loss": 0.6743507828712464,
+        "train samples": 8000,
+        "train time": 41.605423752000206,
+        "eval time": 8.617376164009329,
+        "tokens / sec": 4992.041452047821,
+        "mem allocated avg": 6778628939.776,
+        "mem reserved avg": 17182201217.024,
+        "elapsed time": 492.59606386999076
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.34,
+        "train loss": 0.6684295483827591,
+        "train samples": 9000,
+        "train time": 43.60937494493555,
+        "eval time": 10.983761402996606,
+        "tokens / sec": 4928.940171039126,
+        "mem allocated avg": 6790529105.92,
+        "mem reserved avg": 17474376433.664,
+        "elapsed time": 551.9724235679896
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.36,
+        "train loss": 0.6670271315574646,
+        "train samples": 10000,
+        "train time": 40.90206856712757,
+        "eval time": 13.784692518005613,
+        "tokens / sec": 5035.6132884079325,
+        "mem allocated avg": 6776260329.472,
+        "mem reserved avg": 16917104427.008,
+        "elapsed time": 611.4947228949895
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.5,
+        "train loss": 0.6589599785804748,
+        "train samples": 11000,
+        "train time": 42.355896609893534,
+        "eval time": 8.928344394007581,
+        "tokens / sec": 5002.396760750157,
+        "mem allocated avg": 6785940545.536,
+        "mem reserved avg": 17310001659.904,
+        "elapsed time": 667.5795067779982
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.34,
+        "train loss": 0.6532612586021423,
+        "train samples": 12000,
+        "train time": 41.950381183982245,
+        "eval time": 13.837643670005491,
+        "tokens / sec": 4975.663965592259,
+        "mem allocated avg": 6781165772.8,
+        "mem reserved avg": 17263159672.832,
+        "elapsed time": 728.2849911759986
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.44,
+        "train loss": 0.6626448401212692,
+        "train samples": 13000,
+        "train time": 42.59864776597533,
+        "eval time": 9.815955368991126,
+        "tokens / sec": 4950.884853402606,
+        "mem allocated avg": 6783855228.928,
+        "mem reserved avg": 17137053728.768,
+        "elapsed time": 785.4447581689892
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.4,
+        "train loss": 0.6481621752977371,
+        "train samples": 14000,
+        "train time": 42.129510829021456,
+        "eval time": 13.821907288001967,
+        "tokens / sec": 4978.695358017569,
+        "mem allocated avg": 6781411620.864,
+        "mem reserved avg": 17163662393.344,
+        "elapsed time": 846.3086622769915
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.4,
+        "train loss": 0.6454143435955048,
+        "train samples": 15000,
+        "train time": 43.71391549293185,
+        "eval time": 13.818641671998193,
+        "tokens / sec": 4957.300153884384,
+        "mem allocated avg": 6793252151.296,
+        "mem reserved avg": 17430436904.96,
+        "elapsed time": 908.7084292200016
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.42,
+        "train loss": 0.6614621320962906,
+        "train samples": 16000,
+        "train time": 41.143020007017185,
+        "eval time": 8.143757469995762,
+        "tokens / sec": 4967.379642163919,
+        "mem allocated avg": 6773322760.192,
+        "mem reserved avg": 17159862353.92,
+        "elapsed time": 962.8818788310018
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.44,
+        "train loss": 0.6446791313886643,
+        "train samples": 17000,
+        "train time": 42.63129717807169,
+        "eval time": 9.233205483993515,
+        "tokens / sec": 4958.5401803990235,
+        "mem allocated avg": 6784610023.424,
+        "mem reserved avg": 17104522706.944,
+        "elapsed time": 1019.3990020450001
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.38,
+        "train loss": 0.6513511871099472,
+        "train samples": 18000,
+        "train time": 42.117793060067925,
+        "eval time": 8.520607718994142,
+        "tokens / sec": 4934.209152497908,
+        "mem allocated avg": 6780054568.96,
+        "mem reserved avg": 17095957938.176,
+        "elapsed time": 1074.9711790169968
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.4,
+        "train loss": 0.6432328459024429,
+        "train samples": 19000,
+        "train time": 42.501656148029724,
+        "eval time": 13.760509013009141,
+        "tokens / sec": 4939.548691203937,
+        "mem allocated avg": 6782216679.424,
+        "mem reserved avg": 17137917755.392,
+        "elapsed time": 1135.984748848001
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.42,
+        "train loss": 0.6497887889146805,
+        "train samples": 20000,
+        "train time": 42.3493788199994,
+        "eval time": 11.90411888899689,
+        "tokens / sec": 4918.135892506651,
+        "mem allocated avg": 6778881710.08,
+        "mem reserved avg": 16799521308.672,
+        "elapsed time": 1195.0309052809898
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.39651250947687644,
+        "train loss": 0.6497887889146805,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": 0.04330921173095703
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/peanut--llama-3.2-3B-rank32-relu-depth0-s2.0.json
+++ b/method_comparison/MetaMathQA/results/peanut--llama-3.2-3B-rank32-relu-depth0-s2.0.json
@@ -1,0 +1,355 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T16:40:28+00:00",
+    "total_time": 1573.527884997995,
+    "experiment_name": "peanut/llama-3.2-3B-rank32-relu-depth0-s2.0",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.0001,
+        "weight_decay": 0.1
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": null,
+      "peft_type": "PEANUT",
+      "auto_mapping": null,
+      "peft_version": "0.18.2.dev0@UNKNOWN",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 32,
+      "depth": 0,
+      "act_fn": "relu",
+      "scaling": 2.0,
+      "target_modules": [
+        "q_proj",
+        "v_proj"
+      ],
+      "exclude_modules": null,
+      "modules_to_save": null,
+      "layers_to_transform": null,
+      "layers_pattern": null,
+      "init_weights": true
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 17292783622,
+    "accelerator_memory_max": 25216155648,
+    "accelerator_memory_reserved_99th": 22913482752,
+    "train_time": 1324.3875514060055,
+    "file_size": 29375392,
+    "num_trainable_params": 7340032,
+    "num_total_params": 3220089856,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.34,
+        "train loss": 1.0151871349811554,
+        "train samples": 1000,
+        "train time": 44.021378575009294,
+        "eval time": 14.376052794992574,
+        "tokens / sec": 4809.458650624626,
+        "mem allocated avg": 6898786570.24,
+        "mem reserved avg": 17395422855.168,
+        "elapsed time": 85.73105101600231
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.36,
+        "train loss": 0.7329526348114014,
+        "train samples": 2000,
+        "train time": 44.562354755951674,
+        "eval time": 14.344671937011299,
+        "tokens / sec": 4667.504694020249,
+        "mem allocated avg": 6892317472.768,
+        "mem reserved avg": 17048168038.4,
+        "elapsed time": 149.5062317289994
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.38,
+        "train loss": 0.6915021198987961,
+        "train samples": 3000,
+        "train time": 45.2565884070209,
+        "eval time": 14.244411489999038,
+        "tokens / sec": 4737.453872389966,
+        "mem allocated avg": 6901853413.376,
+        "mem reserved avg": 17230175666.176,
+        "elapsed time": 213.76587189899874
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.46,
+        "train loss": 0.6705982208251953,
+        "train samples": 4000,
+        "train time": 43.60357639606809,
+        "eval time": 12.205957198995748,
+        "tokens / sec": 4777.956700331271,
+        "mem allocated avg": 6893099798.528,
+        "mem reserved avg": 17291538333.696,
+        "elapsed time": 274.51652191899484
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.4,
+        "train loss": 0.6671838570833206,
+        "train samples": 5000,
+        "train time": 44.5333500400302,
+        "eval time": 9.193823512992822,
+        "tokens / sec": 4682.737764227238,
+        "mem allocated avg": 6893480824.832,
+        "mem reserved avg": 17332801896.448,
+        "elapsed time": 333.0422079429991
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.38,
+        "train loss": 0.6596062692403794,
+        "train samples": 6000,
+        "train time": 43.14656171298702,
+        "eval time": 10.896760057003121,
+        "tokens / sec": 4851.626449228556,
+        "mem allocated avg": 6895295387.648,
+        "mem reserved avg": 17295741026.304,
+        "elapsed time": 391.9642643400002
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.44,
+        "train loss": 0.6502646441459656,
+        "train samples": 7000,
+        "train time": 43.222262079041684,
+        "eval time": 12.457048503987608,
+        "tokens / sec": 4843.684479473726,
+        "mem allocated avg": 6896549773.312,
+        "mem reserved avg": 17676307005.44,
+        "elapsed time": 452.51822785299737
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.4,
+        "train loss": 0.6535031509399414,
+        "train samples": 8000,
+        "train time": 43.33418614100083,
+        "eval time": 14.309704052997404,
+        "tokens / sec": 4792.890290455634,
+        "mem allocated avg": 6892434849.792,
+        "mem reserved avg": 17262002044.928,
+        "elapsed time": 515.1359422499954
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.4,
+        "train loss": 0.6466518994569779,
+        "train samples": 9000,
+        "train time": 45.30572651808325,
+        "eval time": 10.579045053993468,
+        "tokens / sec": 4744.389209037538,
+        "mem allocated avg": 6904245090.304,
+        "mem reserved avg": 17572732862.464,
+        "elapsed time": 575.8882168769924
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.38,
+        "train loss": 0.6441503465175629,
+        "train samples": 10000,
+        "train time": 42.67895923292963,
+        "eval time": 10.036433415007195,
+        "tokens / sec": 4825.961169200276,
+        "mem allocated avg": 6890186133.504,
+        "mem reserved avg": 17048050597.888,
+        "elapsed time": 633.4232634090004
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.48,
+        "train loss": 0.6352012549638748,
+        "train samples": 11000,
+        "train time": 44.22804318890849,
+        "eval time": 13.283268603001488,
+        "tokens / sec": 4790.6483019157295,
+        "mem allocated avg": 6899866554.368,
+        "mem reserved avg": 17445360238.592,
+        "elapsed time": 695.7300765889959
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.4,
+        "train loss": 0.6280081766843796,
+        "train samples": 12000,
+        "train time": 44.57390221796231,
+        "eval time": 10.617056177012273,
+        "tokens / sec": 4682.807418998777,
+        "mem allocated avg": 6895103715.328,
+        "mem reserved avg": 17359997763.584,
+        "elapsed time": 755.8395442329929
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.5,
+        "train loss": 0.6369541518688202,
+        "train samples": 13000,
+        "train time": 44.50311762790079,
+        "eval time": 11.93099128700851,
+        "tokens / sec": 4739.016303607856,
+        "mem allocated avg": 6897675378.688,
+        "mem reserved avg": 17245728145.408,
+        "elapsed time": 817.0161534090003
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.46,
+        "train loss": 0.6206858913898468,
+        "train samples": 14000,
+        "train time": 44.9908673119935,
+        "eval time": 9.960958727999241,
+        "tokens / sec": 4662.057269211292,
+        "mem allocated avg": 6895242215.424,
+        "mem reserved avg": 17262169817.088,
+        "elapsed time": 876.9033543609985
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.38,
+        "train loss": 0.6189992456436157,
+        "train samples": 15000,
+        "train time": 45.45867533796991,
+        "eval time": 14.245861356001114,
+        "tokens / sec": 4767.032879618386,
+        "mem allocated avg": 6907035766.784,
+        "mem reserved avg": 17541258805.248,
+        "elapsed time": 941.4479730729945
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.5,
+        "train loss": 0.6326132407188415,
+        "train samples": 16000,
+        "train time": 42.56708373287984,
+        "eval time": 11.076982978993328,
+        "tokens / sec": 4801.198063801993,
+        "mem allocated avg": 6887389437.952,
+        "mem reserved avg": 17258218782.72,
+        "elapsed time": 1000.0103693019919
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.38,
+        "train loss": 0.6174385570287705,
+        "train samples": 17000,
+        "train time": 44.078655502045876,
+        "eval time": 12.323570092994487,
+        "tokens / sec": 4795.722500886819,
+        "mem allocated avg": 6898492084.224,
+        "mem reserved avg": 17216485457.92,
+        "elapsed time": 1061.1080808269908
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.38,
+        "train loss": 0.6236197687387467,
+        "train samples": 18000,
+        "train time": 44.025015621009516,
+        "eval time": 14.296635860999231,
+        "tokens / sec": 4720.452612419417,
+        "mem allocated avg": 6893971208.192,
+        "mem reserved avg": 17208499503.104,
+        "elapsed time": 1124.3825900560041
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.36,
+        "train loss": 0.6151172000169755,
+        "train samples": 19000,
+        "train time": 44.508093398908386,
+        "eval time": 10.900150568995741,
+        "tokens / sec": 4716.872459990592,
+        "mem allocated avg": 6896253108.224,
+        "mem reserved avg": 17249184251.904,
+        "elapsed time": 1184.5931518430007
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.52,
+        "train loss": 0.6224583629369735,
+        "train samples": 20000,
+        "train time": 43.60898305509181,
+        "eval time": 14.021379313999205,
+        "tokens / sec": 4776.0801882694,
+        "mem allocated avg": 6892680140.8,
+        "mem reserved avg": 16915829358.592,
+        "elapsed time": 1246.993633168997
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.4533737680060652,
+        "train loss": 0.6224583629369735,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": 0.3534202575683594
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/prefixtuning--llama-3.2-3B-lr_0.005_zero_init.json
+++ b/method_comparison/MetaMathQA/results/prefixtuning--llama-3.2-3B-lr_0.005_zero_init.json
@@ -1,0 +1,350 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T17:06:46+00:00",
+    "total_time": 1255.1344404510019,
+    "experiment_name": "prefixtuning/llama-3.2-3B-lr_0.005_zero_init",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.005
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": "CAUSAL_LM",
+      "peft_type": "PREFIX_TUNING",
+      "auto_mapping": null,
+      "peft_version": "0.19.0",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "num_virtual_tokens": 200,
+      "token_dim": 1024,
+      "num_transformer_submodules": 1,
+      "num_attention_heads": 8,
+      "num_layers": 28,
+      "modules_to_save": null,
+      "init_weights": "zero",
+      "encoder_hidden_size": 3072,
+      "prefix_projection": false
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 13987667876,
+    "accelerator_memory_max": 21969764352,
+    "accelerator_memory_reserved_99th": 19157483520,
+    "train_time": 970.3953097560006,
+    "file_size": 45875328,
+    "num_trainable_params": 11468800,
+    "num_total_params": 3224218624,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.2,
+        "train loss": 1.2678344011306764,
+        "train samples": 1000,
+        "train time": 27.194034429907333,
+        "eval time": 15.960887206005282,
+        "tokens / sec": 7785.494298233168,
+        "mem allocated avg": 7055727894.528,
+        "mem reserved avg": 14077342515.2,
+        "elapsed time": 65.7957478990138
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.36,
+        "train loss": 0.7902288379669189,
+        "train samples": 2000,
+        "train time": 27.01687965914607,
+        "eval time": 11.780722531999345,
+        "tokens / sec": 7698.705499085536,
+        "mem allocated avg": 7047839463.424,
+        "mem reserved avg": 13768356528.128,
+        "elapsed time": 107.10377580400382
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.24,
+        "train loss": 0.7467671196460723,
+        "train samples": 3000,
+        "train time": 27.93710034090327,
+        "eval time": 13.317983273998834,
+        "tokens / sec": 7674.418511003849,
+        "mem allocated avg": 7058360565.76,
+        "mem reserved avg": 13883792162.816,
+        "elapsed time": 150.8143266110128
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.28,
+        "train loss": 0.7247283264398575,
+        "train samples": 4000,
+        "train time": 28.07561205892125,
+        "eval time": 15.844377710003755,
+        "tokens / sec": 7420.532794183539,
+        "mem allocated avg": 7050874298.368,
+        "mem reserved avg": 13931053580.288,
+        "elapsed time": 197.35486783200759
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.28,
+        "train loss": 0.7230025169849396,
+        "train samples": 5000,
+        "train time": 27.4366716020304,
+        "eval time": 15.843770207007765,
+        "tokens / sec": 7600.703285910508,
+        "mem allocated avg": 7049694097.408,
+        "mem reserved avg": 13987190145.024,
+        "elapsed time": 243.09947748400737
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.3,
+        "train loss": 0.7165617660284043,
+        "train samples": 6000,
+        "train time": 27.41693946205487,
+        "eval time": 15.844231765004224,
+        "tokens / sec": 7635.097283185629,
+        "mem allocated avg": 7052062963.712,
+        "mem reserved avg": 13884471640.064,
+        "elapsed time": 288.92823548801243
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.38,
+        "train loss": 0.7077521693706512,
+        "train samples": 7000,
+        "train time": 27.86099931402714,
+        "eval time": 15.84966672999144,
+        "tokens / sec": 7514.267440313827,
+        "mem allocated avg": 7052561504.256,
+        "mem reserved avg": 14377218473.984,
+        "elapsed time": 335.2041009560053
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.42,
+        "train loss": 0.7111810308694839,
+        "train samples": 8000,
+        "train time": 27.7813215659844,
+        "eval time": 13.623913794013788,
+        "tokens / sec": 7476.102225975604,
+        "mem allocated avg": 7049145475.072,
+        "mem reserved avg": 14036481605.632,
+        "elapsed time": 379.2373954960058
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.38,
+        "train loss": 0.7035314469337464,
+        "train samples": 9000,
+        "train time": 28.324825873816735,
+        "eval time": 15.338107262999984,
+        "tokens / sec": 7588.678601505416,
+        "mem allocated avg": 7059892746.24,
+        "mem reserved avg": 14239712411.648,
+        "elapsed time": 425.4388579290098
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.3,
+        "train loss": 0.70130124771595,
+        "train samples": 10000,
+        "train time": 27.76416820794111,
+        "eval time": 15.847382225998444,
+        "tokens / sec": 7418.4466272283025,
+        "mem allocated avg": 7045819248.64,
+        "mem reserved avg": 13771493867.52,
+        "elapsed time": 471.59908634400927
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.38,
+        "train loss": 0.6942626680135727,
+        "train samples": 11000,
+        "train time": 27.77380103613541,
+        "eval time": 11.25709281899617,
+        "tokens / sec": 7628.808160767404,
+        "mem allocated avg": 7056581769.216,
+        "mem reserved avg": 14109697376.256,
+        "elapsed time": 513.1207982520136
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.34,
+        "train loss": 0.6865150318145752,
+        "train samples": 12000,
+        "train time": 27.40294734176132,
+        "eval time": 15.83896046000882,
+        "tokens / sec": 7617.1003577377915,
+        "mem allocated avg": 7051527202.816,
+        "mem reserved avg": 14113497415.68,
+        "elapsed time": 559.0147692530008
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.32,
+        "train loss": 0.6951180123090744,
+        "train samples": 13000,
+        "train time": 27.608605705041555,
+        "eval time": 15.836226497005555,
+        "tokens / sec": 7638.958745442468,
+        "mem allocated avg": 7052913205.248,
+        "mem reserved avg": 13957486084.096,
+        "elapsed time": 604.9435471830075
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.46,
+        "train loss": 0.6807289460897445,
+        "train samples": 14000,
+        "train time": 28.273788013044395,
+        "eval time": 15.85275076299149,
+        "tokens / sec": 7418.5319598219285,
+        "mem allocated avg": 7052796133.376,
+        "mem reserved avg": 13872937304.064,
+        "elapsed time": 651.6589886930014
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.38,
+        "train loss": 0.6770447121858597,
+        "train samples": 15000,
+        "train time": 28.624993037970853,
+        "eval time": 10.463159157996415,
+        "tokens / sec": 7570.412321587118,
+        "mem allocated avg": 7062565990.4,
+        "mem reserved avg": 14240719044.608,
+        "elapsed time": 693.3172026100074
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.44,
+        "train loss": 0.6930302439928054,
+        "train samples": 16000,
+        "train time": 27.629406421037856,
+        "eval time": 9.406142670995905,
+        "tokens / sec": 7396.937772951368,
+        "mem allocated avg": 7044787052.544,
+        "mem reserved avg": 13913278119.936,
+        "elapsed time": 732.9555247080134
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.46,
+        "train loss": 0.672576385140419,
+        "train samples": 17000,
+        "train time": 28.082130014998256,
+        "eval time": 10.856074246999924,
+        "tokens / sec": 7527.527288247017,
+        "mem allocated avg": 7054679074.816,
+        "mem reserved avg": 14022187417.6,
+        "elapsed time": 774.335282400003
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.36,
+        "train loss": 0.6801181032657623,
+        "train samples": 18000,
+        "train time": 27.873706766869873,
+        "eval time": 15.860146595994593,
+        "tokens / sec": 7455.700159944578,
+        "mem allocated avg": 7049662265.344,
+        "mem reserved avg": 13916012806.144,
+        "elapsed time": 820.668733826009
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.42,
+        "train loss": 0.6726169712543487,
+        "train samples": 19000,
+        "train time": 27.956917096104007,
+        "eval time": 15.841582774999551,
+        "tokens / sec": 7509.375918607867,
+        "mem allocated avg": 7052527755.264,
+        "mem reserved avg": 14004571340.8,
+        "elapsed time": 866.9247034900036
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.4,
+        "train loss": 0.6787571088075638,
+        "train samples": 20000,
+        "train time": 27.523053067998262,
+        "eval time": 10.57767208799487,
+        "tokens / sec": 7567.474418096891,
+        "mem allocated avg": 7049240582.144,
+        "mem reserved avg": 13645857685.504,
+        "elapsed time": 907.492314247007
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.36694465504169826,
+        "train loss": 0.6787571088075638,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": 2.828566551208496
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/prefixtuning--llama-3.2-3B-tokens50-init_prefix-lr_0.005.json
+++ b/method_comparison/MetaMathQA/results/prefixtuning--llama-3.2-3B-tokens50-init_prefix-lr_0.005.json
@@ -1,0 +1,350 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T17:27:47+00:00",
+    "total_time": 1081.9605887679936,
+    "experiment_name": "prefixtuning/llama-3.2-3B-tokens50-init_prefix-lr_0.005",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.005
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": "You are a helpful math assistant. Solve mathematical problems by thinking step by step. First, identify what the problem is asking. Then, break down the solution into clear logical steps. Show all your work and calculations. Finally, verify that your answer makes sense."
+    },
+    "peft_config": {
+      "task_type": "CAUSAL_LM",
+      "peft_type": "PREFIX_TUNING",
+      "auto_mapping": null,
+      "peft_version": "0.19.0",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "num_virtual_tokens": 50,
+      "token_dim": 1024,
+      "num_transformer_submodules": 1,
+      "num_attention_heads": 8,
+      "num_layers": 28,
+      "modules_to_save": null,
+      "init_weights": "zero",
+      "encoder_hidden_size": 3072,
+      "prefix_projection": false
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 13483572933,
+    "accelerator_memory_max": 20598226944,
+    "accelerator_memory_reserved_99th": 18910019584,
+    "train_time": 876.9671407810383,
+    "file_size": 11468928,
+    "num_trainable_params": 2867200,
+    "num_total_params": 3215617024,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.42,
+        "train loss": 0.8770561032295227,
+        "train samples": 1000,
+        "train time": 27.075058152986458,
+        "eval time": 12.278193292004289,
+        "tokens / sec": 7819.7061961489,
+        "mem allocated avg": 6850508638.208,
+        "mem reserved avg": 13529004376.064,
+        "elapsed time": 59.77307076699799
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.32,
+        "train loss": 0.7323095265626908,
+        "train samples": 2000,
+        "train time": 25.9315507930296,
+        "eval time": 12.18094836299133,
+        "tokens / sec": 8020.924072767335,
+        "mem allocated avg": 6844681697.28,
+        "mem reserved avg": 13250326429.696,
+        "elapsed time": 100.36647598700074
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.32,
+        "train loss": 0.7008617881536484,
+        "train samples": 3000,
+        "train time": 26.427966193965403,
+        "eval time": 12.173006537996116,
+        "tokens / sec": 8112.656056331592,
+        "mem allocated avg": 6853247197.184,
+        "mem reserved avg": 13445747441.664,
+        "elapsed time": 141.34405067499029
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.28,
+        "train loss": 0.6788400970697402,
+        "train samples": 4000,
+        "train time": 25.98687330308894,
+        "eval time": 8.224064269001246,
+        "tokens / sec": 8016.97062859948,
+        "mem allocated avg": 6846228791.296,
+        "mem reserved avg": 13453565624.32,
+        "elapsed time": 178.0648215330002
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.38,
+        "train loss": 0.6749719911813736,
+        "train samples": 5000,
+        "train time": 26.186906341084978,
+        "eval time": 9.531287125995732,
+        "tokens / sec": 7963.4454442150745,
+        "mem allocated avg": 6845613846.528,
+        "mem reserved avg": 13454270267.392,
+        "elapsed time": 216.16001013299683
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.46,
+        "train loss": 0.667180904507637,
+        "train samples": 6000,
+        "train time": 26.662186090034083,
+        "eval time": 10.567809118991136,
+        "tokens / sec": 7851.231676694535,
+        "mem allocated avg": 6847045138.432,
+        "mem reserved avg": 13407772213.248,
+        "elapsed time": 255.88970967099885
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.46,
+        "train loss": 0.6559479324817657,
+        "train samples": 7000,
+        "train time": 26.49516641102673,
+        "eval time": 12.163915039011044,
+        "tokens / sec": 7901.629933257217,
+        "mem allocated avg": 6848404830.208,
+        "mem reserved avg": 13917791191.04,
+        "elapsed time": 297.1118020349968
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.4,
+        "train loss": 0.6591078944206238,
+        "train samples": 8000,
+        "train time": 26.275470316875726,
+        "eval time": 8.645700470995507,
+        "tokens / sec": 7904.558795532,
+        "mem allocated avg": 6845511892.992,
+        "mem reserved avg": 13459672530.944,
+        "elapsed time": 334.5593292220001
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.4,
+        "train loss": 0.6502013274431229,
+        "train samples": 9000,
+        "train time": 27.61604808192351,
+        "eval time": 8.71540480099793,
+        "tokens / sec": 7783.445312752674,
+        "mem allocated avg": 6856188073.984,
+        "mem reserved avg": 13818822393.856,
+        "elapsed time": 373.383077571998
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.3,
+        "train loss": 0.6463649077415466,
+        "train samples": 10000,
+        "train time": 25.71797766610689,
+        "eval time": 12.1855976539955,
+        "tokens / sec": 8008.677924603652,
+        "mem allocated avg": 6841198448.64,
+        "mem reserved avg": 13211906605.056,
+        "elapsed time": 413.7216535589978
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.46,
+        "train loss": 0.6392199238538742,
+        "train samples": 11000,
+        "train time": 26.202791606934625,
+        "eval time": 7.22116273798747,
+        "tokens / sec": 8086.1994850932315,
+        "mem allocated avg": 6852461844.48,
+        "mem reserved avg": 13564337192.96,
+        "elapsed time": 449.5270742329885
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.48,
+        "train loss": 0.6317592755556106,
+        "train samples": 12000,
+        "train time": 25.93028078901989,
+        "eval time": 8.178787294003996,
+        "tokens / sec": 8049.700722422821,
+        "mem allocated avg": 6846777763.84,
+        "mem reserved avg": 13549866844.16,
+        "elapsed time": 486.16456745499454
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.42,
+        "train loss": 0.6396716977357865,
+        "train samples": 13000,
+        "train time": 25.985331026968197,
+        "eval time": 8.20254961399769,
+        "tokens / sec": 8116.155987434677,
+        "mem allocated avg": 6848086245.376,
+        "mem reserved avg": 13484653805.568,
+        "elapsed time": 522.7170732099912
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.34,
+        "train loss": 0.6240959404706955,
+        "train samples": 14000,
+        "train time": 26.13682606702787,
+        "eval time": 12.181133142992621,
+        "tokens / sec": 8025.0754036506305,
+        "mem allocated avg": 6847662497.792,
+        "mem reserved avg": 13383730462.72,
+        "elapsed time": 563.5027851319901
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.4,
+        "train loss": 0.622292353630066,
+        "train samples": 15000,
+        "train time": 27.131869087956147,
+        "eval time": 8.023930148992804,
+        "tokens / sec": 7987.028070107953,
+        "mem allocated avg": 6858720468.992,
+        "mem reserved avg": 13744801316.864,
+        "elapsed time": 601.1192357580003
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.54,
+        "train loss": 0.6341568591594696,
+        "train samples": 16000,
+        "train time": 26.46197854007187,
+        "eval time": 12.196425275004003,
+        "tokens / sec": 7723.2698110806095,
+        "mem allocated avg": 6839325679.616,
+        "mem reserved avg": 13483773001.728,
+        "elapsed time": 642.3214606379915
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.42,
+        "train loss": 0.6193043732643128,
+        "train samples": 17000,
+        "train time": 26.90304671296326,
+        "eval time": 8.022700519009959,
+        "tokens / sec": 7857.437198670216,
+        "mem allocated avg": 6851016419.328,
+        "mem reserved avg": 13403921842.176,
+        "elapsed time": 679.6091405869956
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.46,
+        "train loss": 0.6262495114803314,
+        "train samples": 18000,
+        "train time": 26.447085382867954,
+        "eval time": 12.189505065995036,
+        "tokens / sec": 7857.879119436789,
+        "mem allocated avg": 6844825409.536,
+        "mem reserved avg": 13365854339.072,
+        "elapsed time": 720.788875756989
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.38,
+        "train loss": 0.6178192925453186,
+        "train samples": 19000,
+        "train time": 26.904425678018015,
+        "eval time": 11.104270746989641,
+        "tokens / sec": 7803.139993117508,
+        "mem allocated avg": 6848209059.84,
+        "mem reserved avg": 13499510030.336,
+        "elapsed time": 761.1998116350005
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.46,
+        "train loss": 0.6229302062988281,
+        "train samples": 20000,
+        "train time": 26.149641662093927,
+        "eval time": 6.978471010006615,
+        "tokens / sec": 7964.927500399332,
+        "mem allocated avg": 6843759417.344,
+        "mem reserved avg": 13242130759.68,
+        "elapsed time": 796.7215869979991
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.400303260045489,
+        "train loss": 0.6229302062988281,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": 0.5316238403320312
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/psoft--llama-3.2-3B-default.json
+++ b/method_comparison/MetaMathQA/results/psoft--llama-3.2-3B-default.json
@@ -1,0 +1,364 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T17:45:54+00:00",
+    "total_time": 1937.8156919419998,
+    "experiment_name": "psoft/llama-3.2-3B-default",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.0001,
+        "weight_decay": 0.1
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": null,
+      "peft_type": "PSOFT",
+      "auto_mapping": null,
+      "peft_version": "0.19.0",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 256,
+      "target_modules": [
+        "q_proj",
+        "v_proj"
+      ],
+      "exclude_modules": null,
+      "psoft_alpha": 256,
+      "psoft_dropout": 0.0,
+      "fan_in_fan_out": false,
+      "ab_svd_init": "psoft_init",
+      "psoft_svd": "full",
+      "psoft_svd_lowrank_niter": 10,
+      "psoft_orth": true,
+      "psoft_mag_b": true,
+      "psoft_mag_a": true,
+      "use_cayley_neumann": false,
+      "num_cayley_neumann_terms": 5,
+      "cayley_neumann_eps": null,
+      "modules_to_save": null,
+      "init_weights": true,
+      "layers_to_transform": null,
+      "layers_pattern": null
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 15026516446,
+    "accelerator_memory_max": 21990735872,
+    "accelerator_memory_reserved_99th": 20199768064,
+    "train_time": 1505.385764200997,
+    "file_size": 7448144,
+    "num_trainable_params": 1856512,
+    "num_total_params": 3214606336,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.34,
+        "train loss": 1.01516472530365,
+        "train samples": 1000,
+        "train time": 43.33842796702811,
+        "eval time": 24.252313315009815,
+        "tokens / sec": 4885.248725705415,
+        "mem allocated avg": 8375423072.256,
+        "mem reserved avg": 15119048245.248,
+        "elapsed time": 90.0036859739921
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.32,
+        "train loss": 0.7340580285787582,
+        "train samples": 2000,
+        "train time": 43.51892344804946,
+        "eval time": 24.25320322001062,
+        "tokens / sec": 4779.415103139975,
+        "mem allocated avg": 8368352468.992,
+        "mem reserved avg": 14813082157.056,
+        "elapsed time": 160.662997152991
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.44,
+        "train loss": 0.6879250873327255,
+        "train samples": 3000,
+        "train time": 43.93279401304608,
+        "eval time": 23.87379320099717,
+        "tokens / sec": 4880.204066609842,
+        "mem allocated avg": 8378198431.744,
+        "mem reserved avg": 14968892162.048,
+        "elapsed time": 231.33524189700256
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.5,
+        "train loss": 0.6680566596984864,
+        "train samples": 4000,
+        "train time": 43.45829963689903,
+        "eval time": 24.127080324993585,
+        "tokens / sec": 4793.928932808698,
+        "mem allocated avg": 8369458450.432,
+        "mem reserved avg": 15005365829.632,
+        "elapsed time": 301.8884777850035
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.42,
+        "train loss": 0.6644437726736069,
+        "train samples": 5000,
+        "train time": 42.981003544147825,
+        "eval time": 19.512033010993036,
+        "tokens / sec": 4851.864377382458,
+        "mem allocated avg": 8369734297.6,
+        "mem reserved avg": 14974629969.92,
+        "elapsed time": 367.2329926319944
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.5,
+        "train loss": 0.656409296989441,
+        "train samples": 6000,
+        "train time": 43.40368786803447,
+        "eval time": 24.234126267998363,
+        "tokens / sec": 4822.885111432342,
+        "mem allocated avg": 8371589535.744,
+        "mem reserved avg": 14985442885.632,
+        "elapsed time": 437.7650993739953
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.4,
+        "train loss": 0.6492917109727859,
+        "train samples": 7000,
+        "train time": 43.8191164049349,
+        "eval time": 17.957069406998926,
+        "tokens / sec": 4777.709300784131,
+        "mem allocated avg": 8373423994.88,
+        "mem reserved avg": 15362972188.672,
+        "elapsed time": 502.5296421480016
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.4,
+        "train loss": 0.651351011633873,
+        "train samples": 8000,
+        "train time": 43.91826998388569,
+        "eval time": 19.85821281799872,
+        "tokens / sec": 4729.148030562382,
+        "mem allocated avg": 8368890132.48,
+        "mem reserved avg": 15046822330.368,
+        "elapsed time": 569.3082349729957
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.46,
+        "train loss": 0.6434478094577789,
+        "train samples": 9000,
+        "train time": 44.214122023113305,
+        "eval time": 24.340498196994304,
+        "tokens / sec": 4861.52365272874,
+        "mem allocated avg": 8379377248.256,
+        "mem reserved avg": 15277374832.64,
+        "elapsed time": 640.7805861020024
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.44,
+        "train loss": 0.6421752452850342,
+        "train samples": 10000,
+        "train time": 43.76370210298046,
+        "eval time": 24.20965617800539,
+        "tokens / sec": 4706.343158888583,
+        "mem allocated avg": 8365997271.04,
+        "mem reserved avg": 14821965692.928,
+        "elapsed time": 711.6298649300006
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.44,
+        "train loss": 0.634340330004692,
+        "train samples": 11000,
+        "train time": 43.842665812029736,
+        "eval time": 21.91094351799984,
+        "tokens / sec": 4832.758138120862,
+        "mem allocated avg": 8375715567.616,
+        "mem reserved avg": 15151327608.832,
+        "elapsed time": 780.2465031659958
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.4,
+        "train loss": 0.6267138615846634,
+        "train samples": 12000,
+        "train time": 43.95662597400951,
+        "eval time": 24.438440626996453,
+        "tokens / sec": 4748.567374652858,
+        "mem allocated avg": 8371726731.264,
+        "mem reserved avg": 15071677775.872,
+        "elapsed time": 851.6106786309974
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.46,
+        "train loss": 0.6364041697978974,
+        "train samples": 13000,
+        "train time": 43.44346187009069,
+        "eval time": 13.787291264001396,
+        "tokens / sec": 4854.608516942293,
+        "mem allocated avg": 8373763536.896,
+        "mem reserved avg": 14988026576.896,
+        "elapsed time": 911.682741933997
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.48,
+        "train loss": 0.6214166321754455,
+        "train samples": 14000,
+        "train time": 43.80178445095953,
+        "eval time": 17.285016585999983,
+        "tokens / sec": 4788.617692843908,
+        "mem allocated avg": 8371230976.0,
+        "mem reserved avg": 15019198644.224,
+        "elapsed time": 975.6572376149998
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.48,
+        "train loss": 0.6196781145334244,
+        "train samples": 15000,
+        "train time": 44.90675747311616,
+        "eval time": 17.868283932999475,
+        "tokens / sec": 4825.621180280746,
+        "mem allocated avg": 8381897398.272,
+        "mem reserved avg": 15295502614.528,
+        "elapsed time": 1041.3160545689898
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.46,
+        "train loss": 0.6325693914890289,
+        "train samples": 16000,
+        "train time": 43.95797020303144,
+        "eval time": 21.001378130997182,
+        "tokens / sec": 4649.282008610716,
+        "mem allocated avg": 8363390388.224,
+        "mem reserved avg": 15030305161.216,
+        "elapsed time": 1109.2579419859976
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.48,
+        "train loss": 0.6181137851476669,
+        "train samples": 17000,
+        "train time": 43.63497660578287,
+        "eval time": 14.508927531001973,
+        "tokens / sec": 4844.485237376865,
+        "mem allocated avg": 8374695139.328,
+        "mem reserved avg": 15006825447.424,
+        "elapsed time": 1170.2475494539976
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.44,
+        "train loss": 0.6251096996068954,
+        "train samples": 18000,
+        "train time": 43.71482467187161,
+        "eval time": 17.362020947999554,
+        "tokens / sec": 4753.9479240716455,
+        "mem allocated avg": 8369678581.76,
+        "mem reserved avg": 14920213069.824,
+        "elapsed time": 1234.2639348649973
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.4,
+        "train loss": 0.6170058059692383,
+        "train samples": 19000,
+        "train time": 44.26034616607649,
+        "eval time": 14.061754546011798,
+        "tokens / sec": 4743.275147741808,
+        "mem allocated avg": 8372185092.096,
+        "mem reserved avg": 14964882407.424,
+        "elapsed time": 1295.4217767660011
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.42,
+        "train loss": 0.6243607197999954,
+        "train samples": 20000,
+        "train time": 43.99801491193648,
+        "eval time": 15.62990901999001,
+        "tokens / sec": 4733.849934295434,
+        "mem allocated avg": 8368538847.232,
+        "mem reserved avg": 14706773327.872,
+        "elapsed time": 1357.9020721779962
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.4488248673237301,
+        "train loss": 0.6243607197999954,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": 0.5123701095581055
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/psoft--llama-3.2-3B-fast.json
+++ b/method_comparison/MetaMathQA/results/psoft--llama-3.2-3B-fast.json
@@ -1,0 +1,364 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T18:18:17+00:00",
+    "total_time": 1468.6276556560042,
+    "experiment_name": "psoft/llama-3.2-3B-fast",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.0001,
+        "weight_decay": 0.1
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": null,
+      "peft_type": "PSOFT",
+      "auto_mapping": null,
+      "peft_version": "0.19.0",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 256,
+      "target_modules": [
+        "v_proj",
+        "q_proj"
+      ],
+      "exclude_modules": null,
+      "psoft_alpha": 256,
+      "psoft_dropout": 0.0,
+      "fan_in_fan_out": false,
+      "ab_svd_init": "psoft_init",
+      "psoft_svd": "lowrank",
+      "psoft_svd_lowrank_niter": 10,
+      "psoft_orth": true,
+      "psoft_mag_b": true,
+      "psoft_mag_a": true,
+      "use_cayley_neumann": true,
+      "num_cayley_neumann_terms": 5,
+      "cayley_neumann_eps": null,
+      "modules_to_save": null,
+      "init_weights": true,
+      "layers_to_transform": null,
+      "layers_pattern": null
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 13830374345,
+    "accelerator_memory_max": 20770193408,
+    "accelerator_memory_reserved_99th": 18964545536,
+    "train_time": 1200.1861080279923,
+    "file_size": 7448144,
+    "num_trainable_params": 1856512,
+    "num_total_params": 3214606336,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.38,
+        "train loss": 1.0145607323646546,
+        "train samples": 1000,
+        "train time": 36.71533618000103,
+        "eval time": 15.666215841993107,
+        "tokens / sec": 5766.5003790793035,
+        "mem allocated avg": 7133637742.592,
+        "mem reserved avg": 13938871762.944,
+        "elapsed time": 74.23814530199161
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.36,
+        "train loss": 0.7338115975856782,
+        "train samples": 2000,
+        "train time": 37.135233334905934,
+        "eval time": 15.582825934994617,
+        "tokens / sec": 5601.015028616808,
+        "mem allocated avg": 7126403880.96,
+        "mem reserved avg": 13578312613.888,
+        "elapsed time": 130.02693150399136
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.4,
+        "train loss": 0.688268399477005,
+        "train samples": 3000,
+        "train time": 37.55874616494111,
+        "eval time": 11.907032759001595,
+        "tokens / sec": 5708.417396535211,
+        "mem allocated avg": 7136393115.648,
+        "mem reserved avg": 13794109554.688,
+        "elapsed time": 182.50203327499912
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.44,
+        "train loss": 0.6681705112457276,
+        "train samples": 4000,
+        "train time": 37.44897099403897,
+        "eval time": 15.572288518989808,
+        "tokens / sec": 5563.196917564501,
+        "mem allocated avg": 7127546568.704,
+        "mem reserved avg": 13830113460.224,
+        "elapsed time": 238.6246955839888
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.5,
+        "train loss": 0.66438540828228,
+        "train samples": 5000,
+        "train time": 37.498516489053145,
+        "eval time": 11.428519556997344,
+        "tokens / sec": 5561.233337347572,
+        "mem allocated avg": 7128205649.92,
+        "mem reserved avg": 13868633948.16,
+        "elapsed time": 290.5487072549877
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.34,
+        "train loss": 0.6563739287853241,
+        "train samples": 6000,
+        "train time": 37.84935744001996,
+        "eval time": 11.965642277995357,
+        "tokens / sec": 5530.635502378812,
+        "mem allocated avg": 7129830410.24,
+        "mem reserved avg": 13790418567.168,
+        "elapsed time": 343.42470807499194
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.46,
+        "train loss": 0.6491832717657089,
+        "train samples": 7000,
+        "train time": 37.42066152404004,
+        "eval time": 9.395735846002935,
+        "tokens / sec": 5594.6365316258425,
+        "mem allocated avg": 7131694694.4,
+        "mem reserved avg": 14133361639.424,
+        "elapsed time": 393.339392444992
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.42,
+        "train loss": 0.6512416273355484,
+        "train samples": 8000,
+        "train time": 37.458074163863785,
+        "eval time": 15.324161733005894,
+        "tokens / sec": 5544.759164377078,
+        "mem allocated avg": 7127220852.736,
+        "mem reserved avg": 13816918179.84,
+        "elapsed time": 449.26280711599975
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.42,
+        "train loss": 0.6431628746986389,
+        "train samples": 9000,
+        "train time": 38.11420117891976,
+        "eval time": 15.267252121004276,
+        "tokens / sec": 5639.57772566105,
+        "mem allocated avg": 7137530970.112,
+        "mem reserved avg": 14086007947.264,
+        "elapsed time": 505.74102219998895
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.36,
+        "train loss": 0.6422915599346161,
+        "train samples": 10000,
+        "train time": 37.665808972960804,
+        "eval time": 15.502652708993992,
+        "tokens / sec": 5468.274958540192,
+        "mem allocated avg": 7124247066.624,
+        "mem reserved avg": 13621077737.472,
+        "elapsed time": 561.9800479659898
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.48,
+        "train loss": 0.6344620395898819,
+        "train samples": 11000,
+        "train time": 37.729417049049516,
+        "eval time": 14.667384405009216,
+        "tokens / sec": 5615.803703633893,
+        "mem allocated avg": 7134092083.2,
+        "mem reserved avg": 13956924047.36,
+        "elapsed time": 617.4243246029946
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.44,
+        "train loss": 0.6265726834535599,
+        "train samples": 12000,
+        "train time": 37.67032070188725,
+        "eval time": 10.909270905001904,
+        "tokens / sec": 5540.993442870869,
+        "mem allocated avg": 7129951842.304,
+        "mem reserved avg": 13895787872.256,
+        "elapsed time": 669.1392444079975
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.4,
+        "train loss": 0.6364836758375167,
+        "train samples": 13000,
+        "train time": 37.44520631492196,
+        "eval time": 15.535097809988656,
+        "tokens / sec": 5632.256322111803,
+        "mem allocated avg": 7132112439.296,
+        "mem reserved avg": 13748290977.792,
+        "elapsed time": 725.1316548469913
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.42,
+        "train loss": 0.6213824005126953,
+        "train samples": 14000,
+        "train time": 37.835670114000095,
+        "eval time": 15.68471787100134,
+        "tokens / sec": 5543.710455451601,
+        "mem allocated avg": 7129427118.08,
+        "mem reserved avg": 13794428321.792,
+        "elapsed time": 781.7749934619933
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.44,
+        "train loss": 0.6196332731246948,
+        "train samples": 15000,
+        "train time": 38.61936162307393,
+        "eval time": 10.862610769996536,
+        "tokens / sec": 5611.252773026842,
+        "mem allocated avg": 7140212428.8,
+        "mem reserved avg": 14072191909.888,
+        "elapsed time": 834.3267648119945
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.46,
+        "train loss": 0.6326277133226395,
+        "train samples": 16000,
+        "train time": 37.171097063837806,
+        "eval time": 10.443736899003852,
+        "tokens / sec": 5498.169710972181,
+        "mem allocated avg": 7121660831.744,
+        "mem reserved avg": 13814359654.4,
+        "elapsed time": 885.054980269997
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.38,
+        "train loss": 0.618290886759758,
+        "train samples": 17000,
+        "train time": 37.33161400198878,
+        "eval time": 14.996235694008647,
+        "tokens / sec": 5662.4661336297595,
+        "mem allocated avg": 7132966852.608,
+        "mem reserved avg": 13792633159.68,
+        "elapsed time": 940.3594205099944
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.42,
+        "train loss": 0.6252515635490418,
+        "train samples": 18000,
+        "train time": 37.50360515809734,
+        "eval time": 11.315083836001577,
+        "tokens / sec": 5541.280608195885,
+        "mem allocated avg": 7127867189.248,
+        "mem reserved avg": 13762828435.456,
+        "elapsed time": 992.3431118549925
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.4,
+        "train loss": 0.6172080825567245,
+        "train samples": 19000,
+        "train time": 37.360017932980554,
+        "eval time": 9.651658456001314,
+        "tokens / sec": 5619.349551079063,
+        "mem allocated avg": 7130523303.936,
+        "mem reserved avg": 13808235970.56,
+        "elapsed time": 1042.3337350419897
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.42,
+        "train loss": 0.6243040920495987,
+        "train samples": 20000,
+        "train time": 37.632196523059974,
+        "eval time": 10.714210777005064,
+        "tokens / sec": 5534.622457457984,
+        "mem allocated avg": 7126828070.912,
+        "mem reserved avg": 13503981158.4,
+        "elapsed time": 1093.72050657199
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.44351781652767247,
+        "train loss": 0.6243040920495987,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": 0.5018253326416016
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/pvera--llama-3.2-3B-default.json
+++ b/method_comparison/MetaMathQA/results/pvera--llama-3.2-3B-default.json
@@ -1,0 +1,357 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T18:42:51+00:00",
+    "total_time": 1291.4271428469947,
+    "experiment_name": "pvera/llama-3.2-3B-default",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.003
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": null,
+      "peft_type": "PVERA",
+      "auto_mapping": null,
+      "peft_version": "0.19.0",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 256,
+      "target_modules": [
+        "v_proj",
+        "q_proj"
+      ],
+      "projection_prng_key": 0,
+      "save_projection": true,
+      "pvera_dropout": 0.0,
+      "d_initial": 0.1,
+      "fan_in_fan_out": false,
+      "bias": "none",
+      "modules_to_save": null,
+      "init_weights": true,
+      "layers_to_transform": null,
+      "layers_pattern": null,
+      "sample_at_inference": false
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 14228733401,
+    "accelerator_memory_max": 22152216576,
+    "accelerator_memory_reserved_99th": 20065550336,
+    "train_time": 1069.4061620029825,
+    "file_size": 10025160,
+    "num_trainable_params": 143360,
+    "num_total_params": 3212893184,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.0,
+        "train loss": 1.3202282037734985,
+        "train samples": 1000,
+        "train time": 32.67286523502844,
+        "eval time": 12.301227215008112,
+        "tokens / sec": 6479.964290766179,
+        "mem allocated avg": 6789406173.184,
+        "mem reserved avg": 14332498804.736,
+        "elapsed time": 67.55532218200096
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.34,
+        "train loss": 1.1538902192115783,
+        "train samples": 2000,
+        "train time": 32.96136713196756,
+        "eval time": 12.322236451000208,
+        "tokens / sec": 6310.266172129619,
+        "mem allocated avg": 6782129682.432,
+        "mem reserved avg": 13934107033.6,
+        "elapsed time": 116.44386823300738
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.34,
+        "train loss": 0.898421834230423,
+        "train samples": 3000,
+        "train time": 33.59121551607677,
+        "eval time": 12.133125199994538,
+        "tokens / sec": 6382.650842074696,
+        "mem allocated avg": 6792430583.808,
+        "mem reserved avg": 14168837062.656,
+        "elapsed time": 165.66208046700922
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.3,
+        "train loss": 0.8379638421535492,
+        "train samples": 4000,
+        "train time": 32.67811248412181,
+        "eval time": 8.892382420992362,
+        "tokens / sec": 6375.398827004766,
+        "mem allocated avg": 6784067207.168,
+        "mem reserved avg": 14229713190.912,
+        "elapsed time": 210.88579634900088
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.34,
+        "train loss": 0.8170157277584076,
+        "train samples": 5000,
+        "train time": 32.431128902884666,
+        "eval time": 12.215805946005275,
+        "tokens / sec": 6430.180109501248,
+        "mem allocated avg": 6784477261.824,
+        "mem reserved avg": 14274600632.32,
+        "elapsed time": 259.07680079800775
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.38,
+        "train loss": 0.7990756661891937,
+        "train samples": 6000,
+        "train time": 32.99714762700023,
+        "eval time": 11.58432873399579,
+        "tokens / sec": 6343.911975855541,
+        "mem allocated avg": 6785691637.76,
+        "mem reserved avg": 14198213967.872,
+        "elapsed time": 307.29504832200473
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.26,
+        "train loss": 0.7860628130435944,
+        "train samples": 7000,
+        "train time": 32.93966836592881,
+        "eval time": 12.32378633999906,
+        "tokens / sec": 6355.710618402783,
+        "mem allocated avg": 6786881329.152,
+        "mem reserved avg": 14573822279.68,
+        "elapsed time": 356.20853258200805
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.32,
+        "train loss": 0.7856944581270218,
+        "train samples": 8000,
+        "train time": 32.91093613029807,
+        "eval time": 12.19419355399441,
+        "tokens / sec": 6310.850568871951,
+        "mem allocated avg": 6783044034.56,
+        "mem reserved avg": 14224982016.0,
+        "elapsed time": 404.9654307870078
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.36,
+        "train loss": 0.7764198180437089,
+        "train samples": 9000,
+        "train time": 34.04934502001561,
+        "eval time": 10.626323529999354,
+        "tokens / sec": 6312.838025919286,
+        "mem allocated avg": 6793975109.632,
+        "mem reserved avg": 14508609241.088,
+        "elapsed time": 453.26413831600803
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.4,
+        "train loss": 0.7704147508144379,
+        "train samples": 10000,
+        "train time": 32.65568613614596,
+        "eval time": 12.24934491699969,
+        "tokens / sec": 6307.232349713792,
+        "mem allocated avg": 6780232609.792,
+        "mem reserved avg": 14000259596.288,
+        "elapsed time": 501.78799178201007
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.34,
+        "train loss": 0.7629369251728058,
+        "train samples": 11000,
+        "train time": 34.34300080695539,
+        "eval time": 12.220637089994852,
+        "tokens / sec": 6169.554058219874,
+        "mem allocated avg": 6790175119.36,
+        "mem reserved avg": 14390975791.104,
+        "elapsed time": 551.9675445120083
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.48,
+        "train loss": 0.7516447757482528,
+        "train samples": 12000,
+        "train time": 33.29613821301609,
+        "eval time": 12.233222769995336,
+        "tokens / sec": 6268.925202815355,
+        "mem allocated avg": 6786514487.296,
+        "mem reserved avg": 14305999192.064,
+        "elapsed time": 601.2189341290068
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.28,
+        "train loss": 0.7555468535423279,
+        "train samples": 13000,
+        "train time": 32.999268432031386,
+        "eval time": 12.178287804010324,
+        "tokens / sec": 6391.081076066669,
+        "mem allocated avg": 6787544530.944,
+        "mem reserved avg": 14133839790.08,
+        "elapsed time": 649.8716620650084
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.36,
+        "train loss": 0.7404804437160492,
+        "train samples": 14000,
+        "train time": 32.64920209176489,
+        "eval time": 12.186518534013885,
+        "tokens / sec": 6424.3530181984215,
+        "mem allocated avg": 6785403799.552,
+        "mem reserved avg": 14191570190.336,
+        "elapsed time": 698.362258417008
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.34,
+        "train loss": 0.7344836096763611,
+        "train samples": 15000,
+        "train time": 33.48411372501869,
+        "eval time": 8.465133406003588,
+        "tokens / sec": 6471.8153145586675,
+        "mem allocated avg": 6796390723.584,
+        "mem reserved avg": 14502049349.632,
+        "elapsed time": 743.888114567002
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.32,
+        "train loss": 0.7513675209283829,
+        "train samples": 16000,
+        "train time": 32.732514199859,
+        "eval time": 7.7433306710008765,
+        "tokens / sec": 6243.730583973302,
+        "mem allocated avg": 6777416720.384,
+        "mem reserved avg": 14199237378.048,
+        "elapsed time": 788.0349280920054
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.28,
+        "train loss": 0.7285181393623352,
+        "train samples": 17000,
+        "train time": 33.14160475527751,
+        "eval time": 7.952340036004898,
+        "tokens / sec": 6378.357401849654,
+        "mem allocated avg": 6788771710.976,
+        "mem reserved avg": 14182678265.856,
+        "elapsed time": 832.6118042430026
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.42,
+        "train loss": 0.7370574896335602,
+        "train samples": 18000,
+        "train time": 32.7690467388602,
+        "eval time": 7.387523283003247,
+        "tokens / sec": 6341.89946555731,
+        "mem allocated avg": 6783872323.584,
+        "mem reserved avg": 14155977326.592,
+        "elapsed time": 876.4409682330006
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.36,
+        "train loss": 0.7286350094079971,
+        "train samples": 19000,
+        "train time": 33.32835812299163,
+        "eval time": 12.151384285010863,
+        "tokens / sec": 6299.110181943622,
+        "mem allocated avg": 6786492006.4,
+        "mem reserved avg": 14207953141.76,
+        "elapsed time": 925.4097285200114
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.34,
+        "train loss": 0.7356556997299194,
+        "train samples": 20000,
+        "train time": 32.469325570142246,
+        "eval time": 8.883527666999726,
+        "tokens / sec": 6414.669733439971,
+        "mem allocated avg": 6782703605.76,
+        "mem reserved avg": 13858743779.328,
+        "elapsed time": 970.3014086380135
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.3305534495830174,
+        "train loss": 0.7356556997299194,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": 0.29680824279785156
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/tinylora--llama-3.2-3B-default.json
+++ b/method_comparison/MetaMathQA/results/tinylora--llama-3.2-3B-default.json
@@ -1,0 +1,358 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T19:04:28+00:00",
+    "total_time": 1280.5890959829994,
+    "experiment_name": "tinylora/llama-3.2-3B-default",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.001
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": null,
+      "peft_type": "TINYLORA",
+      "auto_mapping": null,
+      "peft_version": "0.19.0",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 2,
+      "u": 64,
+      "weight_tying": 0.0,
+      "projection_seed": 42,
+      "save_projection": true,
+      "init_v_bound": 0.02,
+      "target_modules": [
+        "v_proj",
+        "q_proj"
+      ],
+      "tinylora_dropout": 0.0,
+      "fan_in_fan_out": false,
+      "bias": "none",
+      "modules_to_save": null,
+      "init_weights": true,
+      "layers_to_transform": null,
+      "layers_pattern": null
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 13315370437,
+    "accelerator_memory_max": 20126367744,
+    "accelerator_memory_reserved_99th": 18343788544,
+    "train_time": 1005.6939271469892,
+    "file_size": 2391912,
+    "num_trainable_params": 3584,
+    "num_total_params": 3212753408,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.0,
+        "train loss": 1.2781277766227723,
+        "train samples": 1000,
+        "train time": 29.62463812986971,
+        "eval time": 12.268791488997522,
+        "tokens / sec": 7146.720208761961,
+        "mem allocated avg": 6782683836.416,
+        "mem reserved avg": 13404014116.864,
+        "elapsed time": 63.092878730007214
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.0,
+        "train loss": 1.2406480107307434,
+        "train samples": 2000,
+        "train time": 29.568441232899204,
+        "eval time": 12.359398319997126,
+        "tokens / sec": 7034.357961642402,
+        "mem allocated avg": 6775698290.688,
+        "mem reserved avg": 13079584702.464,
+        "elapsed time": 107.82620730499912
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.02,
+        "train loss": 1.1951167840957642,
+        "train samples": 3000,
+        "train time": 29.82903349219123,
+        "eval time": 12.353063451009803,
+        "tokens / sec": 7187.661647036831,
+        "mem allocated avg": 6785483120.64,
+        "mem reserved avg": 13268521320.448,
+        "elapsed time": 152.80012364900904
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.02,
+        "train loss": 1.196952908039093,
+        "train samples": 4000,
+        "train time": 29.21191224195354,
+        "eval time": 12.419155650000903,
+        "tokens / sec": 7131.885043143193,
+        "mem allocated avg": 6776640491.52,
+        "mem reserved avg": 13314843213.824,
+        "elapsed time": 197.2873525449977
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.0,
+        "train loss": 1.1898907599449158,
+        "train samples": 5000,
+        "train time": 29.00116592599079,
+        "eval time": 12.263450048994855,
+        "tokens / sec": 7190.676420809297,
+        "mem allocated avg": 6777077430.272,
+        "mem reserved avg": 13365250359.296,
+        "elapsed time": 241.3598588379973
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.0,
+        "train loss": 1.1793672075271606,
+        "train samples": 6000,
+        "train time": 29.21511149003345,
+        "eval time": 12.238495423996937,
+        "tokens / sec": 7165.1617715514085,
+        "mem allocated avg": 6779007174.656,
+        "mem reserved avg": 13277757177.856,
+        "elapsed time": 285.6396420480014
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.02,
+        "train loss": 1.1763010482788085,
+        "train samples": 7000,
+        "train time": 29.251842216108344,
+        "eval time": 12.174482814996736,
+        "tokens / sec": 7156.98513800655,
+        "mem allocated avg": 6780389603.328,
+        "mem reserved avg": 13619811057.664,
+        "elapsed time": 329.89888020399667
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.02,
+        "train loss": 1.1813358347415923,
+        "train samples": 8000,
+        "train time": 29.418175176848308,
+        "eval time": 12.335072386005777,
+        "tokens / sec": 7060.125203260529,
+        "mem allocated avg": 6776134410.24,
+        "mem reserved avg": 13301312389.12,
+        "elapsed time": 374.5338296889968
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.0,
+        "train loss": 1.172850294113159,
+        "train samples": 9000,
+        "train time": 29.904061377135804,
+        "eval time": 12.285082250004052,
+        "tokens / sec": 7187.919971443946,
+        "mem allocated avg": 6786565449.728,
+        "mem reserved avg": 13564848898.048,
+        "elapsed time": 419.51835140399635
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.02,
+        "train loss": 1.1793990023136138,
+        "train samples": 10000,
+        "train time": 29.20591944696207,
+        "eval time": 12.41826296299405,
+        "tokens / sec": 7052.234748987647,
+        "mem allocated avg": 6773510297.6,
+        "mem reserved avg": 13106612797.44,
+        "elapsed time": 463.9779940340086
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.0,
+        "train loss": 1.180105079650879,
+        "train samples": 11000,
+        "train time": 29.320615836040815,
+        "eval time": 12.377129669010174,
+        "tokens / sec": 7226.348900201356,
+        "mem allocated avg": 6782631518.208,
+        "mem reserved avg": 13437618880.512,
+        "elapsed time": 508.437297217999
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.0,
+        "train loss": 1.1744389948844909,
+        "train samples": 12000,
+        "train time": 29.53985286586976,
+        "eval time": 12.229440000999602,
+        "tokens / sec": 7066.081234316744,
+        "mem allocated avg": 6778503475.2,
+        "mem reserved avg": 13380526014.464,
+        "elapsed time": 553.0742953360023
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.02,
+        "train loss": 1.172437875032425,
+        "train samples": 13000,
+        "train time": 29.548683459026506,
+        "eval time": 12.297136758003035,
+        "tokens / sec": 7137.40767139235,
+        "mem allocated avg": 6781349326.848,
+        "mem reserved avg": 13244496347.136,
+        "elapsed time": 597.6882013260038
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.0,
+        "train loss": 1.1740667581558228,
+        "train samples": 14000,
+        "train time": 29.95824750296015,
+        "eval time": 12.355832200992154,
+        "tokens / sec": 7001.410879567464,
+        "mem allocated avg": 6778354403.328,
+        "mem reserved avg": 13265174265.856,
+        "elapsed time": 642.876650516002
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.0,
+        "train loss": 1.1586440045833588,
+        "train samples": 15000,
+        "train time": 30.502618752914714,
+        "eval time": 12.421693063995917,
+        "tokens / sec": 7104.40640377124,
+        "mem allocated avg": 6789483493.376,
+        "mem reserved avg": 13573707268.096,
+        "elapsed time": 688.6765086410014
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.06,
+        "train loss": 1.1851642508506774,
+        "train samples": 16000,
+        "train time": 29.493367298011435,
+        "eval time": 12.399896686998545,
+        "tokens / sec": 6929.456305715885,
+        "mem allocated avg": 6770658635.776,
+        "mem reserved avg": 13280558972.928,
+        "elapsed time": 733.4192178939993
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.0,
+        "train loss": 1.157331362247467,
+        "train samples": 17000,
+        "train time": 29.721664497148595,
+        "eval time": 12.352380377997179,
+        "tokens / sec": 7112.286730114998,
+        "mem allocated avg": 6782410606.592,
+        "mem reserved avg": 13262255030.272,
+        "elapsed time": 778.2037502510066
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.0,
+        "train loss": 1.1738232126235961,
+        "train samples": 18000,
+        "train time": 29.415511626095395,
+        "eval time": 12.387085970010958,
+        "tokens / sec": 7064.911963511059,
+        "mem allocated avg": 6776753987.584,
+        "mem reserved avg": 13233884758.016,
+        "elapsed time": 822.8698514100106
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.0,
+        "train loss": 1.1605148227214814,
+        "train samples": 19000,
+        "train time": 30.141289916908136,
+        "eval time": 12.342347552010324,
+        "tokens / sec": 6965.163089527634,
+        "mem allocated avg": 6779153461.248,
+        "mem reserved avg": 13314037907.456,
+        "elapsed time": 868.1438604020077
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.02,
+        "train loss": 1.1730116956233978,
+        "train samples": 20000,
+        "train time": 29.35209196503274,
+        "eval time": 12.416217063000659,
+        "tokens / sec": 7095.91671517399,
+        "mem allocated avg": 6776144590.848,
+        "mem reserved avg": 13012593278.976,
+        "elapsed time": 912.6687434610067
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.009855951478392721,
+        "train loss": 1.1730116956233978,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": -0.7508955001831055
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}

--- a/method_comparison/MetaMathQA/results/tinylora--llama-3.2-3B-weight-tying.json
+++ b/method_comparison/MetaMathQA/results/tinylora--llama-3.2-3B-weight-tying.json
@@ -1,0 +1,358 @@
+{
+  "run_info": {
+    "created_at": "2026-04-14T19:25:53+00:00",
+    "total_time": 1291.7770112069993,
+    "experiment_name": "tinylora/llama-3.2-3B-weight-tying",
+    "peft_branch": "main",
+    "train_config": {
+      "model_id": "meta-llama/Llama-3.2-3B",
+      "dtype": "bfloat16",
+      "max_seq_length": 768,
+      "batch_size": 4,
+      "batch_size_eval": 50,
+      "max_steps": 5000,
+      "eval_steps": 250,
+      "compile": false,
+      "query_template": "Question: {query} Think step by step.\nAnswer:",
+      "seed": 0,
+      "grad_norm_clip": 1.0,
+      "optimizer_type": "AdamW",
+      "optimizer_kwargs": {
+        "lr": 0.001
+      },
+      "lr_scheduler": "cosine",
+      "use_amp": false,
+      "autocast_adapter_dtype": true,
+      "generation_kwargs": {
+        "max_length": 800,
+        "max_new_tokens": 300
+      },
+      "attn_implementation": null,
+      "init_kv_cache_prefix": null
+    },
+    "peft_config": {
+      "task_type": null,
+      "peft_type": "TINYLORA",
+      "auto_mapping": null,
+      "peft_version": "0.19.0",
+      "base_model_name_or_path": "meta-llama/Llama-3.2-3B",
+      "revision": null,
+      "inference_mode": false,
+      "r": 2,
+      "u": 64,
+      "weight_tying": 1.0,
+      "projection_seed": 42,
+      "save_projection": true,
+      "init_v_bound": 0.02,
+      "target_modules": [
+        "q_proj",
+        "v_proj"
+      ],
+      "tinylora_dropout": 0.0,
+      "fan_in_fan_out": false,
+      "bias": "none",
+      "modules_to_save": null,
+      "init_weights": true,
+      "layers_to_transform": null,
+      "layers_pattern": null
+    },
+    "error_msg": ""
+  },
+  "train_info": {
+    "accelerator_memory_reserved_avg": 13316334288,
+    "accelerator_memory_max": 20126367744,
+    "accelerator_memory_reserved_99th": 18335399936,
+    "train_time": 1014.8198497519916,
+    "file_size": 2372944,
+    "num_trainable_params": 64,
+    "num_total_params": 3212749888,
+    "status": "success",
+    "metrics": [
+      {
+        "step": 250,
+        "valid accuracy": 0.0,
+        "train loss": 1.3195916001796721,
+        "train samples": 1000,
+        "train time": 29.320167769066757,
+        "eval time": 12.472152602000278,
+        "tokens / sec": 7220.934125191702,
+        "mem allocated avg": 6782729830.4,
+        "mem reserved avg": 13416806744.064,
+        "elapsed time": 62.99944108699856
+      },
+      {
+        "step": 500,
+        "valid accuracy": 0.0,
+        "train loss": 1.3382048671245574,
+        "train samples": 2000,
+        "train time": 29.643070286067086,
+        "eval time": 12.378917232999811,
+        "tokens / sec": 7016.648342859489,
+        "mem allocated avg": 6775546707.968,
+        "mem reserved avg": 13078989111.296,
+        "elapsed time": 107.84316255799786
+      },
+      {
+        "step": 750,
+        "valid accuracy": 0.0,
+        "train loss": 1.3136957421302795,
+        "train samples": 3000,
+        "train time": 30.28413043904584,
+        "eval time": 12.397852306006826,
+        "tokens / sec": 7079.648545020437,
+        "mem allocated avg": 6785373798.4,
+        "mem reserved avg": 13267313360.896,
+        "elapsed time": 153.33072755200556
+      },
+      {
+        "step": 1000,
+        "valid accuracy": 0.0,
+        "train loss": 1.3295996901988982,
+        "train samples": 4000,
+        "train time": 29.893614863831317,
+        "eval time": 12.44242364699312,
+        "tokens / sec": 6969.247478064906,
+        "mem allocated avg": 6776612499.456,
+        "mem reserved avg": 13325463191.552,
+        "elapsed time": 198.5323697959975
+      },
+      {
+        "step": 1250,
+        "valid accuracy": 0.0,
+        "train loss": 1.329271419763565,
+        "train samples": 5000,
+        "train time": 29.7562353319081,
+        "eval time": 12.420886085994425,
+        "tokens / sec": 7008.211814227093,
+        "mem allocated avg": 6776831610.88,
+        "mem reserved avg": 13364965146.624,
+        "elapsed time": 243.53589431100409
+      },
+      {
+        "step": 1500,
+        "valid accuracy": 0.0,
+        "train loss": 1.32270361495018,
+        "train samples": 6000,
+        "train time": 29.733648805966368,
+        "eval time": 12.510866166005144,
+        "tokens / sec": 7040.205572011584,
+        "mem allocated avg": 6778860009.472,
+        "mem reserved avg": 13277211918.336,
+        "elapsed time": 288.61189743199793
+      },
+      {
+        "step": 1750,
+        "valid accuracy": 0.0,
+        "train loss": 1.3246964557170868,
+        "train samples": 7000,
+        "train time": 29.924207624033443,
+        "eval time": 12.557893115998013,
+        "tokens / sec": 6996.175224765445,
+        "mem allocated avg": 6780314126.336,
+        "mem reserved avg": 13617286086.656,
+        "elapsed time": 333.9531167160021
+      },
+      {
+        "step": 2000,
+        "valid accuracy": 0.0,
+        "train loss": 1.3275963261127472,
+        "train samples": 8000,
+        "train time": 32.08173063819413,
+        "eval time": 12.476057071995456,
+        "tokens / sec": 6473.964959756022,
+        "mem allocated avg": 6776051113.984,
+        "mem reserved avg": 13300733575.168,
+        "elapsed time": 381.4403149379941
+      },
+      {
+        "step": 2250,
+        "valid accuracy": 0.0,
+        "train loss": 1.3165799739360808,
+        "train samples": 9000,
+        "train time": 30.135037008090876,
+        "eval time": 12.622973126999568,
+        "tokens / sec": 7132.82681359539,
+        "mem allocated avg": 6786442688.512,
+        "mem reserved avg": 13567432589.312,
+        "elapsed time": 427.01142006700684
+      },
+      {
+        "step": 2500,
+        "valid accuracy": 0.0,
+        "train loss": 1.332935559272766,
+        "train samples": 10000,
+        "train time": 29.332992679148447,
+        "eval time": 12.479970840009628,
+        "tokens / sec": 7021.683817021951,
+        "mem allocated avg": 6773380962.304,
+        "mem reserved avg": 13105488723.968,
+        "elapsed time": 471.6480772560026
+      },
+      {
+        "step": 2750,
+        "valid accuracy": 0.0,
+        "train loss": 1.3219903807640077,
+        "train samples": 11000,
+        "train time": 30.02839250290708,
+        "eval time": 12.423003805990447,
+        "tokens / sec": 7056.022062435995,
+        "mem allocated avg": 6782555439.104,
+        "mem reserved avg": 13428836007.936,
+        "elapsed time": 516.9036575339996
+      },
+      {
+        "step": 3000,
+        "valid accuracy": 0.0,
+        "train loss": 1.3261709277629852,
+        "train samples": 12000,
+        "train time": 29.508888696116628,
+        "eval time": 12.425764952000463,
+        "tokens / sec": 7073.495791370449,
+        "mem allocated avg": 6778509414.4,
+        "mem reserved avg": 13381465538.56,
+        "elapsed time": 561.7012977739942
+      },
+      {
+        "step": 3250,
+        "valid accuracy": 0.0,
+        "train loss": 1.3258510191440582,
+        "train samples": 13000,
+        "train time": 29.32331385197176,
+        "eval time": 12.37602518600761,
+        "tokens / sec": 7192.263502844805,
+        "mem allocated avg": 6781252022.272,
+        "mem reserved avg": 13241946210.304,
+        "elapsed time": 606.1447115960036
+      },
+      {
+        "step": 3500,
+        "valid accuracy": 0.0,
+        "train loss": 1.3274540011882783,
+        "train samples": 14000,
+        "train time": 29.492625459082774,
+        "eval time": 12.444265147001715,
+        "tokens / sec": 7111.947367690312,
+        "mem allocated avg": 6778363799.552,
+        "mem reserved avg": 13280340869.12,
+        "elapsed time": 650.959727473004
+      },
+      {
+        "step": 3750,
+        "valid accuracy": 0.0,
+        "train loss": 1.306462818145752,
+        "train samples": 15000,
+        "train time": 30.15356982103549,
+        "eval time": 12.43603616701148,
+        "tokens / sec": 7186.64494075343,
+        "mem allocated avg": 6789369143.296,
+        "mem reserved avg": 13572583194.624,
+        "elapsed time": 696.4128272789967
+      },
+      {
+        "step": 4000,
+        "valid accuracy": 0.0,
+        "train loss": 1.3445083932876587,
+        "train samples": 16000,
+        "train time": 29.836878458983847,
+        "eval time": 12.350287249006215,
+        "tokens / sec": 6849.677665877395,
+        "mem allocated avg": 6770480697.344,
+        "mem reserved avg": 13279736889.344,
+        "elapsed time": 741.4584507380059
+      },
+      {
+        "step": 4250,
+        "valid accuracy": 0.0,
+        "train loss": 1.3090761578083039,
+        "train samples": 17000,
+        "train time": 29.33308357889473,
+        "eval time": 12.378393848994165,
+        "tokens / sec": 7206.504540562358,
+        "mem allocated avg": 6782331011.072,
+        "mem reserved avg": 13263328772.096,
+        "elapsed time": 785.8608458889939
+      },
+      {
+        "step": 4500,
+        "valid accuracy": 0.0,
+        "train loss": 1.3359132213592528,
+        "train samples": 18000,
+        "train time": 29.127323688036995,
+        "eval time": 12.45233793699299,
+        "tokens / sec": 7134.81273548499,
+        "mem allocated avg": 6776620081.152,
+        "mem reserved avg": 13231770828.8,
+        "elapsed time": 830.2824437300005
+      },
+      {
+        "step": 4750,
+        "valid accuracy": 0.0,
+        "train loss": 1.3187625818252564,
+        "train samples": 19000,
+        "train time": 29.46111865786952,
+        "eval time": 12.408654205006314,
+        "tokens / sec": 7125.968380155927,
+        "mem allocated avg": 6779007021.056,
+        "mem reserved avg": 13310204313.6,
+        "elapsed time": 874.9263411550055
+      },
+      {
+        "step": 5000,
+        "valid accuracy": 0.0,
+        "train loss": 1.3322124259471892,
+        "train samples": 20000,
+        "train time": 29.690198107098695,
+        "eval time": 12.44290265199379,
+        "tokens / sec": 7015.109809934272,
+        "mem allocated avg": 6776081250.304,
+        "mem reserved avg": 13014782705.664,
+        "elapsed time": 919.8232776560035
+      },
+      {
+        "step": 5000,
+        "test accuracy": 0.001516300227445034,
+        "train loss": 1.3322124259471892,
+        "train samples": 20000,
+        "train total tokens": 4198051,
+        "forgetting": -0.37198925018310547
+      }
+    ]
+  },
+  "meta_info": {
+    "model_info": {
+      "sha": "13afe5124825b4f3751f836b40dafda64c1ed062",
+      "created_at": "2024-09-18T15:23:48+00:00"
+    },
+    "dataset_info": {
+      "metamath": {
+        "sha": "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18",
+        "created_at": "2023-09-21T17:22:46+00:00"
+      },
+      "gsm8k": {
+        "sha": "740312add88f781978c0658806c59bc2815b9866",
+        "created_at": "2022-04-12T10:22:10+00:00"
+      }
+    },
+    "package_info": {
+      "transformers-version": "5.5.4",
+      "transformers-commit-hash": null,
+      "peft-version": "0.19.0",
+      "peft-commit-hash": "6d5a6f4f2f902dbf13d21d2661d57c3c05df1dae",
+      "datasets-version": "4.2.0",
+      "datasets-commit-hash": null,
+      "bitsandbytes-version": "0.46.0",
+      "bitsandbytes-commit-hash": null,
+      "torch-version": "2.9.0+cu128",
+      "torch-commit-hash": null
+    },
+    "system_info": {
+      "system": "Linux",
+      "release": "6.17.0-1009-aws",
+      "version": "#9~24.04.2-Ubuntu SMP Fri Mar  6 23:50:29 UTC 2026",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "accelerator": "NVIDIA L40S"
+    },
+    "pytorch_info": "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX2\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 90.7.1\n    - Built with CuDNN 90.8\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=0fabc3ba44823f257e70ce397d989c8de5e362c1, CUDA_VERSION=12.8, CUDNN_VERSION=9.8.0, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"
+  }
+}


### PR DESCRIPTION
It seems that lily performs the best in the bunch.

TinyLoRA is, as discussed in the initial PR, using very limited parameter counts which explain the perfomrance in fully supervised training.

Quick glance at the results:

```
adamss--llama-3.2-3B-rank32.json:        "test accuracy": 0.3366186504927976,                                                                                                  
adamss--llama-3.2-3B-rank32.json:        "forgetting": 0.1917562484741211                       
                                                                               
lily--llama-3.2-3B-rank140-mlp-a2-b2-s8.0.json:        "test accuracy": 0.5489006823351024,                                                                                    
lily--llama-3.2-3B-rank140-mlp-a2-b2-s8.0.json:        "forgetting": -0.09576702117919922        
                                                                              
lily--llama-3.2-3B-rank896-a2-b2-s2.0.json:        "test accuracy": 0.4973464746019712,                                                                                        
lily--llama-3.2-3B-rank896-a2-b2-s2.0.json:        "forgetting": 0.5971565246582031                    
                                                                        
peanut--llama-3.2-3B-rank1-relu-depth0-s32.0.json:        "test accuracy": 0.39651250947687644,                                                                                
peanut--llama-3.2-3B-rank1-relu-depth0-s32.0.json:        "forgetting": 0.04330921173095703          
                                                                          
peanut--llama-3.2-3B-rank32-relu-depth0-s2.0.json:        "test accuracy": 0.4533737680060652,
peanut--llama-3.2-3B-rank32-relu-depth0-s2.0.json:        "forgetting": 0.3534202575683594               
                                                                      
prefixtuning--llama-3.2-3B-lr_0.005_zero_init.json:        "test accuracy": 0.36694465504169826,
prefixtuning--llama-3.2-3B-lr_0.005_zero_init.json:        "forgetting": 2.828566551208496

prefixtuning--llama-3.2-3B-tokens50-init_prefix-lr_0.005.json:        "test accuracy": 0.400303260045489,
prefixtuning--llama-3.2-3B-tokens50-init_prefix-lr_0.005.json:        "forgetting": 0.5316238403320312     
                                                                    
psoft--llama-3.2-3B-default.json:        "test accuracy": 0.4488248673237301,                  
psoft--llama-3.2-3B-default.json:        "forgetting": 0.5123701095581055                  

psoft--llama-3.2-3B-fast.json:        "test accuracy": 0.44351781652767247,      
psoft--llama-3.2-3B-fast.json:        "forgetting": 0.5018253326416016                                            
                                                             
pvera--llama-3.2-3B-default.json:        "test accuracy": 0.3305534495830174,                 
pvera--llama-3.2-3B-default.json:        "forgetting": 0.29680824279785156                 

tinylora--llama-3.2-3B-default.json:        "test accuracy": 0.009855951478392721,
tinylora--llama-3.2-3B-default.json:        "forgetting": -0.7508955001831055                                       
                                                           
tinylora--llama-3.2-3B-weight-tying.json:        "test accuracy": 0.001516300227445034,         
tinylora--llama-3.2-3B-weight-tying.json:        "forgetting": -0.37198925018310547         
```