### PR TITLE
fix(ia3): use division for unmerging ConvNd bias

### DIFF
--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -286,7 +286,7 @@ class _ConvNd(nn.Module, IA3Layer):
                 if not self.is_feedforward and (base_layer.bias is not None):
                     scaling = self.ia3_l[active_adapter].reshape(base_layer.bias.shape)
                     orig_dtype = base_layer.bias.data.dtype
-                    base_layer.bias.data = torch.mul(base_layer.bias.data, scaling.data).to(orig_dtype)
+                    base_layer.bias.data = torch.div(base_layer.bias.data, scaling.data + 1e-8).to(orig_dtype)
 
     def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
         dtype = previous_dtype = x.dtype

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1167,7 +1167,8 @@ class BaseTuner(nn.Module, ABC):
             child = child.base_layer
 
         if not hasattr(new_module, "base_layer"):
-            new_module.weight = child.weight
+            if hasattr(child, "weight"):
+                new_module.weight = child.weight
             if hasattr(child, "bias"):
                 new_module.bias = child.bias
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -274,6 +274,37 @@ class TestModulesToSaveAttributeAccess:
             model.lin1.weight
 
 
+class TestModulesToSaveMergeAndUnload:
+    def test_merge_and_unload_without_weight(self):
+        # Regression test for #3213: merge_and_unload should not crash when modules_to_save
+        # targets a module without a weight attribute (e.g., a transformer encoder block)
+        class ModuleWithoutWeight(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.foo = nn.Linear(1, 1)
+            
+            def forward(self, x):
+                return self.foo(x)
+
+        class Model(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin0 = nn.Linear(1, 2)
+                self.mod1 = ModuleWithoutWeight()
+            
+            def forward(self, x):
+                return self.mod1(self.lin0(x))
+
+        from peft import LoraConfig, get_peft_model
+        config = LoraConfig(target_modules=["lin0"], modules_to_save=["mod1"])
+        model = get_peft_model(Model(), config)
+        
+        # This should not raise an AttributeError
+        merged = model.merge_and_unload()
+        assert not hasattr(merged.mod1, "weight")
+
+
+
 class TestModulesToSaveKwargsOnlyForward:
     """Regression test for #3191: modules listed in `modules_to_save` whose parent calls them with keyword arguments
     only (e.g. Gemma's `vision_tower(pixel_values=...)`) used to crash with `TypeError: forward() missing 1 required


### PR DESCRIPTION
Bug: IA3 unmerge for ConvNd bias uses multiplication instead of division.
Root cause: In `_ConvNd.unmerge`, `base_layer.bias.data` was multiplied by `scaling.data`, whereas it should be divided since merging uses multiplication.
Why fix is correct: Using `torch.div` with `scaling.data + 1e-8` correctly reverses the `torch.mul` applied during merge, matching the behavior for weights.