### PR TITLE
fix(tuners/lora/bnb): normalize output device for CPU-offloaded BnB layers

### DIFF
--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -247,6 +247,7 @@ if is_bnb_available():
                 result = self.base_layer(x, *args, **kwargs)
             else:
                 result = self.base_layer(x, *args, **kwargs)
+                result = result.to(x.device)  # normalize device for CPU-offloaded layers
                 for active_adapter in self.active_adapters:
                     if active_adapter not in self.lora_A.keys():
                         continue
@@ -521,6 +522,7 @@ if is_bnb_4bit_available():
                 result = self.base_layer(x, *args, **kwargs)
             else:
                 result = self.base_layer(x, *args, **kwargs)
+                result = result.to(x.device)  # normalize device for CPU-offloaded layers
                 # As per Tim Dettmers, for 4bit, we need to defensively clone here.
                 # The reason is that in some cases, an error can occur that backprop
                 # does not work on a manipulated view. This issue may be solved with


### PR DESCRIPTION
## Problem

When using LoRA with bitsandbytes INT8 or INT4 quantization combined with CPU offload (via `accelerate` `device_map`), the forward pass raises:

```
RuntimeError: Expected all tensors to be on the same device,
but found at least two devices, cuda:0 and cpu!
```

**Root cause:** In `Linear8bitLt.forward` and `Linear4bit.forward`, after calling `self.base_layer(x, ...)`, the `result` tensor may be on CPU (because the offloaded layer computed on CPU), while the LoRA delta `output = lora_B(lora_A(dropout(x))) * scaling` is computed on CUDA. Adding them together raises a device mismatch.

## Fix

Normalize `result` to match the input device (`x.device`) immediately after calling the base layer in both `Linear8bitLt.forward` and `Linear4bit.forward`:

```python
result = self.base_layer(x, *args, **kwargs)
result = result.to(x.device)  # normalize device for CPU-offloaded layers
```

This is a no-op when the layer is not offloaded (tensor is already on the correct device), so it does not affect normal usage.

## Reproducer

Reported setup: Gemma4 26B-A4B-it, `load_in_8bit=True`, `device_map` with CPU offload, LoRA r=16.

Fixes #3169