### PR TITLE
FIX Resolve regex target_modules in MoE config conversion

### DIFF
--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -400,10 +400,9 @@ def _resolve_string_target_modules(peft_config, model, target_module_mapping: di
         if is_all_linear:
             matched.add(old_name)
             continue
-        # a representative expert index (0/1) is enough for the regexes seen in practice
+        # probe the reconstructed v4 key (the fused parameter's container + the pre-fusion projection name)
         for container in containers:
-            candidates = (f"{container}.{old_name}", f"{container}.0.{old_name}", f"{container}.1.{old_name}")
-            if any(check_target_module_exists(peft_config, candidate) for candidate in candidates):
+            if check_target_module_exists(peft_config, f"{container}.{old_name}"):
                 matched.add(old_name)
                 break
     return matched

--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -358,13 +358,13 @@ def _resolve_string_target_modules(
     """Resolve a string `target_modules` (a regex or `"all-linear"`) to the concrete leaf names it targets.
 
     The keys of `target_module_mapping` are the v4 projection names that were renamed/fused on v5: the expert
-    projections (`gate_proj`, `up_proj`, `down_proj`) and the router `gate`. Resolving the string to leaf names up front
-    lets the list-based remap downstream stay unchanged for a regex and for `"all-linear"` alike.
+    projections (`gate_proj`, `up_proj`, `down_proj`) and the router `gate`. Resolving the string to leaf names up
+    front lets the list-based remap downstream stay unchanged for a regex and for `"all-linear"` alike.
 
-    `"all-linear"` matched every `nn.Linear` on the v4 model, so it targeted all of those projections; on v5 they are no
-    longer `nn.Linear` (the experts are fused into stacked parameters, the router became a custom module), so they are
-    added directly by name. A regex only targets what it spells out, so the experts -- which no longer exist as real
-    keys -- are recovered by probing each reconstructed v4 key against the pattern.
+    `"all-linear"` matched every `nn.Linear` on the v4 model, so it targeted all of those projections; on v5 they are
+    no longer `nn.Linear` (the experts are fused into stacked parameters, the router became a custom module), so they
+    are added directly by name. A regex only targets what it spells out, so the experts -- which no longer exist as
+    real keys -- are recovered by probing each reconstructed v4 key against the pattern.
     """
     if peft_config.target_modules.lower() == INCLUDE_LINEAR_LAYERS_SHORTHAND:
         # attention projections are still `nn.Linear` on v5, so resolve them by type; the experts and router were
@@ -407,7 +407,8 @@ def _convert_peft_config_moe(peft_config: PeftConfig, model: torch.nn.Module) ->
     requires updating the rank and alpha values of those parameters.
 
     A string `target_modules` (a regex, or `"all-linear"`) is resolved against the model up front (see
-    `_resolve_string_target_modules`), so the list-based remap below applies to lists, regexes and `"all-linear"` alike.
+    `_resolve_string_target_modules`), so the list-based remap below applies to lists, regexes and `"all-linear"`
+    alike.
     """
     model_type = getattr(model.config, "model_type", None)
     base_model_type = _MODEL_TO_CONVERSION_PATTERN.get(model_type, None)

--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -357,44 +357,42 @@ def _resolve_string_target_modules(
 ) -> set[str]:
     """Resolve a string `target_modules` (a regex or `"all-linear"`) to the concrete leaf names it targets.
 
-    Resolving up front lets the list-based remap downstream stay unchanged. The pre-fusion expert projections
-    (`gate_proj`, `up_proj`) are absent from a v5 model -- they live inside the stacked `gate_up_proj` parameter -- so
-    they are recovered from each fused parameter's container, not from `named_modules()`/`named_parameters()`.
+    The keys of `target_module_mapping` are the v4 projection names that were renamed/fused on v5: the expert
+    projections (`gate_proj`, `up_proj`, `down_proj`) and the router `gate`. Resolving the string to leaf names up front
+    lets the list-based remap downstream stay unchanged for a regex and for `"all-linear"` alike.
+
+    `"all-linear"` matched every `nn.Linear` on the v4 model, so it targeted all of those projections; on v5 they are no
+    longer `nn.Linear` (the experts are fused into stacked parameters, the router became a custom module), so they are
+    added directly by name. A regex only targets what it spells out, so the experts -- which no longer exist as real
+    keys -- are recovered by probing each reconstructed v4 key against the pattern.
     """
+    if peft_config.target_modules.lower() == INCLUDE_LINEAR_LAYERS_SHORTHAND:
+        # attention projections are still `nn.Linear` on v5, so resolve them by type; the experts and router were
+        # `nn.Linear` in v4 too but are now parameters / a custom module, so add their v4 names (the mapping keys).
+        resolved = _maybe_include_all_linear_layers(copy.copy(peft_config), model).target_modules
+        return {name.rsplit(".", 1)[-1] for name in resolved} | target_module_mapping.keys()
+
+    # regex: leaf names of the real module/parameter keys it matches (q/k/v_proj, the router module, `down_proj`, ...)
     module_keys = [name for name, _ in model.named_modules()]
     param_keys = [name for name, _ in model.named_parameters()]
-    # new (fused) name -> container paths, used to reconstruct the pre-fusion expert keys
+    matched = {
+        key.rsplit(".", 1)[-1]
+        for key in itertools.chain(module_keys, param_keys)
+        if check_target_module_exists(peft_config, key)
+    }
+
+    # The pre-fusion experts (`gate_proj`, `up_proj`) live inside the stacked `gate_up_proj` parameter, so a regex
+    # naming them matches no real key. Recover them from that parameter's container: e.g. for the parameter
+    # `model.layers.0.mlp.experts.gate_up_proj`, probe the reconstructed v4 key `model.layers.0.mlp.experts.gate_proj`.
     new_name_to_containers: dict[str, set[str]] = {}
     for name in param_keys:
         container, _, leaf = name.rpartition(".")
         new_name_to_containers.setdefault(leaf, set()).add(container)
-
-    is_all_linear = peft_config.target_modules.lower() == INCLUDE_LINEAR_LAYERS_SHORTHAND
-    if is_all_linear:
-        resolved = _maybe_include_all_linear_layers(copy.copy(peft_config), model).target_modules
-        matched: set[str] = {name.rsplit(".", 1)[-1] for name in resolved}
-    else:
-        # leaf names of the real module/parameter keys the regex matches (q/k/v_proj, router `gate`, `down_proj`)
-        matched = {
-            key.rsplit(".", 1)[-1]
-            for key in itertools.chain(module_keys, param_keys)
-            if check_target_module_exists(peft_config, key)
-        }
-
-    # Recover the fused experts: container `model.layers.0.mlp.experts` of `...experts.gate_up_proj` reconstructs the
-    # v4 keys `...experts.gate_proj` / `.up_proj` a regex targets. "all-linear" matches a fused expert iff its
-    # container is present (it was `nn.Linear` in v4); a regex is probed against the reconstructed key.
     for old_name, new_name in target_module_mapping.items():
         if old_name in matched:
             continue
-        containers = new_name_to_containers.get(new_name, ())
-        if not containers:
-            continue
-        if is_all_linear:
-            matched.add(old_name)
-            continue
         # one hit suffices -- `matched` holds leaf names, so stop at the first container (layer) the regex matches
-        for container in containers:
+        for container in new_name_to_containers.get(new_name, ()):
             if check_target_module_exists(peft_config, f"{container}.{old_name}"):
                 matched.add(old_name)
                 break

--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -14,6 +14,7 @@
 
 # NOTE: don't import from this module unless transformers v5+ is used
 import copy
+import itertools
 import re
 from typing import Any
 
@@ -349,13 +350,78 @@ _MOE_FUSED_TARGETS: dict[str, dict[str, set[str]]] = {
 }
 
 
-def _convert_peft_config_moe(peft_config, model_type: str) -> None:
+def _resolve_string_target_modules(peft_config, model, target_module_mapping: dict[str, str]) -> set[str]:
+    """Resolve a string ``target_modules`` (a regex or the ``"all-linear"`` shorthand) to a concrete set of leaf names.
+
+    Resolving the string up front lets the regular list-based remap downstream work unchanged. The pre-fusion expert
+    projections (e.g. ``gate_proj``, ``up_proj``) no longer exist as submodules on a Transformers v5 model -- they are
+    fused into stacked parameters such as ``gate_up_proj`` -- so they cannot be discovered via
+    ``model.named_modules()``. We therefore match against both real module/parameter keys and v4-style expert keys
+    reconstructed from each fused parameter's container.
+
+    ``"all-linear"`` is matched by module *type* rather than as a regex (see ``_maybe_include_all_linear_layers``). On
+    the original v4 architecture the experts were ``nn.Linear``, so ``"all-linear"`` targeted them; we preserve that by
+    also adding any old projection name whose fused container is present on the model.
+    """
+    from peft.tuners.tuners_utils import _maybe_include_all_linear_layers, check_target_module_exists
+    from peft.utils.constants import INCLUDE_LINEAR_LAYERS_SHORTHAND
+
+    module_keys = [name for name, _ in model.named_modules()]
+    param_keys = [name for name, _ in model.named_parameters()]
+    # new (fused) name -> container paths, used to reconstruct the pre-fusion expert keys
+    new_name_to_containers: dict[str, set[str]] = {}
+    for name in param_keys:
+        container, _, leaf = name.rpartition(".")
+        new_name_to_containers.setdefault(leaf, set()).add(container)
+
+    is_all_linear = peft_config.target_modules.lower() == INCLUDE_LINEAR_LAYERS_SHORTHAND
+    if is_all_linear:
+        # resolve the shorthand to the concrete linear module names (matched by type), then keep only the leaf names
+        resolved = _maybe_include_all_linear_layers(copy.copy(peft_config), model).target_modules
+        matched: set[str] = {name.rsplit(".", 1)[-1] for name in resolved}
+    else:
+        # regex: every real module/parameter whose key matches the pattern (covers the attention projections that stay
+        # in `target_modules` as well as the router `gate` and the `down_proj` parameter, which keep their v5 names)
+        matched = {
+            key.rsplit(".", 1)[-1]
+            for key in itertools.chain(module_keys, param_keys)
+            if check_target_module_exists(peft_config, key)
+        }
+
+    # the pre-fusion expert projections (e.g. `gate_proj`, `up_proj`) were fused and renamed, so they are absent from
+    # the v5 model. Recover them from each fused parameter's container: for "all-linear", a present container means the
+    # projection was an `nn.Linear` in v4 and would have been targeted; for a regex, probe the reconstructed v4 keys.
+    for old_name, new_name in target_module_mapping.items():
+        if old_name in matched:
+            continue
+        containers = new_name_to_containers.get(new_name, ())
+        if not containers:
+            continue
+        if is_all_linear:
+            matched.add(old_name)
+            continue
+        # a representative expert index (0/1) is enough for the regexes seen in practice
+        for container in containers:
+            candidates = (f"{container}.{old_name}", f"{container}.0.{old_name}", f"{container}.1.{old_name}")
+            if any(check_target_module_exists(peft_config, candidate) for candidate in candidates):
+                matched.add(old_name)
+                break
+    return matched
+
+
+def _convert_peft_config_moe(peft_config, model) -> None:
     """
     In-place convert the PEFT config of MoE models whose architecture changed from transformers v4 to v5.
 
     Since the model architecture changed, the targets have to updated accordingly. Moreover, when weights are fused, it
     requires updating the rank and alpha values of those parameters.
+
+    ``target_modules`` may be a list/set of names, the special string ``"all-linear"``, or a regex string (e.g. a
+    pattern produced by an upstream framework like ms-swift). A string is resolved against the model up front (see
+    ``_resolve_string_target_modules``) into the concrete projection names it targets, so the regular list-based remap
+    below applies to all input shapes alike.
     """
+    model_type = getattr(getattr(model, "config", None), "model_type", None)
     base_model_type = _MODEL_TO_CONVERSION_PATTERN.get(model_type, None)
     if base_model_type is None:
         return
@@ -368,12 +434,23 @@ def _convert_peft_config_moe(peft_config, model_type: str) -> None:
     if not fused_targets:
         return
 
-    peft_config.target_parameters = set(peft_config.target_parameters or [])
-    peft_config.target_modules = set(peft_config.target_modules or [])
+    # A string `target_modules` (a regex or the "all-linear" shorthand) is resolved against the model into the concrete
+    # projection names it targets. The pre-fusion expert projections don't exist as submodules on a v5 model, so they
+    # can't be recovered by iterating the string -- they are matched against the (reconstructed) model keys instead.
+    if isinstance(peft_config.target_modules, str):
+        resolved = _resolve_string_target_modules(peft_config, model, target_module_mapping)
+        if not resolved:
+            # The string matches nothing on the model (e.g. an invalid bare name like "q_proj", which is a regex here).
+            # Leave it untouched so the regular injection path raises its usual error instead of remapping anything.
+            return
+        peft_config.target_modules = resolved
+
     if not hasattr(peft_config, "rank_pattern") or peft_config.rank_pattern is None:
         peft_config.rank_pattern = {}
     if not hasattr(peft_config, "alpha_pattern") or peft_config.alpha_pattern is None:
         peft_config.alpha_pattern = {}
+    peft_config.target_parameters = set(peft_config.target_parameters or [])
+    peft_config.target_modules = set(peft_config.target_modules or [])
 
     new_target_parameters = peft_config.target_parameters.copy()
     remaining_target_modules = set()
@@ -441,7 +518,7 @@ def convert_peft_config_for_transformers(peft_config, model: torch.nn.Module, co
 
     model_type = getattr(model.config, "model_type", None)
     if get_checkpoint_conversion_mapping(model_type) is not None:
-        _convert_peft_config_moe(peft_config, model_type)
+        _convert_peft_config_moe(peft_config, model)
 
 
 def _convert_to_peft_serialized_keys(

--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -35,7 +35,9 @@ from transformers.core_model_loading import (
     rename_source_key,
 )
 
-from peft import PeftType
+from peft import PeftConfig, PeftType
+from peft.tuners.tuners_utils import _maybe_include_all_linear_layers, check_target_module_exists
+from peft.utils.constants import INCLUDE_LINEAR_LAYERS_SHORTHAND
 
 
 # https://github.com/huggingface/transformers/pull/45340#issuecomment-4222734042
@@ -350,22 +352,15 @@ _MOE_FUSED_TARGETS: dict[str, dict[str, set[str]]] = {
 }
 
 
-def _resolve_string_target_modules(peft_config, model, target_module_mapping: dict[str, str]) -> set[str]:
-    """Resolve a string ``target_modules`` (a regex or the ``"all-linear"`` shorthand) to a concrete set of leaf names.
+def _resolve_string_target_modules(
+    peft_config: PeftConfig, model: torch.nn.Module, target_module_mapping: dict[str, str]
+) -> set[str]:
+    """Resolve a string `target_modules` (a regex or `"all-linear"`) to the concrete leaf names it targets.
 
-    Resolving the string up front lets the regular list-based remap downstream work unchanged. The pre-fusion expert
-    projections (e.g. ``gate_proj``, ``up_proj``) no longer exist as submodules on a Transformers v5 model -- they are
-    fused into stacked parameters such as ``gate_up_proj`` -- so they cannot be discovered via
-    ``model.named_modules()``. We therefore match against both real module/parameter keys and v4-style expert keys
-    reconstructed from each fused parameter's container.
-
-    ``"all-linear"`` is matched by module *type* rather than as a regex (see ``_maybe_include_all_linear_layers``). On
-    the original v4 architecture the experts were ``nn.Linear``, so ``"all-linear"`` targeted them; we preserve that by
-    also adding any old projection name whose fused container is present on the model.
+    Resolving up front lets the list-based remap downstream stay unchanged. The pre-fusion expert projections
+    (`gate_proj`, `up_proj`) are absent from a v5 model -- they live inside the stacked `gate_up_proj` parameter -- so
+    they are recovered from each fused parameter's container, not from `named_modules()`/`named_parameters()`.
     """
-    from peft.tuners.tuners_utils import _maybe_include_all_linear_layers, check_target_module_exists
-    from peft.utils.constants import INCLUDE_LINEAR_LAYERS_SHORTHAND
-
     module_keys = [name for name, _ in model.named_modules()]
     param_keys = [name for name, _ in model.named_parameters()]
     # new (fused) name -> container paths, used to reconstruct the pre-fusion expert keys
@@ -376,21 +371,19 @@ def _resolve_string_target_modules(peft_config, model, target_module_mapping: di
 
     is_all_linear = peft_config.target_modules.lower() == INCLUDE_LINEAR_LAYERS_SHORTHAND
     if is_all_linear:
-        # resolve the shorthand to the concrete linear module names (matched by type), then keep only the leaf names
         resolved = _maybe_include_all_linear_layers(copy.copy(peft_config), model).target_modules
         matched: set[str] = {name.rsplit(".", 1)[-1] for name in resolved}
     else:
-        # regex: every real module/parameter whose key matches the pattern (covers the attention projections that stay
-        # in `target_modules` as well as the router `gate` and the `down_proj` parameter, which keep their v5 names)
+        # leaf names of the real module/parameter keys the regex matches (q/k/v_proj, router `gate`, `down_proj`)
         matched = {
             key.rsplit(".", 1)[-1]
             for key in itertools.chain(module_keys, param_keys)
             if check_target_module_exists(peft_config, key)
         }
 
-    # the pre-fusion expert projections (e.g. `gate_proj`, `up_proj`) were fused and renamed, so they are absent from
-    # the v5 model. Recover them from each fused parameter's container: for "all-linear", a present container means the
-    # projection was an `nn.Linear` in v4 and would have been targeted; for a regex, probe the reconstructed v4 keys.
+    # Recover the fused experts: container `model.layers.0.mlp.experts` of `...experts.gate_up_proj` reconstructs the
+    # v4 keys `...experts.gate_proj` / `.up_proj` a regex targets. "all-linear" matches a fused expert iff its
+    # container is present (it was `nn.Linear` in v4); a regex is probed against the reconstructed key.
     for old_name, new_name in target_module_mapping.items():
         if old_name in matched:
             continue
@@ -400,7 +393,7 @@ def _resolve_string_target_modules(peft_config, model, target_module_mapping: di
         if is_all_linear:
             matched.add(old_name)
             continue
-        # probe the reconstructed v4 key (the fused parameter's container + the pre-fusion projection name)
+        # one hit suffices -- `matched` holds leaf names, so stop at the first container (layer) the regex matches
         for container in containers:
             if check_target_module_exists(peft_config, f"{container}.{old_name}"):
                 matched.add(old_name)
@@ -408,19 +401,17 @@ def _resolve_string_target_modules(peft_config, model, target_module_mapping: di
     return matched
 
 
-def _convert_peft_config_moe(peft_config, model) -> None:
+def _convert_peft_config_moe(peft_config: PeftConfig, model: torch.nn.Module) -> None:
     """
     In-place convert the PEFT config of MoE models whose architecture changed from transformers v4 to v5.
 
     Since the model architecture changed, the targets have to updated accordingly. Moreover, when weights are fused, it
     requires updating the rank and alpha values of those parameters.
 
-    ``target_modules`` may be a list/set of names, the special string ``"all-linear"``, or a regex string (e.g. a
-    pattern produced by an upstream framework like ms-swift). A string is resolved against the model up front (see
-    ``_resolve_string_target_modules``) into the concrete projection names it targets, so the regular list-based remap
-    below applies to all input shapes alike.
+    A string `target_modules` (a regex, or `"all-linear"`) is resolved against the model up front (see
+    `_resolve_string_target_modules`), so the list-based remap below applies to lists, regexes and `"all-linear"` alike.
     """
-    model_type = getattr(getattr(model, "config", None), "model_type", None)
+    model_type = getattr(model.config, "model_type", None)
     base_model_type = _MODEL_TO_CONVERSION_PATTERN.get(model_type, None)
     if base_model_type is None:
         return
@@ -433,14 +424,10 @@ def _convert_peft_config_moe(peft_config, model) -> None:
     if not fused_targets:
         return
 
-    # A string `target_modules` (a regex or the "all-linear" shorthand) is resolved against the model into the concrete
-    # projection names it targets. The pre-fusion expert projections don't exist as submodules on a v5 model, so they
-    # can't be recovered by iterating the string -- they are matched against the (reconstructed) model keys instead.
     if isinstance(peft_config.target_modules, str):
         resolved = _resolve_string_target_modules(peft_config, model, target_module_mapping)
         if not resolved:
-            # The string matches nothing on the model (e.g. an invalid bare name like "q_proj", which is a regex here).
-            # Leave it untouched so the regular injection path raises its usual error instead of remapping anything.
+            # nothing matched (e.g. bare "q_proj", invalid as a regex) -- leave it for the standard not-found error
             return
         peft_config.target_modules = resolved
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -391,3 +391,147 @@ class TestTransformersV5:
             # target up_proj and gate_proj
             config = LoraConfig(target_modules=["gate_proj", "up_proj", "down_proj", "score"])
             get_peft_model(model, config)  # does not raise
+
+    @pytest.mark.parametrize(
+        "regex",
+        [
+            # The shape ms-swift's `get_multimodal_target_regex` helper produces (anchored, lookahead on the prefix);
+            # see https://github.com/huggingface/peft/issues/3229 and https://github.com/modelscope/ms-swift/issues/9321.
+            r"^(model(?=\.).*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj))$",
+            # A plain "ends with one of these projections" pattern.
+            r".*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj)",
+        ],
+    )
+    def test_qwen3_moe_regex_target_modules_works(self, regex):
+        # Regression test for https://github.com/huggingface/peft/issues/3229. The MoE config conversion did
+        # `set(peft_config.target_modules)`, which for a regex `target_modules` splits the string into its characters
+        # (`{'^', '(', 'q', '_', ...}`) and fails downstream with "Target modules ... not found in the base model".
+        # The fused expert projections (`gate_proj`/`up_proj`) don't exist as submodules on a v5 model, so a string
+        # `target_modules` is resolved against the model into concrete projection names before the usual remap runs:
+        # the fused experts move to `target_parameters` and the attention projections stay in `target_modules`.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            peft_model = get_peft_model(model, LoraConfig(target_modules=regex))  # does not raise
+
+        config = peft_model.peft_config["default"]
+        # the regex is resolved to the concrete non-fused targets (q/k/v_proj)
+        assert config.target_modules == {"q_proj", "k_proj", "v_proj"}
+        # the fused experts are moved to target_parameters, with the rank/alpha doubled for the 2-way `gate_up_proj`
+        assert {"gate_up_proj", "down_proj"} <= set(config.target_parameters)
+        assert config.rank_pattern == {r".*\.gate_up_proj": config.r * 2}
+        assert config.alpha_pattern == {r".*\.gate_up_proj": config.lora_alpha * 2}
+        # the experts are actually adapted, not just recorded in the config
+        assert any("experts" in name for name, _ in peft_model.named_modules() if name.endswith("lora_A.default"))
+
+    def test_qwen3_moe_single_attention_regex_target_modules_works(self):
+        # A string `target_modules` that resolves to a single attention projection (no experts) must convert cleanly:
+        # the conversion resolves the string against the model rather than splitting it into characters.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            peft_model = get_peft_model(model, LoraConfig(target_modules=r".*\.q_proj"))  # does not raise
+
+        config = peft_model.peft_config["default"]
+        assert config.target_modules == {"q_proj"}
+        # a bare attention projection touches no experts, so nothing is moved to target_parameters
+        assert not config.target_parameters
+        assert not config.rank_pattern
+        adapted = {
+            name.rsplit(".lora_A", 1)[0].rsplit(".", 1)[-1]
+            for name, _ in peft_model.named_modules()
+            if name.endswith("lora_A.default")
+        }
+        assert adapted == {"q_proj"}
+
+    def test_qwen3_moe_unresolvable_string_target_modules_raises_standard_error(self):
+        # A string `target_modules` is matched as a regex (`re.fullmatch`), so a bare leaf name like "q_proj" matches
+        # nothing and is invalid on *any* model -- the MoE conversion must not turn this into a different/confusing
+        # error (previously `set("q_proj")` split it into characters). The standard "not found" error is expected.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            with pytest.raises(ValueError, match="Target modules q_proj not found in the base model"):
+                get_peft_model(model, LoraConfig(target_modules="q_proj"))
+
+    def test_qwen3_moe_regex_partial_fusion_raises(self):
+        # A regex that targets `up_proj` but not `gate_proj` cannot be converted, because the two are fused into
+        # `gate_up_proj` -- same contract as the list path in `test_qwen3_moe_error_message`.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            msg = re.escape(
+                "Cannot convert PEFT target(s) up_proj without also targeting gate_proj because they are fused into "
+                "gate_up_proj."
+            )
+            with pytest.raises(ValueError, match=msg):
+                get_peft_model(model, LoraConfig(target_modules=r".*\.(up_proj|down_proj)"))
+
+    def test_qwen3_moe_regex_attention_only_no_moe_conversion(self):
+        # A regex that only matches attention projections must not trigger any MoE remap (no fused parameters added).
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            peft_model = get_peft_model(model, LoraConfig(target_modules=r".*\.(q_proj|v_proj)"))
+
+        config = peft_model.peft_config["default"]
+        assert not config.target_parameters
+        assert not config.rank_pattern
+
+    def test_qwen3_moe_all_linear_target_modules_works(self):
+        # `"all-linear"` is a special shorthand matched by module *type*, not a regex (previously `set("all-linear")`
+        # corrupted it into a set of characters and injection failed). On the original v4 architecture the experts were
+        # `nn.Linear`, so `"all-linear"` targeted them; on the converted v5 model they are fused `nn.Parameter`s. To
+        # preserve that intent across the conversion, `"all-linear"` must still pull the experts into
+        # `target_parameters` -- in addition to resolving the attention projections.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            peft_model = get_peft_model(model, LoraConfig(target_modules="all-linear"))  # does not raise
+
+        config = peft_model.peft_config["default"]
+        adapted = {
+            name.rsplit(".lora_A", 1)[0].rsplit(".", 1)[-1]
+            for name, _ in peft_model.named_modules()
+            if name.endswith("lora_A.default")
+        }
+        # resolved to the actual linear modules (attention projections)
+        assert {"q_proj", "k_proj", "v_proj", "o_proj"} <= adapted
+        # the experts (linear in v4) are carried over to target_parameters with the rank/alpha doubled for `gate_up_proj`
+        assert {"gate_up_proj", "down_proj"} <= set(config.target_parameters)
+        assert config.rank_pattern == {r".*\.gate_up_proj": config.r * 2}
+        assert config.alpha_pattern == {r".*\.gate_up_proj": config.lora_alpha * 2}
+        assert any("experts" in name for name, _ in peft_model.named_modules() if name.endswith("lora_A.default"))
+
+    def test_qwen3_moe_regex_target_modules_save_load_roundtrip(self, tmp_path):
+        # Full lifecycle for a regex `target_modules` on a v5 MoE model: create the adapter, save it, and load it back.
+        # Reloading runs the config conversion a second time (now on the already-converted config), so this also guards
+        # against the conversion not being idempotent.
+        inputs = torch.arange(10).view(1, -1).to(self.torch_device)
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        regex = r"^(model(?=\.).*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj))$"
+
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id).to(self.torch_device)
+            peft_model = get_peft_model(model, LoraConfig(target_modules=regex))
+            # perturb the (zero-initialized) LoRA B weights so the adapter actually changes the output
+            with torch.no_grad():
+                for name, param in peft_model.named_parameters():
+                    if "lora_B" in name:
+                        param.add_(0.02)
+            with torch.inference_mode():
+                logits_before = peft_model(inputs).logits
+            peft_model.save_pretrained(tmp_path)
+            del model, peft_model
+
+            model = AutoModelForCausalLM.from_pretrained(model_id).to(self.torch_device)
+            reloaded = PeftModel.from_pretrained(model, tmp_path)
+            with torch.inference_mode():
+                logits_after = reloaded(inputs).logits
+
+        assert torch.allclose(logits_before, logits_after, atol=1e-5, rtol=1e-5)
+        # the second conversion (on load) is idempotent: the regex was already resolved to concrete names on save
+        reloaded_config = reloaded.peft_config["default"]
+        assert reloaded_config.target_modules == {"q_proj", "k_proj", "v_proj"}
+        assert {"gate_up_proj", "down_proj"} <= set(reloaded_config.target_parameters)
+        assert reloaded_config.rank_pattern == {r".*\.gate_up_proj": reloaded_config.r * 2}

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -304,7 +304,6 @@ class TestTransformersV5:
         # Ensure that using LoRA directly with a v5 model still works
         inputs = torch.arange(10).view(1, -1).to(device=self.torch_device)
         model_id = "hf-internal-testing/Mixtral-tiny"
-        lora_id = "peft-internal-testing/mixtral-pre-v5-lora"
 
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id).to(self.torch_device)
@@ -365,22 +364,22 @@ class TestTransformersV5:
             config = LoraConfig(target_modules=["q_proj", "v_proj"])
             get_peft_model(model, config)  # does not raise
 
-    def test_qwen3_moe_error_message(self):
+    @pytest.mark.parametrize(
+        "target_modules", [["up_proj", "down_proj", "score"], r".*\.(up_proj|down_proj)"], ids=["list", "regex"]
+    )
+    def test_qwen3_moe_partial_fusion_raises(self, target_modules):
         # https://github.com/huggingface/trl/issues/5428
-        # When only targeting the up_proj, we should get an error because up and gate projection are fused. There was an
-        # error during handling of the error message. This test ensure that the error is handled correctly. See the net
-        # test for a correct PEFT config.
+        # Targeting up_proj but not gate_proj must raise -- they are fused into gate_up_proj. Covers the list and regex
+        # paths and guards the error-message handling. See `test_qwen3_moe_works` for a valid config.
         model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
-            # only target up_proj but not gate_proj
-            config = LoraConfig(target_modules=["up_proj", "down_proj", "score"])
             msg = re.escape(
                 "Cannot convert PEFT target(s) up_proj without also targeting gate_proj because they are fused into "
                 "gate_up_proj."
             )
             with pytest.raises(ValueError, match=msg):
-                get_peft_model(model, config)
+                get_peft_model(model, LoraConfig(target_modules=target_modules))
 
     def test_qwen3_moe_works(self):
         # https://github.com/huggingface/trl/issues/5428
@@ -395,29 +394,24 @@ class TestTransformersV5:
     @pytest.mark.parametrize(
         "regex",
         [
-            # The shape ms-swift's `get_multimodal_target_regex` helper produces (anchored, lookahead on the prefix);
-            # see https://github.com/huggingface/peft/issues/3229 and https://github.com/modelscope/ms-swift/issues/9321.
+            # the shape ms-swift's get_multimodal_target_regex emits: anchored, prefix lookahead
             r"^(model(?=\.).*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj))$",
-            # A plain "ends with one of these projections" pattern.
+            # a plain "ends with one of these projections" pattern
             r".*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj)",
         ],
     )
     def test_qwen3_moe_regex_target_modules_works(self, regex):
-        # Regression test for https://github.com/huggingface/peft/issues/3229. The MoE config conversion did
-        # `set(peft_config.target_modules)`, which for a regex `target_modules` splits the string into its characters
-        # (`{'^', '(', 'q', '_', ...}`) and fails downstream with "Target modules ... not found in the base model".
-        # The fused expert projections (`gate_proj`/`up_proj`) don't exist as submodules on a v5 model, so a string
-        # `target_modules` is resolved against the model into concrete projection names before the usual remap runs:
-        # the fused experts move to `target_parameters` and the attention projections stay in `target_modules`.
+        # Regression test for https://github.com/huggingface/peft/issues/3229: the conversion used to `set()` the regex
+        # string, splitting it into characters. It is now resolved to concrete names against the model.
         model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
             peft_model = get_peft_model(model, LoraConfig(target_modules=regex))  # does not raise
 
         config = peft_model.peft_config["default"]
-        # the regex is resolved to the concrete non-fused targets (q/k/v_proj)
+        # non-fused targets stay in target_modules; fused experts move to target_parameters (rank/alpha doubled for the
+        # 2-way gate_up_proj)
         assert config.target_modules == {"q_proj", "k_proj", "v_proj"}
-        # the fused experts are moved to target_parameters, with the rank/alpha doubled for the 2-way `gate_up_proj`
         assert {"gate_up_proj", "down_proj"} <= set(config.target_parameters)
         assert config.rank_pattern == {r".*\.gate_up_proj": config.r * 2}
         assert config.alpha_pattern == {r".*\.gate_up_proj": config.lora_alpha * 2}
@@ -425,8 +419,7 @@ class TestTransformersV5:
         assert any("experts" in name for name, _ in peft_model.named_modules() if name.endswith("lora_A.default"))
 
     def test_qwen3_moe_single_attention_regex_target_modules_works(self):
-        # A string `target_modules` that resolves to a single attention projection (no experts) must convert cleanly:
-        # the conversion resolves the string against the model rather than splitting it into characters.
+        # A regex resolving to a single attention projection (no experts) converts cleanly: nothing moves to parameters.
         model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
@@ -434,7 +427,6 @@ class TestTransformersV5:
 
         config = peft_model.peft_config["default"]
         assert config.target_modules == {"q_proj"}
-        # a bare attention projection touches no experts, so nothing is moved to target_parameters
         assert not config.target_parameters
         assert not config.rank_pattern
         adapted = {
@@ -444,46 +436,9 @@ class TestTransformersV5:
         }
         assert adapted == {"q_proj"}
 
-    def test_qwen3_moe_unresolvable_string_target_modules_raises_standard_error(self):
-        # A string `target_modules` is matched as a regex (`re.fullmatch`), so a bare leaf name like "q_proj" matches
-        # nothing and is invalid on *any* model -- the MoE conversion must not turn this into a different/confusing
-        # error (previously `set("q_proj")` split it into characters). The standard "not found" error is expected.
-        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
-        with hub_online_once(model_id):
-            model = AutoModelForCausalLM.from_pretrained(model_id)
-            with pytest.raises(ValueError, match="Target modules q_proj not found in the base model"):
-                get_peft_model(model, LoraConfig(target_modules="q_proj"))
-
-    def test_qwen3_moe_regex_partial_fusion_raises(self):
-        # A regex that targets `up_proj` but not `gate_proj` cannot be converted, because the two are fused into
-        # `gate_up_proj` -- same contract as the list path in `test_qwen3_moe_error_message`.
-        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
-        with hub_online_once(model_id):
-            model = AutoModelForCausalLM.from_pretrained(model_id)
-            msg = re.escape(
-                "Cannot convert PEFT target(s) up_proj without also targeting gate_proj because they are fused into "
-                "gate_up_proj."
-            )
-            with pytest.raises(ValueError, match=msg):
-                get_peft_model(model, LoraConfig(target_modules=r".*\.(up_proj|down_proj)"))
-
-    def test_qwen3_moe_regex_attention_only_no_moe_conversion(self):
-        # A regex that only matches attention projections must not trigger any MoE remap (no fused parameters added).
-        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
-        with hub_online_once(model_id):
-            model = AutoModelForCausalLM.from_pretrained(model_id)
-            peft_model = get_peft_model(model, LoraConfig(target_modules=r".*\.(q_proj|v_proj)"))
-
-        config = peft_model.peft_config["default"]
-        assert not config.target_parameters
-        assert not config.rank_pattern
-
     def test_qwen3_moe_all_linear_target_modules_works(self):
-        # `"all-linear"` is a special shorthand matched by module *type*, not a regex (previously `set("all-linear")`
-        # corrupted it into a set of characters and injection failed). On the original v4 architecture the experts were
-        # `nn.Linear`, so `"all-linear"` targeted them; on the converted v5 model they are fused `nn.Parameter`s. To
-        # preserve that intent across the conversion, `"all-linear"` must still pull the experts into
-        # `target_parameters` -- in addition to resolving the attention projections.
+        # "all-linear" is matched by module type, not as a regex. The experts were nn.Linear in v4, so it targeted
+        # them; after fusion they are parameters, so it must still pull them into target_parameters.
         model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
@@ -495,30 +450,24 @@ class TestTransformersV5:
             for name, _ in peft_model.named_modules()
             if name.endswith("lora_A.default")
         }
