### PR TITLE
Add a generator to the PVeRA reparameterization function.

### DIFF
--- a/src/peft/tuners/pvera/bnb.py
+++ b/src/peft/tuners/pvera/bnb.py
@@ -227,7 +227,7 @@ if is_bnb_available():
                     x_temp = dropout(x.to(lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
                     adapter_output = lambda_b * F.linear(
-                        self._reparametrize(mu, logvar, self.sample_at_inference, generator=self.generator), sliced_B
+                        self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
                     )
 
                     if requires_conversion:
@@ -397,7 +397,7 @@ if is_bnb_4bit_available():
                     x_temp = dropout(x.to(lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
                     adapter_output = lambda_b * F.linear(
-                        self._reparametrize(mu, logvar, self.sample_at_inference, generator=self.generator), sliced_B
+                        self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
                     )
 
                     if requires_conversion:

--- a/src/peft/tuners/pvera/bnb.py
+++ b/src/peft/tuners/pvera/bnb.py
@@ -227,7 +227,7 @@ if is_bnb_available():
                     x_temp = dropout(x.to(lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
                     adapter_output = lambda_b * F.linear(
-                        self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
+                        self._reparametrize(mu, logvar, self.sample_at_inference, generator=self.generator), sliced_B
                     )
 
                     if requires_conversion:
@@ -397,7 +397,7 @@ if is_bnb_4bit_available():
                     x_temp = dropout(x.to(lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
                     adapter_output = lambda_b * F.linear(
-                        self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
+                        self._reparametrize(mu, logvar, self.sample_at_inference, generator=self.generator), sliced_B
                     )
 
                     if requires_conversion:

--- a/src/peft/tuners/pvera/config.py
+++ b/src/peft/tuners/pvera/config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import torch
 import warnings
 from dataclasses import dataclass, field
 from typing import Optional, Union
@@ -75,6 +76,8 @@ class PveraConfig(PeftConfig):
             default for non-specified adapters). For example
             `sample_at_inference={'encoder.layer.0.attention.attention.query': True}` will only sample at inference for
             one specific adapter.
+        generator (`torch.Generator`, defaults to None):
+            Random generator for sampling from the learned distribution.
     """
 
     r: int = field(
@@ -187,6 +190,7 @@ class PveraConfig(PeftConfig):
             ),
         },
     )
+    generator: torch.Generator = field(default=None, metadata={"help": "Random generator for sampling from the learned distribution."})
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/peft/tuners/pvera/config.py
+++ b/src/peft/tuners/pvera/config.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import torch
 import warnings
 from dataclasses import dataclass, field
 from typing import Optional, Union
@@ -76,8 +75,8 @@ class PveraConfig(PeftConfig):
             default for non-specified adapters). For example
             `sample_at_inference={'encoder.layer.0.attention.attention.query': True}` will only sample at inference for
             one specific adapter.
-        generator (`torch.Generator`, defaults to None):
-            Random generator for sampling from the learned distribution.
+        generator_seed (`int`, defaults to None):
+            Random seed for the generator for sampling from the learned distribution.
     """
 
     r: int = field(
@@ -190,7 +189,7 @@ class PveraConfig(PeftConfig):
             ),
         },
     )
-    generator: torch.Generator = field(default=None, metadata={"help": "Random generator for sampling from the learned distribution."})
+    generator_seed: int = field(default=None, metadata={"help": "Random seed for the generator for sampling from the learned distribution."})
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/peft/tuners/pvera/config.py
+++ b/src/peft/tuners/pvera/config.py
@@ -189,7 +189,9 @@ class PveraConfig(PeftConfig):
             ),
         },
     )
-    generator_seed: int = field(default=None, metadata={"help": "Random seed for the generator for sampling from the learned distribution."})
+    generator_seed: int = field(
+        default=None, metadata={"help": "Random seed for the generator for sampling from the learned distribution."}
+    )
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -94,7 +94,7 @@ class PveraLayer(BaseTunerLayer):
             self.generator.manual_seed(config.generator_seed)
         else:
             self.generator = None
-        
+
         self.pvera_dropout.update(nn.ModuleDict({adapter_name: pvera_dropout_layer}))
         # Actual trainable parameters
         self.pvera_lambda_b[adapter_name] = nn.Parameter(torch.ones(self.out_features), requires_grad=True)

--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -89,6 +89,7 @@ class PveraLayer(BaseTunerLayer):
         else:
             pvera_dropout_layer = nn.Identity()
 
+        self.generator = config.generator
         self.pvera_dropout.update(nn.ModuleDict({adapter_name: pvera_dropout_layer}))
         # Actual trainable parameters
         self.pvera_lambda_b[adapter_name] = nn.Parameter(torch.ones(self.out_features), requires_grad=True)
@@ -143,10 +144,10 @@ class PveraLayer(BaseTunerLayer):
                 nn.init.zeros_(self.pvera_lambda_d[adapter_name]).fill_(d_initial)
                 nn.init.zeros_(self.pvera_lambda_b[adapter_name])
 
-    def _reparametrize(self, mu, logvar, sample_at_inference):
+    def _reparametrize(self, mu, logvar, sample_at_inference, generator=None):
         if self.training or (not self.training and sample_at_inference):
             std = torch.exp(0.5 * logvar)
-            eps = torch.randn_like(std)
+            eps = torch.randn_like(std, generator=self.generator)
             z = mu + eps * std
         else:
             z = mu
@@ -299,7 +300,7 @@ class Linear(nn.Linear, PveraLayer):
                 x = x.to(lambda_d.dtype)
                 mu, logvar = (lambda_d * F.linear(dropout(x), sliced_A)).chunk(2, dim=-1)
                 result = result + lambda_b * F.linear(
-                    self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
+                    self._reparametrize(mu, logvar, self.sample_at_inference, generator=self.generator), sliced_B
                 )
 
         result = result.to(previous_dtype)

--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -89,7 +89,12 @@ class PveraLayer(BaseTunerLayer):
         else:
             pvera_dropout_layer = nn.Identity()
 
-        self.generator = config.generator
+        if config.generator_seed is not None:
+            self.generator = torch.Generator()
+            self.generator.manual_seed(config.generator_seed)
+        else:
+            self.generator = None
+        
         self.pvera_dropout.update(nn.ModuleDict({adapter_name: pvera_dropout_layer}))
         # Actual trainable parameters
         self.pvera_lambda_b[adapter_name] = nn.Parameter(torch.ones(self.out_features), requires_grad=True)
@@ -144,9 +149,10 @@ class PveraLayer(BaseTunerLayer):
                 nn.init.zeros_(self.pvera_lambda_d[adapter_name]).fill_(d_initial)
                 nn.init.zeros_(self.pvera_lambda_b[adapter_name])
 
-    def _reparametrize(self, mu, logvar, sample_at_inference, generator=None):
+    def _reparametrize(self, mu, logvar, sample_at_inference):
         if self.training or (not self.training and sample_at_inference):
             std = torch.exp(0.5 * logvar)
+            print(self.generator)
             eps = torch.randn_like(std, generator=self.generator)
             z = mu + eps * std
         else:
@@ -300,7 +306,7 @@ class Linear(nn.Linear, PveraLayer):
                 x = x.to(lambda_d.dtype)
                 mu, logvar = (lambda_d * F.linear(dropout(x), sliced_A)).chunk(2, dim=-1)
                 result = result + lambda_b * F.linear(
-                    self._reparametrize(mu, logvar, self.sample_at_inference, generator=self.generator), sliced_B
+                    self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
                 )
 
         result = result.to(previous_dtype)

--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -152,7 +152,6 @@ class PveraLayer(BaseTunerLayer):
     def _reparametrize(self, mu, logvar, sample_at_inference):
         if self.training or (not self.training and sample_at_inference):
             std = torch.exp(0.5 * logvar)
-            print(self.generator)
             eps = torch.randn_like(std, generator=self.generator)
             z = mu + eps * std
         else:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -3794,22 +3794,23 @@ class TestPeftCustomModel(PeftCommonTester):
 
     def test_pvera_reproducible(self):
         inputs = {"input_ids": torch.arange(10).view(-1, 1).to(self.torch_device)}
-        config = PveraConfig(r=4, sample_at_inference=True, generator_seed=0)
+        config = PveraConfig(init_weights=False, sample_at_inference=True, generator_seed=0)
         base_model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/tiny-random-OPTForCausalLM")
-        model1 = get_peft_model(base_model, config).to(self.torch_device)
+        torch.manual_seed(0)
+        model = get_peft_model(base_model, config).to(self.torch_device)
+        torch.manual_seed(1)
+        output1 = model(**inputs).logits
 
-        optimizer = torch.optim.SGD(model1.parameters())
-        y_pred = model1(**inputs).logits
-        dummy_y = torch.randn_like(y_pred)
-        loss = (y_pred - dummy_y).abs().mean()
-        loss.backward()
-        optimizer.step()
+        del model
 
-        model2 = copy.deepcopy(model1)
+        config = PveraConfig(init_weights=False, sample_at_inference=True, generator_seed=0)
+        base_model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/tiny-random-OPTForCausalLM")
+        torch.manual_seed(0)
+        model = get_peft_model(base_model, config).to(self.torch_device)
+        torch.manual_seed(2)
+        output2 = model(**inputs).logits
 
-        y1 = model1(**inputs).logits
-        y2 = model2(**inputs).logits
-        assert (y1 == y2).all()
+        assert (output1 == output2).all()
 
 
 class TestMultiRankAdapter:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -3792,6 +3792,25 @@ class TestPeftCustomModel(PeftCommonTester):
         assert model.base_model.model.mha.base_layer.out_proj.base_layer.weight.requires_grad is True
         assert model.base_model.model.mha.base_layer.in_proj_weight.requires_grad is True
 
+    def test_pvera_reproducible(self):
+        inputs = {"input_ids": torch.arange(10).view(-1, 1).to(self.torch_device)}
+        config = PveraConfig(r=4, sample_at_inference=True, generator_seed=0)
+        base_model = AutoModelForCausalLM.from_pretrained("peft-internal-testing/tiny-random-OPTForCausalLM")
+        model1 = get_peft_model(base_model, config).to(self.torch_device)
+
+        optimizer = torch.optim.SGD(model1.parameters())
+        y_pred = model1(**inputs).logits
+        dummy_y = torch.randn_like(y_pred)
+        loss = (y_pred - dummy_y).abs().mean()
+        loss.backward()
+        optimizer.step()
+
+        model2 = copy.deepcopy(model1)
+
+        y1 = model1(**inputs).logits
+        y2 = model2(**inputs).logits
+        assert (y1 == y2).all()
+
 
 class TestMultiRankAdapter:
     """Tests related to multirank LoRA adapters"""


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/huggingface/peft/pull/3189#discussion_r3140569649) from PR #3189.

It integrates a generator in the reparameterization function from PVeRA, and uses it for sampling the random epsilon. This generator (`torch.Generator`) can be specified in the config.