### PR TITLE
fix(gralora): use _cast_input_dtype in forward instead of raw .to()

### DIFF
--- a/src/peft/tuners/gralora/layer.py
+++ b/src/peft/tuners/gralora/layer.py
@@ -364,7 +364,7 @@ class Linear(nn.Linear, GraloraLayer):
                     "bljr, jro -> bljo",
                     torch.einsum(
                         "blni, nir -> blnr",
-                        dropout(x.to(gralora_dtype)).view(B, L, N, in_features // N),
+                        dropout(self._cast_input_dtype(x, gralora_dtype)).view(B, L, N, in_features // N),
                         gralora_A,
                     )
                     .view(B, L, N, N, subblock_gralora_rank)
@@ -379,7 +379,7 @@ class Linear(nn.Linear, GraloraLayer):
 
                 result += scaling * output.to(torch_result_dtype)
                 if hybrid_r > 0:
-                    hybrid_output = gralora_B_general(gralora_A_general(dropout(x.to(gralora_dtype))))
+                    hybrid_output = gralora_B_general(gralora_A_general(dropout(self._cast_input_dtype(x, gralora_dtype))))
                     if x_is_2d:
                         hybrid_output = hybrid_output.squeeze(1)
                     result += scaling * hybrid_output.to(torch_result_dtype)


### PR DESCRIPTION
## Bug

`Linear.forward` in `src/peft/tuners/gralora/layer.py` casts the input tensor with `x.to(gralora_dtype)` in two places. This bypasses the `disable_lora_input_dtype_casting` context manager provided by `BaseTunerLayer`, which lets callers suppress dtype casting during specific operations (e.g. AMP, mixed-precision inference).

## Root cause

`BaseTunerLayer._cast_input_dtype` checks `self._disable_lora_input_dtype_casting` and is a no-op when the context manager is active. A bare `.to(dtype)` call has no such guard.

## Fix

Replace both raw casts with the inherited helper:

```python
# before (line 367)
dropout(x.to(gralora_dtype)).view(...)
# after
dropout(self._cast_input_dtype(x, gralora_dtype)).view(...)

# before (line 382)
gralora_B_general(gralora_A_general(dropout(x.to(gralora_dtype))))
# after
gralora_B_general(gralora_A_general(dropout(self._cast_input_dtype(x, gralora_dtype))))
```

This is the same pattern already applied to `vera` (#3172), `poly` (#3177), `fourierft` (#3170), and `pvera` (#3208). `gralora` was missed in those fixes.