### PR TITLE
Fix C3ALinear.forward chaining active adapters through x instead of summing

### DIFF
--- a/src/peft/tuners/c3a/layer.py
+++ b/src/peft/tuners/c3a/layer.py
@@ -191,8 +191,8 @@ class C3ALinear(nn.Module, C3ALayer):
                 if active_adapter not in self.c3a_kernel.keys():
                     continue
                 c3a_kernel = self.c3a_kernel[active_adapter].to(torch.float32)
-                x = BlockCircularConvolution.apply(x, c3a_kernel) / x.size(-1)
-                result += x.to(result.dtype)
+                delta = BlockCircularConvolution.apply(x, c3a_kernel) / x.size(-1)
+                result += delta.to(result.dtype)
 
         result = result.to(previous_dtype)
         return result


### PR DESCRIPTION
## Bug

When more than one C3A adapter is active simultaneously, \`C3ALinear.forward\` feeds the **previous adapter's output** into the next adapter instead of feeding every adapter the original input. As a result, the unmerged forward pass produces a different value than the merged model for any multi-adapter configuration, and later adapters are spuriously applied on top of earlier adapters' low-rank outputs.

## Root cause

In the active branch of \`forward\` (in \`src/peft/tuners/c3a/layer.py\`):

\`\`\`python
result = self.base_layer(x, *args, **kwargs)
x = x.to(torch.float32)
for active_adapter in self.active_adapters:
    if active_adapter not in self.c3a_kernel.keys():
        continue
    c3a_kernel = self.c3a_kernel[active_adapter].to(torch.float32)
    x = BlockCircularConvolution.apply(x, c3a_kernel) / x.size(-1)
    result += x.to(result.dtype)
\`\`\`

The loop rebinds \`x\` to the current adapter's \`BlockCircularConvolution(x, kernel_A) / x.size(-1)\`. On the next iteration, that already-transformed \`x\` is passed into the next \`BlockCircularConvolution\`. For \`N\` active adapters the output becomes

\`\`\`
W0·x + A1(x) + A2(A1(x)) + A3(A2(A1(x))) + ...
\`\`\`

instead of the linear sum the merge path implements:

\`\`\`python
# merge():
base_layer.weight.data = base_layer.weight.data + delta_weight  # one adapter at a time
\`\`\`

which yields \`W0·x + A1(x) + A2(x) + … + An(x)\`. The unmerged and merged models therefore disagree whenever \`len(active_adapters) > 1\`, and the unmerged forward is incorrect on its own terms (each adapter should see the shared input, not the previous adapter's output).

## Fix

Bind the per-adapter contribution to a local \`delta\` instead of reassigning \`x\`, so every adapter sees the original \`x\`:

\`\`\`diff
-                x = BlockCircularConvolution.apply(x, c3a_kernel) / x.size(-1)
-                result += x.to(result.dtype)
+                delta = BlockCircularConvolution.apply(x, c3a_kernel) / x.size(-1)
+                result += delta.to(result.dtype)
\`\`\`

When at most one C3A adapter is active (the path covered by existing tests) behaviour is identical; for multiple active adapters it now matches the merged model.