-        # resolved to the actual linear modules (attention projections)
+        # attention projections resolved as modules; experts (linear in v4) carried into target_parameters
         assert {"q_proj", "k_proj", "v_proj", "o_proj"} <= adapted
-        # the experts (linear in v4) are carried over to target_parameters with the rank/alpha doubled for `gate_up_proj`
         assert {"gate_up_proj", "down_proj"} <= set(config.target_parameters)
         assert config.rank_pattern == {r".*\.gate_up_proj": config.r * 2}
         assert config.alpha_pattern == {r".*\.gate_up_proj": config.lora_alpha * 2}
         assert any("experts" in name for name, _ in peft_model.named_modules() if name.endswith("lora_A.default"))
 
     def test_qwen3_moe_regex_target_modules_save_load_roundtrip(self, tmp_path):
-        # Full lifecycle for a regex `target_modules` on a v5 MoE model: create the adapter, save it, and load it back.
-        # Reloading runs the config conversion a second time (now on the already-converted config), so this also guards
-        # against the conversion not being idempotent.
+        # Save/reload a regex-targeted adapter. Reload re-runs the conversion on the already-converted config, so this
+        # also guards idempotency.
         inputs = torch.arange(10).view(1, -1).to(self.torch_device)
         model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
         regex = r"^(model(?=\.).*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj))$"
 
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id).to(self.torch_device)
-            peft_model = get_peft_model(model, LoraConfig(target_modules=regex))
-            # perturb the (zero-initialized) LoRA B weights so the adapter actually changes the output
-            with torch.no_grad():
-                for name, param in peft_model.named_parameters():
-                    if "lora_B" in name:
-                        param.add_(0.02)
+            # init_lora_weights=False gives the adapter non-zero (random) weights so it actually changes the output
+            peft_model = get_peft_model(model, LoraConfig(target_modules=regex, init_lora_weights=False))
             with torch.inference_mode():
                 logits_before = peft_model(inputs).logits
             peft_model.save_pretrained(tmp_path)
