### PR TITLE
Fix prepare model for compiled hotswap requires grad

### DIFF
--- a/src/peft/utils/hotswap.py
+++ b/src/peft/utils/hotswap.py
@@ -124,6 +124,7 @@ def _get_padded_linear(lora_module: torch.nn.Module, target_rank: int, is_lora_A
         padded = torch.zeros(out_features, target_rank, device=weight.device, dtype=weight.dtype)
         padded[:, :original_rank] = weight
         new_layer = torch.nn.Linear(target_rank, out_features, bias=lora_module.bias is not None)
+    new_layer.weight.requires_grad_(lora_module.weight.requires_grad)
 
     # Sanity check
     if new_layer.weight.shape != padded.shape:
@@ -204,6 +205,7 @@ def _get_padded_conv2d(lora_module: torch.nn.Module, target_rank: int, is_lora_A
             bias=lora_module.bias is not None,
             groups=lora_module.groups,
         )
+    new_layer.weight.requires_grad_(lora_module.weight.requires_grad)
 
     # Sanity check
     if new_layer.weight.shape != padded.shape:
@@ -254,11 +256,15 @@ def _pad_lora_weights(model: torch.nn.Module, target_rank: int) -> bool:
         # Pad LoRA A
         for adapter_name, lora_A_module in module.lora_A.items():
             new_layer = pad_fn(lora_A_module, target_rank=target_rank, is_lora_A=True)
+            assert module.lora_A[adapter_name].weight.requires_grad is new_layer.weight.requires_grad
+            # FIXME new_layer.weight.requires_grad
             module.lora_A[adapter_name] = new_layer
 
         # Pad LoRA B
         for adapter_name, lora_B_module in module.lora_B.items():
             new_layer = pad_fn(lora_B_module, target_rank=target_rank, is_lora_A=False)
+            assert module.lora_A[adapter_name].weight.requires_grad is new_layer.weight.requires_grad
+            # FIXME new_layer.weight.requires_grad
             module.lora_B[adapter_name] = new_layer
 
         found_adapter = True

--- a/src/peft/utils/hotswap.py
+++ b/src/peft/utils/hotswap.py
@@ -256,15 +256,11 @@ def _pad_lora_weights(model: torch.nn.Module, target_rank: int) -> bool:
         # Pad LoRA A
         for adapter_name, lora_A_module in module.lora_A.items():
             new_layer = pad_fn(lora_A_module, target_rank=target_rank, is_lora_A=True)
-            assert module.lora_A[adapter_name].weight.requires_grad is new_layer.weight.requires_grad
-            # FIXME new_layer.weight.requires_grad
             module.lora_A[adapter_name] = new_layer
 
         # Pad LoRA B
         for adapter_name, lora_B_module in module.lora_B.items():
             new_layer = pad_fn(lora_B_module, target_rank=target_rank, is_lora_A=False)
-            assert module.lora_A[adapter_name].weight.requires_grad is new_layer.weight.requires_grad
-            # FIXME new_layer.weight.requires_grad
             module.lora_B[adapter_name] = new_layer
 
         found_adapter = True

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -4244,6 +4244,48 @@ class TestHotSwapping:
             elif "lora_B" in name:
                 assert param.shape[1] == new_rank
 
+    @pytest.mark.parametrize("previous_requires_grad", [False, True])
+    def test_prepare_model_for_compiled_hotswap_conserves_requires_grad(self, previous_requires_grad):
+        # check that preparing the LoRA weights does not change requires_grad
+        old_rank = 8
+        target_rank = old_rank + 1
+        config = LoraConfig(target_modules=["lin0", "lin1"], r=old_rank)
+        model = self.get_model()
+        model = get_peft_model(model, config)
+
+        # set requires_grad of LoRA weights
+        for name, param in model.named_parameters():
+            if "lora_" in name:
+                param.requires_grad_(previous_requires_grad)
+
+        prepare_model_for_compiled_hotswap(model, target_rank=target_rank)
+
+        # check requires_grad of LoRA weights
+        for name, param in model.named_parameters():
+            if "lora_" in name:
+                assert param.requires_grad is previous_requires_grad
+
+    @pytest.mark.parametrize("previous_requires_grad", [False, True])
+    def test_prepare_model_for_compiled_hotswap_conv2d_conserves_requires_grad(self, previous_requires_grad):
+        # check that preparing the LoRA weights does not change requires_grad
+        old_rank = 8
+        target_rank = old_rank + 1
+        config = LoraConfig(target_modules=["conv"], r=old_rank)
+        model = self.get_model_conv2d()
+        model = get_peft_model(model, config)
+
+        # set requires_grad of LoRA weights
+        for name, param in model.named_parameters():
+            if "lora_" in name:
+                param.requires_grad_(previous_requires_grad)
+
+        prepare_model_for_compiled_hotswap(model, target_rank=target_rank)
+
+        # check requires_grad of LoRA weights
+        for name, param in model.named_parameters():
+            if "lora_" in name:
+                assert param.requires_grad is previous_requires_grad
+
     def test_prepare_model_for_compiled_hotswap_model_already_compiled_raises(self):
         config = LoraConfig(target_modules=["lin0"])
         model = self.get_model()


### PR DESCRIPTION
There was a bug that after calling `prepare_model_for_compiled_hotswap`, the `requires_grad` of the newly created LoRA layer may have a different value from what it was previously. This is now fixed.