### PR TITLE
FIX TinyLoRA non-determinism

### DIFF
--- a/src/peft/tuners/tinylora/layer.py
+++ b/src/peft/tuners/tinylora/layer.py
@@ -46,11 +46,12 @@ class TinyLoraLayer(BaseTunerLayer):
     adapter_layer_names = ("tinylora_v",)
     other_param_names = ("tinylora_A", "tinylora_B", "tinylora_P")
 
-    def __init__(self, base_layer: nn.Module, **kwargs):
+    def __init__(self, base_layer: nn.Module, layer_idx: int, **kwargs):
         self.base_layer = base_layer
         self.r = {}
         self.u = {}
         self.tinylora_dropout = nn.ModuleDict({})
+        self._layer_idx = layer_idx  # used for deterministic seeding of projection matrices
 
         # Reference to the model-level ModuleDict (set during update_layer).
         # PyTorch won't double-register the same ModuleDict object across layers.
@@ -72,9 +73,6 @@ class TinyLoraLayer(BaseTunerLayer):
         # Mark the weight as unmerged
         self._disable_adapters = False
         self.merged_adapters = []
-
-        # Track layer index for seeding
-        self._layer_idx: Optional[int] = None
 
         self.in_features, self.out_features = _get_in_out_features(self.get_base_layer())
         self.kwargs = kwargs
@@ -132,16 +130,9 @@ class TinyLoraLayer(BaseTunerLayer):
     def supports_lora_conversion(self, adapter_name: str = "default") -> bool:
         return True
 
-    def set_layer_idx(self, idx: int):
-        """Set the layer index, used for deterministic seeding of projection matrices."""
-        self._layer_idx = idx
-
     def _get_layer_seed(self, adapter_name: str, base_seed: int) -> int:
         """Get a deterministic seed for this layer's projection matrices."""
-        if self._layer_idx is not None:
-            return base_seed + self._layer_idx
-        # Fallback: use hash of the adapter name
-        return base_seed + hash(adapter_name) % 10000
+        return base_seed + self._layer_idx
 
     def update_layer(
         self,

--- a/src/peft/tuners/tinylora/layer.py
+++ b/src/peft/tuners/tinylora/layer.py
@@ -181,16 +181,15 @@ class TinyLoraLayer(BaseTunerLayer):
 
         # Compute truncated SVD of base weights (following LoRA-XS convention)
         # actual_r may be less than r if matrix dimensions are smaller
-        actual_r = self._init_svd(adapter_name, r, fan_in_fan_out)
-        self.r[adapter_name] = actual_r
+        self._init_svd(adapter_name, r, fan_in_fan_out)
 
         # Initialize random projection tensors P using the actual rank
-        self._init_projection(adapter_name, u, actual_r, projection_seed)
+        self._init_projection(adapter_name, u, projection_seed)
 
         self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters, inference_mode=inference_mode)
 
-    def _init_svd(self, adapter_name: str, r: int, fan_in_fan_out: bool) -> int:
+    def _init_svd(self, adapter_name: str, r: int, fan_in_fan_out: bool) -> None:
         """
         Compute truncated SVD of base weights and store as frozen buffers.
 
@@ -234,20 +233,19 @@ class TinyLoraLayer(BaseTunerLayer):
         # Use .contiguous() to ensure tensors can be saved with safetensors
         self.tinylora_A[adapter_name] = (sqrt_S_r.unsqueeze(1) * V_r).contiguous()
         self.tinylora_B[adapter_name] = (U_r * sqrt_S_r.unsqueeze(0)).contiguous()
+        self.r[adapter_name] = actual_r
 
-        return actual_r
-
-    def _init_projection(self, adapter_name: str, u: int, r: int, base_seed: int):
+    def _init_projection(self, adapter_name: str, u: int, base_seed: int):
         """Initialize fixed random projection tensors P ∈ R^{u×r×r}."""
         seed = self._get_layer_seed(adapter_name, base_seed)
         gen = torch.Generator().manual_seed(seed)
+        r = self.r[adapter_name]
 
         # P has shape (u, r, r)
         # Note: The paper describes P as "fixed random matrices" but does not specify the distribution.
         # We sample from N(0, 1/r) which is standard for random projections
         # (see Johnson-Lindenstrauss lemma: https://en.wikipedia.org/wiki/Johnson-Lindenstrauss_lemma).
         P = torch.normal(mean=0.0, std=1.0 / (r**0.5), size=(u, r, r), generator=gen)
-
         self.tinylora_P[adapter_name] = P
 
     def _compute_R(self, adapter_name: str) -> torch.Tensor:

--- a/src/peft/tuners/tinylora/layer.py
+++ b/src/peft/tuners/tinylora/layer.py
@@ -480,16 +480,15 @@ class Embedding(nn.Module, TinyLoraLayer):
         self._tinylora_v_ref[adapter_name] = tinylora_v[adapter_name][v_key]
 
         # Compute truncated SVD of embedding weights
-        actual_r = self._init_svd_embedding(adapter_name, r)
-        self.r[adapter_name] = actual_r
+        self._init_svd_embedding(adapter_name, r)
 
         # Initialize random projection tensors P using the actual rank
-        self._init_projection(adapter_name, u, actual_r, projection_seed)
+        self._init_projection(adapter_name, u, projection_seed)
 
         self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters, inference_mode=inference_mode)
 
-    def _init_svd_embedding(self, adapter_name: str, r: int) -> int:
+    def _init_svd_embedding(self, adapter_name: str, r: int) -> None:
         """
         Compute truncated SVD of embedding weights and store as frozen buffers.
 