@@ -530,7 +479,7 @@ class TestTransformersV5:
                 logits_after = reloaded(inputs).logits
 
         assert torch.allclose(logits_before, logits_after, atol=1e-5, rtol=1e-5)
-        # the second conversion (on load) is idempotent: the regex was already resolved to concrete names on save
+        # reload re-runs the conversion on the already-resolved config -- idempotent
         reloaded_config = reloaded.peft_config["default"]
         assert reloaded_config.target_modules == {"q_proj", "k_proj", "v_proj"}
         assert {"gate_up_proj", "down_proj"} <= set(reloaded_config.target_parameters)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -410,9 +410,10 @@ class TestTransformersV5:
 
         config = peft_model.peft_config["default"]
         # non-fused targets stay in target_modules; fused experts move to target_parameters (rank/alpha doubled for the
-        # 2-way gate_up_proj)
+        # 2-way gate_up_proj). The regex does not name the router, so `gate.weight` is *not* pulled in (contrast
+        # `test_qwen3_moe_all_linear_target_modules_works`, where "all-linear" does pull it in).
         assert config.target_modules == {"q_proj", "k_proj", "v_proj"}
-        assert {"gate_up_proj", "down_proj"} <= set(config.target_parameters)
+        assert set(config.target_parameters) == {"gate_up_proj", "down_proj"}
         assert config.rank_pattern == {r".*\.gate_up_proj": config.r * 2}
         assert config.alpha_pattern == {r".*\.gate_up_proj": config.lora_alpha * 2}
         # the experts are actually adapted, not just recorded in the config
