### PR TITLE
FIX Clip module structure since transformers > 5.5

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -27,6 +27,8 @@ is_transformers_ge_v5_1_0 = packaging.version.parse(transformers.__version__) >=
 
 is_transformers_ge_v5_4_0 = packaging.version.parse(transformers.__version__) >= packaging.version.parse("5.4.0")
 
+is_transformers_gt_v5_5_0 = packaging.version.parse(transformers.__version__) > packaging.version.parse("5.5.0")
+
 is_transformers_le_4_53 = packaging.version.parse(transformers.__version__) < packaging.version.parse("4.54.0.dev0")
 
 

--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -27,7 +27,7 @@ is_transformers_ge_v5_1_0 = packaging.version.parse(transformers.__version__) >=
 
 is_transformers_ge_v5_4_0 = packaging.version.parse(transformers.__version__) >= packaging.version.parse("5.4.0")
 
-is_transformers_gt_v5_5_0 = packaging.version.parse(transformers.__version__) > packaging.version.parse("5.5.0")
+is_transformers_ge_v5_6_0 = packaging.version.parse(transformers.__version__) >= packaging.version.parse("5.6.0.dev0")
 
 is_transformers_le_4_53 = packaging.version.parse(transformers.__version__) < packaging.version.parse("4.54.0.dev0")
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -27,7 +27,7 @@ from transformers import (
 )
 
 from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
-from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_gt_v5_5_0
+from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_ge_v5_6_0
 from peft.utils.other import ModulesToSaveWrapper, _get_module_names_tied_with_embedding, _get_no_split_modules
 
 from .testing_utils import hub_online_once
@@ -547,7 +547,7 @@ class TestGetNoSplitModules:
             assert model._no_split_modules == []
             no_split_modules = _get_no_split_modules(model)
             assert no_split_modules == {"CLIPEncoderLayer", "LlamaDecoderLayer"}
-        elif not is_transformers_gt_v5_5_0:
+        elif not is_transformers_ge_v5_6_0:
             # TODO remove this once transformers <5.6.0 is not supported anymore
             assert model._no_split_modules == {"CLIPEncoderLayer", "LlamaDecoderLayer"}
             no_split_modules = _get_no_split_modules(model)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -27,7 +27,7 @@ from transformers import (
 )
 
 from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
-from peft.import_utils import is_transformers_ge_v5_1_0
+from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_gt_v5_5_0
 from peft.utils.other import ModulesToSaveWrapper, _get_module_names_tied_with_embedding, _get_no_split_modules
 
 from .testing_utils import hub_online_once
@@ -545,11 +545,30 @@ class TestGetNoSplitModules:
         if not is_transformers_ge_v5_1_0:
             # sanity check: just visiting the model itself is not enough:
             assert model._no_split_modules == []
-        else:
+            no_split_modules = _get_no_split_modules(model)
+            assert no_split_modules == {"CLIPEncoderLayer", "LlamaDecoderLayer"}
+        elif not is_transformers_gt_v5_5_0:
+            # TODO remove this once transformers <5.6.0 is not supported anymore
             assert model._no_split_modules == {"CLIPEncoderLayer", "LlamaDecoderLayer"}
-
-        no_split_modules = _get_no_split_modules(model)
-        assert no_split_modules == {"CLIPEncoderLayer", "LlamaDecoderLayer"}
+            no_split_modules = _get_no_split_modules(model)
+            assert no_split_modules == {"CLIPEncoderLayer", "LlamaDecoderLayer"}
+        else:
+            # in transformers > 5.5.0, the structure of the model was changed, see
+            # https://github.com/huggingface/transformers/pull/45361
+            # https://github.com/huggingface/transformers/pull/45448
+            assert model._no_split_modules == {
+                "CLIPEncoderLayer",
+                "CLIPTextEmbeddings",
+                "CLIPVisionEmbeddings",
+                "LlamaDecoderLayer",
+            }
+            no_split_modules = _get_no_split_modules(model)
+            assert no_split_modules == {
+                "CLIPEncoderLayer",
+                "CLIPTextEmbeddings",
+                "CLIPVisionEmbeddings",
+                "LlamaDecoderLayer",
+            }
 
 
 class TestGetModuleNamesTiedWithEmbedding:


### PR DESCRIPTION
The model structure of Clip and similar models sharing the archicture has changed in Transformers. See:

- https://github.com/huggingface/transformers/pull/45361
- https://github.com/huggingface/transformers/pull/45448

This resulted in an [error in our CI with transformers main](https://github.com/huggingface/peft/actions/runs/24567401253/job/72096062190#step:6:2522). The test was updated to reflect the change.