### PR TITLE
Resolve #2944: ensure_weight_tying respects config + improved tests

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1657,9 +1657,8 @@ def _get_module_names_tied_with_embedding(model) -> list[str]:
     to the base model anyway. Non-transformer models have to provide a `_tied_weights_keys` attribute for this function
     to work.
 
-    Note that this function will not check if weight tying is disabled by the model's config. There can be the case
-    that the weight tying definition is present but the tying is disabled via `model_config.tie_word_embeddings=False`.
-    You have to check that yourself.
+    If the model's config has `tie_word_embeddings` set to `False`, this function returns an empty list, as weight
+    tying is explicitly disabled for that model checkpoint.
     """
     tied_weights: list[str] = []
 
@@ -1670,6 +1669,16 @@ def _get_module_names_tied_with_embedding(model) -> list[str]:
     if hasattr(model, "tuner_layer_cls"):
         # unpack BaseTuner
         model = model.model
+
+    # `_tied_weights_keys` is architectural capability; `tie_word_embeddings=False` means tying is
+    # explicitly disabled for this checkpoint and must be respected.
+    model_config = getattr(model, "config", None)
+    if (
+        model_config is not None
+        and hasattr(model_config, "tie_word_embeddings")
+        and getattr(model_config, "tie_word_embeddings") is False
+    ):
+        return []
 
     if not hasattr(model, "_tied_weights_keys"):
         return []

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -5442,10 +5442,15 @@ class TestWeightTying:
         else:
             assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
 
+        assert (
+            model.base_model.model.model.embed_tokens.weight.data_ptr()
+            != model.base_model.model.lm_head.weight.data_ptr()
+        )
+
     @pytest.mark.parametrize("target_modules", [["lm_head"], ["embed_tokens"], ["lm_head", "embed_tokens"]])
     def test_ensure_weight_tying_not_tying_when_model_config_tie_false_target_modules(self, target_modules):
         # When tie_word_embeddings=False, ensure_weight_tying=True should not tie weights.
-        # Regression test for issue #2944 targeting target_modules flow
+        # Regression test for issue #2944
         model = self.get_lm_model(tie_weights=True, config_tie_word_embeddings=False)
         config = LoraConfig(
             target_modules=["linear"] + target_modules,
@@ -5464,3 +5469,12 @@ class TestWeightTying:
             assert isinstance(model.base_model.model.lm_head, LoraLayer)
         else:
             assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
+
+        if set(target_modules) == {"embed_tokens", "lm_head"}:
+            adapter_name = "default"
+            embed_lora_A = model.base_model.model.model.embed_tokens.lora_embedding_A[adapter_name]
+            embed_lora_B = model.base_model.model.model.embed_tokens.lora_embedding_B[adapter_name]
+            lm_lora_A = model.base_model.model.lm_head.lora_A[adapter_name].weight
+            lm_lora_B = model.base_model.model.lm_head.lora_B[adapter_name].weight
+            assert embed_lora_A.data_ptr() != lm_lora_B.data_ptr()
+            assert embed_lora_B.data_ptr() != lm_lora_A.data_ptr()

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -5027,14 +5027,23 @@ class TestWeightTying:
                 self.embed_tokens = nn.Embedding(1000, 1000)
                 self.linear = nn.Linear(1000, 1000, bias=False)
 
+        # Config object
+        class ModelConfig:
+            def __init__(self, tie_word_embeddings):
+                self.tie_word_embeddings = tie_word_embeddings
+
+            def to_dict(self):
+                return {"tie_word_embeddings": self.tie_word_embeddings}
+
         class CausalLM(nn.Module):
-            if tie_weights:
-                _tied_weights_keys = ["lm_head.weight"]
+            # _tied_weights_keys on class-level architectural
+            # so it exists regardless of whether tying is actually enabled
+            _tied_weights_keys = ["lm_head.weight"]
 
             def __init__(self):
                 super().__init__()
                 self.model = MyModule()
-                self.config = {"tie_word_embeddings": tie_weights}
+                self.config = ModelConfig(tie_word_embeddings=tie_weights)  # Updated Config Object!
                 self.lm_head = nn.Linear(1000, 1000, bias=False)
 
                 if tie_weights:
@@ -5063,18 +5072,26 @@ class TestWeightTying:
                 self.encoder = Seq2SeqStack()
                 self.decoder = Seq2SeqStack()
 
+        class ModelConfig:
+            def __init__(self, tie_word_embeddings):
+                self.tie_word_embeddings = tie_word_embeddings
+
+            def to_dict(self):
+                return {"tie_word_embeddings": self.tie_word_embeddings}
+
         class Seq2SeqLM(nn.Module):
-            if tie_weights:
-                _tied_weights_keys = {
-                    "model.encoder.embed_tokens.weight": "model.shared.weight",
-                    "model.decoder.embed_tokens.weight": "model.shared.weight",
-                    "lm_head.weight": "model.shared.weight",
-                }
+            # _tied_weights_keys on class-level architectural
+            # so it exists regardless of whether tying is actually enabled
+            _tied_weights_keys = {
+                "model.encoder.embed_tokens.weight": "model.shared.weight",
+                "model.decoder.embed_tokens.weight": "model.shared.weight",
+                "lm_head.weight": "model.shared.weight",
+            }
 
             def __init__(self):
                 super().__init__()
                 self.model = MySeq2SeqModule()
-                self.config = {"tie_word_embeddings": tie_weights}
+                self.config = ModelConfig(tie_word_embeddings=tie_weights)
                 self.lm_head = nn.Linear(1000, 1000, bias=False)
 
                 if tie_weights:
@@ -5395,3 +5412,60 @@ class TestWeightTying:
         assert isinstance(model.base_model.model.model.encoder.embed_tokens, torch.nn.modules.sparse.Embedding)
         assert isinstance(model.base_model.model.model.decoder.embed_tokens, torch.nn.modules.sparse.Embedding)
         assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
+
+    @pytest.mark.parametrize("modules_to_save", [["lm_head"], ["embed_tokens"], ["lm_head", "embed_tokens"]])
+    def test_ensure_weight_tying_not_tying_when_model_config_tie_false(self, modules_to_save):
+        # When tie_word_embeddings=False, ensure_weight_tying=True should not tie weights.
+        # Regression test for issue #2944
+        model = self.get_lm_model(tie_weights=False)
+        config = LoraConfig(
+            modules_to_save=modules_to_save,
+            target_modules=["linear"],
+            ensure_weight_tying=True,
+        )
+
+        with pytest.warns(UserWarning, match="no tied modules were found in the model"):
+            model = get_peft_model(model, config)
+
+        if "embed_tokens" in modules_to_save:
+            assert isinstance(model.base_model.model.model.embed_tokens, ModulesToSaveWrapper)
+        else:
+            assert isinstance(model.base_model.model.model.embed_tokens, torch.nn.modules.Embedding)
+
+        if "lm_head" in modules_to_save:
+            assert isinstance(model.base_model.model.lm_head, ModulesToSaveWrapper)
+        else:
+            assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
+
+        # weights must NOT share memory (they should be separate)
+        embed_ptr = model.base_model.model.model.embed_tokens.weight.data_ptr()
+        lm_head_ptr = model.base_model.model.lm_head.weight.data_ptr()
+        assert embed_ptr != lm_head_ptr
+
+    @pytest.mark.parametrize("target_modules", [["lm_head"], ["embed_tokens"], ["lm_head", "embed_tokens"]])
+    def test_ensure_weight_tying_not_tying_when_model_config_tie_false_target_modules(self, target_modules):
+        # When tie_word_embeddings=False, ensure_weight_tying=True should not tie weights.
+        # Regression test for issue #2944 targeting target_modules flow
+        model = self.get_lm_model(tie_weights=False)
+        config = LoraConfig(
+            target_modules=["linear"] + target_modules,  # Passing to target_module
+            ensure_weight_tying=True,
+        )
+
+        with pytest.warns(UserWarning, match="no tied modules were found in the model"):
+            model = get_peft_model(model, config)
+
+        if "embed_tokens" in target_modules:
+            assert isinstance(model.base_model.model.model.embed_tokens, LoraLayer)
+        else:
+            assert isinstance(model.base_model.model.model.embed_tokens, torch.nn.modules.Embedding)
+
+        if "lm_head" in target_modules:
+            assert isinstance(model.base_model.model.lm_head, LoraLayer)
+        else:
+            assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
+
+        # weights must NOT share memory (they should be separate)
+        embed_ptr = model.base_model.model.model.embed_tokens.weight.data_ptr()
+        lm_head_ptr = model.base_model.model.lm_head.weight.data_ptr()
+        assert embed_ptr != lm_head_ptr

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -5017,9 +5017,13 @@ class TestWeightTying:
 
     torch_device = infer_device()
 
-    def get_lm_model(self, tie_weights=True):
+    def get_lm_model(self, tie_weights=True, config_tie_word_embeddings=None):
         # Mimicking a LM with embed_tokens and lm_head layers
         # to test weight tying of adapters
+
+        if config_tie_word_embeddings is None:
+            config_tie_word_embeddings = tie_weights
+
         class MyModule(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -5027,7 +5031,6 @@ class TestWeightTying:
                 self.embed_tokens = nn.Embedding(1000, 1000)
                 self.linear = nn.Linear(1000, 1000, bias=False)
 
-        # Config object
         class ModelConfig:
             def __init__(self, tie_word_embeddings):
                 self.tie_word_embeddings = tie_word_embeddings
@@ -5036,14 +5039,13 @@ class TestWeightTying:
                 return {"tie_word_embeddings": self.tie_word_embeddings}
 
         class CausalLM(nn.Module):
-            # _tied_weights_keys on class-level architectural
-            # so it exists regardless of whether tying is actually enabled
-            _tied_weights_keys = ["lm_head.weight"]
+            if tie_weights:
+                _tied_weights_keys = ["lm_head.weight"]
 
             def __init__(self):
                 super().__init__()
                 self.model = MyModule()
-                self.config = ModelConfig(tie_word_embeddings=tie_weights)  # Updated Config Object!
+                self.config = ModelConfig(tie_word_embeddings=config_tie_word_embeddings)
                 self.lm_head = nn.Linear(1000, 1000, bias=False)
 
                 if tie_weights:
@@ -5057,8 +5059,12 @@ class TestWeightTying:
 
         return CausalLM().eval().to(self.torch_device)
 
-    def get_seq2seq_lm_model(self, tie_weights=True):
+    def get_seq2seq_lm_model(self, tie_weights=True, config_tie_word_embeddings=None):
         # Mimicking a encoder-decoder LM with shared embeddings
+
+        if config_tie_word_embeddings is None:
+            config_tie_word_embeddings = tie_weights
+
         class Seq2SeqStack(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -5080,18 +5086,17 @@ class TestWeightTying:
                 return {"tie_word_embeddings": self.tie_word_embeddings}
 
         class Seq2SeqLM(nn.Module):
-            # _tied_weights_keys on class-level architectural
-            # so it exists regardless of whether tying is actually enabled
-            _tied_weights_keys = {
-                "model.encoder.embed_tokens.weight": "model.shared.weight",
-                "model.decoder.embed_tokens.weight": "model.shared.weight",
-                "lm_head.weight": "model.shared.weight",
-            }
+            if tie_weights:
+                _tied_weights_keys = {
+                    "model.encoder.embed_tokens.weight": "model.shared.weight",
+                    "model.decoder.embed_tokens.weight": "model.shared.weight",
+                    "lm_head.weight": "model.shared.weight",
+                }
 
             def __init__(self):
                 super().__init__()
                 self.model = MySeq2SeqModule()
-                self.config = ModelConfig(tie_word_embeddings=tie_weights)
+                self.config = ModelConfig(tie_word_embeddings=config_tie_word_embeddings)
                 self.lm_head = nn.Linear(1000, 1000, bias=False)
 
                 if tie_weights:
@@ -5417,7 +5422,7 @@ class TestWeightTying:
     def test_ensure_weight_tying_not_tying_when_model_config_tie_false(self, modules_to_save):
         # When tie_word_embeddings=False, ensure_weight_tying=True should not tie weights.
         # Regression test for issue #2944
-        model = self.get_lm_model(tie_weights=False)
+        model = self.get_lm_model(tie_weights=True, config_tie_word_embeddings=False)
         config = LoraConfig(
             modules_to_save=modules_to_save,
             target_modules=["linear"],
@@ -5437,18 +5442,13 @@ class TestWeightTying:
         else:
             assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
 
-        # weights must NOT share memory (they should be separate)
-        embed_ptr = model.base_model.model.model.embed_tokens.weight.data_ptr()
-        lm_head_ptr = model.base_model.model.lm_head.weight.data_ptr()
-        assert embed_ptr != lm_head_ptr
-
     @pytest.mark.parametrize("target_modules", [["lm_head"], ["embed_tokens"], ["lm_head", "embed_tokens"]])
     def test_ensure_weight_tying_not_tying_when_model_config_tie_false_target_modules(self, target_modules):
         # When tie_word_embeddings=False, ensure_weight_tying=True should not tie weights.
         # Regression test for issue #2944 targeting target_modules flow
-        model = self.get_lm_model(tie_weights=False)
+        model = self.get_lm_model(tie_weights=True, config_tie_word_embeddings=False)
         config = LoraConfig(
-            target_modules=["linear"] + target_modules,  # Passing to target_module
+            target_modules=["linear"] + target_modules,
             ensure_weight_tying=True,
         )
 
@@ -5464,8 +5464,3 @@ class TestWeightTying:
             assert isinstance(model.base_model.model.lm_head, LoraLayer)
         else:
             assert isinstance(model.base_model.model.lm_head, torch.nn.modules.linear.Linear)
-
-        # weights must NOT share memory (they should be separate)
-        embed_ptr = model.base_model.model.model.embed_tokens.weight.data_ptr()
-        lm_head_ptr = model.base_model.model.lm_head.weight.data_ptr()
-        assert embed_ptr != lm_head_ptr

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -634,6 +634,18 @@ class TestGetModuleNamesTiedWithEmbedding:
 
             assert expected == modules
 
+    @pytest.mark.parametrize("tied_weights_type", ["list", "mapping"])
+    @pytest.mark.parametrize("model_id", model_ids)
+    def test_get_modules_tied_returns_empty_when_tying_disabled(self, model_id, tied_weights_type):
+        # When tie_word_embeddings=False, no tied modules should be reported even if _tied_weights_keys exists
+        # Linked to origin issue #2944
+        with self.patch_model(model_id, tied_weights_type) as (model, _):
+            # Model has _tied_weights_keys (architectural capability) but tying is disabled
+            model.config.tie_word_embeddings = False
+
+            modules = _get_module_names_tied_with_embedding(model)
+            assert modules == []
+
 
 # TODO for PEFT 0.20 remove this
 class TestLoftQDeprecation:


### PR DESCRIPTION
@romitjain and @BenjaminBossan sir, As I said in #3148 PR get messed up so start again from fresh and raise this New PR solving the issue https://github.com/huggingface/peft/issues/2944 with following the suggestions on test cases.


As I described in #3148 
> Updated _get_module_names_tied_with_embedding() in `src/peft/utils/other.py` to respect `model.config.tie_word_embeddings`. Previously, the function read` _tied_weights_key`s a class-level architectural attribute  without checking the instance-level config flag, causing embeddings to be incorrectly tied even when `tie_word_embeddings=False`
>### Problem
>When `ensure_weight_tying=True` in `LoraConfig`, PEFT ties `embed_tokens` and `lm_head` weights 
even when the model's config has `tie_word_embeddings=False`. This happens because 
`_get_module_names_tied_with_embedding()` returns tied module names based on the class-level 
`_tied_weights_keys` attribute (architectural capability) without checking the instance-level 
`tie_word_embeddings` config (actual tying state).
>### Fix
> Added a guard in `_get_module_names_tied_with_embedding()` in `src/peft/utils/other.py` that 
returns an empty list when `model.config.tie_word_embeddings` is explicitly `False`. This is 
the correct layer to fix because:
> - The function has multiple callers; fixing it here protects all of them
>  - `_tied_weights_keys` is a class-level declaration of capability, not configuration
>- Other callers already had their own `tie_word_embeddings` guards, but `_check_tied_modules()` 
>-  `tuners_utils.py` did not — this fix makes the utility function self-consistent

**Use the same code update in `other.py` that were previously verified in #3148 .**

### Coming to the main concern: Improvised test cases
* **Refactored the Mock Configurations:** Updated `get_lm_model` and `get_seq2seq_lm_model` to instantiate an actual `ModelConfig` class object instead of a basic dictionary. I also included a `.to_dict()` method because PEFT tuners naturally expect this mapping when evaluating configuration attributes internally. This perfectly mimics the behavior of native HF Transformers objects.
* **Added Explicit `target_modules` Test Flow:** Just as requested, I added `test_ensure_weight_tying_not_tying_when_model_config_tie_false_target_modules`. This specifically evaluates what happens when `"lm_head"` and `"embed_tokens"` are injected into `target_modules` instead of `modules_to_save`.
* **Validated Memory Separation:** The new test accurately confirms that PEFT issues a correct warning safely, initializes `LoraLayers` respectively instead of `ModulesToSaveWrappers`, and uses assertion checks (`embed_ptr != lm_head_ptr`) to strongly verify that the weights remain explicitly untied in memory. 
* **Verified Robust Feature Isolation:** `_get_module_names_tied_with_embedding` perfectly skips the tying procedure when `model_config.tie_word_embeddings=False` is set globally.

### Output of bug reproduction script from issue #2944:
```python
from peft import LoraConfig, get_peft_model
from transformers import AutoModelForCausalLM

model_name = "Isotonic/TinyMixtral-4x248M-MoE"
device = "cuda:0"

model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device)
print(f"Is weight tying enabled?: {model.config.tie_word_embeddings}")

if not model.config.tie_word_embeddings:
    emb = model.get_input_embeddings()
    lm = model.get_output_embeddings()
    assert emb.weight.data_ptr() != lm.weight.data_ptr()
    print("Loaded model does not have tied embeddings")

modules_to_save = ["embed_tokens"]
target_modules = ["q_proj"]

lora_cfg = LoraConfig(
    modules_to_save=modules_to_save,
    target_modules=target_modules,
    task_type="CAUSAL_LM",
    ensure_weight_tying=True
)

model = get_peft_model(model, lora_cfg)

if not model.config.tie_word_embeddings:
    emb = model.get_input_embeddings()
    lm = model.get_output_embeddings()
    assert emb.weight.data_ptr() != lm.weight.data_ptr(), "PEFT model has tied embeddings"
    print("PEFT model does not have tied embeddings")
```

**Output before code updates:** 

```bash
Loading weights: 100%
Is weight tying enabled?: False
Loaded model does not have tied embeddings
Traceback (most recent call last):
  File "D:\peft\temp-testing\test.py", line 31, in <module>
    assert emb.weight.data_ptr() != lm.weight.data_ptr(), "PEFT model has tied embeddings"
AssertionError: PEFT model has tied embeddings
```

**Output after code updates:**

```python
Loading weights: 100% | 111/111 [00:13<00:00,  8.00it/s]
Is weight tying enabled?: False
Loaded model does not have tied embeddings
D:\peft\src\peft\tuners\tuners_utils.py:1337: UserWarning: You have requested `ensure_weight_tying`, but no tied modules were found in the model
  warnings.warn("You have requested `ensure_weight_tying`, but no tied modules were found in the model")
PEFT model does not have tied embeddings
```

### Tests logs after updates

```bash
(.venv) PS D:\peft> python -m pytest tests/test_other.py -k "TestGetModuleNamesTiedWithEmbedding" -v
========================================================================== test session starts ==========================================================================
platform win32 -- Python 3.12.0, pytest-9.0.3, pluggy-1.6.0 -- D:\peft\.venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: D:\peft
configfile: pyproject.toml
plugins: anyio-4.13.0, cov-7.1.0, xdist-3.8.0
collected 43 items / 25 deselected / 18 selected                                                                                                                         

tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/opt-125m-list] PASSED                           [  5%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/opt-125m-mapping] PASSED                        [ 11%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/tiny-random-BertModel-list] PASSED              [ 16%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_to_embedding[peft-internal-testing/tiny-random-BertModel-mapping] PASSED           [ 22%]
...
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/tiny-random-BertModel-list] PASSED [ 83%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/tiny-random-BertModel-mapping] PASSED [ 88%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/tiny-random-t5-list] PASSED [ 94%]
tests/test_other.py::TestGetModuleNamesTiedWithEmbedding::test_get_modules_tied_returns_empty_when_tying_disabled[peft-internal-testing/tiny-random-t5-mapping] PASSED [100%]

====================== 18 passed, 25 deselected, 2 warnings in 24.34s =========================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
Exception ignored in: <function ResourceTracker.__del__ at 0x000001A1AF839EE0>
Traceback (most recent call last):
  File "D:\peft\.venv\Lib\site-packages\multiprocess\resource_tracker.py", line 80, in __del__
  File "D:\peft\.venv\Lib\site-packages\multiprocess\resource_tracker.py", line 89, in _stop
  File "D:\peft\.venv\Lib\site-packages\multiprocess\resource_tracker.py", line 102, in _stop_locked
AttributeError: '_thread.RLock' object has no attribute '_recursion_count'
```
```bash
(.venv) PS D:\peft> python -m pytest tests/test_initialization.py::TestWeightTying -v
============= test session starts ==============
platform win32 -- Python 3.12.0, pytest-9.0.3, pluggy-1.6.0 -- D:\peft\.venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: D:\peft
configfile: pyproject.toml
plugins: anyio-4.13.0, cov-7.1.0, xdist-3.8.0
collected 40 items                                                                                                            
tests/test_initialization.py::TestWeightTying::test_weight_tying_tied_model_lora[modules_to_save0] PASSED                [  2%]
tests/test_initialization.py::TestWeightTying::test_weight_tying_tied_model_lora[modules_to_save1] PASSED                [  5%]
tests/test_initialization.py::TestWeightTying::test_weight_tying_tied_model_lora[modules_to_save2] PASSED                [  7%]
tests/test_initialization.py::TestWeightTying::test_alt_weight_tying_tied_model_lora[modules_to_save0-True] PASSED       [ 10%]
...
tests/test_initialization.py::TestWeightTying::test_weight_tying_enc_dec_modules_to_save_lora[modules_to_save0] PASSED   [ 65%]
tests/test_initialization.py::TestWeightTying::test_weight_tying_enc_dec_modules_to_save_lora[modules_to_save1] PASSED   [ 67%]
tests/test_initialization.py::TestWeightTying::test_weight_tying_enc_dec_no_tied_module_targeted_warns[target_modules1] PASSED [ 82%]
tests/test_initialization.py::TestWeightTying::test_weight_tying_enc_dec_no_tied_module_targeted_warns[target_modules2] PASSED [ 85%]
tests/test_initialization.py::TestWeightTying::test_ensure_weight_tying_not_tying_when_model_config_tie_false[modules_to_save0] PASSED [ 87%]
tests/test_initialization.py::TestWeightTying::test_ensure_weight_tying_not_tying_when_model_config_tie_false[modules_to_save1] PASSED [ 90%]
tests/test_initialization.py::TestWeightTying::test_ensure_weight_tying_not_tying_when_model_config_tie_false[modules_to_save2] PASSED [ 92%]
tests/test_initialization.py::TestWeightTying::test_ensure_weight_tying_not_tying_when_model_config_tie_false_target_modules[target_modules0] PASSED [ 95%]
tests/test_initialization.py::TestWeightTying::test_ensure_weight_tying_not_tying_when_model_config_tie_false_target_modules[target_modules1] PASSED [ 97%]
tests/test_initialization.py::TestWeightTying::test_ensure_weight_tying_not_tying_when_model_config_tie_false_target_modules[target_modules2] PASSED [100%]
====================== 40 passed, 3 warnings in 15.90s =======================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
Exception ignored in: <function ResourceTracker.__del__ at 0x0000015DA3A14C20>
Traceback (most recent call last):
  File "D:\peft\.venv\Lib\site-packages\multiprocess\resource_tracker.py", line 80, in __del__
  File "D:\peft\.venv\Lib\site-packages\multiprocess\resource_tracker.py", line 89, in _stop
  File "D:\peft\.venv\Lib\site-packages\multiprocess\resource_tracker.py", line 102, in _stop_locked
AttributeError: '_thread.RLock' object has no attribute '_recursion_count'
```
```bash
(.venv) PS D:\peft> ruff check --fix src tests
All checks passed!
(.venv) PS D:\peft> ruff format src tests
2 files reformatted, 273 files left unchanged
(.venv) PS D:\peft> ruff check src tests      
All checks passed!
(.venv) PS D:\peft> ruff format .
6 files reformatted, 375 files left unchanged
(.venv) PS D:\peft> git commit -m "Resolve #2944: ensure_weight_tying respects config + improved tests"
[WARNING] Unstaged files detected. (Changed due to ruff format!)
[INFO] Stashing unstaged files to C:\Users\Babu\.cache\pre-commit\patch1776420540-6068.
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
check for merge conflicts................................................Passed
check yaml...........................................(no files to check)Skipped
[INFO] Restored changes from C:\Users\Babu\.cache\pre-commit\patch1776420540-6068.
[Adya/weight-tying-config 399e55a] Resolve #2944: ensure_weight_tying respects config + improved tests
 3 files changed, 108 insertions(+), 13 deletions(-)
```

> ### sorry for earlier PR mess!