### PR TITLE
FIX State dict injection with weight conversion

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -827,7 +827,7 @@ def set_peft_model_state_dict(
     prefix = "base_model.model."
     requires_prefix = any(n.startswith(prefix) for n, _ in model.named_parameters())
     if not requires_prefix:
-        peft_model_state_dict = {k.removeprefix("base_model.model."): v for k, v in peft_model_state_dict.items()}
+        peft_model_state_dict = {k.removeprefix(prefix): v for k, v in peft_model_state_dict.items()}
 
     peft_model_state_dict, mismatched_keys = _find_mismatched_keys(
         model, peft_model_state_dict, ignore_mismatched_sizes=ignore_mismatched_sizes

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -821,6 +821,14 @@ def set_peft_model_state_dict(
     else:
         raise NotImplementedError
 
+    # Updating the state dict for Transformers weight conversion with convert_peft_adapter_state_dict_for_transformers
+    # can introduce the base model prefix, but when loading the state_dict directly into the model (i.e. no PeftModel,
+    # e.g. when using set_peft_model_state_dict), there is no prefix.
+    prefix = "base_model.model."
+    requires_prefix = any(n.startswith(prefix) for n, _ in model.named_parameters())
+    if not requires_prefix:
+        peft_model_state_dict = {k.removeprefix("base_model.model."): v for k, v in peft_model_state_dict.items()}
+
     peft_model_state_dict, mismatched_keys = _find_mismatched_keys(
         model, peft_model_state_dict, ignore_mismatched_sizes=ignore_mismatched_sizes
     )

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -22,7 +22,13 @@ import pytest
 import torch
 from diffusers import StableDiffusionPipeline
 from torch import nn
-from transformers import AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoModelForSequenceClassification
+from transformers import (
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoModelForSeq2SeqLM,
+    AutoModelForSequenceClassification,
+    CLIPTextModel,
+)
 
 from peft import (
     AdaLoraConfig,
@@ -427,6 +433,48 @@ class TestInjectAdapterFromStateDict:
             assert sd_before.keys() == sd_after.keys()
             for key in sd_before.keys():
                 assert sd_before[key].shape == sd_after[key].shape
+
+    def test_inject_from_state_dict_low_cpu_mem_usage_with_weight_conversion(self):
+        # Tests if we can inject LoRA state dict with low_cpu_mem_usage for a model that uses Transformers weight
+        # conversion. This checks a regression reported by Sayak of this Diffusers test:
+        # tests/lora/test_lora_layers_flux.py::FluxLoRATests::test_low_cpu_mem_usage_with_injection
+        config = LoraConfig(target_modules=["q_proj", "v_proj"])
+        # must be a model with `get_checkpoint_conversion_mapping(model_type) != None`
+        model_id = "peft-internal-testing/tiny-clip-text-2"
+
+        with hub_online_once(model_id):
+            model = CLIPTextModel.from_pretrained(model_id)
+            inject_adapter_in_model(config, model, low_cpu_mem_usage=True)
+            assert all(p.device.type == "meta" for n, p in model.named_parameters() if "lora." in n)
+
+            state_dict = get_peft_model_state_dict(model)
+            state_dict_no_meta = {k: torch.randn(v.shape, dtype=v.dtype) for k, v in state_dict.items()}
+            set_peft_model_state_dict(model, state_dict_no_meta, low_cpu_mem_usage=True)
+            assert not any(p.device.type == "meta" for p in model.parameters())
+
+    def test_inject_from_state_dict_model_with_weight_conversion(self):
+        # similar test to test_inject_from_state_dict_low_cpu_mem_usage_with_weight_conversion but without
+        # low_cpu_mem_usage
+        config = LoraConfig(target_modules=["q_proj", "v_proj"])
+        # must be a model with `get_checkpoint_conversion_mapping(model_type) != None`
+        model_id = "peft-internal-testing/tiny-clip-text-2"
+
+        with hub_online_once(model_id):
+            model = CLIPTextModel.from_pretrained(model_id)
+            inject_adapter_in_model(config, model)
+            # sanity check:
+            assert (model.encoder.layers[0].self_attn.v_proj.lora_B.default.weight == 0).all()
+
+            state_dict = get_peft_model_state_dict(model)
+            state_dict = {k: torch.ones_like(v) * 555 for k, v in state_dict.items()}
+            load_result = set_peft_model_state_dict(model, state_dict)
+
+            assert not load_result.unexpected_keys
+            # base model weights may be missing, but LoRA weights should never be missing
+            assert not any("lora" in k for k in load_result.missing_keys)
+
+            # sanity check:
+            assert (model.encoder.layers[0].self_attn.v_proj.lora_B.default.weight == 555).all()
 
 
 class TestPeftStateDict:


### PR DESCRIPTION
As reported by Sayak, resolves failing Diffusers test:

`tests/lora/test_lora_layers_flux.py::FluxLoRATests::test_low_cpu_mem_usage_with_injection`

When a model with Transformers weight conversion is being loaded, the `state_dict` needs to be converted using
`convert_peft_adapter_state_dict_for_transformers` (#3083). This introduces base model prefixes to the `state_dict`. If the `state_dict` is loaded directly into the model, e.g. via `set_peft_model_state_dict`, the prefix leads to a mismatch. The solution is thus to remove the prefix in this case.

The Diffusers test for direct `state_dict` injection uncovered this because it uses Clip, which has weight conversions, whereas the models in the PEFT tests happened not to have weight conversions. The fact that the Diffusers test uses `low_cpu_mem_usage` is coincidental to the problem. I added new PEFT tests to catch this regression (both with and without `low_cpu_mem_usage`) and ensured that the tests fail without the fix.