### PR TITLE
FIX How to swapped in/out features for transposed

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2199,7 +2199,8 @@ class ParamWrapper(nn.Module, LoraLayer):
             raise ValueError(f"lora.{self.__class__.__name__} does not work with LoRA variants like DoRA.")
 
         # for some MoE layers, the order is (experts, out_features, in_features)
-        swap_in_out_features = getattr(self.get_base_layer(), "is_transposed", False)
+        is_transposed = getattr(self.get_base_layer(), "is_transposed", False)
+        swap_in_out_features = (self.get_param().ndim == 3) and not is_transposed
         if swap_in_out_features and not self._did_swap_in_out_features:
             self.in_features, self.out_features = self.out_features, self.in_features
             self._did_swap_in_out_features = True

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import re
 
 import packaging.version
@@ -108,10 +109,84 @@ class TestInitEmptyWeights:
         assert all(p.device == expected for p in mlp1.parameters())
 
 
+# TODO Remove this once patch_moe_parameter_targeting is removed from Transformers
+@pytest.fixture(params=[False, True], ids=["without_transformers_moe_patch", "with_transformers_moe_patch"])
+def _transformers_moe_patch(request):
+    """Parametrize tests over the MoE parameter-targeting patch being active/inactive.
+
+    The transformers patch `patch_moe_parameter_targeting` could hide a bug in PEFT when it comes to detecting the
+    correct in_features/out_features of a 3-dim MoE parameter. The patch is applied by transformers when their
+    `load_adapter` method is being called. Therefore, the order in which the tests were executed could hide or surface
+    the bug.
+
+    With this fixture, we ensure that each test is run twice, once without and once with the patch. At fixture exit,
+    the previous state is restored.
+
+    For details, see discussion in #3165
+
+    """
+    try:
+        from transformers.integrations.peft import patch_moe_parameter_targeting
+    except (ImportError, AttributeError):
+        patch_moe_parameter_targeting = None
+
+    should_patch = request.param
+
+    if should_patch and patch_moe_parameter_targeting is None:
+        pytest.skip(
+            "Transformers patch_moe_parameter_targeting no longer exists; skipping the 'patched' test variant."
+        )
+
+    is_patched = hasattr(lora.layer.ParamWrapper.update_layer, "__wrapped__")
+
+    # 4 cases:
+    # should_patch | is_patched
+    #         true |       true
+    #         true |      false
+    #        false |       true
+    #        false |      false
+
+    if should_patch is is_patched:
+        # agreement, nothing to do
+        yield
+        return
+
+    orig_update_layer = inspect.unwrap(lora.layer.ParamWrapper.update_layer)
+
+    def new_update_layer(layer, *args, **kwargs):
+        # this is copied 1:1 from transformers:
+        # https://github.com/huggingface/transformers/blob/bc7ee236fca35e771b6b393178a192add1469243/src/transformers/integrations/peft.py#L394-L401
+        did_swap = getattr(layer, "_did_swap_in_out_features", False)
+        if not did_swap and layer.parameter_name in ("down_proj", "gate_up_proj"):
+            tmp_in_features = layer.in_features
+            layer.in_features = layer.out_features
+            layer.out_features = tmp_in_features
+            layer._did_swap_in_out_features = True
+        return orig_update_layer(layer, *args, **kwargs)
+
+    if should_patch and not is_patched:
+        try:
+            lora.layer.ParamWrapper.update_layer = new_update_layer
+            yield
+        finally:
+            lora.layer.ParamWrapper.update_layer = orig_update_layer
+        return
+
+    if not should_patch and is_patched:
+        try:
+            lora.layer.ParamWrapper.update_layer = orig_update_layer
+            yield
+        finally:
+            lora.layer.ParamWrapper.update_layer = new_update_layer
+        return
+    # this is unreachable
+
+
 @pytest.mark.skipif(
     packaging.version.parse(transformers.__version__) < packaging.version.parse("5.4.0"),
     reason="PEFT weight conversion is fixed in transformers 5.4.0",
 )
+@pytest.mark.usefixtures("_transformers_moe_patch")  # TODO remove once patch_moe_parameter_targeting is removed
 class TestTransformersV5:
     """Unit tests intended to test proper working of PEFT with Transformers v5"""
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import inspect
 import re
 
