### PR TITLE
Fix DoRA inf/NaN from zero or near-zero rows in base weight (#2049)

### DIFF
--- a/src/peft/tuners/lora/dora.py
+++ b/src/peft/tuners/lora/dora.py
@@ -28,6 +28,14 @@ ENABLE_DORA_CACHING = False
 """Whether to enable DoRA caching, which makes it faster at inference but requires more memory"""
 
 
+DORA_WEIGHT_NORM_EPS: float = 1e-6
+"""Lower bound applied to the row-wise L2 norm of the merged (base + scaled LoRA) weight in DoRA
+layers. Prevents the ``magnitude / weight_norm`` divide in ``forward`` from producing inf/NaN when
+the merged weight has zero or near-zero rows (real-world incidence: Llama-3.1 ``o_proj``, see
+issue #2049; Qwen3.5/3.6-MoE ``linear_attn.in_proj_qkv``). ``1e-6`` follows the bf16/fp16 convention
+from "Scaling DoRA" (arxiv:2603.22276); a smaller value (e.g. ``1e-12``) would also be safe for fp32."""
+
+
 def cache_decorator(cache_key: str):
     """Caching decorator for DoRA
 
@@ -84,11 +92,16 @@ class DoraLinearLayer(nn.Module):
 
     @cache_decorator("weight-norm")
     def get_weight_norm(self, weight, lora_weight, scaling, adapter_name: Optional[str] = None) -> torch.Tensor:
-        # calculate L2 norm of weight matrix, column-wise
+        # Row-wise L2 norm of (base + scaled LoRA). Upcast to fp32 for the norm to avoid bf16/fp16
+        # underflow on near-zero rows, and clamp the result at DORA_WEIGHT_NORM_EPS so the
+        # downstream `magnitude / weight_norm` divide in `forward` cannot produce inf/NaN on
+        # genuinely zero rows. See issue #2049 and "Scaling DoRA" (arxiv:2603.22276).
+        target_dtype = weight.dtype
         weight = transpose(weight, self.fan_in_fan_out)
-        weight = weight + scaling * lora_weight
-        weight_norm = torch.linalg.norm(weight, dim=1).to(weight.dtype)
-        return weight_norm
+        merged = weight.float() + scaling * lora_weight.float()
+        weight_norm = torch.linalg.norm(merged, dim=1)
+        weight_norm = torch.clamp(weight_norm, min=DORA_WEIGHT_NORM_EPS)
+        return weight_norm.to(target_dtype)
 
     @cache_decorator("lora-weight")
     def get_lora_weight(self, lora_A, lora_B, adapter_name: Optional[str] = None):
@@ -205,12 +218,14 @@ class DoraEmbeddingLayer(DoraLinearLayer):
 class _DoraConvNdLayer(DoraLinearLayer):
     @cache_decorator("weight-norm")
     def get_weight_norm(self, weight, lora_weight, scaling, adapter_name: Optional[str] = None) -> torch.Tensor:
-        # calculate L2 norm of weight matrix, column-wise
-        weight = weight + scaling * lora_weight
+        # Same fp32-upcast + clamp rationale as DoraLinearLayer.get_weight_norm (see #2049).
+        target_dtype = weight.dtype
+        merged = weight.float() + scaling * lora_weight.float()
         # the following is needed to have compatibility with the 4/5D weight tensors of Conv2D/3D
-        dim = tuple(range(1, weight.dim()))
-        weight_norm = weight.norm(p=2, dim=dim, keepdim=True).transpose(1, 0)
-        return weight_norm
+        dim = tuple(range(1, merged.dim()))
+        weight_norm = merged.norm(p=2, dim=dim, keepdim=True).transpose(1, 0)
+        weight_norm = torch.clamp(weight_norm, min=DORA_WEIGHT_NORM_EPS)
+        return weight_norm.to(target_dtype)
 
     @cache_decorator("lora-weight")
     def get_lora_weight(self, lora_A, lora_B, adapter_name: Optional[str] = None) -> torch.Tensor:

--- a/tests/test_dora_bf16_zero_rows.py
+++ b/tests/test_dora_bf16_zero_rows.py
@@ -1,0 +1,80 @@
+"""Regression test for peft#2049: DoRA on a Linear with zero or low-precision-underflowing rows must not NaN.
+
+Drop into ``peft/tests/test_dora_bf16_zero_rows.py``. Both tests fail in peft 0.19.1 / main
+without the get_weight_norm fix, and pass after the fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from peft import LoraConfig, get_peft_model
+
+
+class _TinyLinear(nn.Module):
+    def __init__(self, in_features: int = 64, out_features: int = 32):
+        super().__init__()
+        self.proj = nn.Linear(in_features, out_features, bias=False)
+
+    def forward(self, x):
+        return self.proj(x)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_dora_does_not_nan_on_zero_rows(dtype):
+    """A Linear whose base weight contains all-zero rows must not produce inf/NaN under DoRA.
+
+    Real-world incidence: Llama-3.1-8B ``o_proj`` has 511 zero rows (issue #2049);
+    Qwen3.5/3.6 MoE ``linear_attn.in_proj_qkv`` has 434 zero rows across the SSM layers
+    (concentrated in layers 0/1/2).
+    """
+    torch.manual_seed(0)
+    model = _TinyLinear().to(dtype)
+    with torch.no_grad():
+        model.proj.weight[:8].zero_()
+
+    config = LoraConfig(
+        r=4,
+        lora_alpha=8,
+        target_modules=["proj"],
+        use_dora=True,
+        bias="none",
+    )
+    peft_model = get_peft_model(model, config)
+    peft_model.eval()
+
+    x = torch.randn(2, 64, dtype=dtype)
+    with torch.no_grad():
+        out = peft_model(x)
+    assert torch.isfinite(out).all(), (
+        f"DoRA forward produced non-finite output on Linear with zero rows (dtype={dtype})"
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_dora_does_not_nan_on_low_precision_underflow_rows(dtype):
+    """Rows whose entries are nonzero in fp32 but round to zero in bf16/fp16 must also not NaN."""
+    torch.manual_seed(0)
+    model = _TinyLinear()  # fp32 init
+    with torch.no_grad():
+        model.proj.weight[:8] = 1e-30  # far below the smallest representable bf16/fp16 normal
+    model = model.to(dtype)
+
+    config = LoraConfig(
+        r=4,
+        lora_alpha=8,
+        target_modules=["proj"],
+        use_dora=True,
+        bias="none",
+    )
+    peft_model = get_peft_model(model, config)
+    peft_model.eval()
+
+    x = torch.randn(2, 64, dtype=dtype)
+    with torch.no_grad():
+        out = peft_model(x)
+    assert torch.isfinite(out).all(), (
+        f"DoRA forward produced non-finite output on Linear with bf16/fp16-underflow rows (dtype={dtype})"
+    )


### PR DESCRIPTION
## What this PR does

Adds an fp32 upcast and an epsilon floor to `DoraLinearLayer.get_weight_norm` (and `_DoraConvNdLayer.get_weight_norm`). Without this change, any DoRA target whose base weight contains a row with all-zero values, or a row whose values underflow to zero in bf16/fp16, produces `inf` (and downstream `NaN`) at the very first forward pass: `weight_norm = 0` then `magnitude / weight_norm = inf` in `DoraLinearLayer.forward`.

## Why

This affects real checkpoints. Two concrete cases:

- **Llama-3.1-8B `o_proj`** (issue [#2049](https://github.com/huggingface/peft/issues/2049)): 511 rows with `||W||_2 = 0` in the released checkpoint. `use_dora=True` NaNs at step 0.
- **Qwen3.5-MoE / Qwen3.6-MoE `linear_attn.in_proj_qkv`**: 434 rows with fp32 `||W||_2 = 0` across the model's 30 SSM-style layers (concentrated in layers 0/1/2: 112/198/112 rows). `use_dora=True` NaNs at step 0 the same way. See e.g. [ollama/ollama#15866](https://github.com/ollama/ollama/issues/15866) for an independent observation that these specific rows are small enough to round to zero in low-precision quantization.

The current `get_weight_norm` has no protection against either case. Plain LoRA on the same targets is unaffected (no normalization step).

## The change

Two layers, same shape of fix:

```python
target_dtype = weight.dtype
merged = (weight + scaling * lora_weight).float()   # bf16/fp16 -> fp32 for the norm
weight_norm = torch.linalg.norm(merged, dim=...)
weight_norm = torch.clamp(weight_norm, min=DORA_WEIGHT_NORM_EPS)
return weight_norm.to(target_dtype)
```

`DORA_WEIGHT_NORM_EPS` is a new module-level constant defaulting to `1e-6`. This value follows the bf16/fp16 recommendation in "Scaling DoRA" ([arxiv:2603.22276](https://arxiv.org/abs/2603.22276)); `torchtune`'s DoRA also accumulates the norm in fp32 under `torch.no_grad`. For an fp32-only workflow `1e-6` is conservative; happy to switch to a dtype-conditioned value (e.g. `1e-6` for bf16/fp16, `1e-12` for fp32) on review.

## Behavior change

- For rows where the unpatched code returned a finite, nonzero norm in the input dtype, the patched code returns the same value (the fp32 norm cast back to input dtype is bitwise identical for finite normal values within bf16/fp16 range). No regression for the common case.
- For rows where the unpatched code returned `0`, the patched code returns `1e-6`. In `DoraLinearLayer.forward`, `mag_norm_scale = magnitude / weight_norm`. With `magnitude` also initialized from the (now-clamped) norm, `mag_norm_scale` is approximately 1 at init for these rows; the DoRA residual gracefully degenerates to standard LoRA on those rows rather than producing `inf`.
- Per-step cost: one fp32 norm plus one `clamp` per DoRA forward, negligible relative to the actual matmul.

## Tests

Adds `tests/test_dora_bf16_zero_rows.py` with two parameterized cases:

1. `test_dora_does_not_nan_on_zero_rows`: a Linear with all-zero rows in the base weight, attached DoRA, one forward in bf16 / fp16 / fp32, assert `torch.isfinite(out).all()`.
2. `test_dora_does_not_nan_on_low_precision_underflow_rows`: a Linear whose rows are nonzero in fp32 but underflow in bf16/fp16, same assertion.

Both tests fail on `main` and pass after this change.

## Things I deliberately did not change

- Did not introduce a configurable `eps` on `LoraConfig`. One module-level constant keeps the public API surface unchanged; happy to make it `LoraConfig.dora_weight_norm_eps` on review if maintainers prefer.
- Did not patch the magnitude vector initialization in `update_layer`. With this change, `update_layer`'s call to `get_weight_norm` already inherits the clamp, so the trainable magnitude starts at `1e-6` rather than `0` for affected rows, which is sufficient.
- Did not touch `DoraEmbeddingLayer`; it inherits the patched `get_weight_norm` from `DoraLinearLayer`.

## Validated downstream

- Synthetic tests above (pass under the patch on bf16/fp16/fp32).
- Full fine-tune of Qwen3.6-MoE (35B, hybrid SSM/attention/MoE) with `use_dora=True`, `target_modules="all-linear"`, r=16, α=32, 3 epochs, bf16, on an SFT chat dataset (340 train / 67 val rows): trained to completion with finite loss throughout. Final val_loss **0.7647**; plain LoRA at the same r/α/targets and dataset on the same model finishes at **0.7635** (matched within 0.2 %). Without the patch, the same DoRA config NaNs at step 0.

## Refs

- Issue [#2049](https://github.com/huggingface/peft/issues/2049)
- Prior art: "Scaling DoRA" ([arxiv:2603.22276](https://arxiv.org/abs/2603.22276)) for the eps convention
- Prior art: [torchtune DoRA](https://github.com/pytorch/torchtune) for fp32 accumulation
