### PR TITLE
fix: guard UPCAST_DTYPES lookup with hasattr to support older PyTorch

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -2167,8 +2167,8 @@ def cast_adapter_dtype(model: nn.Module, adapter_name: str, autocast_adapter_dty
     # Upcast lower precision floats like float8_e4m3fn; defensively only include dtypes that are actually found, as this
     # could depend on torch version and platform
     for name in UPCAST_DTYPES:
-        torch_dtype = getattr(torch, name)
-        dtypes_to_convert_to_fp32.add(torch_dtype)
+        if (torch_dtype := getattr(torch, name, None)) is not None:
+            dtypes_to_convert_to_fp32.add(torch_dtype)
 
     for module in model.modules():
         if not isinstance(module, BaseTunerLayer):


### PR DESCRIPTION
## Problem

Fixes #3158.

`cast_adapter_dtype` in `tuners_utils.py` iterates over `UPCAST_DTYPES` (which includes `float8_e8m0fnu`) and calls `getattr(torch, name)` unconditionally:

```python
for name in UPCAST_DTYPES:
    torch_dtype = getattr(torch, name)      # <-- crashes if dtype not in this torch version
    dtypes_to_convert_to_fp32.add(torch_dtype)
```

The comment directly above this code says *"defensively only include dtypes that are actually found, as this could depend on torch version and platform"*, but the code doesn't implement that defence.  On PyTorch 2.5.1 (stable), `torch.float8_e8m0fnu` does not exist, so any `get_peft_model` call with a quantized model crashes with:

```
AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'
```

## Fix

Use `getattr(torch, name, None)` with a `None` sentinel so unknown dtypes are silently skipped, matching the stated intent of the comment:

```python
for name in UPCAST_DTYPES:
    if (torch_dtype := getattr(torch, name, None)) is not None:
        dtypes_to_convert_to_fp32.add(torch_dtype)
```

This is a one-line behaviour change; the set only grows when the dtype actually exists in the running PyTorch installation.

## Testing

- Verified the diff is minimal: only the `getattr` / guard line changes.
- Reproducer from the issue: initialise a 4-bit quantised model with `get_peft_model` on PyTorch 2.5.1 — no longer crashes.