### PR TITLE
fix(pvera): use _cast_input_dtype in forward instead of raw .to()

### DIFF
--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -296,7 +296,7 @@ class Linear(nn.Linear, PveraLayer):
                 sliced_B = pvera_B[: self.out_features, :].to(x.device)
 
                 dropout = self.pvera_dropout[active_adapter]
-                x = x.to(lambda_d.dtype)
+                x = self._cast_input_dtype(x, lambda_d.dtype)
                 mu, logvar = (lambda_d * F.linear(dropout(x), sliced_A)).chunk(2, dim=-1)
                 result = result + lambda_b * F.linear(
                     self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B


### PR DESCRIPTION
## Bug

`Linear.forward` in `src/peft/tuners/pvera/layer.py` casts the input tensor with `x = x.to(lambda_d.dtype)`. This bypasses the `disable_lora_input_dtype_casting` context manager provided by `BaseTunerLayer`, which is intended to let callers suppress dtype casting during specific operations (e.g. AMP, mixed-precision inference).

## Root cause

`BaseTunerLayer._cast_input_dtype` checks `self._disable_lora_input_dtype_casting` and is a no-op when the context manager is active. A bare `.to(dtype)` call has no such guard.

## Fix

Replace the raw cast with the inherited helper:

```python
# before
x = x.to(lambda_d.dtype)
# after
x = self._cast_input_dtype(x, lambda_d.dtype)
```

This is the same pattern already applied to `vera` (#3172), `poly` (#3177), and `fourierft` (#3170); `pvera` was the only tuner that still used the raw `.to()` call.