### PR TITLE
TST Correctly resolve GLUE dataset

### DIFF
--- a/tests/test_cpt.py
+++ b/tests/test_cpt.py
@@ -77,7 +77,7 @@ def config_random():
 @pytest.fixture(scope="module")
 def sst_data():
     """Load the SST2 dataset and prepare it for testing."""
-    data = load_dataset("glue", "sst2")
+    data = load_dataset("nyu-mll/glue", "sst2")
 
     def add_string_labels(example):
         if example["label"] == 0:


### PR DESCRIPTION
Some tests are using the GLUE dataset, which lived on HF datasets without a namespace. This no longer works with the latest `huggingface_hub`, resulting in [CI errors](https://github.com/huggingface/peft/actions/runs/26261682388/job/77296425430?pr=3230#step:8:1459). Now the test uses `nyu-mll/glue`.

Failing CI is unrelated.