### PR TITLE
Use _cast_input_dtype in FourierFTLinear.forward

### DIFF
--- a/src/peft/tuners/fourierft/layer.py
+++ b/src/peft/tuners/fourierft/layer.py
@@ -182,7 +182,7 @@ class FourierFTLinear(nn.Module, FourierFTLayer):
                     continue
 
                 delta_w = self.get_delta_weight(active_adapter)
-                x = x.to(delta_w.dtype)
+                x = self._cast_input_dtype(x, delta_w.dtype)
                 result = result + F.linear(x, delta_w)
 
         result = result.to(previous_dtype)


### PR DESCRIPTION
## Bug

`FourierFTLinear.forward` in `src/peft/tuners/fourierft/layer.py` casts the input to the adapter's dtype with a raw `x.to(delta_w.dtype)`:

```python
for active_adapter in self.active_adapters:
    if active_adapter not in self.fourierft_spectrum.keys():
        continue

    delta_w = self.get_delta_weight(active_adapter)
    x = x.to(delta_w.dtype)                        # <- raw cast
    result = result + F.linear(x, delta_w)
```

This bypasses `BaseTunerLayer._cast_input_dtype`, which is the method that consults `cast_input_dtype_enabled` (toggled by the `peft.helpers.disable_lora_input_dtype_casting` context manager introduced in #2353 and generalized to non-LoRA tuners in #2433).

## Root cause

\#2433 consolidated dtype handling across additive tuners onto `self._cast_input_dtype`. Every comparable tuner's forward uses the helper:

- `lora/layer.py:967` — `x = self._cast_input_dtype(x, lora_A.weight.dtype)`
- `waveft/layer.py:283` — `x = self._cast_input_dtype(x, delta_w.dtype)`
- `hra/layer.py:260, 445` — `x = self._cast_input_dtype(x, new_weight.dtype)`
- `psoft/layer.py:447` — `x_cast = self._cast_input_dtype(x, A.dtype)`

FourierFT was missed in that sweep, so toggling `disable_lora_input_dtype_casting` silently has no effect on FourierFT layers — the cast still happens unconditionally.

## Fix

Route the cast through `self._cast_input_dtype` to match the established pattern. Behavior is identical when the casting context manager is not used (both call `x.to(dtype)`); the difference is that users can now opt out as documented.