@@ -523,8 +522,7 @@ class Embedding(nn.Module, TinyLoraLayer):
         # Distribute singular values equally to both A and B via sqrt(S_r)
         self.tinylora_A[adapter_name] = (sqrt_S_r.unsqueeze(1) * V_r).contiguous()
         self.tinylora_B[adapter_name] = (U_r * sqrt_S_r.unsqueeze(0)).contiguous()
-
-        return actual_r
+        self.r[adapter_name] = actual_r
 
     def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """Merge the active adapter weights into the base weights."""

--- a/src/peft/tuners/tinylora/layer.py
+++ b/src/peft/tuners/tinylora/layer.py
@@ -190,10 +190,7 @@ class TinyLoraLayer(BaseTunerLayer):
         - We store: tinylora_B = U[:, :r] @ diag(sqrt(S[:r])) (shape: out_features x r)
 
         Distributing S equally avoids imbalanced norms between A and B. This allows: delta_W = tinylora_B @ R @
-        tinylora_A
-
-        Returns:
-            int: The actual rank used (may be less than r if matrix dimensions are smaller)
+        tinylora_A.
         """
         base_layer = self.get_base_layer()
         weight = base_layer.weight.data
@@ -496,9 +493,6 @@ class Embedding(nn.Module, TinyLoraLayer):
         - W = U @ S @ V^T (full SVD)
         - tinylora_A = diag(sqrt(S[:r])) @ V[:r, :] (shape: r x embedding_dim)
         - tinylora_B = U[:, :r] @ diag(sqrt(S[:r])) (shape: num_embeddings x r)
-
-        Returns:
-            int: The actual rank used (may be less than r if dimensions are smaller)
         """
         base_layer = self.get_base_layer()
         weight = base_layer.weight.data  # (num_embeddings, embedding_dim)

--- a/src/peft/tuners/tinylora/model.py
+++ b/src/peft/tuners/tinylora/model.py
@@ -168,17 +168,18 @@ class TinyLoraModel(BaseTuner):
             self.tinylora_v[adapter_name][v_key] = v
 
         if isinstance(target, TinyLoraLayer):
-            target.set_layer_idx(layer_idx)
             target.update_layer(
                 adapter_name,
                 self.tinylora_v,
                 v_key,
                 tinylora_config.r,
                 tinylora_config,
+                layer_idx=layer_idx,
             )
         else:
-            new_module = self._create_new_module(tinylora_config, self.tinylora_v, v_key, adapter_name, target)
-            new_module.set_layer_idx(layer_idx)
+            new_module = self._create_new_module(
+                tinylora_config, self.tinylora_v, v_key, adapter_name, target, layer_idx=layer_idx
+            )
 
             if adapter_name not in self.active_adapter:
                 # adding an additional adapter: it is not automatically trainable

--- a/src/peft/tuners/tinylora/model.py
+++ b/src/peft/tuners/tinylora/model.py
@@ -174,7 +174,6 @@ class TinyLoraModel(BaseTuner):
                 v_key,
                 tinylora_config.r,
                 tinylora_config,
