### PR TITLE
TST Remove unnecessary use of trust_remote_code

### DIFF
--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -109,7 +109,7 @@ class TestXlora:
 
     @pytest.fixture(scope="class")
     def tokenizer(self):
-        tokenizer = AutoTokenizer.from_pretrained(self.model_id, trust_remote_code=True, device_map=self.torch_device)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_id, device_map=self.torch_device)
         return tokenizer
 
     @pytest.fixture(scope="function")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -289,7 +289,7 @@ def load_dataset_english_quotes():
 @lru_cache
 def load_cat_image():
     # can't use pytest fixtures for now because of unittest style tests
-    dataset = load_dataset("huggingface/cats-image", trust_remote_code=True)
+    dataset = load_dataset("huggingface/cats-image")
     image = dataset["test"]["image"][0]
     return image
 


### PR DESCRIPTION
Resolves #3240.

Some tests were unnecessarily using `trust_remote_code=True`. These arguments have been removed. Now, no test uses `trust_remote_code=True` anymore (except those specifically testing for this), which is better for security.