### PR TITLE
docs(prepare_model_for_kbit_training): note the ~0.5–1 GB CUDA reserved overhead (#3265)

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -146,6 +146,15 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
         1- Cast the layernorm in fp32 2- making output embedding layer require grads 3- Add the upcasting of the lm
         head to fp32 4- Freezing the base model layers to ensure they are not updated during training
 
+    <Tip warning={true}>
+
+    Memory note: the layernorm/RMSNorm fp32 upcast performed for non-quantized and bnb 4bit/8bit paths can
+    grow CUDA reserved memory by roughly 0.5–1 GB for 7B-class models in addition to the allocated bytes,
+    because the CUDA caching allocator holds the transient buffers from the upcast op. On 8 GB consumer or
+    edge accelerators (Jetson Orin Nano, Apple Silicon unified memory, RTX 4060 8 GB, …) this overhead can
+    be the difference between a recipe that fits and one that OOMs — budget for it explicitly.
+
+    </Tip>
 
     Args:
         model (`transformers.PreTrainedModel`):


### PR DESCRIPTION
Closes #3265.

## Why

#3265 describes that `prepare_model_for_kbit_training` adds ~1 GB of CUDA reserved memory in ~500 ms for 7B-class models on top of the loaded weights, and that this overhead is not documented anywhere. On 8 GB unified-memory or consumer accelerators (Jetson Orin Nano 8 GB, Apple Silicon, RTX 4060 8 GB) this is the difference between a recipe that fits and one that OOMs.

The issue author proposed three fixes (docs / new kwarg / lean variant). This PR takes **Fix 1 (docs only, easy)** so users can at least account for the overhead. The new-kwarg / lean-variant options can land separately if maintainers want them — happy to follow up.

## What

Adds a `<Tip warning={true}>` block to the `prepare_model_for_kbit_training` docstring noting:
- the source of the overhead (norm fp32 upcast + transient allocator buffers),
- a rough magnitude (~0.5–1 GB CUDA reserved on 7B-class),
- and the device classes most affected.

No behavior change.

## Test plan

- [ ] Docs build (`make docs` / nbsphinx) renders the `<Tip warning>` block correctly.
- [ ] No code paths touched, so no new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
