### PR TITLE
Fix TrainableTokensLayer.update_layer referencing self.weight instead of the local weight

### DIFF
--- a/src/peft/tuners/trainable_tokens/layer.py
+++ b/src/peft/tuners/trainable_tokens/layer.py
@@ -143,7 +143,7 @@ class TrainableTokensLayer(nn.Module, BaseTunerLayer):
             if check_deepspeed_zero3_enabled():
                 values = self._collect_token_weights(weight, self.token_indices[adapter_name], embed_dim)
             else:
-                values = self.weight[self.token_indices[adapter_name]]
+                values = weight[self.token_indices[adapter_name]]
         else:
             # random init with matching dtype/device
             values = torch.randn(


### PR DESCRIPTION
## Bug

In `src/peft/tuners/trainable_tokens/layer.py`, the non-DeepSpeed-Zero-3 branch of `TrainableTokensLayer.update_layer` raises `AttributeError: 'TrainableTokensLayer' object has no attribute 'weight'` the first time it's hit with `init_weights=True`:

```python
weight = self.get_base_layer().weight

...

if init_weights:
    if check_deepspeed_zero3_enabled():
        values = self._collect_token_weights(weight, self.token_indices[adapter_name], embed_dim)
    else:
        values = self.weight[self.token_indices[adapter_name]]
```

## Root cause

`TrainableTokensLayer(nn.Module, BaseTunerLayer)` never registers a `.weight` parameter or attribute. The layer only stores the wrapped embedding via `self.base_layer`, which is why the local `weight = self.get_base_layer().weight` is computed a few lines earlier. The Zero-3 branch correctly passes that local `weight` into `_collect_token_weights`, but the non-Zero-3 branch reads `self.weight` — an attribute that doesn't exist — instead of the local variable.

This is the default code path for anyone using `trainable_token_indices` without DeepSpeed Zero-3, so the bug is immediately reachable on a vanilla setup.

## Fix

Drop the `self.` prefix so the non-Zero-3 branch slices the same `weight` tensor the Zero-3 branch uses:

```diff
-                values = self.weight[self.token_indices[adapter_name]]
+                values = weight[self.token_indices[adapter_name]]
```

One-character edit on the single offending line. No signature, attribute, or behaviour change beyond removing the crash — the two branches now agree on their source tensor.