@@ -437,8 +438,9 @@ class TestTransformersV5:
         assert adapted == {"q_proj"}
 
     def test_qwen3_moe_all_linear_target_modules_works(self):
-        # "all-linear" is matched by module type, not as a regex. The experts were nn.Linear in v4, so it targeted
-        # them; after fusion they are parameters, so it must still pull them into target_parameters.
+        # "all-linear" is matched by module type, not as a regex. On v4 the experts *and* the router `gate` were
+        # nn.Linear, so "all-linear" targeted them; after fusion the experts are stacked parameters and the router is a
+        # custom module, so "all-linear" must still carry all of them into target_parameters (gate -> gate.weight).
         model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
         with hub_online_once(model_id):
             model = AutoModelForCausalLM.from_pretrained(model_id)
@@ -450,12 +452,16 @@ class TestTransformersV5:
             for name, _ in peft_model.named_modules()
             if name.endswith("lora_A.default")
         }
-        # attention projections resolved as modules; experts (linear in v4) carried into target_parameters
+        # attention projections resolved as modules; experts and router (linear in v4) carried into target_parameters
         assert {"q_proj", "k_proj", "v_proj", "o_proj"} <= adapted
-        assert {"gate_up_proj", "down_proj"} <= set(config.target_parameters)
+        # the router `gate` is adapted too -- it is a parameter (`gate.weight`) on v5, so unlike the regex case it has
+        # to be added by name; this is exactly what distinguishes "all-linear" from a regex that omits the router
+        assert set(config.target_parameters) == {"gate.weight", "gate_up_proj", "down_proj"}
         assert config.rank_pattern == {r".*\.gate_up_proj": config.r * 2}
         assert config.alpha_pattern == {r".*\.gate_up_proj": config.lora_alpha * 2}
