### PR TITLE
[BUG FIX] tuners/lora/eva: fix label mask check using `in` instead of `hasattr` for dict

### DIFF
--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -249,7 +249,7 @@ def prepare_model_inputs_fn_language_modeling(model_input, peft_config: LoraConf
     if not isinstance(model_input, dict):
         raise TypeError("When using `prepare_model_inputs_fn_language_modeling` inputs must be a dictionary")
     mask = model_input.get("attention_mask", torch.ones_like(model_input["input_ids"])).bool()
-    if peft_config.eva_config.use_label_mask and "labels" in model_input:
+    if peft_config.eva_config.use_label_mask and ("labels" in model_input):
         mask = torch.logical_and(mask, model_input["labels"] != peft_config.eva_config.label_mask_value)
     return mask.nonzero()
 

--- a/src/peft/tuners/lora/eva.py
+++ b/src/peft/tuners/lora/eva.py
@@ -249,7 +249,7 @@ def prepare_model_inputs_fn_language_modeling(model_input, peft_config: LoraConf
     if not isinstance(model_input, dict):
         raise TypeError("When using `prepare_model_inputs_fn_language_modeling` inputs must be a dictionary")
     mask = model_input.get("attention_mask", torch.ones_like(model_input["input_ids"])).bool()
-    if peft_config.eva_config.use_label_mask and hasattr(model_input, "labels"):
+    if peft_config.eva_config.use_label_mask and "labels" in model_input:
         mask = torch.logical_and(mask, model_input["labels"] != peft_config.eva_config.label_mask_value)
     return mask.nonzero()
 

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -5399,6 +5399,32 @@ class TestEvaInitializationGPU:
         peft_model = PeftModel.from_pretrained(model, tmp_path, torch_device=self.DEVICE, low_cpu_mem_usage=True)
         peft_model(**{k: v.to(self.DEVICE) for k, v in next(iter(dataloader)).items()})
 
+    @pytest.mark.parametrize("use_label_mask", [True, False])
+    def test_eva_label_mask(self, model, dataset, peft_config, use_label_mask):
+        """
+        Tests that label masking works correctly in get_eva_state_dict.
+        Exercises the fix for the hasattr -> 'in' dict membership check.
+        """
+
+        def add_labels(x):
+            return {
+                "labels": torch.where(
+                    x["attention_mask"].bool(),
+                    torch.ones_like(x["attention_mask"]),
+                    -100 * torch.ones_like(x["attention_mask"]),
+                )
+            }
+
+        dataset_with_labels = dataset.map(add_labels)
+        dataset_with_labels.set_format(type="torch")
+        dataloader = self.get_dataloader(dataset_with_labels)
+
+        modified_peft_config = deepcopy(peft_config)
+        modified_peft_config.eva_config = EvaConfig(rho=2, use_label_mask=use_label_mask)
+
+        sd = get_eva_state_dict(deepcopy(model), dataloader, modified_peft_config, show_progress_bar=False)
+        assert len(sd) > 0
+
     def test_eva_initialization_with_invalid_dataloader(self, model, peft_config):
         """Test that appropriate error is raised when dataloader is empty."""
         empty_dataset = Dataset.from_dict({"text": []})
@@ -5406,7 +5432,6 @@ class TestEvaInitializationGPU:
 
         with pytest.raises(ValueError, match="dataloader is empty"):
             get_eva_state_dict(model, dataloader, peft_config)
-
 
 class TestALoRAInferenceGPU:
     """GPU inference for Activated LoRA."""

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -5414,13 +5414,14 @@ class TestEvaInitializationGPU:
                 )
             }
 
-        dataset_with_labels = dataset.map(add_labels)
         dataset_with_labels.set_format(type="torch")
         dataloader = self.get_dataloader(dataset_with_labels)
+
         modified_peft_config = deepcopy(peft_config)
         modified_peft_config.eva_config = EvaConfig(rho=2, use_label_mask=use_label_mask)
         sd = get_eva_state_dict(deepcopy(model), dataloader, modified_peft_config, show_progress_bar=False)
         assert len(sd) > 0
+
     def test_eva_initialization_with_invalid_dataloader(self, model, peft_config):
         """Test that appropriate error is raised when dataloader is empty."""
         empty_dataset = Dataset.from_dict({"text": []})

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -5417,13 +5417,10 @@ class TestEvaInitializationGPU:
         dataset_with_labels = dataset.map(add_labels)
         dataset_with_labels.set_format(type="torch")
         dataloader = self.get_dataloader(dataset_with_labels)
-
         modified_peft_config = deepcopy(peft_config)
         modified_peft_config.eva_config = EvaConfig(rho=2, use_label_mask=use_label_mask)
-
         sd = get_eva_state_dict(deepcopy(model), dataloader, modified_peft_config, show_progress_bar=False)
         assert len(sd) > 0
-
     def test_eva_initialization_with_invalid_dataloader(self, model, peft_config):
         """Test that appropriate error is raised when dataloader is empty."""
         empty_dataset = Dataset.from_dict({"text": []})

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -5402,8 +5402,7 @@ class TestEvaInitializationGPU:
     @pytest.mark.parametrize("use_label_mask", [True, False])
     def test_eva_label_mask(self, model, dataset, peft_config, use_label_mask):
         """
-        Tests that label masking works correctly in get_eva_state_dict.
-        Exercises the fix for the hasattr -> 'in' dict membership check.
+        Tests that label masking works correctly in get_eva_state_dict (see PR #3233).
         """
 
         def add_labels(x):


### PR DESCRIPTION
## What

In `prepare_model_inputs_fn_language_modeling`, the condition guarding the label mask branch uses `hasattr(model_input, "labels")` to test whether labels are present. However, `model_input` is a plain Python `dict` (enforced by the `isinstance` check three lines above), and `hasattr` on a plain dict **always returns `False`** regardless of its keys — dict keys are not exposed as object attributes.

This means the label masking feature (`use_label_mask=True`) has never actually executed, even though it is the **default** in `EvaConfig`. As a result, ignored/padding positions (label value `−100`) are silently included in the SVD computation during EVA initialization, degrading initialization quality in every standard language modeling use case.

## Fix

Replace `hasattr(model_input, "labels")` with `"labels" in model_input`, which is the correct Python idiom for dict key membership.

```python
# Before
if peft_config.eva_config.use_label_mask and hasattr(model_input, "labels"):

# After
if peft_config.eva_config.use_label_mask and "labels" in model_input:
```

The body of the branch already uses `model_input["labels"]` (subscript access), so the access pattern was always correct — only the guard was wrong. This is a one-word change with no downstream side-effects for callers that don't include a `"labels"` key.