### PR TITLE
FIX Transformers argument name in rename_source_key

### DIFF
--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -562,9 +562,7 @@ def convert_peft_adapter_state_dict_for_transformers(
             and new_key_is_suffix_of_old_key
         ):
             # Key should probably not have been renamed but we might need the `prefix` to be added.
-            renamed_key, source_pattern = rename_source_key(
-                original_key, [], [], prefix, adapter_state_dict
-            )
+            renamed_key, source_pattern = rename_source_key(original_key, [], [], prefix, adapter_state_dict)
 
         if source_pattern is not None:
             new_converter = copy.deepcopy(pattern_to_converter[source_pattern])

--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -563,7 +563,7 @@ def convert_peft_adapter_state_dict_for_transformers(
         ):
             # Key should probably not have been renamed but we might need the `prefix` to be added.
             renamed_key, source_pattern = rename_source_key(
-                original_key, [], [], prefix=prefix, meta_state_dict=adapter_state_dict
+                original_key, [], [], prefix, adapter_state_dict
             )
 
         if source_pattern is not None:


### PR DESCRIPTION
Transformers PR https://github.com/huggingface/transformers/pull/46067 changed the argument name in `rename_source_key`, breaking PEFT code. This PR switches to using positional arguments only to allow PEFT to work with Transformers from both before and after this change.