### PR TITLE
feat(tuners): suggest valid target modules when resolution fails (LoRA)

### DIFF
--- a/src/peft/tuners/ia3/__init__.py
+++ b/src/peft/tuners/ia3/__init__.py
@@ -18,6 +18,7 @@ from peft.utils import register_peft_method
 from .config import IA3Config
 from .layer import Conv2d, Conv3d, IA3Layer, Linear
 from .model import IA3Model
+from . import candidate_collector  # noqa: F401  # registers IA3 collector stub via decorator
 
 
 __all__ = ["Conv2d", "Conv3d", "IA3Config", "IA3Layer", "IA3Model", "Linear"]

--- a/src/peft/tuners/ia3/candidate_collector.py
+++ b/src/peft/tuners/ia3/candidate_collector.py
@@ -1,0 +1,29 @@
+# Copyright 2026-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IA3 candidate enumerator. STUB. Returns empty until implemented.
+
+TODO: implement candidate enumeration for IA3. The function should yield
+full module names that IA3 could validly adapt. IA3 has a feedforward vs
+attention distinction (see PR #3154 comment 4250868072) which is out of
+scope for the initial draft and should be addressed in a follow-up PR.
+"""
+
+from peft.tuners.target_suggester import register_candidate_collector
+
+
+@register_candidate_collector("IA3")
+def ia3_candidates(model):
+    """Yield full module names that IA3 could validly adapt. STUB."""
+    return iter(())

--- a/src/peft/tuners/loha/candidate_collector.py
+++ b/src/peft/tuners/loha/candidate_collector.py
@@ -1,4 +1,4 @@
-# Copyright 2023-present the HuggingFace Inc. team.
+# Copyright 2026-present the HuggingFace Inc. team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from peft.utils import register_peft_method
+"""LoHa candidate enumerator. STUB. Returns empty until implemented.
 
-from .config import LoHaConfig
-from .layer import Conv2d, Linear, LoHaLayer
-from .model import LoHaModel
-from . import candidate_collector  # noqa: F401  # registers LoHa collector stub via decorator
+TODO: implement candidate enumeration for LoHa. The function should yield
+full module names that LoHa could validly adapt. See lora/candidate_collector.py
+for the implemented LoRA pattern.
+"""
+
+from peft.tuners.target_suggester import register_candidate_collector
 
 
-__all__ = ["Conv2d", "Linear", "LoHaConfig", "LoHaLayer", "LoHaModel"]
-
-register_peft_method(name="loha", config_cls=LoHaConfig, model_cls=LoHaModel, prefix="hada_", is_mixed_compatible=True)
+@register_candidate_collector("LOHA")
+def loha_candidates(model):
+    """Yield full module names that LoHa could validly adapt. STUB."""
+    return iter(())

--- a/src/peft/tuners/lokr/__init__.py
+++ b/src/peft/tuners/lokr/__init__.py
@@ -17,6 +17,7 @@ from peft.utils import register_peft_method
 from .config import LoKrConfig
 from .layer import Conv2d, Linear, LoKrLayer
 from .model import LoKrModel
+from . import candidate_collector  # noqa: F401  # registers LoKr collector stub via decorator
 
 
 __all__ = ["Conv2d", "Linear", "LoKrConfig", "LoKrLayer", "LoKrModel"]

--- a/src/peft/tuners/lokr/candidate_collector.py
+++ b/src/peft/tuners/lokr/candidate_collector.py
@@ -1,4 +1,4 @@
-# Copyright 2023-present the HuggingFace Inc. team.
+# Copyright 2026-present the HuggingFace Inc. team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from peft.utils import register_peft_method
+"""LoKr candidate enumerator. STUB. Returns empty until implemented.
 
-from .config import LoHaConfig
-from .layer import Conv2d, Linear, LoHaLayer
-from .model import LoHaModel
-from . import candidate_collector  # noqa: F401  # registers LoHa collector stub via decorator
+TODO: implement candidate enumeration for LoKr. The function should yield
+full module names that LoKr could validly adapt. See lora/candidate_collector.py
+for the implemented LoRA pattern.
+"""
+
+from peft.tuners.target_suggester import register_candidate_collector
 
 
-__all__ = ["Conv2d", "Linear", "LoHaConfig", "LoHaLayer", "LoHaModel"]
-
-register_peft_method(name="loha", config_cls=LoHaConfig, model_cls=LoHaModel, prefix="hada_", is_mixed_compatible=True)
+@register_candidate_collector("LOKR")
+def lokr_candidates(model):
+    """Yield full module names that LoKr could validly adapt. STUB."""
+    return iter(())

--- a/src/peft/tuners/lora/__init__.py
+++ b/src/peft/tuners/lora/__init__.py
@@ -23,6 +23,7 @@ from .gptq import GPTQLoraLinear
 from .layer import Conv2d, Conv3d, Embedding, Linear, LoraLayer, ParamWrapper
 from .loraga import preprocess_loraga
 from .model import LoraModel
+from . import candidate_collector  # noqa: F401  # registers LoRA collector via decorator
 
 
 __all__ = [

--- a/src/peft/tuners/lora/candidate_collector.py
+++ b/src/peft/tuners/lora/candidate_collector.py
@@ -1,0 +1,55 @@
+# Copyright 2026-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LoRA candidate enumerator. Registered for `PeftType.LORA`.
+
+The supported-types tuple mirrors `peft.tuners.lora.layer.dispatch_default`
+but this module does NOT call dispatch_default itself: dispatch_default has
+side effects on `config.fan_in_fan_out` (lines 2495-2500 and 2502-2508 of
+layer.py at commit 2859358). If LoRA gains support for a new module type,
+both this tuple and dispatch_default need updating.
+"""
+
+from torch import nn
+from transformers.pytorch_utils import Conv1D
+
+from peft.tuners.target_suggester import register_candidate_collector
+from peft.tuners.tuners_utils import BaseTunerLayer
+
+_LORA_SUPPORTED_TYPES = (
+    nn.Linear,
+    nn.Embedding,
+    nn.Conv1d,
+    nn.Conv2d,
+    nn.Conv3d,
+    nn.MultiheadAttention,
+    Conv1D,
+)
+
+
+@register_candidate_collector("LORA")
+def lora_candidates(model):
+    """Yield full module names that LoRA could validly adapt.
+
+    Skips:
+        - the root module (empty name)
+        - modules already wrapped by PEFT (BaseTunerLayer instances)
+    """
+    for name, module in model.named_modules():
+        if not name:
+            continue
+        if isinstance(module, BaseTunerLayer):
+            continue
+        if isinstance(module, _LORA_SUPPORTED_TYPES):
+            yield name

--- a/src/peft/tuners/lora/candidate_collector.py
+++ b/src/peft/tuners/lora/candidate_collector.py
@@ -14,11 +14,10 @@
 
 """LoRA candidate enumerator. Registered for `PeftType.LORA`.
 
-The supported-types tuple mirrors `peft.tuners.lora.layer.dispatch_default`
-but this module does NOT call dispatch_default itself: dispatch_default has
-side effects on `config.fan_in_fan_out` (lines 2495-2500 and 2502-2508 of
-layer.py at commit 2859358). If LoRA gains support for a new module type,
-both this tuple and dispatch_default need updating.
+The supported-types tuple mirrors `peft.tuners.lora.layer.dispatch_default` but this module does NOT call
+dispatch_default itself: dispatch_default has side effects on `config.fan_in_fan_out` (lines 2495-2500 and 2502-2508 of
+layer.py at commit 2859358). If LoRA gains support for a new module type, both this tuple and dispatch_default need
+updating.
 """
 
 from torch import nn
@@ -26,6 +25,7 @@ from transformers.pytorch_utils import Conv1D
 
 from peft.tuners.target_suggester import register_candidate_collector
 from peft.tuners.tuners_utils import BaseTunerLayer
+
 
 _LORA_SUPPORTED_TYPES = (
     nn.Linear,

--- a/src/peft/tuners/oft/__init__.py
+++ b/src/peft/tuners/oft/__init__.py
@@ -19,6 +19,7 @@ from .config import OFTConfig
 from .gptq import GPTQOFTLinear
 from .layer import Conv2d, Linear, OFTLayer
 from .model import OFTModel
+from . import candidate_collector  # noqa: F401  # registers OFT collector stub via decorator
 
 
 __all__ = [

--- a/src/peft/tuners/oft/candidate_collector.py
+++ b/src/peft/tuners/oft/candidate_collector.py
@@ -1,4 +1,4 @@
-# Copyright 2023-present the HuggingFace Inc. team.
+# Copyright 2026-present the HuggingFace Inc. team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from peft.utils import register_peft_method
+"""OFT candidate enumerator. STUB. Returns empty until implemented.
 
-from .config import LoHaConfig
-from .layer import Conv2d, Linear, LoHaLayer
-from .model import LoHaModel
-from . import candidate_collector  # noqa: F401  # registers LoHa collector stub via decorator
+TODO: implement candidate enumeration for OFT. The function should yield
+full module names that OFT could validly adapt. See lora/candidate_collector.py
+for the implemented LoRA pattern.
+"""
+
+from peft.tuners.target_suggester import register_candidate_collector
 
 
-__all__ = ["Conv2d", "Linear", "LoHaConfig", "LoHaLayer", "LoHaModel"]
-
-register_peft_method(name="loha", config_cls=LoHaConfig, model_cls=LoHaModel, prefix="hada_", is_mixed_compatible=True)
+@register_candidate_collector("OFT")
+def oft_candidates(model):
+    """Yield full module names that OFT could validly adapt. STUB."""
+    return iter(())

--- a/src/peft/tuners/target_suggester.py
+++ b/src/peft/tuners/target_suggester.py
@@ -1,0 +1,98 @@
+# Copyright 2026-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Target module suggester.
+
+When a user passes a `target_modules` value that does not match any module
+in the model, `suggest_target_modules` returns a tuner-aware suggestion of
+valid candidates, compressed via `_find_minimal_target_modules`. Behavior is
+purely additive: callers should treat `None` returns as "no decoration" and
+leave the original error message unchanged.
+
+Extension: per-tuner candidate enumeration is registered via the
+`register_candidate_collector` decorator. Each tuner package registers its
+own collector at import time. To add a new tuner, create a candidate
+collector module under `src/peft/tuners/<tuner>/` and import it from that
+package's `__init__.py`.
+
+IMPORTANT: do NOT add module-top-level imports from `peft.tuners.tuners_utils`.
+The local import of `_find_minimal_target_modules` inside
+`suggest_target_modules` is required for circular-import safety.
+"""
+
+from typing import Callable
+
+TUNER_TYPE_TO_CANDIDATE_COLLECTOR: dict[str, Callable] = {}
+
+
+def register_candidate_collector(tuner_type: str) -> Callable:
+    """Decorator to register a per-tuner candidate enumerator.
+
+    Args:
+        tuner_type: The `PeftType` value as a string, e.g. "LORA", "IA3".
+
+    The decorated function should accept a `model` argument and yield full
+    module names (str) that this tuner could validly adapt.
+    """
+    def decorator(fn: Callable) -> Callable:
+        TUNER_TYPE_TO_CANDIDATE_COLLECTOR[tuner_type] = fn
+        return fn
+    return decorator
+
+
+def suggest_target_modules(tuner, model, peft_config, unmatched_modules) -> str | None:
+    """Return a compressed human-readable suggestion of valid target modules,
+    or None if no suggestion can be made.
+
+    Returns None when:
+        - peft_config.peft_type is not registered with a candidate collector
+        - the model has zero candidate modules for this tuner
+        - _find_minimal_target_modules returns empty (defensive; given the
+          upstream candidate-set non-empty check, this branch is technically
+          unreachable for the current implementation of
+          _find_minimal_target_modules)
+    """
+    peft_type = getattr(peft_config, "peft_type", None)
+    if peft_type is None:
+        return None
+    collector = TUNER_TYPE_TO_CANDIDATE_COLLECTOR.get(peft_type)
+    if collector is None:
+        return None
+
+    candidate_names = list(collector(model))
+    if not candidate_names:
+        return None
+
+    candidate_set = set(candidate_names)
+    non_candidate_names = [
+        n for n, _ in model.named_modules()
+        if n and n not in candidate_set
+    ]
+
+    # Local import for circular-import safety. Do NOT promote to module top.
+    from peft.tuners.tuners_utils import _find_minimal_target_modules
+
+    minimal = _find_minimal_target_modules(candidate_names, non_candidate_names)
+    if not minimal:
+        return None
+
+    return _format_suggestion(sorted(minimal), peft_type)
+
+
+def _format_suggestion(minimal_targets: list[str], peft_type: str) -> str:
+    """First-version output format. Bossan invited iteration via tests."""
+    return (
+        f"Did you mean one of these? Valid `target_modules` candidates "
+        f"for {peft_type} on this model: {set(minimal_targets)}."
+    )

--- a/src/peft/tuners/target_suggester.py
+++ b/src/peft/tuners/target_suggester.py
@@ -90,9 +90,15 @@ def suggest_target_modules(tuner, model, peft_config, unmatched_modules) -> str 
     return _format_suggestion(sorted(minimal), peft_type)
 
 
-def _format_suggestion(minimal_targets: list[str], peft_type: str) -> str:
+def _format_suggestion(minimal_targets: list[str], peft_type) -> str:
     """First-version output format. Bossan invited iteration via tests."""
+    # `peft_type` is typically a `PeftType` enum member (a `str`-mixin Enum).
+    # In Python 3.12, `f"{peft_type}"` returns the enum's __str__ ("PeftType.LORA")
+    # rather than the value ("LORA"). Use `.value` when available to keep the
+    # user-facing message clean. Fall back to str() for plain-string callers
+    # (e.g. test fixtures that use a fabricated `peft_type`).
+    type_name = getattr(peft_type, "value", peft_type)
     return (
         f"Did you mean one of these? Valid `target_modules` candidates "
-        f"for {peft_type} on this model: {set(minimal_targets)}."
+        f"for {type_name} on this model: {set(minimal_targets)}."
     )

--- a/src/peft/tuners/target_suggester.py
+++ b/src/peft/tuners/target_suggester.py
@@ -91,7 +91,11 @@ def _format_suggestion(minimal_targets: list[str], peft_type) -> str:
     # user-facing message clean. Fall back to str() for plain-string callers
     # (e.g. test fixtures that use a fabricated `peft_type`).
     type_name = getattr(peft_type, "value", peft_type)
+    # Render the minimal targets as a deterministic set-shaped string. The caller
+    # passes `sorted(minimal)`, but using `set(minimal_targets)` in the f-string
+    # would re-randomize the order via Python's hash randomization. Build the
+    # set-shaped repr by hand to preserve the sort and stay run-to-run stable.
+    sorted_repr = "{" + ", ".join(repr(t) for t in minimal_targets) + "}"
     return (
-        f"Did you mean one of these? Valid `target_modules` candidates "
-        f"for {type_name} on this model: {set(minimal_targets)}."
+        f"Did you mean one of these? Valid `target_modules` candidates for {type_name} on this model: {sorted_repr}."
     )

--- a/src/peft/tuners/target_suggester.py
+++ b/src/peft/tuners/target_suggester.py
@@ -14,24 +14,20 @@
 
 """Target module suggester.
 
-When a user passes a `target_modules` value that does not match any module
-in the model, `suggest_target_modules` returns a tuner-aware suggestion of
-valid candidates, compressed via `_find_minimal_target_modules`. Behavior is
-purely additive: callers should treat `None` returns as "no decoration" and
-leave the original error message unchanged.
+When a user passes a `target_modules` value that does not match any module in the model, `suggest_target_modules`
+returns a tuner-aware suggestion of valid candidates, compressed via `_find_minimal_target_modules`. Behavior is purely
+additive: callers should treat `None` returns as "no decoration" and leave the original error message unchanged.
 
-Extension: per-tuner candidate enumeration is registered via the
-`register_candidate_collector` decorator. Each tuner package registers its
-own collector at import time. To add a new tuner, create a candidate
-collector module under `src/peft/tuners/<tuner>/` and import it from that
-package's `__init__.py`.
+Extension: per-tuner candidate enumeration is registered via the `register_candidate_collector` decorator. Each tuner
+package registers its own collector at import time. To add a new tuner, create a candidate collector module under
+`src/peft/tuners/<tuner>/` and import it from that package's `__init__.py`.
 
-IMPORTANT: do NOT add module-top-level imports from `peft.tuners.tuners_utils`.
-The local import of `_find_minimal_target_modules` inside
-`suggest_target_modules` is required for circular-import safety.
+IMPORTANT: do NOT add module-top-level imports from `peft.tuners.tuners_utils`. The local import of
+`_find_minimal_target_modules` inside `suggest_target_modules` is required for circular-import safety.
 """
 
-from typing import Callable
+from collections.abc import Callable
+
 
 TUNER_TYPE_TO_CANDIDATE_COLLECTOR: dict[str, Callable] = {}
 
@@ -42,12 +38,14 @@ def register_candidate_collector(tuner_type: str) -> Callable:
     Args:
         tuner_type: The `PeftType` value as a string, e.g. "LORA", "IA3".
 
-    The decorated function should accept a `model` argument and yield full
-    module names (str) that this tuner could validly adapt.
+    The decorated function should accept a `model` argument and yield full module names (str) that this tuner could
+    validly adapt.
     """
+
     def decorator(fn: Callable) -> Callable:
         TUNER_TYPE_TO_CANDIDATE_COLLECTOR[tuner_type] = fn
         return fn
+
     return decorator
 
 
@@ -58,10 +56,8 @@ def suggest_target_modules(tuner, model, peft_config, unmatched_modules) -> str 
     Returns None when:
         - peft_config.peft_type is not registered with a candidate collector
         - the model has zero candidate modules for this tuner
-        - _find_minimal_target_modules returns empty (defensive; given the
-          upstream candidate-set non-empty check, this branch is technically
-          unreachable for the current implementation of
-          _find_minimal_target_modules)
+        - _find_minimal_target_modules returns empty (defensive; given the upstream candidate-set non-empty check, this
+          branch is technically unreachable for the current implementation of _find_minimal_target_modules)
     """
     peft_type = getattr(peft_config, "peft_type", None)
     if peft_type is None:
@@ -75,10 +71,7 @@ def suggest_target_modules(tuner, model, peft_config, unmatched_modules) -> str 
         return None
 
     candidate_set = set(candidate_names)
-    non_candidate_names = [
-        n for n, _ in model.named_modules()
-        if n and n not in candidate_set
-    ]
+    non_candidate_names = [n for n, _ in model.named_modules() if n and n not in candidate_set]
 
     # Local import for circular-import safety. Do NOT promote to module top.
     from peft.tuners.tuners_utils import _find_minimal_target_modules

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1008,6 +1008,7 @@ class BaseTuner(nn.Module, ABC):
                 # Suggest valid target modules if a tuner-specific collector is registered.
                 # Local import to avoid circular dependency with target_suggester.
                 from peft.tuners.target_suggester import suggest_target_modules
+
                 suggestion = suggest_target_modules(self, model, peft_config, unmatched_modules)
                 if suggestion:
                     error_msg += f"\n\n{suggestion}"

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1005,6 +1005,12 @@ class BaseTuner(nn.Module, ABC):
                     error_msg += f" Note: You specified 'layers_to_transform': {peft_config.layers_to_transform}."
                 if getattr(peft_config, "layers_pattern", None) is not None:
                     error_msg += f" You also specified 'layers_pattern': {peft_config.layers_pattern}."
+                # Suggest valid target modules if a tuner-specific collector is registered.
+                # Local import to avoid circular dependency with target_suggester.
+                from peft.tuners.target_suggester import suggest_target_modules
+                suggestion = suggest_target_modules(self, model, peft_config, unmatched_modules)
+                if suggestion:
+                    error_msg += f"\n\n{suggestion}"
                 raise ValueError(error_msg)
             else:
                 # Some modules did not match and some matched but were excluded

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -706,6 +706,7 @@ class TestTargetModuleSuggester:
 
     def test_all_known_tuners_have_candidate_collector_registered(self):
         from peft.tuners.target_suggester import TUNER_TYPE_TO_CANDIDATE_COLLECTOR
+
         # LoRA must be registered with a real collector.
         # IA3, LOHA, LOKR, OFT are stubs added in Phase 4 but must be present.
         for peft_type in ("LORA", "IA3", "LOHA", "LOKR", "OFT"):
@@ -732,13 +733,17 @@ class TestTargetModuleSuggester:
         class HierarchicalModel(nn.Module):
             def __init__(self):
                 super().__init__()
-                self.layers = nn.ModuleList([
-                    nn.ModuleDict({
-                        "q_proj": nn.Linear(8, 8),
-                        "v_proj": nn.Linear(8, 8),
-                    })
-                    for _ in range(3)
-                ])
+                self.layers = nn.ModuleList(
+                    [
+                        nn.ModuleDict(
+                            {
+                                "q_proj": nn.Linear(8, 8),
+                                "v_proj": nn.Linear(8, 8),
+                            }
+                        )
+                        for _ in range(3)
+                    ]
+                )
 
             def forward(self, x):
                 for layer in self.layers:

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -595,6 +595,127 @@ class TestExcludedModuleNames:
         assert model.targeted_module_names == expected
 
 
+class TestTargetModuleSuggester:
+    """Tests for the target module suggester hook at tuners_utils.py:1008.
+
+    The suggester appends a "Did you mean" paragraph to the existing error
+    message when the user named modules that do not exist in the model.
+    Behavior is purely additive: when no suggestion is possible, the original
+    message is unchanged.
+    """
+
+    def test_suggests_valid_lora_targets_when_user_names_wrong(self):
+        model = MLP()
+        with pytest.raises(ValueError) as excinfo:
+            get_peft_model(model, LoraConfig(target_modules=["non_existent"]))
+        msg = str(excinfo.value)
+        assert "Target modules" in msg
+        assert "Did you mean" in msg
+        assert ("lin0" in msg) or ("lin1" in msg)
+
+    def test_returns_no_suggestion_when_model_has_no_candidates(self):
+        # Model with only Dropout/ReLU (no LoRA-compatible types).
+        class NoCandidates(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.drop = nn.Dropout(0.5)
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                return self.relu(self.drop(x))
+
+        model = NoCandidates()
+        with pytest.raises(ValueError) as excinfo:
+            get_peft_model(model, LoraConfig(target_modules=["non_existent"]))
+        msg = str(excinfo.value)
+        assert "Target modules" in msg
+        assert "Did you mean" not in msg
+
+    def test_suggestion_does_not_leak_unsupported_types(self):
+        model = MLP()
+        with pytest.raises(ValueError) as excinfo:
+            get_peft_model(model, LoraConfig(target_modules=["non_existent"]))
+        msg = str(excinfo.value)
+        assert "Did you mean" in msg
+        # Inspect only the suggestion paragraph to avoid matching the
+        # original message (which echoes the user's unmatched name).
+        suggestion = msg.split("Did you mean", 1)[1]
+        # MLP fixture has lin0, relu, drop, lin1, sm. Only lin0 and lin1
+        # are LoRA-compatible.
+        assert "drop" not in suggestion
+        assert "relu" not in suggestion
+        assert "'sm'" not in suggestion
+
+    def test_suggestion_absent_when_modules_excluded(self):
+        # Triggers line-1021 raise (combination case) on MLP because the
+        # non-target modules (relu, drop, sm) populate unmatched_modules.
+        # Line-989 ("All modules were excluded") only fires when EVERY module
+        # matches the target pattern, which is hard to construct with MLP and
+        # exact-name targeting. The behavioral guarantee we are testing here
+        # is that the suggester is NOT called when excluded_modules is
+        # non-empty, regardless of which specific raise fires.
+        model = MLP()
+        with pytest.raises(ValueError) as excinfo:
+            get_peft_model(
+                model,
+                LoraConfig(
+                    target_modules=["lin0", "lin1"],
+                    exclude_modules=["lin0", "lin1"],
+                ),
+            )
+        msg = str(excinfo.value)
+        assert "Did you mean" not in msg
+
+    def test_suggestion_absent_at_combination_raise(self):
+        # Triggers line-1021 raise: some matched-and-excluded, some unmatched.
+        model = MLP()
+        with pytest.raises(ValueError) as excinfo:
+            get_peft_model(
+                model,
+                LoraConfig(
+                    target_modules=["lin0", "non_existent"],
+                    exclude_modules=["lin0"],
+                ),
+            )
+        msg = str(excinfo.value)
+        assert "No modules were targeted" in msg
+        assert "Did you mean" not in msg
+
+    def test_unregistered_tuner_returns_none(self):
+        from peft.tuners.target_suggester import suggest_target_modules
+
+        class FakeConfig:
+            peft_type = "DEFINITELY_NOT_REGISTERED"
+            target_modules = ["non_existent"]
+
+        model = MLP()
+        result = suggest_target_modules(None, model, FakeConfig(), ["non_existent"])
+        assert result is None
+
+    def test_lora_collector_is_side_effect_free(self):
+        from peft.tuners.lora.candidate_collector import lora_candidates
+
+        model = MLP()
+        before_state = {k: v.clone() for k, v in model.state_dict().items()}
+        names_first = list(lora_candidates(model))
+        names_second = list(lora_candidates(model))
+        after_state = {k: v.clone() for k, v in model.state_dict().items()}
+        assert names_first == names_second
+        for key in before_state:
+            assert torch.equal(before_state[key], after_state[key])
+
+    def test_all_known_tuners_have_candidate_collector_registered(self):
+        from peft.tuners.target_suggester import TUNER_TYPE_TO_CANDIDATE_COLLECTOR
+        # LoRA must be registered with a real collector.
+        # IA3, LOHA, LOKR, OFT are stubs added in Phase 4 but must be present.
+        for peft_type in ("LORA", "IA3", "LOHA", "LOKR", "OFT"):
+            assert peft_type in TUNER_TYPE_TO_CANDIDATE_COLLECTOR, (
+                f"Tuner {peft_type} has no registered candidate collector. "
+                f"Either add a stub via @register_candidate_collector('{peft_type}') "
+                f"or remove it from this assertion."
+            )
+
+
 class TestModelAndLayerStatus:
     """Check the methods `get_layer_status` and `get_model_status`.`
 

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -715,6 +715,49 @@ class TestTargetModuleSuggester:
                 f"or remove it from this assertion."
             )
 
+    def test_suggestion_absent_at_no_target_modules_raise(self):
+        # Triggers line-994 raise: no target_modules and no target_parameters passed.
+        # Hook is only at line-1008, so no "Did you mean" should appear here.
+        model = MLP()
+        with pytest.raises(ValueError) as excinfo:
+            get_peft_model(model, LoraConfig(target_modules=[]))
+        msg = str(excinfo.value)
+        # The line-994 error message starts with "No `target_modules` passed".
+        assert "Did you mean" not in msg
+
+    def test_suggestion_uses_minimal_suffix_compression(self):
+        # Hierarchical model with repeated submodule names. The suggester should
+        # compress fully-qualified names like layers.0.q_proj, layers.1.q_proj
+        # into the minimal suffix set {q_proj, v_proj} via _find_minimal_target_modules.
+        class HierarchicalModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.ModuleList([
+                    nn.ModuleDict({
+                        "q_proj": nn.Linear(8, 8),
+                        "v_proj": nn.Linear(8, 8),
+                    })
+                    for _ in range(3)
+                ])
+
+            def forward(self, x):
+                for layer in self.layers:
+                    x = layer["v_proj"](layer["q_proj"](x))
+                return x
+
+        model = HierarchicalModel()
+        with pytest.raises(ValueError) as excinfo:
+            get_peft_model(model, LoraConfig(target_modules=["non_existent"]))
+        msg = str(excinfo.value)
+        assert "Did you mean" in msg
+        suggestion = msg.split("Did you mean", 1)[1]
+        # Both compressed suffixes should appear.
+        assert "q_proj" in suggestion
+        assert "v_proj" in suggestion
+        # Fully-qualified paths should NOT appear: the minimal form must be used.
+        assert "layers.0.q_proj" not in suggestion
+        assert "layers.2.v_proj" not in suggestion
+
 
 class TestModelAndLayerStatus:
     """Check the methods `get_layer_status` and `get_model_status`.`


### PR DESCRIPTION
## Context

Per @BenjaminBossan's invitation in [#3154 (comment)](https://github.com/huggingface/peft/pull/3154#issuecomment-4243860185) and the scope reply in [#3154 (comment)](https://github.com/huggingface/peft/pull/3154#issuecomment-4250868072), this is a draft of the general-purpose target module suggester. Closes the loop on the narrower attempt in PR #3154. Complements #3136 (merged 2026-04-09), which set Gemma 4 default `target_modules`. This PR addresses the broader UX failure mode surfaced in #3129: when a user (or a default config) names modules that do not exist in the model, suggest valid ones before raising. Towards #3129.

## What this does

Adds a tuner-aware suggestion paragraph to the existing `ValueError` raised at the line-1008 raise site in `src/peft/tuners/tuners_utils.py` (commit `2859358`, the merge base), only at the case where the user named modules that do not exist. The other three raises in the same block (lines 989, 994, 1021) are out of scope for this PR.

Suggestions are produced by a per-tuner candidate collector registered via decorator, mirroring the existing `register_peft_method` pattern in `src/peft/utils/peft_types.py`. The output is compressed via `_find_minimal_target_modules` so suggestions look like `{'q_proj', 'v_proj'}` rather than fully-qualified paths.

## Scope (LoRA only in this PR)

- LoRA collector: implemented.
- IA3, LoKr, LoHa, OFT: registered with stub collectors and TODO markers. Five-line follow-up PRs to fill in.
- `target_parameters` (MoE) path: out of scope.
- IA3 feedforward / attention split: out of scope per [#3154 (comment)](https://github.com/huggingface/peft/pull/3154#issuecomment-4250868072).

## Behavior

Purely additive. When the suggester returns `None` (unregistered tuner, no candidates, empty minimal set), the original error message is unchanged. The pre-existing `tests/test_tuners_utils.py::TestExcludedModuleNames::test_no_modules_matched` still passes against its original substring match.

## Tests

New `TestTargetModuleSuggester` class in `tests/test_tuners_utils.py` covers ten cases:

1. Suggests valid LoRA targets when user names a non-existent module
2. Returns no suggestion when model has no LoRA-compatible candidates
3. Suggestion does not leak module names of types LoRA cannot adapt
4. No suggestion when modules are excluded (line-1021 combination raise on the MLP fixture; the strict line-989 "all excluded" raise is unreachable with this fixture because non-target modules populate `unmatched_modules` per `tuners_utils.py:906`)
5. No suggestion at the line-1021 raise (combination case)
6. No suggestion at the line-994 raise (no target_modules and no target_parameters passed)
7. Suggestion uses minimal suffix compression (hierarchical model with `q_proj` and `v_proj` at three layers; verifies the suggestion compresses to `{q_proj, v_proj}` rather than listing six fully-qualified names)
8. Calling the suggester with an unregistered tuner type returns `None`, no exception
9. The LoRA collector is side-effect-free (snapshot model state, run twice, compare)
10. All five known tuner types (LORA, IA3, LOHA, LOKR, OFT) have a registered collector

## Output format

First version. Open to redlines.

```
Target modules {'non_existent_module'} not found in the base model. Please check the target modules and try again.

Did you mean one of these? Valid `target_modules` candidates for LORA on this model: {'lin0', 'lin1'}.
```

Tests assert structural properties (suggestion contains a real candidate name, suggestion is omitted when no candidates exist), not exact wording. The wording can be redlined without test churn. The set-shaped output is rendered deterministically (sorted, run-to-run stable) so reviewers can rely on the example above matching real runs.

## Architecture notes

- `src/peft/tuners/target_suggester.py`: new module. `TUNER_TYPE_TO_CANDIDATE_COLLECTOR` dict, `register_candidate_collector` decorator, `suggest_target_modules` top-level entrypoint, `_format_suggestion` formatter. No module-top-level imports from `peft.tuners.tuners_utils` to avoid circular dependency.
- `src/peft/tuners/lora/candidate_collector.py`: new module. Parallel `isinstance` walk against the same supported-types tuple as `dispatch_default`. Does NOT call `dispatch_default` itself because `dispatch_default` has side effects on `config.fan_in_fan_out` (`lora/layer.py:2495-2500` and `2502-2508`).
- Hook in `tuners_utils.py`: six lines between current line 1007 and current line 1008. Local import of `suggest_target_modules` for circular-import safety.

## Open questions for review

1. Registry pattern OK, or would you prefer a `BaseTuner.get_candidates()` method?
2. Output format: keep "Did you mean one of these?" or change to "Valid candidates are:" or similar?
3. Cap the suggested set at top N, or always show all minimal targets?
4. You wrote "intercept exactly the right errors" (plural) in the invitation. This PR limits the hook to the line-1008 raise (the canonical "user named wrong modules" case). Should suggestions also fire at the line-1021 raise (combination case: some matched, some excluded)? Easy to extend if so.