### PR TITLE
fix(tuners): bundle use of _cast_input_dtype across all PEFT methods

### DIFF
--- a/src/peft/tuners/adamss/layer.py
+++ b/src/peft/tuners/adamss/layer.py
@@ -395,7 +395,7 @@ class Linear(nn.Module, AdamssLayer):
             result = self.base_layer(x, *args, **kwargs)
         else:
             # Cast input to layer dtype
-            x = x.to(self.dtype)
+            x = self._cast_input_dtype(x, self.dtype)
 
             # Add bias column only when the base layer has a bias
             # (update_layer concatenates bias into newB only when bias is not None)

--- a/src/peft/tuners/boft/layer.py
+++ b/src/peft/tuners/boft/layer.py
@@ -638,7 +638,7 @@ class Linear(nn.Module, BOFTLayer):
                 boft_rotation = butterfly_oft_mat @ boft_rotation
                 boft_scale = boft_s * boft_scale
 
-            x = x.to(self.get_base_layer().weight.data.dtype)
+            x = self._cast_input_dtype(x, self.get_base_layer().weight.data.dtype)
 
             orig_weight = self.get_base_layer().weight.data
             orig_weight = torch.transpose(orig_weight, 0, 1)
@@ -969,7 +969,7 @@ class Conv2d(nn.Module, BOFTLayer):
                 boft_rotation = butterfly_oft_mat @ boft_rotation
                 boft_scale = boft_s * boft_scale
 