@@ -119,8 +120,8 @@ def _transformers_moe_patch(request):
     `load_adapter` method is being called. Therefore, the order in which the tests were executed could hide or surface
     the bug.
 
-    With this fixture, we ensure that each test is run twice, once without and once with the patch. At fixture exit,
-    the previous state is restored.
+    With this fixture, we ensure that each test is run twice, once without and once with the patch. This should mirror
+    real world usage, where the patch may or may not be active. At fixture exit, the patch is always removed.
 
     For details, see discussion in #3165
 
@@ -138,19 +139,6 @@ def _transformers_moe_patch(request):
         )
 
     is_patched = hasattr(lora.layer.ParamWrapper.update_layer, "__wrapped__")
-
-    # 4 cases:
-    # should_patch | is_patched
-    #         true |       true
-    #         true |      false
-    #        false |       true
-    #        false |      false
-
-    if should_patch is is_patched:
-        # agreement, nothing to do
-        yield
-        return
-
     orig_update_layer = inspect.unwrap(lora.layer.ParamWrapper.update_layer)
 
     def new_update_layer(layer, *args, **kwargs):
@@ -164,20 +152,37 @@ def _transformers_moe_patch(request):
             layer._did_swap_in_out_features = True
         return orig_update_layer(layer, *args, **kwargs)
 
-    if should_patch and not is_patched:
+    # 4 cases:
+    # should_patch | is_patched
+    #         true |       true
+    #         true |      false
+    #        false |       true
+    #        false |      false
+
+    if not should_patch and not is_patched:
+        yield
+        return
+
+    if not should_patch and is_patched:
+        lora.layer.ParamWrapper.update_layer = orig_update_layer
+        yield
+        return
+
+    if should_patch and is_patched:
         try:
-            lora.layer.ParamWrapper.update_layer = new_update_layer
             yield
         finally:
             lora.layer.ParamWrapper.update_layer = orig_update_layer
         return
 
-    if not should_patch and is_patched:
+    if should_patch and not is_patched:
         try:
-            lora.layer.ParamWrapper.update_layer = orig_update_layer
+            lora.layer.ParamWrapper.update_layer = functools.wraps(lora.layer.ParamWrapper.update_layer)(
+                new_update_layer
+            )
             yield
         finally:
-            lora.layer.ParamWrapper.update_layer = new_update_layer
+            lora.layer.ParamWrapper.update_layer = orig_update_layer
         return
     # this is unreachable
 


### PR DESCRIPTION
When targeting 3-dim MoE parameters with LoRA, we need to check which dimenion corresponds to `in_features` and which to `out_features`. For this, we use the is_transposed attribute but the logic was actually the wrong way round. This PR fixes the issue.

In general, this reversal does not really matter because it means that first, we initialize the weight in the wrong shape and then we apply the wrong shape again the forward step, so the two errors cancel out. However, when loading a model that uses the correct shape, the errors don't cancel.

To test this, run this test which uses a v4 Qwen checkpoint:

`pytest tests/test_integrations.py -k test_qwen_v4_lora_weight_conversion_peft_model_from_pretrained`

Now we might wonder why the error wasn't discovered even though there is a corresponding test. The reason is that in transformers, there is a monkey patch for PEFT to invert the order (`patch_moe_parameter_targeting`). If this monkey patch is applied before the Qwen test runs, the test passes. In rare circumstances, owing to tests running in parallel, the patch might come too late and the test fails. This is why it is flaky in our CI.

To see this in action, run the tests like so:

`pytest tests/test_integrations.py -k "test_mixtral_v4_lora_weight_conversion_transformers_load_adapter or test_qwen_v4_lora_weight_conversion_peft_model_from_pretrained"`

The first test applies the patch and that makes the second test pass.

What this PR doesn't do is to add extra logic to recover checkpoints that were created with the incorrect shape. This is because the PEFT v0.19.0 release is just from yesterday and we plan to do a patch release tomorrow. So the time window should be very small for incorrect checkpoints to be created. And even if they exist, they can be fixed without too much effort.

Regarding testing, this is not quite trivial to check, as it relies on test order. Therefore, I added a pytest fixture that makes each test run twice, once with the test applied and once without. After adding this fixture, the `test_qwen_v4_lora_weight_conversion_peft_model_from_pretrained` will reliably fail without the fix.