-                layer_idx=layer_idx,
             )
         else:
             new_module = self._create_new_module(

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1444,21 +1444,21 @@ MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES = [
         {"target_modules": ["lin0"], "r": 2, "depth": 1, "act_fn": "relu", "init_weights": False},
         {"target_modules": ["lin1"], "r": 2, "depth": 1, "act_fn": "relu", "init_weights": False},
     ),
-    # for TinyLoRA, choosing a very high r; this is just so that when the 2nd adapter is created, it is sufficiently
-    # different from the first to detect the difference above tolerance level
+    # for TinyLoRA, use uniform init, which allows the different adapters to be sufficiently different that they don't
+    # produce identical results within allowed tolerance
     (
         "TinyLora Same",
         "tinylora",
         TinyLoraConfig,
-        {"target_modules": ["lin0"], "r": 1024, "u": 16, "init_weights": False},
-        {"target_modules": ["lin0"], "r": 1024, "u": 16, "init_weights": False},
+        {"target_modules": ["lin0"], "init_weights": "uniform"},
+        {"target_modules": ["lin0"], "init_weights": "uniform"},
     ),
     (
         "TinyLora Different",
         "tinylora",
         TinyLoraConfig,
-        {"target_modules": ["lin0"], "r": 1024, "u": 16, "init_weights": False},
-        {"target_modules": ["lin1"], "r": 1024, "u": 16, "init_weights": False},
+        {"target_modules": ["lin0"], "init_weights": "uniform"},
+        {"target_modules": ["lin1"], "init_weights": "uniform"},
     ),
 ]
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -651,6 +651,12 @@ TEST_CASES = [
         TinyLoraConfig,
         {"target_modules": ["conv1d"], "r": 2, "u": 16, "init_v_bound": 0.5},
     ),
+    (
+        "Embedding + transformers Conv1D 2 TinyLoRA",
+        "EmbConv1D",
+        TinyLoraConfig,
+        {"target_modules": ["emb"], "r": 2, "u": 16},
+    ),
     #############
     #########
     # PVERA #

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1447,14 +1447,14 @@ MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES = [
     # for TinyLoRA, use uniform init, which allows the different adapters to be sufficiently different that they don't
     # produce identical results within allowed tolerance
     (
-        "TinyLora Same",
+        "TinyLoRA Same",
         "tinylora",
         TinyLoraConfig,
         {"target_modules": ["lin0"], "init_weights": "uniform"},
         {"target_modules": ["lin0"], "init_weights": "uniform"},
     ),
     (
-        "TinyLora Different",
+        "TinyLoRA Different",
         "tinylora",
         TinyLoraConfig,
         {"target_modules": ["lin0"], "init_weights": "uniform"},

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1444,6 +1444,22 @@ MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES = [
         {"target_modules": ["lin0"], "r": 2, "depth": 1, "act_fn": "relu", "init_weights": False},
         {"target_modules": ["lin1"], "r": 2, "depth": 1, "act_fn": "relu", "init_weights": False},
     ),
+    # for TinyLoRA, choosing a very high r; this is just so that when the 2nd adapter is created, it is sufficiently
+    # different from the first to detect the difference above tolerance level
+    (
+        "TinyLora Same",
+        "tinylora",
+        TinyLoraConfig,
+        {"target_modules": ["lin0"], "r": 1024, "u": 16, "init_weights": False},
+        {"target_modules": ["lin0"], "r": 1024, "u": 16, "init_weights": False},
+    ),
+    (
+        "TinyLora Different",
+        "tinylora",
+        TinyLoraConfig,
+        {"target_modules": ["lin0"], "r": 1024, "u": 16, "init_weights": False},
+        {"target_modules": ["lin1"], "r": 1024, "u": 16, "init_weights": False},
+    ),
 ]
 
 


### PR DESCRIPTION
TinyLoRA initialization is not completely deterministic because it partly relies on Python hash, which is not fixed. One of the tests (`test_merge_layers_multi`) is a bit sensitive because the TinyLoRA contribution is rather small, which would result in a ~5% chance of the test failing.

This PR fixes this issue and makes the initialization completely deterministic. The fix is to avoid the Python hash completely and instead ensure that the layer index is always set in time so that it can be used instead of the hash.

While working on this PR, I also did a few tangential changes:

1. small refactor of the interface for better consistency
2. missing tests for TinyLoRA targeting the embedding layer
3. missing tests for multiple active adapters

Check the individual commits to distinguish the individual changes.
