### PR TITLE
[LoRA] Add dropout_pattern for per-layer dropout rate overrides

### DIFF
--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -393,6 +393,11 @@ class LoraConfig(PeftConfig):
         alpha_pattern (`dict`):
             The mapping from layer names or regexp expression to alphas which are different from the default alpha
             specified by `lora_alpha`. For example, `{'^model.decoder.layers.0.encoder_attn.k_proj': 16}`.
+        dropout_pattern (`dict`):
+            The mapping from layer names or regexp expression to dropout probabilities which are different from
+            the default dropout specified by `lora_dropout`. For example,
+            `{'^model.decoder.layers.0.encoder_attn.k_proj': 0.05}`. Useful for applying stronger regularization
+            to specific layers while keeping others at a lower (or zero) dropout rate.
         megatron_config (`Optional[dict]`):
             The TransformerConfig arguments for Megatron. It is used to create LoRA's parallel linear layer. You can
             get it like this, `core_transformer_config_from_args(get_args())`, these two functions being from Megatron.
@@ -566,6 +571,16 @@ class LoraConfig(PeftConfig):
             "help": (
                 "The mapping from layer names or regexp expression to alphas which are different from the default alpha specified by `lora_alpha`. "
                 "For example, `{'^model.decoder.layers.0.encoder_attn.k_proj': 16}`."
+            )
+        },
+    )
+    dropout_pattern: Optional[dict] = field(
+        default_factory=dict,
+        metadata={
+            "help": (
+                "The mapping from layer names or regexp expression to dropout probabilities which are different from "
+                "the default dropout specified by `lora_dropout`. "
+                "For example, `{'^model.decoder.layers.0.encoder_attn.k_proj': 0.05}`."
             )
         },
     )

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -156,10 +156,11 @@ class LoraLayer(BaseTunerLayer):
         r: int,
         lora_alpha: int,
         config: LoraConfig,
+        lora_dropout: Optional[float] = None,
         **kwargs,
     ) -> None:
         # collect the kwargs
-        lora_dropout = config.lora_dropout
+        lora_dropout = config.lora_dropout if lora_dropout is None else lora_dropout
         init_lora_weights = config.init_lora_weights
         use_rslora = config.use_rslora
         lora_bias = config.lora_bias

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -204,8 +204,10 @@ class LoraModel(BaseTuner):
         # Regexp matching - Find key which matches current target_name in patterns provided
         r_key = get_pattern_key(lora_config.rank_pattern.keys(), current_key)
         alpha_key = get_pattern_key(lora_config.alpha_pattern.keys(), current_key)
+        dropout_key = get_pattern_key(lora_config.dropout_pattern.keys(), current_key)
         r = lora_config.rank_pattern.get(r_key, lora_config.r)
         alpha = lora_config.alpha_pattern.get(alpha_key, lora_config.lora_alpha)
+        dropout = lora_config.dropout_pattern.get(dropout_key, lora_config.lora_dropout)
 
         # Checks if the target is marked as a tied layer
         # If true, we add the reference to lora adapters of embedding layer in `tied_adapter`
@@ -253,6 +255,7 @@ class LoraModel(BaseTuner):
                 adapter_name,
                 r,
                 lora_alpha=alpha,
+                lora_dropout=dropout,
                 target_name=current_key,
                 config=lora_config,
             )


### PR DESCRIPTION
## What does this PR do?

Adds `dropout_pattern` to `LoraConfig`, enabling per-layer dropout rate overrides that follow the same design as the existing `rank_pattern` and `alpha_pattern` fields.

**Motivation:** `lora_dropout` is currently a single global value applied to every targeted layer. Researchers often want finer control — e.g., heavier regularization on intermediate attention layers while keeping early/late layers at zero dropout, or different dropout rates for Q/K/V vs. output projections. The `rank_pattern` / `alpha_pattern` infrastructure already handles this pattern elegantly; `dropout_pattern` is the natural third member of that set.

## Changes

- `src/peft/tuners/lora/config.py` — adds the `dropout_pattern: Optional[dict]` field (defaulting to `{}`) with docstring, mirroring `rank_pattern` / `alpha_pattern`.
- `src/peft/tuners/lora/model.py` — resolves the per-layer dropout value via `get_pattern_key` in `_create_and_replace`, falling back to `config.lora_dropout` when no pattern matches; passes the resolved value to `update_layer`.
- `src/peft/tuners/lora/layer.py` — adds an explicit `lora_dropout: Optional[float] = None` parameter to `update_layer`; uses it in preference to `config.lora_dropout` when provided.

## Backward compatibility

Fully backward-compatible. `dropout_pattern` defaults to an empty dict, so all existing configs and callers are unaffected. The new `lora_dropout` kwarg on `update_layer` defaults to `None`, preserving the current fallback to `config.lora_dropout`.

## Usage example

```python
config = LoraConfig(
    r=8,
    lora_alpha=16,
    lora_dropout=0.0,           # default for all layers
    dropout_pattern={
        "model.layers.[0-9]+.self_attn.q_proj": 0.1,
        "model.layers.[0-9]+.self_attn.v_proj": 0.1,
    },
    target_modules=["q_proj", "v_proj", "o_proj"],
)
```