### PR TITLE
fix(tuners): use self.active_adapters (list) when guarding requires_grad for newly created sub-adapter modules

### DIFF
--- a/src/peft/tuners/pvera/model.py
+++ b/src/peft/tuners/pvera/model.py
@@ -182,7 +182,7 @@ class PveraModel(BaseTuner):
             new_module = self._create_new_module(
                 pvera_config, self.pvera_A, self.pvera_B, adapter_name, target, current_key, **kwargs
             )
-            if adapter_name not in self.active_adapter:
+            if adapter_name not in self.active_adapters:
                 # adding an additional adapter: it is not automatically trainable
                 new_module.requires_grad_(False)
             self._replace_module(parent, target_name, new_module, target)

--- a/src/peft/tuners/randlora/model.py
+++ b/src/peft/tuners/randlora/model.py
@@ -275,7 +275,7 @@ class RandLoraModel(BaseTuner):
             new_module = self._create_new_module(
                 randlora_config, self.randlora_A, self.randlora_B, adapter_name, target, **kwargs
             )
-            if adapter_name not in self.active_adapter:
+            if adapter_name not in self.active_adapters:
                 # adding an additional adapter: it is not automatically trainable
                 new_module.requires_grad_(False)
             self._replace_module(parent, target_name, new_module, target)

--- a/src/peft/tuners/shira/model.py
+++ b/src/peft/tuners/shira/model.py
@@ -94,7 +94,7 @@ class ShiraModel(BaseTuner):
             )
         else:
             new_module = self._create_new_module(shira_config, adapter_name, target, **kwargs)
-            if adapter_name not in self.active_adapter:
+            if adapter_name not in self.active_adapters:
                 # adding an additional adapter: it is not automatically trainable
                 new_module.requires_grad_(False)
             self._replace_module(parent, target_name, new_module, target)

--- a/src/peft/tuners/tinylora/model.py
+++ b/src/peft/tuners/tinylora/model.py
@@ -180,7 +180,7 @@ class TinyLoraModel(BaseTuner):
                 tinylora_config, self.tinylora_v, v_key, adapter_name, target, layer_idx=layer_idx
             )
 
-            if adapter_name not in self.active_adapter:
+            if adapter_name not in self.active_adapters:
                 # adding an additional adapter: it is not automatically trainable
                 new_module.requires_grad_(False)
             self._replace_module(parent, target_name, new_module, target)

--- a/src/peft/tuners/vblora/model.py
+++ b/src/peft/tuners/vblora/model.py
@@ -112,7 +112,7 @@ class VBLoRAModel(BaseTuner):
                 target=target,
                 **kwargs,
             )
-            if adapter_name not in self.active_adapter:
+            if adapter_name not in self.active_adapters:
                 # adding an additional adapter: it is not automatically trainable
                 new_module.requires_grad_(False)
             self._replace_module(parent, target_name, new_module, target)

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -212,7 +212,7 @@ class VeraModel(BaseTuner):
             )
         else:
             new_module = self._create_new_module(vera_config, self.vera_A, self.vera_B, adapter_name, target, **kwargs)
-            if adapter_name not in self.active_adapter:
+            if adapter_name not in self.active_adapters:
                 # adding an additional adapter: it is not automatically trainable
                 new_module.requires_grad_(False)
             self._replace_module(parent, target_name, new_module, target)


### PR DESCRIPTION
## Bug

In six tuners (`vera`, `vblora`, `tinylora`, `pvera`, `shira`, `randlora`), the `_create_and_replace` non-Linear branch uses:

\`\`\`python
if adapter_name not in self.active_adapter:
    # adding an additional adapter: it is not automatically trainable
    new_module.requires_grad_(False)
\`\`\`

If `self.active_adapter` happens to be a string and `adapter_name` is a substring of it (e.g. `adapter_name="fault"`, `active_adapter="default"`), the `in` operator does a substring match and the condition silently flips, so the newly added adapter keeps `requires_grad=True` when it should not.

## Root cause

`BaseTuner` declares the field as a union (`src/peft/tuners/tuners_utils.py:313`):

\`\`\`python
self.active_adapter: str | list[str] = adapter_name
\`\`\`

`in` on a string is substring containment, not membership. The correct accessor is the `active_adapters` property (same file, lines 324–328) which always normalizes to a list:

\`\`\`python
@property
def active_adapters(self) -> list[str]:
    if isinstance(self.active_adapter, str):
        return [self.active_adapter]
    ...
    return self.active_adapter
\`\`\`

## Why the fix is correct

The plural form is already the established pattern in `lora`, `hra`, `boft`, `beft`, `road`, `gralora`, `peanut`, `psoft`, `adamss`, `lily`, `miss`, etc. — each uses `if adapter_name not in self.active_adapters:` in exactly this guard. The six listed tuners were drifted/copy-paste variants of the older spelling. Switching them to `self.active_adapters` matches the property contract and the rest of the codebase; no other behavior changes.

Mechanical 6-line change, one substitution per file.