### PR TITLE
FIX BdLoraConfig.nblocks default value

### DIFF
--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -216,14 +216,12 @@ class BdLoraConfig:
             "Example: ['out_proj', 'down_proj']"
         },
     )
-    nblocks: int = (
-        field(
-            default=1,
-            metadata={
-                "help": "Number of blocks each block-diagonal matrix has. If using BD-LoRA to speed up inference, "
-                "set it to be equal to the desired sharding degree during serving."
-            },
-        ),
+    nblocks: int = field(
+        default=1,
+        metadata={
+            "help": "Number of blocks each block-diagonal matrix has. If using BD-LoRA to speed up inference, "
+            "set it to be equal to the desired sharding degree during serving."
+        },
     )
     match_strict: bool = field(
         default=True,

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -65,7 +65,7 @@ from peft import (
 )
 from peft.mapping import PEFT_TYPE_TO_PREFIX_MAPPING
 from peft.tuners.lokr.layer import LoKrLayer
-from peft.tuners.lora.config import CordaConfig
+from peft.tuners.lora.config import BdLoraConfig, CordaConfig
 from peft.tuners.lora.corda import preprocess_corda
 from peft.tuners.lora.layer import LoraLayer
 from peft.utils import infer_device
@@ -1232,6 +1232,23 @@ class TestLoraInitialization:
 
         with pytest.raises(ValueError, match="not divisible by"):
             get_peft_model(model, config)
+
+    def test_bdlora_default_nblocks_is_int(self):
+        # The default value of BdLoraConfig.nblocks must be the integer 1, not a wrapped field object. A misplaced
+        # trailing comma previously turned the default into a 1-tuple, which broke get_peft_model whenever the user
+        # did not pass nblocks explicitly.
+        assert BdLoraConfig().nblocks == 1
+
+    def test_bdlora_get_peft_model_with_default_nblocks(self):
+        # Building a BD-LoRA model without specifying nblocks must work and rely on the documented default of 1.
+        # This used to raise a TypeError because nblocks defaulted to a tuple instead of an int.
+        model = self.get_model()
+
+        bdlora_config = {"target_modules_bd_a": ["linear"], "target_modules_bd_b": []}
+        config = LoraConfig(target_modules=["linear"], use_bdlora=bdlora_config)
+        model = get_peft_model(model, config)
+
+        assert model.linear.lora_A["default"].nblocks == 1
 
     @pytest.fixture
     def mha_cls(self):


### PR DESCRIPTION
## What this fixes

`BdLoraConfig.nblocks` is meant to default to the integer `1`, but a misplaced trailing comma wrapped the `field(...)` call in a tuple:

```python
nblocks: int = (
    field(
        default=1,
        ...
    ),
)
```

Because the assigned value is a `tuple` rather than a `Field` instance, the dataclass machinery treats it as a literal default. So `BdLoraConfig().nblocks` is the one-element tuple `(Field(...),)` instead of `1`.

This breaks `get_peft_model` whenever a BD-LoRA config is used without explicitly setting `nblocks`, because the value flows into `BlockDiagonalLinear` where it is used for `%` and `//`:

```python
class MyModule(nn.Module):
    def __init__(self):
        super().__init__()
        self.linear = nn.Linear(1000, 1000)
    def forward(self, x):
        return self.linear(x)

model = MyModule()
bdlora_config = {"target_modules_bd_a": ["linear"], "target_modules_bd_b": []}  # no nblocks -> default
config = LoraConfig(target_modules=["linear"], use_bdlora=bdlora_config)
get_peft_model(model, config)
# TypeError: unsupported operand type(s) for %: 'int' and 'tuple'
```

The existing BD-LoRA tests all pass an explicit `nblocks`, so they did not catch the broken default.

## The fix

Remove the extra parentheses and trailing comma so `nblocks` is a regular integer field defaulting to `1`, consistent with the other fields in `BdLoraConfig`.

## Tests

Added two tests in `TestLoraInitialization` (both fail before the fix, pass after):

- `test_bdlora_default_nblocks_is_int` checks `BdLoraConfig().nblocks == 1`.
- `test_bdlora_get_peft_model_with_default_nblocks` builds a BD-LoRA model relying on the default `nblocks` and checks the resulting block-diagonal layer has `nblocks == 1`.

```
pytest tests/test_initialization.py -k bdlora
# 5 passed
```

`ruff check` and `ruff format --check` are clean on the changed files.

---

Developed with AI coding assistance; reviewed and submitted by the author.