### PR TITLE
fix(tuners_utils): make BaseTunerLayer.bias settable (#3243)

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1472,6 +1472,15 @@ class BaseTunerLayer(ABC):
         base_layer = self.get_base_layer()
         return base_layer.bias
 
+    @bias.setter
+    def bias(self, value) -> None:
+        # Forward assignment to the wrapped base layer so that modeling code
+        # which does ``module.bias = X`` (e.g. legacy Jamba modeling files that
+        # temporarily null out ``dt_proj.bias`` during the SSM forward) keeps
+        # working after the layer is wrapped by a PEFT tuner.
+        base_layer = self.get_base_layer()
+        base_layer.bias = value
+
     def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         raise NotImplementedError
 


### PR DESCRIPTION
Fixes #3243.

`BaseTunerLayer.bias` is declared as a read-only `@property`, so any modeling code that does `module.bias = X` raises `AttributeError: property 'bias' of 'Linear' object has no setter` once the layer is wrapped by a PEFT tuner. This breaks several legacy trust-remote-code Jamba modeling files on the Hub whose `JambaMambaMixer.forward` temporarily nulls out `self.dt_proj.bias` during the SSM step (see `ai21labs/Jamba-v0.1@9efd11575b` `modeling_jamba.py:856-861`).

This PR adds a setter that forwards assignment to the wrapped base layer, restoring the pre-PEFT `nn.Linear` contract while preserving the existing read path. No behavior change for code that only reads `module.bias`.

### Repro (from the issue)

```python
import torch
from torch import nn
from peft import LoraConfig, inject_adapter_in_model

class Mixer(nn.Module):
    def __init__(self):
        super().__init__()
        self.dt_proj = nn.Linear(16, 16, bias=True)
    def forward(self, x):
        time_proj_bias = self.dt_proj.bias
        self.dt_proj.bias = None
        out = self.dt_proj(x)
        self.dt_proj.bias = time_proj_bias
        return out

m = Mixer()
inject_adapter_in_model(LoraConfig(r=4, lora_alpha=8, target_modules=["dt_proj"]), m)
m(torch.randn(1, 4, 16))  # was: AttributeError; now: passes
```

---
AI-assisted, human reviewed.
