### PR TITLE
Fix: target_modules as string incorrectly converted to set of characters

### DIFF
--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -368,8 +368,16 @@ def _convert_peft_config_moe(peft_config, model_type: str) -> None:
     if not fused_targets:
         return
 
-    peft_config.target_parameters = set(peft_config.target_parameters or [])
-    peft_config.target_modules = set(peft_config.target_modules or [])
+    peft_config.target_parameters = (
+        {peft_config.target_parameters}
+        if isinstance(peft_config.target_parameters, str)
+        else set(peft_config.target_parameters or [])
+    )
+    peft_config.target_modules = (
+        {peft_config.target_modules}
+        if isinstance(peft_config.target_modules, str)
+        else set(peft_config.target_modules or [])
+    )
     if not hasattr(peft_config, "rank_pattern") or peft_config.rank_pattern is None:
         peft_config.rank_pattern = {}
     if not hasattr(peft_config, "alpha_pattern") or peft_config.alpha_pattern is None:


### PR DESCRIPTION
Bug: In `transformers_weight_conversion.py`, when `target_modules` or `target_parameters` is provided as a string (e.g. `"all-linear"`), passing it to `set()` splits the string into individual characters (e.g., `{'a', 'l', '-', ...}`). Root cause: `set(str)` iterates over characters instead of creating a set containing the string. Why fix is correct: Explicitly checking if the input is a string and wrapping it in a set with a single element prevents the string from being erroneously unpacked.