### PR TITLE
chore: add missing return type annotations in import_utils and other

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -48,7 +48,7 @@ def is_bnb_4bit_available() -> bool:
 
 
 @lru_cache
-def is_gptqmodel_available():
+def is_gptqmodel_available() -> bool:
     if importlib.util.find_spec("gptqmodel") is not None:
         GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("7.0.0")
         OPTIMUM_MINIMUM_VERSION = packaging.version.parse("1.24.0")
@@ -89,7 +89,7 @@ def is_optimum_available() -> bool:
 
 
 @lru_cache
-def is_torch_tpu_available(check_device=True):
+def is_torch_tpu_available(check_device=True) -> bool:
     "Checks if `torch_xla` is installed and potentially if a TPU is in the environment"
     if importlib.util.find_spec("torch_xla") is not None:
         if check_device:
@@ -106,27 +106,27 @@ def is_torch_tpu_available(check_device=True):
 
 
 @lru_cache
-def is_aqlm_available():
+def is_aqlm_available() -> bool:
     return importlib.util.find_spec("aqlm") is not None
 
 
 @lru_cache
-def is_eetq_available():
+def is_eetq_available() -> bool:
     return importlib.util.find_spec("eetq") is not None
 
 
 @lru_cache
-def is_hqq_available():
+def is_hqq_available() -> bool:
     return importlib.util.find_spec("hqq") is not None
 
 
 @lru_cache
-def is_inc_available():
+def is_inc_available() -> bool:
     return importlib.util.find_spec("neural_compressor") is not None
 
 
 @lru_cache
-def is_torchao_available():
+def is_torchao_available() -> bool:
     if importlib.util.find_spec("torchao") is None:
         return False
 
@@ -150,7 +150,7 @@ def is_torchao_available():
 
 
 @lru_cache
-def is_xpu_available(check_device=False):
+def is_xpu_available(check_device=False) -> bool:
     """
     Checks if XPU acceleration is available and potentially if a XPU is in the environment
     """
@@ -170,17 +170,17 @@ def is_xpu_available(check_device=False):
 
 
 @lru_cache
-def is_diffusers_available():
+def is_diffusers_available() -> bool:
     return importlib.util.find_spec("diffusers") is not None
 
 
 @lru_cache
-def is_te_available():
+def is_te_available() -> bool:
     return importlib.util.find_spec("transformer_engine") is not None
 
 
 @lru_cache
-def is_te_pytorch_available():
+def is_te_pytorch_available() -> bool:
     if not is_te_available():
         return False
 

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -229,7 +229,7 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
 
 
 # copied from transformers.models.bart.modeling_bart
-def shift_tokens_right(input_ids: torch.Tensor, pad_token_id: int, decoder_start_token_id: int):
+def shift_tokens_right(input_ids: torch.Tensor, pad_token_id: int, decoder_start_token_id: int) -> torch.Tensor:
     """
     Shift input ids one token to the right.
 


### PR DESCRIPTION
Add the missing `-> bool` / `-> torch.Tensor` / `-> None` return annotations on a handful of helper functions in `src/peft/import_utils.py` and `src/peft/utils/other.py`.

Pure type-annotation improvement: no runtime behavior change, no public API change. Helps `mypy` / `pyright` produce more precise inferences for callers.