### PR TITLE
Avoid TP helper imports for non-TP distributed LoRA loads

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -497,14 +497,30 @@ def _maybe_shard_state_dict_for_tp(model, state_dict, adapter_name):
         state_dict (`dict`): The adapter state dict to shard in-place (as loaded from a checkpoint).
         adapter_name (`str`): The name of the adapter whose weights are being sharded.
     """
+    from ..tuners.lora.layer import LoraLayer  # lazy import to avoid circular import
+
+    tp_lora_modules = []
+    for name, module in model.named_modules():
+        if not isinstance(module, LoraLayer):
+            continue
+
+        base_layer = module.get_base_layer()
+        tp_plan = getattr(base_layer, "_hf_tp_plan", None)
+        device_mesh = getattr(base_layer, "_hf_device_mesh", None)
+        if tp_plan is None or device_mesh is None:
+            continue
+
+        tp_lora_modules.append((name, module, base_layer, tp_plan, device_mesh))
+
+    if not tp_lora_modules:
+        return
+
     from transformers.integrations.tensor_parallel import (
         ALL_PARALLEL_STYLES,
         ColwiseParallel,
         EmbeddingParallel,
         RowwiseParallel,
     )
-
-    from ..tuners.lora.layer import LoraLayer  # lazy import to avoid circular import
 
     should_check = True
     prefix_to_remove = None
@@ -513,16 +529,8 @@ def _maybe_shard_state_dict_for_tp(model, state_dict, adapter_name):
 
     possible_prefixes = ["base_model.model.", "base_model."]
 
-    for name, module in model.named_modules():
-        if not isinstance(module, LoraLayer):
-            continue
-        base_layer = module.get_base_layer()
+    for name, module, base_layer, tp_plan, device_mesh in tp_lora_modules:
         device = base_layer.weight.device
-        tp_plan = getattr(base_layer, "_hf_tp_plan", None)
-        device_mesh = getattr(base_layer, "_hf_device_mesh", None)
-
-        if tp_plan is None or device_mesh is None:
-            continue
 
         # One time check to make sure we are adding / removing a potential prefix to get the proper key in the state
         # dict. Same thing for the adapter name.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -29,6 +29,7 @@ from transformers import (
 from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
 from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_ge_v5_6_0
 from peft.utils.other import ModulesToSaveWrapper, _get_module_names_tied_with_embedding, _get_no_split_modules
+from peft.utils.save_and_load import _maybe_shard_state_dict_for_tp
 
 from .testing_utils import hub_online_once
 
@@ -87,6 +88,18 @@ def test_modules_to_save_targets_module_dict_raises(cls):
     msg = "modules_to_save cannot be applied to modules of type"
     with pytest.raises(TypeError, match=msg):
         get_peft_model(model=model, peft_config=peft_config)
+
+
+def test_maybe_shard_state_dict_for_tp_noops_without_tp_layers():
+    model = get_peft_model(ModelWithModuleDict(), LoraConfig(target_modules=["other_layer"]))
+    model._tp_plan = {"other_layer": "colwise"}
+    weight = torch.rand(8, 10)
+    state_dict = {"other_layer.lora_A.weight": weight}
+
+    _maybe_shard_state_dict_for_tp(model, state_dict, adapter_name="default")
+
+    assert list(state_dict) == ["other_layer.lora_A.weight"]
+    assert state_dict["other_layer.lora_A.weight"] is weight
 
 
 def test_get_peft_model_revision_warning(tmp_path):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -29,7 +29,7 @@ from transformers import (
 from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
 from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_ge_v5_6_0
 from peft.utils.other import ModulesToSaveWrapper, _get_module_names_tied_with_embedding, _get_no_split_modules
-from peft.utils.save_and_load import _maybe_shard_state_dict_for_tp
+from peft.utils.save_and_load import get_peft_model_state_dict, set_peft_model_state_dict
 
 from .testing_utils import hub_online_once
 
@@ -90,16 +90,17 @@ def test_modules_to_save_targets_module_dict_raises(cls):
         get_peft_model(model=model, peft_config=peft_config)
 
 
-def test_maybe_shard_state_dict_for_tp_noops_without_tp_layers():
+def test_set_peft_model_state_dict_noops_tp_sharding_without_tp_layers(monkeypatch):
     model = get_peft_model(ModelWithModuleDict(), LoraConfig(target_modules=["other_layer"]))
-    model._tp_plan = {"other_layer": "colwise"}
-    weight = torch.rand(8, 10)
-    state_dict = {"other_layer.lora_A.weight": weight}
+    state_dict = get_peft_model_state_dict(model)
 
-    _maybe_shard_state_dict_for_tp(model, state_dict, adapter_name="default")
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
 
-    assert list(state_dict) == ["other_layer.lora_A.weight"]
-    assert state_dict["other_layer.lora_A.weight"] is weight
+    # Simulate DDP: distributed is initialized, but no LoRA base layer has TP metadata to shard.
+    load_result = set_peft_model_state_dict(model, state_dict)
+
+    assert not load_result.unexpected_keys
 
 
 def test_get_peft_model_revision_warning(tmp_path):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -29,8 +29,6 @@ from transformers import (
 from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
 from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_ge_v5_6_0
 from peft.utils.other import ModulesToSaveWrapper, _get_module_names_tied_with_embedding, _get_no_split_modules
-from peft.utils.save_and_load import _maybe_shard_state_dict_for_tp
-
 from .testing_utils import hub_online_once
 
 
@@ -88,18 +86,6 @@ def test_modules_to_save_targets_module_dict_raises(cls):
     msg = "modules_to_save cannot be applied to modules of type"
     with pytest.raises(TypeError, match=msg):
         get_peft_model(model=model, peft_config=peft_config)
-
-
-def test_maybe_shard_state_dict_for_tp_noops_without_tp_layers():
-    model = get_peft_model(ModelWithModuleDict(), LoraConfig(target_modules=["other_layer"]))
-    weight = torch.rand(8, 10)
-    state_dict = {"other_layer.lora_A.weight": weight}
-
-    # Without TP metadata on the LoRA base layers, the helper should be a no-op.
-    _maybe_shard_state_dict_for_tp(model, state_dict, adapter_name="default")
-
-    assert list(state_dict) == ["other_layer.lora_A.weight"]
-    assert state_dict["other_layer.lora_A.weight"] is weight
 
 
 def test_get_peft_model_revision_warning(tmp_path):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -29,7 +29,7 @@ from transformers import (
 from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
 from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_ge_v5_6_0
 from peft.utils.other import ModulesToSaveWrapper, _get_module_names_tied_with_embedding, _get_no_split_modules
-from peft.utils.save_and_load import get_peft_model_state_dict, set_peft_model_state_dict
+from peft.utils.save_and_load import _maybe_shard_state_dict_for_tp
 
 from .testing_utils import hub_online_once
 
@@ -90,17 +90,16 @@ def test_modules_to_save_targets_module_dict_raises(cls):
         get_peft_model(model=model, peft_config=peft_config)
 
 
-def test_set_peft_model_state_dict_noops_tp_sharding_without_tp_layers(monkeypatch):
+def test_maybe_shard_state_dict_for_tp_noops_without_tp_layers():
     model = get_peft_model(ModelWithModuleDict(), LoraConfig(target_modules=["other_layer"]))
-    state_dict = get_peft_model_state_dict(model)
+    weight = torch.rand(8, 10)
+    state_dict = {"other_layer.lora_A.weight": weight}
 
-    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
-    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    # Without TP metadata on the LoRA base layers, the helper should be a no-op.
+    _maybe_shard_state_dict_for_tp(model, state_dict, adapter_name="default")
 
-    # Simulate DDP: distributed is initialized, but no LoRA base layer has TP metadata to shard.
-    load_result = set_peft_model_state_dict(model, state_dict)
-
-    assert not load_result.unexpected_keys
+    assert list(state_dict) == ["other_layer.lora_A.weight"]
+    assert state_dict["other_layer.lora_A.weight"] is weight
 
 
 def test_get_peft_model_revision_warning(tmp_path):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -29,6 +29,7 @@ from transformers import (
 from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
 from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_ge_v5_6_0
 from peft.utils.other import ModulesToSaveWrapper, _get_module_names_tied_with_embedding, _get_no_split_modules
+
 from .testing_utils import hub_online_once
 
 


### PR DESCRIPTION
## Summary

Fix a `ModuleNotFoundError` in distributed LoRA adapter loading when `torch.distributed` is initialized but the model is not actually tensor-parallel sharded.

## Problem

`set_peft_model_state_dict` calls `_maybe_shard_state_dict_for_tp` whenever distributed is initialized. This also happens for regular DDP runs. The helper imported `transformers.integrations.tensor_parallel` before checking whether any LoRA layer had TP metadata, so non-TP distributed runs could fail immediately with:

```text
ModuleNotFoundError: No module named 'transformers.integrations.tensor_parallel'
```

## Fix

Check for real TP-sharded LoRA layers first by looking for `_hf_tp_plan` and `_hf_device_mesh` on the base layers. If none are found, return early. Only import Transformers TP helpers when there is actually something to shard.

This keeps the existing TP path intact while avoiding false-positive TP handling for DDP/non-TP workloads.

## Test

Added a regression test for a LoRA model with a model-level `_tp_plan` but no layer-level TP metadata:

```bash
python -m pytest -o addopts="" tests/test_other.py::test_maybe_shard_state_dict_for_tp_noops_without_tp_layers -q
```

Result: `1 passed`.
