### PR TITLE
FIX Transformers weight conversion regression

### DIFF
--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -255,14 +255,14 @@ def build_peft_weight_mapping(
                 # TODO: this assumption may not hold for models != mixtral
                 # For source, we capture the original weights + the lora weights
                 new_source_patterns = []
-                for pat in list(orig_conversion._original_source_patterns):
+                for pat in list(orig_conversion.source_patterns):
                     # we replace the weight pattern to colllect loras
                     pat = pat.rsplit(".", 1)[0]
                     # note: the source state_dict does *not* contain the adapter name
                     new_source_patterns.append(f"{pat}.{lora}.*")
 
                 # the gate_up_proj is the innner PEFT ParamWrapper, so we need to use base_layer
-                pat = orig_conversion._original_target_patterns[0]
+                pat = orig_conversion.target_patterns[0]
                 pat = pat.replace("gate_up_proj", "base_layer")
                 # we make sure the target key is correct, add '.weight' because the parameter is targeted directly
                 new_target_patterns = [f"{pat}.{lora}.{adapter_name}.weight"]
@@ -297,14 +297,14 @@ def build_peft_weight_mapping(
                 # TODO: this assumption may not hold for models != mixtral
                 # For source, we capture the original weights + the lora weights
                 new_source_patterns = []
-                for pat in list(orig_conversion._original_source_patterns):
+                for pat in list(orig_conversion.source_patterns):
                     # we replace the weight pattern to colllect loras
                     pat = pat.rsplit(".", 1)[0]
                     # note: the source state_dict does *not* contain the adapter name
                     new_source_patterns.append(f"{pat}.{lora}.*")
 
                 # the down_proj is the outer PEFT ParamWrapper, so we remove the prefix
-                pat = orig_conversion._original_target_patterns[0]
+                pat = orig_conversion.target_patterns[0]
                 pat = pat.replace(".down_proj", "")
                 # we make sure the target key is correct, add '.weight' because the parameter is targeted directly
                 new_target_patterns = [f"{pat}.{lora}.{adapter_name}.weight"]

--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -206,7 +206,10 @@ def build_peft_weight_mapping(
         return []
 
     # strip "base_model.model" and add adapter name
-    new_weight_conversions = [WeightRenaming("base_model.model.model.", "model.")]
+    new_weight_conversions = [
+        WeightRenaming("base_model.model.model.", "model."),
+        WeightRenaming("base_model.model.", ""),
+    ]
 
     prefixes = set()
     from peft.mapping import PEFT_TYPE_TO_PREFIX_MAPPING
@@ -252,14 +255,14 @@ def build_peft_weight_mapping(
                 # TODO: this assumption may not hold for models != mixtral
                 # For source, we capture the original weights + the lora weights
                 new_source_patterns = []
-                for pat in list(orig_conversion.source_patterns):
+                for pat in list(orig_conversion._original_source_patterns):
                     # we replace the weight pattern to colllect loras
                     pat = pat.rsplit(".", 1)[0]
                     # note: the source state_dict does *not* contain the adapter name
                     new_source_patterns.append(f"{pat}.{lora}.*")
 
                 # the gate_up_proj is the innner PEFT ParamWrapper, so we need to use base_layer
-                pat = orig_conversion.target_patterns[0]
+                pat = orig_conversion._original_target_patterns[0]
                 pat = pat.replace("gate_up_proj", "base_layer")
                 # we make sure the target key is correct, add '.weight' because the parameter is targeted directly
                 new_target_patterns = [f"{pat}.{lora}.{adapter_name}.weight"]
@@ -268,10 +271,10 @@ def build_peft_weight_mapping(
                 new_conversion = orig_conversion.__class__(
                     source_patterns=new_source_patterns,
                     target_patterns=new_target_patterns,
-                    distributed_operation=orig_conversion.distributed_operation,
-                    quantization_operation=orig_conversion.quantization_operation,
                     operations=peft_weight_operations,
                 )
+                new_conversion.distributed_operation = orig_conversion.distributed_operation
+                new_conversion.quantization_operation = orig_conversion.quantization_operation
                 new_weight_conversions.append(new_conversion)
 
         elif len(orig_conversion.target_patterns) == 1 and orig_conversion.target_patterns[0].endswith("down_proj"):
@@ -294,14 +297,14 @@ def build_peft_weight_mapping(
                 # TODO: this assumption may not hold for models != mixtral
                 # For source, we capture the original weights + the lora weights
                 new_source_patterns = []
-                for pat in list(orig_conversion.source_patterns):
+                for pat in list(orig_conversion._original_source_patterns):
                     # we replace the weight pattern to colllect loras
                     pat = pat.rsplit(".", 1)[0]
                     # note: the source state_dict does *not* contain the adapter name
                     new_source_patterns.append(f"{pat}.{lora}.*")
 
                 # the down_proj is the outer PEFT ParamWrapper, so we remove the prefix
-                pat = orig_conversion.target_patterns[0]
+                pat = orig_conversion._original_target_patterns[0]
                 pat = pat.replace(".down_proj", "")
                 # we make sure the target key is correct, add '.weight' because the parameter is targeted directly
                 new_target_patterns = [f"{pat}.{lora}.{adapter_name}.weight"]
@@ -310,10 +313,10 @@ def build_peft_weight_mapping(
                 new_conversion = orig_conversion.__class__(
                     source_patterns=new_source_patterns,
                     target_patterns=new_target_patterns,
-                    distributed_operation=orig_conversion.distributed_operation,
-                    quantization_operation=orig_conversion.quantization_operation,
                     operations=peft_weight_operations,
                 )
+                new_conversion.distributed_operation = orig_conversion.distributed_operation
+                new_conversion.quantization_operation = orig_conversion.quantization_operation
                 new_weight_conversions.append(new_conversion)
 
     return new_weight_conversions


### PR DESCRIPTION
After a change in https://github.com/huggingface/transformers/pull/45448, weight conversion tests started failing. Transformers provided a fix in https://github.com/huggingface/transformers/pull/45622 but it needs to be ported to PEFT too. The PR also ports the fix from https://github.com/huggingface/transformers/pull/45428.

This PR fixes the issue from the PEFT side. For the transformers side (`model.load_adapter`), we need to wait for https://github.com/huggingface/transformers/pull/45622 to land and be released.