+        # the experts and the router gate are actually adapted, not just recorded in the config
         assert any("experts" in name for name, _ in peft_model.named_modules() if name.endswith("lora_A.default"))
+        assert any(name.endswith(".mlp.gate.lora_A.default") for name, _ in peft_model.named_modules())
 
     def test_qwen3_moe_regex_target_modules_save_load_roundtrip(self, tmp_path):
         # Save/reload a regex-targeted adapter. Reload re-runs the conversion on the already-converted config, so this


### PR DESCRIPTION
Closes #3229.

`_convert_peft_config_moe` did `set(peft_config.target_modules)` on a value that can be a **string**. A regex `target_modules` — e.g. what ms-swift's `get_multimodal_target_regex` emits for Qwen3-Omni — was split into its characters, and conversion failed downstream:

```
ValueError: Target modules {'^', '(', 'q', '_', ...} not found in the base model.
```

`"all-linear"` hit the same path and became `{'-', 'a', 'e', 'i', 'l', 'n', 'r'}`.

## Fix

Resolve a string `target_modules` to the concrete projection names it targets **before** the list-based remap runs. The remap is left untouched, so a list, a regex, and `"all-linear"` all flow through the same path.

The subtlety is that the pre-fusion experts (`gate_proj`, `up_proj`) no longer exist as modules on a v5 model — they're fused into the `gate_up_proj` parameter — so a regex naming them matches nothing via `named_modules()`. Those names are recovered from the fused parameter's container, so they remap into `target_parameters` instead of being silently dropped (which would leave the experts unadapted). `"all-linear"` resolves through `_maybe_include_all_linear_layers`, and since the experts were `nn.Linear` before fusion, it pulls them in too.