-            x = x.to(self.base_layer.weight.data.dtype)
+            x = self._cast_input_dtype(x, self.base_layer.weight.data.dtype)
 
             orig_weight = self.base_layer.weight.data
             orig_weight = orig_weight.view(

--- a/src/peft/tuners/c3a/layer.py
+++ b/src/peft/tuners/c3a/layer.py
@@ -190,13 +190,13 @@ class C3ALinear(nn.Module, C3ALayer):
             result = self.base_layer(x, *args, **kwargs)
         else:
             result = self.base_layer(x, *args, **kwargs)
-            x = x.to(torch.float32)
+            x = self._cast_input_dtype(x, torch.float32)
             for active_adapter in self.active_adapters:
                 if active_adapter not in self.c3a_kernel.keys():
                     continue
                 c3a_kernel = self.c3a_kernel[active_adapter].to(torch.float32)
                 x = BlockCircularConvolution.apply(x, c3a_kernel) / x.size(-1)
-                result += x.to(result.dtype)
+                result += self._cast_input_dtype(x, result.dtype)
 
         result = result.to(previous_dtype)
         return result

--- a/src/peft/tuners/fourierft/layer.py
+++ b/src/peft/tuners/fourierft/layer.py
@@ -184,7 +184,7 @@ class FourierFTLinear(nn.Module, FourierFTLayer):
                     continue
 
                 delta_w = self.get_delta_weight(active_adapter)
-                x = x.to(delta_w.dtype)
+                x = self._cast_input_dtype(x, delta_w.dtype)
                 result = result + F.linear(x, delta_w)
 
         result = result.to(previous_dtype)

--- a/src/peft/tuners/gralora/layer.py
+++ b/src/peft/tuners/gralora/layer.py
@@ -363,7 +363,7 @@ class Linear(nn.Linear, GraloraLayer):
                     "bljr, jro -> bljo",
                     torch.einsum(
                         "blni, nir -> blnr",
-                        dropout(x.to(gralora_dtype)).view(B, L, N, in_features // N),
+                        dropout(self._cast_input_dtype(x, gralora_dtype)).view(B, L, N, in_features // N),
                         gralora_A,
                     )
                     .view(B, L, N, N, subblock_gralora_rank)
@@ -378,7 +378,7 @@ class Linear(nn.Linear, GraloraLayer):
 
                 result += scaling * output.to(torch_result_dtype)
                 if hybrid_r > 0:
-                    hybrid_output = gralora_B_general(gralora_A_general(dropout(x.to(gralora_dtype))))
+                    hybrid_output = gralora_B_general(gralora_A_general(dropout(self._cast_input_dtype(x, gralora_dtype))))
                     if x_is_2d:
                         hybrid_output = hybrid_output.squeeze(1)
                     result += scaling * hybrid_output.to(torch_result_dtype)

--- a/src/peft/tuners/hra/layer.py
+++ b/src/peft/tuners/hra/layer.py
@@ -261,7 +261,7 @@ class HRALinear(nn.Module, HRALayer):
             if self.cast_input_dtype_enabled:
                 x = self._cast_input_dtype(x, new_weight.dtype)
             else:
-                x = x.to(self.get_base_layer().weight.data.dtype)
+                x = self._cast_input_dtype(x, self.get_base_layer().weight.data.dtype)
             result = F.linear(input=x, weight=new_weight, bias=bias)
 
         result = result.to(previous_dtype)
@@ -445,7 +445,7 @@ class HRAConv2d(nn.Module, HRALayer):
             if self.cast_input_dtype_enabled:
                 x = self._cast_input_dtype(x, new_weight.dtype)
             else:
-                x = x.to(self.get_base_layer().weight.data.dtype)
+                x = self._cast_input_dtype(x, self.get_base_layer().weight.data.dtype)
             result = F.conv2d(
                 input=x,
                 weight=new_weight,

--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -175,7 +175,7 @@ class Linear(nn.Module, IA3Layer):
                 ia3_scaling *= self.ia3_l[active_adapter].flatten()
 
             if self.is_feedforward:
-                x = x.to(dtype)
+                x = self._cast_input_dtype(x, dtype)
                 # TODO: weight.dtype can be != self.ia3_l[self.active_adapters].dtype
                 # e.g. bf16 vs fp32. Is that okay?
                 interm = (x * ia3_scaling).to(previous_dtype)
@@ -306,7 +306,7 @@ class _ConvNd(nn.Module, IA3Layer):
                 ia3_scaling *= self.ia3_l[active_adapter]
 
             if self.is_feedforward:
-                x = x.to(dtype)
+                x = self._cast_input_dtype(x, dtype)
                 # TODO: weight.dtype can be != self.ia3_l[self.active_adapters].dtype
                 # e.g. bf16 vs fp32. Is that okay?
                 interm = (x * ia3_scaling).to(self.get_base_layer().weight.dtype)

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2112,7 +2112,7 @@ class _LoraParameterProxy(nn.Module):
             )
 
         # this operation can be quite costly
-        x = x.to(upcast_dtype)
+        x = self._cast_input_dtype(x, upcast_dtype)
         z = x + y
         # clamp to valid range before casting down, as this is *not* performed automatically and can thus result in NANs
         info = torch.finfo(orig_dtype)

--- a/src/peft/tuners/lora/variants.py
+++ b/src/peft/tuners/lora/variants.py
@@ -581,7 +581,7 @@ class ALoraLinearVariant(LoraVariant):
         lora_B = module.lora_B[active_adapter]
         dropout = module.lora_dropout[active_adapter]
         scaling = module.scaling[active_adapter]
-        x = x.to(lora_A.weight.dtype)
+        x = self._cast_input_dtype(x, lora_A.weight.dtype)
         result_shape = result.shape
         B = result_shape[0]  # batch
         if len(result_shape) == 3:
@@ -1195,7 +1195,7 @@ class MontecloraLinearVariant(LoraVariant):
             )
         sampler = module.lora_monteclora_sampler[active_adapter]
 
-        x = x.to(lora_A.weight.dtype)
+        x = self._cast_input_dtype(x, lora_A.weight.dtype)
         if isinstance(dropout, nn.Identity) or not module.training:
             x_dropped = x
         else:

--- a/src/peft/tuners/oft/awq.py
+++ b/src/peft/tuners/oft/awq.py
@@ -63,7 +63,7 @@ class AwqOFTLinear(torch.nn.Module, OFTLayer):
 
             x = oft_R(x)
             if requires_conversion:
-                x = x.to(expected_dtype)
+                x = self._cast_input_dtype(x, expected_dtype)
 
         result = self.quant_linear_module(x)
         return result

--- a/src/peft/tuners/oft/bnb.py
+++ b/src/peft/tuners/oft/bnb.py
@@ -159,7 +159,7 @@ if is_bnb_available():
 
                     x = oft_R(x)
                     if requires_conversion:
-                        x = x.to(expected_dtype)
+                        x = self._cast_input_dtype(x, expected_dtype)
 
                 result = self.base_layer(x, *args, **kwargs)
 
@@ -328,7 +328,7 @@ if is_bnb_4bit_available():
 
                     x = oft_R(x)
                     if requires_conversion:
-                        x = x.to(expected_dtype)
+                        x = self._cast_input_dtype(x, expected_dtype)
 
                 result = self.base_layer(x, *args, **kwargs)
 

--- a/src/peft/tuners/oft/gptq.py
+++ b/src/peft/tuners/oft/gptq.py
@@ -61,7 +61,7 @@ class GPTQOFTLinear(torch.nn.Module, OFTLayer):
 
             x = oft_R(x)
             if requires_conversion:
-                x = x.to(expected_dtype)
+                x = self._cast_input_dtype(x, expected_dtype)
 
         result = self.quant_linear_module(x)
         return result

--- a/src/peft/tuners/oft/layer.py
+++ b/src/peft/tuners/oft/layer.py
@@ -251,7 +251,7 @@ class OFTRotationModule(nn.Module):
 
         required_dtype = x.dtype
         if required_dtype != self.weight.dtype:
-            x = x.to(self.weight.dtype)
+            x = self._cast_input_dtype(x, self.weight.dtype)
 
         orig_shape = x.shape
 
@@ -681,7 +681,7 @@ class Linear(nn.Module, OFTLayer):
                 x = self._cast_input_dtype(x, oft_R.weight.dtype)
                 x = oft_R(x)
 
-            result = self.base_layer(x.to(previous_dtype), *args, **kwargs)
+            result = self.base_layer(self._cast_input_dtype(x, previous_dtype), *args, **kwargs)
 
         result = result.to(previous_dtype)
         return result
@@ -934,7 +934,7 @@ class Conv2d(nn.Module, OFTLayer):
                 x = self._cast_input_dtype(x, oft_R.weight.dtype)
                 x = oft_R(x)
 
-            result = self.base_layer(x.to(previous_dtype), *args, **kwargs)
+            result = self.base_layer(self._cast_input_dtype(x, previous_dtype), *args, **kwargs)
 
         result = result.to(previous_dtype)
         return result

--- a/src/peft/tuners/poly/layer.py
+++ b/src/peft/tuners/poly/layer.py
@@ -154,7 +154,7 @@ class Linear(nn.Module, PolyLayer):
                 A = A.reshape(bs, self.in_features, r)
                 B = B.transpose(1, 2).reshape(bs, r, self.out_features)
 
-                x = x.to(A.dtype)
+                x = self._cast_input_dtype(x, A.dtype)
                 result += x.bmm(A).bmm(B) / r
 
         result = result.to(previous_dtype)

--- a/src/peft/tuners/pvera/bnb.py
+++ b/src/peft/tuners/pvera/bnb.py
@@ -219,12 +219,12 @@ if is_bnb_available():
                         expected_dtype = result.dtype
                         compute_dtype = lambda_d.dtype
                         if x.dtype != compute_dtype:
-                            x = x.to(compute_dtype)
+                            x = self._cast_input_dtype(x, compute_dtype)
 
                     sliced_A = pvera_A[:, : self.in_features].to(x.device)
                     sliced_B = pvera_B[: self.out_features, :].to(x.device)
 
-                    x_temp = dropout(x.to(lambda_d.dtype))
+                    x_temp = dropout(self._cast_input_dtype(x, lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
                     adapter_output = lambda_b * F.linear(
                         self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
@@ -389,12 +389,12 @@ if is_bnb_4bit_available():
                         expected_dtype = result.dtype
                         compute_dtype = lambda_d.dtype
                         if x.dtype != compute_dtype:
-                            x = x.to(compute_dtype)
+                            x = self._cast_input_dtype(x, compute_dtype)
 
                     sliced_A = pvera_A[:, : self.in_features].to(x.device)
                     sliced_B = pvera_B[: self.out_features, :].to(x.device)
 
-                    x_temp = dropout(x.to(lambda_d.dtype))
+                    x_temp = dropout(self._cast_input_dtype(x, lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
                     adapter_output = lambda_b * F.linear(
                         self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B

--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -302,7 +302,7 @@ class Linear(nn.Linear, PveraLayer):
                 sliced_B = pvera_B[: self.out_features, :].to(x.device)
 
                 dropout = self.pvera_dropout[active_adapter]
-                x = x.to(lambda_d.dtype)
+                x = self._cast_input_dtype(x, lambda_d.dtype)
                 mu, logvar = (lambda_d * F.linear(dropout(x), sliced_A)).chunk(2, dim=-1)
                 result = result + lambda_b * F.linear(
                     self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B

--- a/src/peft/tuners/randlora/bnb.py
+++ b/src/peft/tuners/randlora/bnb.py
@@ -232,10 +232,10 @@ if is_bnb_available():
                         expected_dtype = result.dtype
                         compute_dtype = update_A.dtype
                         if x.dtype != compute_dtype:
-                            x = x.to(compute_dtype)
+                            x = self._cast_input_dtype(x, compute_dtype)
 
                     dropout = self.randlora_dropout[active_adapter]
-                    x_temp = dropout(x.to(update_A.dtype))
+                    x_temp = dropout(self._cast_input_dtype(x, update_A.dtype))
 
                     adapter_output = torch.nn.functional.linear(torch.nn.functional.linear(x_temp, update_B), update_A)
 
@@ -430,10 +430,10 @@ if is_bnb_4bit_available():
                         expected_dtype = result.dtype
                         compute_dtype = update_A.dtype
                         if x.dtype != compute_dtype:
-                            x = x.to(compute_dtype)
+                            x = self._cast_input_dtype(x, compute_dtype)
 
                     dropout = self.randlora_dropout[active_adapter]
-                    x_temp = dropout(x.to(update_A.dtype))
+                    x_temp = dropout(self._cast_input_dtype(x, update_A.dtype))
 
                     adapter_output = torch.nn.functional.linear(torch.nn.functional.linear(x_temp, update_B), update_A)
 

--- a/src/peft/tuners/randlora/layer.py
+++ b/src/peft/tuners/randlora/layer.py
@@ -339,7 +339,7 @@ class Linear(nn.Linear, RandLoraLayer):
                     continue
                 dropout = self.randlora_dropout[active_adapter]
                 update_B, update_A = self.get_scaled_bases(active_adapter, device=x.device)
-                x = x.to(update_A.dtype)
+                x = self._cast_input_dtype(x, update_A.dtype)
                 scaling = self.scaling[active_adapter]
                 result = result + F.linear(F.linear(dropout(x), update_B), update_A) * scaling
         result = result.to(previous_dtype)

--- a/src/peft/tuners/road/bnb.py
+++ b/src/peft/tuners/road/bnb.py
@@ -184,7 +184,7 @@ if is_bnb_available():
                     )
 
                     if requires_conversion:
-                        x = x.to(expected_dtype)
+                        x = self._cast_input_dtype(x, expected_dtype)
 
             return result
 
@@ -374,7 +374,7 @@ if is_bnb_4bit_available():
                         result,
                     )
                     if requires_conversion:
-                        x = x.to(expected_dtype)
+                        x = self._cast_input_dtype(x, expected_dtype)
 
             return result
 

--- a/src/peft/tuners/vblora/layer.py
+++ b/src/peft/tuners/vblora/layer.py
@@ -241,7 +241,7 @@ class Linear(nn.Linear, VBLoRALayer):
                 if active_adapter not in self.vblora_logits_A.keys():
                     continue
                 A, B = self._get_lora_matrices(active_adapter)
-                x = x.to(self.vblora_vector_bank[active_adapter].dtype)
+                x = self._cast_input_dtype(x, self.vblora_vector_bank[active_adapter].dtype)
                 dropout = self.vblora_dropout[active_adapter]
                 result = result + F.linear(F.linear(dropout(x), A), B)
         result = result.to(previous_dtype)

--- a/src/peft/tuners/vera/bnb.py
+++ b/src/peft/tuners/vera/bnb.py
@@ -214,12 +214,12 @@ if is_bnb_available():
                         expected_dtype = result.dtype
                         compute_dtype = lambda_d.dtype
                         if x.dtype != compute_dtype:
-                            x = x.to(compute_dtype)
+                            x = self._cast_input_dtype(x, compute_dtype)
 
                     sliced_A = vera_A[:, : self.in_features].to(x.device)
                     sliced_B = vera_B[: self.out_features, :].to(x.device)
 
-                    x_temp = dropout(x.to(lambda_d.dtype))
+                    x_temp = dropout(self._cast_input_dtype(x, lambda_d.dtype))
 
                     adapter_output = lambda_b * torch.nn.functional.linear(
                         lambda_d * torch.nn.functional.linear(x_temp, sliced_A), sliced_B
@@ -380,12 +380,12 @@ if is_bnb_4bit_available():
                         expected_dtype = result.dtype
                         compute_dtype = lambda_d.dtype
                         if x.dtype != compute_dtype:
-                            x = x.to(compute_dtype)
+                            x = self._cast_input_dtype(x, compute_dtype)
 
                     sliced_A = vera_A[:, : self.in_features].to(x.device)
                     sliced_B = vera_B[: self.out_features, :].to(x.device)
 
-                    x_temp = dropout(x.to(lambda_d.dtype))
+                    x_temp = dropout(self._cast_input_dtype(x, lambda_d.dtype))
 
                     adapter_output = lambda_b * torch.nn.functional.linear(
                         lambda_d * torch.nn.functional.linear(x_temp, sliced_A), sliced_B

--- a/src/peft/tuners/vera/layer.py
+++ b/src/peft/tuners/vera/layer.py
@@ -280,7 +280,7 @@ class Linear(nn.Linear, VeraLayer):
                 sliced_B = vera_B[: self.out_features, :].to(x.device)
 
                 dropout = self.vera_dropout[active_adapter]
-                x = x.to(lambda_d.dtype)
+                x = self._cast_input_dtype(x, lambda_d.dtype)
                 result = result + lambda_b * F.linear(lambda_d * F.linear(dropout(x), sliced_A), sliced_B)
 
         result = result.to(previous_dtype)

--- a/src/peft/tuners/xlora/layer.py
+++ b/src/peft/tuners/xlora/layer.py
@@ -118,7 +118,7 @@ class XLoraLinearLayer(XLoraLayer):
                 lora_B = self.target.lora_B[active_adapter]
                 dropout = self.target.lora_dropout[active_adapter]
                 scaling = self.target.scaling[active_adapter]
-                x = x.to(lora_A.weight.dtype)  # type: ignore
+                x = self._cast_input_dtype(x, lora_A.weight.dtype)  # type: ignore
                 if scalings is not None:
                     x_mod = self.apply_scalings_to_x(x, xlora_scalings, adapter_n)
                     scaling_weight = self.config.global_scaling_weight
@@ -223,7 +223,7 @@ class XLoraConv2dLayer(XLoraLayer):
                 lora_B = self.target.lora_B[active_adapter]
                 dropout = self.target.lora_dropout[active_adapter]
                 scaling = self.target.scaling[active_adapter]
-                x = x.to(lora_A.weight.dtype)  # type: ignore
+                x = self._cast_input_dtype(x, lora_A.weight.dtype)  # type: ignore
                 if scalings is not None:
                     x_mod = self.apply_scalings_to_x(x, xlora_scalings, adapter_n)
                     scaling_weight = self.config.global_scaling_weight


### PR DESCRIPTION
This PR applies the same `_cast_input_dtype` fix across all PEFT tuners to properly respect the `disable_lora_input_dtype_casting` context manager. It replaces raw `x.to()` calls with `self._cast_input_dtype(x, dtype)` for all remaining tuners that were still using it (such as adamss, boft, c3a, fourierft, gralora, hra, ia3, lora, oft, poly, pvera, randlora, road, vblora, vera, and xlora). This bundles the fixes requested in #3177 and #3208 into a single PR.