### PR TITLE
Use _cast_input_dtype in vera Linear.forward

### DIFF
--- a/src/peft/tuners/vera/layer.py
+++ b/src/peft/tuners/vera/layer.py
@@ -280,7 +280,7 @@ class Linear(nn.Linear, VeraLayer):
                 sliced_B = vera_B[: self.out_features, :].to(x.device)
 
                 dropout = self.vera_dropout[active_adapter]
-                x = x.to(lambda_d.dtype)
+                x = self._cast_input_dtype(x, lambda_d.dtype)
                 result = result + lambda_b * F.linear(lambda_d * F.linear(dropout(x), sliced_A), sliced_B)
 
         result = result.to(previous_dtype)


### PR DESCRIPTION
## Bug

`Linear.forward` in `src/peft/tuners/vera/layer.py:283` casts the input to the adapter's dtype with a raw `x.to(lambda_d.dtype)`:

```python
dropout = self.vera_dropout[active_adapter]
x = x.to(lambda_d.dtype)
result = result + lambda_b * F.linear(lambda_d * F.linear(dropout(x), sliced_A), sliced_B)
```

This bypasses `BaseTunerLayer._cast_input_dtype`, which is the method that consults `cast_input_dtype_enabled` (toggled by the `peft.helpers.disable_lora_input_dtype_casting` context manager introduced in #2353 and generalized to non-LoRA tuners in #2433).

## Root cause

\#2433 consolidated dtype handling across additive tuners onto `self._cast_input_dtype`. Every comparable tuner's forward uses the helper:

- `lora/layer.py:967` — `x = self._cast_input_dtype(x, lora_A.weight.dtype)`
- `fourierft/layer.py:183` (after #3170)
- `waveft/layer.py:283` — `x = self._cast_input_dtype(x, delta_w.dtype)`
- `psoft/layer.py:447` — `x_cast = self._cast_input_dtype(x, A.dtype)`
- `hra/layer.py:260, 445` — `x = self._cast_input_dtype(x, new_weight.dtype)`

VeRA was missed in that sweep, so toggling `disable_lora_input_dtype_casting` silently has no effect on VeRA layers — the cast still happens unconditionally.

## Fix

Route the cast through `self._cast_input_dtype` to match the established pattern. Behavior is identical when the context manager is not used (both call `x.to(dtype)`); the difference is that users can now opt out as documented.