### PR TITLE
refine test_causal_lm_training_multi_accelerator test case

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4159,8 +4159,8 @@ class PeftAwqGPUTests(unittest.TestCase):
                 quantization_config=self.quantization_config,
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 


### PR DESCRIPTION
In test case `tests/test_gpu_examples.py::PeftAwqGPUTests::test_causal_lm_training_multi_accelerator`, the model is dispatched to 2 cards by hardcode, and it will fail if we have cards num>2 (e.g., 8 cards). This PR tries to fix this.