### PR TITLE
fix: use torch.div in _ConvNd.unmerge for bias (was torch.mul)

### DIFF
--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -286,7 +286,7 @@ class _ConvNd(nn.Module, IA3Layer):
                 if not self.is_feedforward and (base_layer.bias is not None):
                     scaling = self.ia3_l[active_adapter].reshape(base_layer.bias.shape)
                     orig_dtype = base_layer.bias.data.dtype
-                    base_layer.bias.data = torch.mul(base_layer.bias.data, scaling.data).to(orig_dtype)
+                    base_layer.bias.data = torch.div(base_layer.bias.data, scaling.data + 1e-8).to(orig_dtype)
 
     def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
         dtype = previous_dtype = x.dtype


### PR DESCRIPTION
## Bug

`_ConvNd.unmerge()` in `src/peft/tuners/ia3/layer.py` uses `torch.mul` for the bias when inverting a merge, but should use `torch.div`:

```python
# merge() — line 262
base_layer.bias.data = torch.mul(base_layer.bias.data, scaling.data).to(orig_dtype)

# unmerge() — line 289 (buggy)
base_layer.bias.data = torch.mul(base_layer.bias.data, scaling.data).to(orig_dtype)
```

## Root cause

`unmerge()` must invert what `merge()` did. `merge()` multiplies the bias by `scaling`, so `unmerge()` must divide — but it multiplies again. A merge/unmerge round-trip leaves the bias scaled by `scaling²` instead of restoring the original value.

The weight unmerge on the line immediately above (line 284) correctly uses `torch.div`:

```python
base_layer.weight.data = torch.div(base_layer.weight.data, ia3_scaling + 1e-8).to(orig_dtype)
```

The `Linear` class's `unmerge()` also correctly uses `torch.div` for both weight and bias (lines 154, 159). `_ConvNd` is the only class with this inconsistency.

## Fix

Change `torch.mul` to `torch.div` and add `+ 1e-8` for numerical stability, matching the weight line directly above it.