### PR TITLE
FIX Saving adapter when other adapters partially match name

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -19,7 +19,7 @@ import platform
 import re
 import warnings
 from collections import namedtuple
-from typing import Optional
+from typing import Literal, Optional
 
 import huggingface_hub
 import torch
@@ -74,8 +74,19 @@ def _get_tp_info(model) -> TpInfo | None:
     return None
 
 
+def _filter_state_dict_for_adapter_name(
+    state_dict: dict[str, torch.Tensor], adapter_name: str
+) -> dict[str, torch.Tensor]:
+    """Filter the state dict to only include keys that correspond to the given adapter"""
+    return {k: v for k, v in state_dict.items() if f".{adapter_name}." in k or k.endswith(f".{adapter_name}")}
+
+
 def get_peft_model_state_dict(
-    model, state_dict=None, adapter_name="default", unwrap_compiled=False, save_embedding_layers="auto"
+    model,
+    state_dict=None,
+    adapter_name: str = "default",
+    unwrap_compiled: bool = False,
+    save_embedding_layers: bool | Literal["auto"] = "auto",
 ):
     """
     Get the state dict of the given adapter of the PEFT model.
@@ -109,6 +120,8 @@ def get_peft_model_state_dict(
     config = model.peft_config[adapter_name]
     if state_dict is None:
         state_dict = model.state_dict()
+
+    state_dict = _filter_state_dict_for_adapter_name(state_dict, adapter_name)
 
     # If model was sharded with TP, gather full tensors for saving
     tp_info = _get_tp_info(model)
@@ -150,7 +163,7 @@ def get_peft_model_state_dict(
                         to_return[bias_name] = state_dict[bias_name]
         else:
             raise NotImplementedError
-        to_return = {k: v for k, v in to_return.items() if (("lora_" in k and adapter_name in k) or ("bias" in k))}
+        to_return = {k: v for k, v in to_return.items() if (("lora_" in k) or ("bias" in k))}
         if config.peft_type == PeftType.ADALORA:
             rank_pattern = config.rank_pattern
             if rank_pattern is not None:
@@ -222,6 +235,8 @@ def get_peft_model_state_dict(
                     to_return[f"{name}.shira_indices.{k}"] = (
                         v.to(torch.float32) if platform.system() == "Windows" else v
                     )
+                    # the above may contain other adapter names, so filter again
+                    to_return = _filter_state_dict_for_adapter_name(to_return, adapter_name)
 
     elif config.peft_type == PeftType.VERA:
         vera_prefix = PEFT_TYPE_TO_PREFIX_MAPPING[config.peft_type]
@@ -300,7 +315,7 @@ def get_peft_model_state_dict(
         ]
     elif config.peft_type in list(PeftType):
         prefix = PEFT_TYPE_TO_PREFIX_MAPPING[config.peft_type]
-        to_return = {k: state_dict[k] for k in state_dict if prefix in k}
+        to_return = {k: v for k, v in state_dict.items() if prefix in k}
     else:
         raise ValueError(f"Unknown PEFT type passed: {config.peft_type}")
 

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -121,8 +121,6 @@ def get_peft_model_state_dict(
     if state_dict is None:
         state_dict = model.state_dict()
 
-    state_dict = _filter_state_dict_for_adapter_name(state_dict, adapter_name)
-
     # If model was sharded with TP, gather full tensors for saving
     tp_info = _get_tp_info(model)
     if tp_info is not None:
@@ -405,6 +403,7 @@ def get_peft_model_state_dict(
         else:
             save_embedding_layers = False
 
+    state_dict_embedding: dict[str, torch.Tensor] = {}
     if save_embedding_layers and hasattr(model, "get_input_embeddings"):
         for layer in [model.get_input_embeddings(), model.get_output_embeddings()]:
             # Either the layer is not targeted, then it must have been resized and needs saving. Or it is targeted and
@@ -412,9 +411,22 @@ def get_peft_model_state_dict(
             if not embedding_is_targeted or has_valid_embedding_base_layer(layer):
                 embedding_module_name = get_embedding_layer_name(model, layer, embedding_is_targeted)
                 if embedding_module_name:
-                    to_return.update({k: v for k, v in state_dict.items() if embedding_module_name in k})
+                    state_dict_embedding.update({k: v for k, v in state_dict.items() if embedding_module_name in k})
     elif save_embedding_layers:
         warnings.warn("Could not identify embedding layer(s) because the model is not a 🤗 transformers model.")
+
+    # FILTER FOR ADAPTER NAME
+    if not config.is_prompt_learning:
+        # Prompt learning methods don't support multiple adapters and hence don't have the adapter name in the Parameter
+        # name.
+        to_return_filtered_for_adapter_name = _filter_state_dict_for_adapter_name(state_dict, adapter_name)
+        if len(to_return_filtered_for_adapter_name) > 0:
+            # If, after filtering the state dict for the adapter name, we end up with an empty state dict, it means that
+            # the adapter weights are not stored with the adapter name as suffix. This can happen e.g. for adaption
+            # prompt (which is not a prompt learning method).
+            to_return = to_return_filtered_for_adapter_name
+
+    to_return.update(state_dict_embedding)
 
     # REMOVE ADAPTER NAME
     # Ensure not to replace in the middle of the key because a module happens to have the same name as the adapter.

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -75,10 +75,20 @@ def _get_tp_info(model) -> TpInfo | None:
 
 
 def _filter_state_dict_for_adapter_name(
-    state_dict: dict[str, torch.Tensor], adapter_name: str
+    state_dict: dict[str, torch.Tensor], unwanted_adapter_names: list[str]
 ) -> dict[str, torch.Tensor]:
-    """Filter the state dict to only include keys that correspond to the given adapter"""
-    return {k: v for k, v in state_dict.items() if f".{adapter_name}." in k or k.endswith(f".{adapter_name}")}
+    """Filter the state dict to remove keys that correspond to the unwanted adapter
+
+    Use a negative filter to avoid removing keys that correspond to keys that contain no adapter name at all, e.g. when
+    using modules_to_save.
+    """
+    return {
+        k: v
+        for k, v in state_dict.items()
+        if not any(
+            f".{adapter_name}." in k or k.endswith(f".{adapter_name}") for adapter_name in unwanted_adapter_names
+        )
+    }
 
 
 def get_peft_model_state_dict(
@@ -120,6 +130,18 @@ def get_peft_model_state_dict(
     config = model.peft_config[adapter_name]
     if state_dict is None:
         state_dict = model.state_dict()
+
+    # FILTER FOR ADAPTER NAME
+    unwanted_adapter_names = [name for name in model.peft_config if name != adapter_name]
+    if not config.is_prompt_learning:
+        # Prompt learning methods don't support multiple adapters and hence don't have the adapter name in the Parameter
+        # name.
+        state_dict_filtered_for_adapter_name = _filter_state_dict_for_adapter_name(state_dict, unwanted_adapter_names)
+        if len(state_dict_filtered_for_adapter_name) > 0:
+            # If, after filtering the state dict for the adapter name, we end up with an empty state dict, it means that
+            # the adapter weights are not stored with the adapter name as suffix. This can happen e.g. for adaption
+            # prompt (which is not a prompt learning method).
+            state_dict = state_dict_filtered_for_adapter_name
 
     # If model was sharded with TP, gather full tensors for saving
     tp_info = _get_tp_info(model)
@@ -234,7 +256,7 @@ def get_peft_model_state_dict(
                         v.to(torch.float32) if platform.system() == "Windows" else v
                     )
                     # the above may contain other adapter names, so filter again
-                    to_return = _filter_state_dict_for_adapter_name(to_return, adapter_name)
+                    to_return = _filter_state_dict_for_adapter_name(to_return, unwanted_adapter_names)
 
     elif config.peft_type == PeftType.VERA:
         vera_prefix = PEFT_TYPE_TO_PREFIX_MAPPING[config.peft_type]
@@ -403,7 +425,6 @@ def get_peft_model_state_dict(
         else:
             save_embedding_layers = False
 
-    state_dict_embedding: dict[str, torch.Tensor] = {}
     if save_embedding_layers and hasattr(model, "get_input_embeddings"):
         for layer in [model.get_input_embeddings(), model.get_output_embeddings()]:
             # Either the layer is not targeted, then it must have been resized and needs saving. Or it is targeted and
@@ -411,22 +432,9 @@ def get_peft_model_state_dict(
             if not embedding_is_targeted or has_valid_embedding_base_layer(layer):
                 embedding_module_name = get_embedding_layer_name(model, layer, embedding_is_targeted)
                 if embedding_module_name:
-                    state_dict_embedding.update({k: v for k, v in state_dict.items() if embedding_module_name in k})
+                    to_return.update({k: v for k, v in state_dict.items() if embedding_module_name in k})
     elif save_embedding_layers:
         warnings.warn("Could not identify embedding layer(s) because the model is not a 🤗 transformers model.")
-
-    # FILTER FOR ADAPTER NAME
-    if not config.is_prompt_learning:
-        # Prompt learning methods don't support multiple adapters and hence don't have the adapter name in the Parameter
-        # name.
-        to_return_filtered_for_adapter_name = _filter_state_dict_for_adapter_name(state_dict, adapter_name)
-        if len(to_return_filtered_for_adapter_name) > 0:
-            # If, after filtering the state dict for the adapter name, we end up with an empty state dict, it means that
-            # the adapter weights are not stored with the adapter name as suffix. This can happen e.g. for adaption
-            # prompt (which is not a prompt learning method).
-            to_return = to_return_filtered_for_adapter_name
-
-    to_return.update(state_dict_embedding)
 
     # REMOVE ADAPTER NAME
     # Ensure not to replace in the middle of the key because a module happens to have the same name as the adapter.

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2137,6 +2137,12 @@ class TestPeftCustomModel(PeftCommonTester):
         self._test_save_pretrained(model_id, config_cls, config_kwargs, safe_serialization=False)
 
     @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
+    def test_save_pretrained_adapter_name_substring(self, test_name, model_id, config_cls, config_kwargs):
+        _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs)
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
+        self._test_save_pretrained_adapter_name_substring(model_id, config_cls, config_kwargs)
+
+    @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
     def test_load_model_low_cpu_mem_usage(self, test_name, model_id, config_cls, config_kwargs):
         _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs)
         self._test_load_model_low_cpu_mem_usage(model_id, config_cls, config_kwargs)

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -28,7 +28,7 @@ import torch
 import yaml
 from diffusers import StableDiffusionPipeline
 from packaging import version
-from safetensors.torch import save_file
+from safetensors.torch import load_file, save_file
 
 from peft import (
     AdaLoraConfig,
@@ -434,6 +434,30 @@ class PeftCommonTester:
 
                 assert "default" in model_from_pretrained.peft_config.keys()
                 assert "new_adapter" not in model_from_pretrained.peft_config.keys()
+
+    def _test_save_pretrained_adapter_name_substring(self, model_id, config_cls, config_kwargs):
+        # Test that if we have multiple adapters, only the specified adapter is saved, even if adapter names match
+        # substrings of other adapter names.
+        with hub_online_once(model_id):
+            model = self.transformers_class.from_pretrained(model_id)
+            config = config_cls(
+                base_model_name_or_path=model_id,
+                **config_kwargs,
+            )
+            model = get_peft_model(model, config)  # adapter name will be "default"
+            # to calculate the expected number of weights, use get_peft_model_state_dict, since some methods like VeRA
+            # will add shared weights there, which we wouldn't count correctly when using model.state_dict()
+            expected_number_of_weights = len(get_peft_model_state_dict(model))
+
+            model.add_adapter("default2", config)  # prefix
+            model.add_adapter("other_default", config)  # suffix
+            model.add_adapter("foodefault_bar", config)  # infix
+            model.add_adapter("efaul", config)  # substring
+
+            with tempfile.TemporaryDirectory() as tmp_dirname:
+                model.save_pretrained(tmp_dirname, selected_adapters=["default"])
+                state_dict = load_file(os.path.join(tmp_dirname, "adapter_model.safetensors"))
+                assert len(state_dict) == expected_number_of_weights
 
     def _test_from_pretrained_config_construction(self, model_id, config_cls, config_kwargs):
         with hub_online_once(model_id):


### PR DESCRIPTION
The logic to filter for a specific adapter name when saving a model was faulty, as it would match a substring. Therefore, if one adapter is called `"foo"` and another `"foobar"`, saving `"foo"` would also save `"foobar"`. This is now fixed for all PEFT methods.