### PR TITLE
DOC Fix incorrect class references in tuner config docstrings

### DIFF
--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -23,7 +23,7 @@ from peft.utils import PeftType
 @dataclass
 class AdaLoraConfig(LoraConfig):
     """
-    This is the configuration class to store the configuration of a [`~peft.AdaLora`].
+    This is the configuration class to store the configuration of a [`AdaLoraModel`].
 
     AdaLoRA has three phases defined by `tinit`, `tfinal` and `total_step`.
 

--- a/src/peft/tuners/hira/config.py
+++ b/src/peft/tuners/hira/config.py
@@ -24,7 +24,7 @@ from peft.utils import PeftType
 @dataclass
 class HiraConfig(PeftConfig):
     """
-    This is the configuration class to store the configuration of a [`HiRAModel`].
+    This is the configuration class to store the configuration of a [`HiraModel`].
 
     Args:
         r (`int`):

--- a/src/peft/tuners/miss/config.py
+++ b/src/peft/tuners/miss/config.py
@@ -24,7 +24,7 @@ from peft.utils import PeftType
 @dataclass
 class MissConfig(PeftConfig):
     """
-    This is the configuration class to store the configuration of a [`MiSSModel`].
+    This is the configuration class to store the configuration of a [`MissModel`].
 
     Args:
         r (`int`):

--- a/src/peft/tuners/vblora/config.py
+++ b/src/peft/tuners/vblora/config.py
@@ -24,7 +24,7 @@ from peft.utils import PeftType
 @dataclass
 class VBLoRAConfig(PeftConfig):
     """
-    This is the configuration class to store the configuration of a [`VBLoRAConfig`].
+    This is the configuration class to store the configuration of a [`VBLoRAModel`].
 
     Paper: https://huggingface.co/papers/2405.15179
 


### PR DESCRIPTION
The opening line of four tuner config docstrings uses a doc-builder
cross-reference that names a class which doesn't exist or isn't the
intended target, so the reference at the top of each rendered config page
is wrong:

- `adalora/config.py`: `~peft.AdaLora` is not an exported symbol; the class is `AdaLoraModel`.
- `hira/config.py`: `HiRAModel` is wrong-cased; the class is `HiraModel`.
- `miss/config.py`: `MiSSModel` is wrong-cased; the class is `MissModel`.
- `vblora/config.py`: `VBLoRAConfig` is a self-reference; it should point at `VBLoRAModel`.

All four now name the real model class, matching the convention the other
configs use (e.g. `LoraModel` in `lora/config.py`). For adalora, miss and
vblora the target has an autodoc page, so the reference now resolves to a
working link. For hira the name is now correct but `HiraModel` has no
autodoc page yet, so it renders as a plain class name (same as the existing
`GraloraModel` reference) rather than a link.

Pure docstring change, +4/-4. Unresolved references render as plain text
and don't affect the doc build (main already carries these references with
green CI).

Out of scope: hira.md is missing a `HiraModel` autodoc block; adding it
would make the hira reference a working link too, but that's a separate
docs change.
