### PR TITLE
Fix SVDQuantLinear __repr__ nested inside forward instead of on the class

### DIFF
--- a/src/peft/tuners/adalora/gptq.py
+++ b/src/peft/tuners/adalora/gptq.py
@@ -66,6 +66,6 @@ class SVDQuantLinear(torch.nn.Module, AdaLoraLayer):
             result += output
         return result
 
-        def __repr__(self) -> str:
-            rep = super().__repr__()
-            return "adalora." + rep
+    def __repr__(self) -> str:
+        rep = super().__repr__()
+        return "adalora." + rep


### PR DESCRIPTION
## Bug

\`src/peft/tuners/adalora/gptq.py:SVDQuantLinear\` is supposed to expose the same \`__repr__\` override as every sibling AdaLoRA variant — \`SVDLinear\` (\`layer.py\`), \`SVDLinear8bitLt\` and \`SVDLinear4bit\` (\`bnb.py\`) — so that adapted layers print as \`adalora.<BaseRepr>\`. Instead, the method is indented one level too deep and ends up as a nested function *inside* \`forward\`, after the unconditional \`return result\`:

\`\`\`python
class SVDQuantLinear(torch.nn.Module, AdaLoraLayer):
    ...
    def forward(self, x: torch.Tensor) -> torch.Tensor:
        ...
        return result

        def __repr__(self) -> str:        # <- 8-space indent, inside forward
            rep = super().__repr__()
            return \"adalora.\" + rep
\`\`\`

## Root cause

The \`def __repr__\` line is indented with 8 spaces instead of 4, so Python binds it inside \`forward\`'s scope rather than on the class. Because it's written after a top-level \`return\` in \`forward\`, the nested definition is also dead code that never executes. Consequently \`SVDQuantLinear\` inherits \`torch.nn.Module.__repr__\` directly, and instances of it print without the \`\"adalora.\"\` prefix that every other AdaLoRA / LoRA variant in this package sets via the exact same three-line override.

## Why the fix is correct

Dedenting those three lines to 4 spaces moves \`__repr__\` out of \`forward\` and onto \`SVDQuantLinear\`, matching the indentation and content of the counterpart methods in \`src/peft/tuners/adalora/bnb.py\` and \`src/peft/tuners/adalora/layer.py\`. The nested definition (unreachable dead code) disappears, and the class now consistently reports as \`adalora.<BaseRepr>\`, which is the behavior relied on by \`print(model)\`, logs, and error messages that include the module. No runtime logic is altered.