### PR TITLE
DOC Fix wrong function name in docstring

### DIFF
--- a/src/peft/tuners/lora/arrow.py
+++ b/src/peft/tuners/lora/arrow.py
@@ -204,7 +204,7 @@ class ArrowLoraLinearLayer(nn.Module):
         Usually, we want to enable this to align the input dtype with the dtype of the weight, but by setting
         layer.cast_input_dtype=False, this can be disabled if necessary.
 
-        Enabling or disabling can be managed via the peft.helpers.disable_lora_input_dtype_casting context manager.
+        Enabling or disabling can be managed via the peft.helpers.disable_input_dtype_casting context manager.
         """
         if x is None:  # useful e.g. if x is the bias, which can be None
             return None

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1685,7 +1685,7 @@ class BaseTunerLayer(ABC):
         Usually, we want to enable this to align the input dtype with the dtype of the weight, but by setting
         layer.cast_input_dtype=False, this can be disabled if necessary.
 
-        Enabling or disabling can be managed via the peft.helpers.disable_lora_input_dtype_casting context manager.
+        Enabling or disabling can be managed via the peft.helpers.disable_input_dtype_casting context manager.
         """
         if x is None:  # useful e.g. if x is the bias, which can be None
             return None


### PR DESCRIPTION
The docstring calls the funciton `disable_lora_input_dtype_casting` but the real name is `disable_input_dtype_casting`. Probably that function was once meant only for LoRA but was then generalized, leading to the name mismatch.

Failing CI is unrelated.