### PR TITLE
FIX Transformers weight conversion undo incorrect key renaming

### DIFF
--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -508,6 +508,7 @@ def convert_peft_adapter_state_dict_for_transformers(
         # no architecture-level conversion registered for this model
         return adapter_state_dict
 
+    prefix: str = getattr(model, "base_model_prefix", "")
     weight_conversions = get_model_conversion_mapping(model)
     peft_weight_conversions = build_peft_weight_mapping(
         weight_conversions, adapter_name=adapter_name, peft_config=peft_config
@@ -539,6 +540,13 @@ def convert_peft_adapter_state_dict_for_transformers(
     state_items = sorted(lora_like_state_dict.items(), key=lambda kv: dot_natural_key(kv[0]))
     for original_key, tensor in state_items:
         renamed_key, source_pattern = rename_source_key(original_key, renamings, converters)
+
+        # https://github.com/huggingface/transformers/blob/027d1a97025295a1346c2eb5c361259e69eedfe7/src/transformers/core_model_loading.py#L1361-L1365
+        if renamed_key not in adapter_state_dict and original_key in adapter_state_dict:
+            # Key should probably not have been renamed but we might need the `prefix` to be added.
+            renamed_key, source_pattern = rename_source_key(
+                original_key, [], [], prefix=prefix, meta_state_dict=adapter_state_dict
+            )
 
         if source_pattern is not None:
             new_converter = copy.deepcopy(pattern_to_converter[source_pattern])

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -25,6 +25,7 @@ from transformers import (
     AutoModelForSeq2SeqLM,
     AutoModelForSequenceClassification,
     CLIPTextModel,
+    CLIPTextModelWithProjection,
 )
 
 from peft import (
@@ -472,6 +473,32 @@ class TestInjectAdapterFromStateDict:
 
             # sanity check:
             assert (model.encoder.layers[0].self_attn.v_proj.lora_B.default.weight == 555).all()
+
+    def test_prefix_removal_is_undone(self):
+        # See discussion starting here: https://github.com/huggingface/peft/pull/3212#issuecomment-4402677775.
+        # For some models like CLIPTextModelWithProjection, transformers would add a removal of the 'text_model.' prefix
+        # to the conversions, but this removal is incorrect. Therefore, there is a logic in transformers to undo the
+        # removal if there is not entry in the state_dict for the renamed key. This logic was missing in PEFT, resulting
+        # in missing and unexpected keys.
+        config = LoraConfig(target_modules=["q_proj", "v_proj"])
+        model_id = "peft-internal-testing/tiny-clip-text-2"
+
+        with hub_online_once(model_id):
+            model = CLIPTextModelWithProjection.from_pretrained(model_id)
+            inject_adapter_in_model(config, model)
+            # sanity check:
+            assert (model.text_model.encoder.layers[0].self_attn.v_proj.lora_B.default.weight == 0).all()
+
+            state_dict = get_peft_model_state_dict(model)
+            state_dict = {k: torch.ones_like(v) * 555 for k, v in state_dict.items()}
+            load_result = set_peft_model_state_dict(model, state_dict)
+
+            assert not load_result.unexpected_keys
+            # base model weights may be missing, but LoRA weights should never be missing
+            assert not any("lora" in k for k in load_result.missing_keys)
+
+            # sanity check:
+            assert (model.text_model.encoder.layers[0].self_attn.v_proj.lora_B.default.weight == 555).all()
 
 
 class TestPeftStateDict:


### PR DESCRIPTION
See [discussion starting here](https://github.com/huggingface/peft/pull/3212#issuecomment-4402677775).

For some models like `CLIPTextModelWithProjection`, transformers would add a removal of the `'text_model.'` prefix to the conversions, but this removal is incorrect. Therefore, there is a logic in transformers to undo the removal if there is not entry in the `state_dict` for the renamed key:

https://github.com/huggingface/transformers/blob/027d1a97025295a1346c2eb5c361259e69eedfe7/src/transformers/core_model_loading.py#L1361-L1365

This logic was missing in PEFT, resulting in missing and unexpected keys.

This PR should fix the failing Diffusers tests. Failing CI is unrelated.