### PR TITLE
SEC Add 7 day cooldown to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       ci-actions:
         patterns:


### PR DESCRIPTION
Makes it less likely to use a compromised GH action.

I did consider setting 8 days, as everyone seems to converge on 7 days, at which point a compromise might not be noticed until after 7 days, so 8 days would be extra secure.