### PR TITLE
DOC: fix adapter_names parameter name in set_requires_grad docstrings

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1584,7 +1584,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         Note: Not supported for prompt learning methods like prompt tuning.
 
         Args:
-            adapter_name (`str` or `Sequence[str]`):
+            adapter_names (`str` or `Sequence[str]`):
                 The name of the adapter(s) whose gradients should be enabled/disabled.
             requires_grad (`bool`, *optional*)
                 Whether to enable (`True`, default) or disable (`False`).

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -545,7 +545,7 @@ class BaseTuner(nn.Module, ABC):
         Enable or disable gradients on the given adapter(s).
 
         Args:
-            adapter_name (`str` or `Sequence[str]`):
+            adapter_names (`str` or `Sequence[str]`):
                 The name of the adapter(s) whose gradients should be enabled/disabled.
             requires_grad (`bool`, *optional*)
                 Whether to enable (`True`, default) or disable (`False`).
@@ -1598,7 +1598,7 @@ class BaseTunerLayer(ABC):
         Enable or disable gradients on the given adapter(s).
 
         Args:
-            adapter_name (`str` or `Sequence[str]`):
+            adapter_names (`str` or `Sequence[str]`):
                 The name of the adapter(s) whose gradients should be enabled/disabled.
             requires_grad (`bool`, *optional*)
                 Whether to enable (`True`, default) or disable (`False`).
@@ -2196,8 +2196,8 @@ def set_requires_grad(model, adapter_names: str | Sequence[str], requires_grad: 
 
     Args:
         model (`nn.Module`):
-            The model from which the adapter should be deleted.
-        adapter_name (`str` or `Sequence[str]`):
+            The model whose adapter gradient requirements should be updated.
+        adapter_names (`str` or `Sequence[str]`):
             The name of the adapter(s) whose gradients should be enabled/disabled.
         requires_grad (`bool`, *optional*)
             Whether to enable (`True`, default) or disable (`False`).

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -525,7 +525,7 @@ class AuxiliaryTrainingWrapper(torch.nn.Module):
         Enable or disable gradients on the given adapter(s).
 
         Args:
-            adapter_name (`str` or `Sequence[str]`):
+            adapter_names (`str` or `Sequence[str]`):
                 The name of the adapter(s) whose gradients should be enabled/disabled.
             requires_grad (`bool`, *optional*)
                 Whether to enable (`True`, default) or disable (`False`).


### PR DESCRIPTION
## What does this fix?

The `set_requires_grad` function and methods across 4 files document the parameter as `adapter_name` (singular) but the actual parameter name in every function signature is `adapter_names` (plural, accepts `str | Sequence[str]`).

Also fixes an incorrect `model` description in the standalone `set_requires_grad` in `tuners_utils.py` — it was copy-pasted from `delete_adapter` and said *"The model from which the adapter should be deleted"* instead of correctly describing the gradient update operation.

## Files changed

- `src/peft/peft_model.py` — `PeftModel.set_requires_grad`
- `src/peft/tuners/tuners_utils.py` — `BaseTuner.set_requires_grad`, `BaseTunerLayer.set_requires_grad`, standalone `set_requires_grad`
- `src/peft/utils/other.py` — `AuxiliaryTrainingWrapper.set_requires_grad`
