### PR TITLE
DOC Fix incorrect imports in helpers.py docstring examples

### DIFF
--- a/src/peft/helpers.py
+++ b/src/peft/helpers.py
@@ -44,7 +44,8 @@ def update_forward_signature(model: PeftModel) -> None:
 
     ```python
     >>> from transformers import WhisperForConditionalGeneration
-    >>> from peft import get_peft_model, LoraConfig, update_forward_signature
+    >>> from peft import get_peft_model, LoraConfig
+    >>> from peft.helpers import update_forward_signature
 
     >>> model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny.en")
     >>> peft_config = LoraConfig(r=8, lora_alpha=32, lora_dropout=0.1, target_modules=["q_proj", "v_proj"])
@@ -77,7 +78,8 @@ def update_generate_signature(model: PeftModel) -> None:
 
     ```python
     >>> from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
-    >>> from peft import get_peft_model, LoraConfig, TaskType, update_generate_signature
+    >>> from peft import get_peft_model, LoraConfig, TaskType
+    >>> from peft.helpers import update_generate_signature
 
     >>> model_name_or_path = "bigscience/mt0-large"
     >>> tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
@@ -117,7 +119,8 @@ def update_signature(model: PeftModel, method: str = "all") -> None:
     Example:
     ```python
     >>> from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
-    >>> from peft import get_peft_model, LoraConfig, TaskType, update_signature
+    >>> from peft import get_peft_model, LoraConfig, TaskType
+    >>> from peft.helpers import update_signature
 
     >>> model_name_or_path = "bigscience/mt0-large"
     >>> tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
@@ -273,7 +276,7 @@ class DoraCaching:
     Example:
 
         ```py
-        >>> from peft.helpers import enable_dora_scaling
+        >>> from peft.helpers import DoraCaching
 
         >>> model.eval()  # put in eval model for caching to work
 


### PR DESCRIPTION
Four docstring examples in `src/peft/helpers.py` raise `ImportError` on their first import line, so a user copy-pasting them dies immediately.

Three (`update_forward_signature`, `update_generate_signature`, `update_signature`) import from `peft` top-level; the functions are only available via `peft.helpers`. The fourth (`DoraCaching` docstring at line 276) imports `enable_dora_scaling`, a name that doesn't exist anywhere in the codebase — should be `DoraCaching`, the class the docstring is for.

Found by running `pytest --doctest-modules src/peft/helpers.py`. After the fix the import lines no longer fail; examples advance past them and execute end-to-end.

Out of scope: the fifth doctest failure (`rescale_adapter_scale` line 194, undefined `ModelWithLoraLayer` placeholder) is a different bug class.