### PR TITLE
Return False from is_gptqmodel_available when gptqmodel isn't installed

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -49,38 +49,40 @@ def is_bnb_4bit_available() -> bool:
 
 @lru_cache
 def is_gptqmodel_available() -> bool:
-    if importlib.util.find_spec("gptqmodel") is not None:
-        GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("7.0.0")
-        OPTIMUM_MINIMUM_VERSION = packaging.version.parse("1.24.0")
-        version_gptqmodel = packaging.version.parse(importlib_metadata.version("gptqmodel"))
-        if GPTQMODEL_MINIMUM_VERSION <= version_gptqmodel:
-            if is_optimum_available():
-                try:
-                    version_optimum = packaging.version.parse(importlib_metadata.version("optimum"))
-                except importlib_metadata.PackageNotFoundError:
-                    # Same idea as in diffusers:
-                    # https://github.com/huggingface/diffusers/blob/9f06a0d1a4a998ac6a463c5be728c892f95320a8/src/diffusers/utils/import_utils.py#L351-L357
-                    # It's not clear under what circumstances `importlib_metadata.version("optimum")` can raise an error
-                    # even though `importlib.util.find_spec("optimum") is not None` but it has been observed, so adding
-                    # this for precaution. If we cannot detect it, we just optimistically assume it's high enough.
-                    return True
+    if importlib.util.find_spec("gptqmodel") is None:
+        return False
 
-                if OPTIMUM_MINIMUM_VERSION <= version_optimum:
-                    return True
-                else:
-                    raise ImportError(
-                        f"gptqmodel requires optimum version `{OPTIMUM_MINIMUM_VERSION}` or higher. Found version `{version_optimum}`, "
-                        f"but only versions above `{OPTIMUM_MINIMUM_VERSION}` are supported"
-                    )
+    GPTQMODEL_MINIMUM_VERSION = packaging.version.parse("7.0.0")
+    OPTIMUM_MINIMUM_VERSION = packaging.version.parse("1.24.0")
+    version_gptqmodel = packaging.version.parse(importlib_metadata.version("gptqmodel"))
+    if GPTQMODEL_MINIMUM_VERSION <= version_gptqmodel:
+        if is_optimum_available():
+            try:
+                version_optimum = packaging.version.parse(importlib_metadata.version("optimum"))
+            except importlib_metadata.PackageNotFoundError:
+                # Same idea as in diffusers:
+                # https://github.com/huggingface/diffusers/blob/9f06a0d1a4a998ac6a463c5be728c892f95320a8/src/diffusers/utils/import_utils.py#L351-L357
+                # It's not clear under what circumstances `importlib_metadata.version("optimum")` can raise an error
+                # even though `importlib.util.find_spec("optimum") is not None` but it has been observed, so adding
+                # this for precaution. If we cannot detect it, we just optimistically assume it's high enough.
+                return True
+
+            if OPTIMUM_MINIMUM_VERSION <= version_optimum:
+                return True
             else:
                 raise ImportError(
-                    f"gptqmodel requires optimum version `{OPTIMUM_MINIMUM_VERSION}` or higher to be installed."
+                    f"gptqmodel requires optimum version `{OPTIMUM_MINIMUM_VERSION}` or higher. Found version `{version_optimum}`, "
+                    f"but only versions above `{OPTIMUM_MINIMUM_VERSION}` are supported"
                 )
         else:
             raise ImportError(
-                f"Found an incompatible version of gptqmodel. Found version `{version_gptqmodel}`, "
-                f"but only versions `{GPTQMODEL_MINIMUM_VERSION}` or higher are supported"
+                f"gptqmodel requires optimum version `{OPTIMUM_MINIMUM_VERSION}` or higher to be installed."
             )
+    else:
+        raise ImportError(
+            f"Found an incompatible version of gptqmodel. Found version `{version_gptqmodel}`, "
+            f"but only versions `{GPTQMODEL_MINIMUM_VERSION}` or higher are supported"
+        )
 
 
 @lru_cache


### PR DESCRIPTION
Found this while reading `import_utils.py`.

`is_gptqmodel_available` is the only `is_*_available` helper that doesn't explicitly return `False` when its package is missing — the whole body is nested inside `if find_spec("gptqmodel") is not None:` with no return on the false branch, so it falls off the end and returns `None`:

```pycon
>>> from peft.import_utils import is_gptqmodel_available
>>> is_gptqmodel_available()
>>> # implicit None, not False
>>> type(_)
<class 'NoneType'>
```

Compare with the siblings:

```pycon
>>> from peft.import_utils import is_bnb_available, is_aqlm_available
>>> is_bnb_available(), is_aqlm_available()
(False, False)
```

Truthiness mostly hides this (\`not None\` and \`not False\` are both True), so \`tests/testing_utils.py\`'s \`not is_gptqmodel_available()\` skip-marker still does the right thing. But the annotation says \`-> bool\`, type checkers complain, and any caller doing \`is False\` / \`is True\` / \`assert ... is True\` would silently take the wrong branch.

Flipped the outer if to an early-return False — also drops one level of nesting as a bonus, no behavior change for the existing branches.