### PR TITLE
fix(tuners): guard child.weight access in _replace_module for non-linear modules

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1167,7 +1167,8 @@ class BaseTuner(nn.Module, ABC):
             child = child.base_layer
 
         if not hasattr(new_module, "base_layer"):
-            new_module.weight = child.weight
+            if hasattr(child, "weight"):
+                new_module.weight = child.weight
             if hasattr(child, "bias"):
                 new_module.bias = child.bias
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -274,6 +274,37 @@ class TestModulesToSaveAttributeAccess:
             model.lin1.weight
 
 
+class TestModulesToSaveMergeAndUnload:
+    def test_merge_and_unload_without_weight(self):
+        # Regression test for #3213: merge_and_unload should not crash when modules_to_save
+        # targets a module without a weight attribute (e.g., a transformer encoder block)
+        class ModuleWithoutWeight(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.foo = nn.Linear(1, 1)
+            
+            def forward(self, x):
+                return self.foo(x)
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin0 = nn.Linear(1, 2)
+                self.mod1 = ModuleWithoutWeight()
+            
+            def forward(self, x):
+                return self.mod1(self.lin0(x))
+
+        from peft import LoraConfig, get_peft_model
+        config = LoraConfig(target_modules=["lin0"], modules_to_save=["mod1"])
+        model = get_peft_model(Model(), config)
+        
+        # This should not raise an AttributeError
+        merged = model.merge_and_unload()
+        assert not hasattr(merged.mod1, "weight")
+
+
+
 class TestModulesToSaveKwargsOnlyForward:
     """Regression test for #3191: modules listed in `modules_to_save` whose parent calls them with keyword arguments
     only (e.g. Gemma's `vision_tower(pixel_values=...)`) used to crash with `TypeError: forward() missing 1 required


### PR DESCRIPTION
**Bug:** `_replace_module` in `tuners_utils.py` unconditionally assigns `new_module.weight = child.weight` without checking whether `child` actually has a `weight` attribute:

```python
if not hasattr(new_module, "base_layer"):
    new_module.weight = child.weight   # crashes if child has no weight
    if hasattr(child, "bias"):
        new_module.bias = child.bias
```

When `modules_to_save` contains non-linear module blocks (e.g. `Siglip2EncoderLayer`, full transformer encoder layers, or any module without a `weight` parameter), calling `merge_and_unload()` raises:
```
AttributeError: 'Siglip2EncoderLayer' object has no attribute 'weight'
```

**Root cause:** The `bias` assignment already uses `hasattr(child, "bias")` as a guard, but the `weight` assignment has no equivalent guard. Non-linear modules in `modules_to_save` legitimately lack `weight`.

**Fix:** Add the same `hasattr` guard for `weight` that already exists for `bias`:

```python
if not hasattr(new_module, "base_layer"):
    if hasattr(child, "weight"):
        new_module.weight = child.weight
    if hasattr(child, "bias"):
        new_module.bias = child.bias
```

This is a one-line addition matching the existing convention in the same block.