### PR TITLE
fix(utils/weight_conversion): handle str target_modules/target_parameters in MoE config conversion

### DIFF
--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -368,8 +368,15 @@ def _convert_peft_config_moe(peft_config, model_type: str) -> None:
     if not fused_targets:
         return
 
-    peft_config.target_parameters = set(peft_config.target_parameters or [])
-    peft_config.target_modules = set(peft_config.target_modules or [])
+    def _normalize_to_set(value):
+        if value is None:
+            return set()
+        if isinstance(value, str):
+            return {value}
+        return set(value)
+
+    peft_config.target_parameters = _normalize_to_set(peft_config.target_parameters)
+    peft_config.target_modules = _normalize_to_set(peft_config.target_modules)
     if not hasattr(peft_config, "rank_pattern") or peft_config.rank_pattern is None:
         peft_config.rank_pattern = {}
     if not hasattr(peft_config, "alpha_pattern") or peft_config.alpha_pattern is None:


### PR DESCRIPTION
## Summary

Closes #3229.

`_convert_peft_config_moe` in `src/peft/utils/transformers_weight_conversion.py` normalized `peft_config.target_modules` and `peft_config.target_parameters` via `set(value or [])` before iterating them against the MoE target-module mapping. When a user passes a single string for these fields (a supported shape elsewhere in PEFT, e.g. `target_modules="gate_up_proj"`), `set("gate_up_proj")` silently splits the string into individual characters (`{"g","a","t","e","_","u","p","r","o","j"}`). The downstream `for target in peft_config.target_modules` loop then matches none of the expected module names, so config conversion for MoE models silently produced wrong results. Reported in [modelscope/ms-swift#9321](https://github.com/modelscope/ms-swift/issues/9321).

## What changed

- `src/peft/utils/transformers_weight_conversion.py` (`_convert_peft_config_moe`): replace
  ```python
  peft_config.target_parameters = set(peft_config.target_parameters or [])
  peft_config.target_modules = set(peft_config.target_modules or [])
  ```
  with a small local `_normalize_to_set` helper that maps `str` to a single-element set, `None` to `set()`, and otherwise falls back to `set(value)`. Pure normalization change; no other code paths affected.

## Verification

- Behavior preserved for list/tuple/set/None: `set([...])`/`set((...))`/`set({...})` semantics unchanged; `None` still becomes `set()` instead of erroring.
- New behavior for `str`: `target_modules="gate_up_proj"` becomes `{"gate_up_proj"}` so the per-target loop sees one well-formed module name instead of ten one-character non-matches.
- No new imports; helper is defined inside the function to keep the public surface unchanged.

AI-assisted, human reviewed.
