### PR TITLE
FIX Model attribute error in get_model_conversion_mapping

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -780,17 +780,16 @@ class BaseTuner(nn.Module, ABC):
         ###################################
         # PREPARATION OF MODEL AND CONFIG #
         ###################################
-        is_transformers_like_model = hasattr(getattr(model, "config", None), "model_type")
+        is_transformers_like_model = isinstance(getattr(getattr(model, "config", None), "model_type", None), str)
         if is_transformers_ge_v5 and is_transformers_like_model:
             # TODO remove once transformers < v5.0 is no longer supported
             # For Transformers v5, some architectures were changed compared to v4, e.g. the MoE layers of Mixtral. To
             # still make it possible to load adapters trained with v4, we have to update the PEFT config so that the
             # right layers are targeted. Call this first and overwrite the peft_config to be sure that changes are
             # applied.
-            from peft.utils.transformers_weight_conversion import (
-                convert_peft_config_for_transformers,
-                get_model_conversion_mapping,
-            )
+            from transformers.conversion_mapping import get_model_conversion_mapping
+
+            from peft.utils.transformers_weight_conversion import convert_peft_config_for_transformers
 
             weight_conversions = get_model_conversion_mapping(model)
             convert_peft_config_for_transformers(

--- a/tests/test_trainable_tokens.py
+++ b/tests/test_trainable_tokens.py
@@ -1239,6 +1239,8 @@ class TestTrainableTokens:
                     "m1.decoder.embed_tokens.weight": "m1.encoder.embed_tokens.weight",
                     "m2.decoder.embed_tokens.weight": "m2.encoder.embed_tokens.weight",
                 }
+                # required for a check in transformers
+                self._named_pretrained_submodules = []
 
             def get_input_embeddings(self):
                 return self.m1.encoder.embed_tokens
@@ -1301,6 +1303,8 @@ class TestTrainableTokens:
                 )
                 self.m1 = BartModel(config)
                 self.config = config
+                # required for a check in transformers
+                self._named_pretrained_submodules = []
 
             def get_input_embeddings(self):
                 return self.m1.encoder.embed_tokens


### PR DESCRIPTION
After a refactor in Transformers (https://github.com/huggingface/transformers/pull/45661), a new attribute is required on Transformers models called `_named_pretrained_submodules`. Some tests used fake models that didn't have the attribute and thus resulted in an error.

We already have checks in place to avoid calling the function unless the model looks like a Transformers model, but these fake models passed muster and then were passed to `get_model_conversion_mapping`, resulting in an `AttributeError`.

The solution is to sharpen the check (`Mock` objects no longer pass it) and to add the attribute on fake transformers model used in some tests.