### PR TITLE
fix(xlora): duplicated "for" in adapters warning message

### DIFF
--- a/src/peft/tuners/xlora/config.py
+++ b/src/peft/tuners/xlora/config.py
@@ -86,7 +86,7 @@ class XLoraConfig(PeftConfig):
             self.hidden_size = 4096
         if self.adapters is None:
             warnings.warn(
-                "No value was provided for for `adapters`. This will be set to empty, please ensure that this is correct."
+                "No value was provided for `adapters`. This will be set to empty, please ensure that this is correct."
             )
             self.adapters = {}
 


### PR DESCRIPTION
One-line typo fix in `src/peft/tuners/xlora/config.py`: warning message "No value was provided for for `adapters`. This will be set to empty, please ensure that this is correct." → "No value was provided for `adapters`. This will be set to empty, please ensure that this is correct.". No code/behavior change.