### PR TITLE
Use _cast_input_dtype in poly Linear.forward

### DIFF
--- a/src/peft/tuners/poly/layer.py
+++ b/src/peft/tuners/poly/layer.py
@@ -154,7 +154,7 @@ class Linear(nn.Module, PolyLayer):
                 A = A.reshape(bs, self.in_features, r)
                 B = B.transpose(1, 2).reshape(bs, r, self.out_features)
 
-                x = x.to(A.dtype)
+                x = self._cast_input_dtype(x, A.dtype)
                 result += x.bmm(A).bmm(B) / r
 
         result = result.to(previous_dtype)


### PR DESCRIPTION
## Bug

`poly.Linear.forward` casts the input with a raw `x.to(A.dtype)` instead of
`self._cast_input_dtype(...)`, bypassing the `disable_lora_input_dtype_casting`
context manager.

## Root cause

`BaseTunerLayer` exposes `_cast_input_dtype`, which respects the module-level
flag for disabling input dtype casting. Most tuners use that helper, but
`poly/layer.py` still uses the raw `.to()` call.

## Why the fix is correct

- `PolyLayer` inherits from `BaseTunerLayer`, so `self._cast_input_dtype` is
  available on the `Linear` subclass.
- The same one-line change was applied to fourierft (#3170) and vera (#3172);
  this brings poly in line with those tuners.
- Behaviour is unchanged when the context manager is not active (the helper
  performs the same cast).

## Change

`src/peft/tuners/poly/layer.py`: `x = x.to(A.dtype)` →
`x = self._cast_input_dtype(x, A.dtype)`.