A regex that targets only one half of a fused pair raises the same completeness error as the list path; a string that resolves to nothing falls through to PEFT's standard "not found" error.

## End-to-end

`trl-internal-testing/tiny-Qwen3MoeForCausalLM`, transformers 5.11.0:

<details><summary>Before (on <code>main</code>): the regex is split into characters</summary>

```python
regex = r"^(model(?=\.).*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj))$"
get_peft_model(model, LoraConfig(target_modules=regex))
```
```
ValueError: Target modules {'e', 'm', '^', '.', 'o', ')', 'p', '$', ...} not found in the base model.
```
</details>

<details><summary>After: attention adapted as modules, fused experts as parameters</summary>

```
target_modules    : {q_proj, k_proj, v_proj}
target_parameters : {gate_up_proj, down_proj}   # r and alpha doubled for the fused pair
adapted leaves    : q_proj, k_proj, v_proj, experts
```
</details>

## Tests

`TestTransformersV5` adds 7 cases (16 with parametrization), each failing on `main` with the character-split error and green here: the two regex shapes, an attention-only regex (no MoE remap), `"all-linear"`, an unresolvable string raising the standard error, a partial-fusion regex raising the completeness error, and a save/reload roundtrip that also covers conversion idempotency.

Verified locally on transformers 5.11.0 (CI on this repo is gated on maintainer approval for external contributors):

<details><summary>Test + lint run</summary>

```
$ pytest tests/test_integrations.py -k "qwen3_moe or mixtral"
30 passed, 9 deselected, 4 warnings in 13.46s

$ ruff check src/peft/utils/transformers_weight_conversion.py tests/test_integrations.py
All checks passed!
$ ruff format --check src/peft/utils/transformers_weight_conversion.py tests/test_integrations.py
2 files already formatted
```
</details>

Refs: modelscope/ms-swift#9321.
