### PR TITLE
FIX VeRA and OFT error after layer init refactor

### DIFF
--- a/src/peft/tuners/oft/gptq.py
+++ b/src/peft/tuners/oft/gptq.py
@@ -74,6 +74,7 @@ class GPTQOFTLinear(torch.nn.Module, OFTLayer):
 def dispatch_gptq(
     target: torch.nn.Module,
     adapter_name: str,
+    oft_config: OFTConfig,
     **kwargs: Any,
 ) -> Optional[torch.nn.Module]:
     new_module = None
@@ -87,7 +88,7 @@ def dispatch_gptq(
         from gptqmodel.nn_modules.qlinear import BaseQuantLinear
 
         if isinstance(target_base_layer, BaseQuantLinear):
-            new_module = GPTQOFTLinear(target, adapter_name, **kwargs)
+            new_module = GPTQOFTLinear(target, adapter_name, config=oft_config, **kwargs)
             target.qweight = target_base_layer.qweight
 
     return new_module

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -242,7 +242,7 @@ class VeraModel(BaseTuner):
                     "index": target_base_layer.index,
                 }
             )
-            return Linear8bitLt(target, adapter_name, vera_A, vera_B, **eightbit_kwargs)
+            return Linear8bitLt(target, adapter_name, vera_A, vera_B, config=vera_config, **eightbit_kwargs)
         elif kwargs["loaded_in_4bit"] and isinstance(target_base_layer, bnb.nn.Linear4bit):
             fourbit_kwargs = kwargs.copy()
             fourbit_kwargs.update(
@@ -252,7 +252,7 @@ class VeraModel(BaseTuner):
                     "quant_type": target_base_layer.weight.quant_type,
                 }
             )
-            return Linear4bit(target, adapter_name, vera_A, vera_B, **fourbit_kwargs)
+            return Linear4bit(target, adapter_name, vera_A, vera_B, config=vera_config, **fourbit_kwargs)
         elif isinstance(target_base_layer, torch.nn.Linear):
             if vera_config.fan_in_fan_out:
                 warnings.warn(


### PR DESCRIPTION
PR #3047 introduced issues with layer initialization for VeRA when using bitsandbytes, as well as for OFT when using GPTQ. These tests failed on the nightly GPU CI.

I confirmed locally that the tests now pass.

Failing tests:

- https://github.com/huggingface/peft/actions/runs/24814323261/job/72625376879#step:6:1483
- https://github.com/huggingface/peft/actions/runs/24814323261/job/72625376879#step:5:1527