### PR TITLE
FIX TST Failing HiRA and EETQ GPU tests.

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -52,7 +52,7 @@ RUN \
     # Add eetq for quantization testing; needs to run without build isolation since the setup
     # script directly imports torch from the environment which would fail with isolation.
     # Ninja should speed up build time.
-    conda run -n peft pip install ninja && conda run -n peft pip install --no-build-isolation git+https://github.com/NetEase-FuXi/EETQ.git
+    conda run -n peft pip install ninja kernels && conda run -n peft pip install --no-build-isolation git+https://github.com/NetEase-FuXi/EETQ.git
 
 # TODO: Importing TE results in: undefined symbol: cublasLtGroupedMatrixLayoutInit_internal, version libcublasLt.so.13
 # Reinstate TE when the issue is resolved (probably this one: https://github.com/NVIDIA/TransformerEngine/issues/2504)

--- a/src/peft/tuners/hira/bnb.py
+++ b/src/peft/tuners/hira/bnb.py
@@ -184,7 +184,6 @@ if is_bnb_available():
             return result
 
         def forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
-            self._check_forward_args(x, *args, **kwargs)
             adapter_names = kwargs.pop("adapter_names", None)
 
             if self.disable_adapters:
@@ -398,7 +397,6 @@ if is_bnb_4bit_available():
             return result
 
         def forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
-            self._check_forward_args(x, *args, **kwargs)
             adapter_names = kwargs.pop("adapter_names", None)
 
             if self.disable_adapters:

--- a/src/peft/tuners/lora/eetq.py
+++ b/src/peft/tuners/lora/eetq.py
@@ -25,6 +25,14 @@ from .config import LoraConfig
 if is_eetq_available():
     from eetq import EetqLinear
 
+    try:
+        from transformers.integrations.eetq import EetqLinear as TransformersEetqLinear
+
+        # in newer transformers versions, EETQ quantization uses a transformers-specific class
+        eetq_classes = (EetqLinear, TransformersEetqLinear)
+    except ImportError:
+        eetq_classes = (EetqLinear,)
+
     class EetqLoraLinear(torch.nn.Module, LoraLayer):
         def __init__(
             self,
@@ -105,7 +113,7 @@ def dispatch_eetq(
     else:
         target_base_layer = target
 
-    if is_eetq_available() and isinstance(target_base_layer, EetqLinear):
+    if is_eetq_available() and isinstance(target_base_layer, eetq_classes):
         new_module = EetqLoraLinear(target, adapter_name, config=config, **kwargs)
         target.weight = target_base_layer.weight
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -209,8 +209,13 @@ def _get_in_out_features(module: nn.Module) -> tuple[int, int] | tuple[None, Non
         # GPT-QModel quantized linears
         in_features, out_features = module.in_features, module.out_features
     elif module.__class__.__name__ == "EetqLinear":
-        # Eetq layers
-        in_features, out_features = module.in_features, module.out_features
+        if hasattr(module, "in_features"):
+            # Eetq layers
+            in_features, out_features = module.in_features, module.out_features
+        else:
+            # Transformers Eetq layers
+            # https://github.com/huggingface/transformers/blob/c220ea9ecee9231927a47d97a63d5604a09d4c63/src/transformers/integrations/eetq.py#L74
+            in_features, out_features = module.weight.shape
     elif hasattr(module, "W_q") and module.__class__.__name__ == "HQQLinear":
         # HQQ layers
         in_features, out_features = module.in_features, module.out_features

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4235,12 +4235,6 @@ class PeftEetqGPUTests(unittest.TestCase):
         assert torch.isfinite(output.logits).all()
         model.train(training)
 
-    @pytest.mark.xfail(
-        reason="EETQ is not yet supported by Transformers v5",
-        condition=is_transformers_ge_v5,
-        strict=True,
-        raises=NotImplementedError,
-    )
     @pytest.mark.single_gpu_tests
     def test_causal_lm_training_eetq(self):
         r"""
@@ -4296,12 +4290,6 @@ class PeftEetqGPUTests(unittest.TestCase):
             # assert loss is not None
             assert trainer.state.log_history[-1]["train_loss"] is not None
 
-    @pytest.mark.xfail(
-        reason="EETQ is not yet supported by Transformers v5",
-        condition=is_transformers_ge_v5,
-        strict=True,
-        raises=NotImplementedError,
-    )
     @pytest.mark.multi_gpu_tests
     @require_torch_multi_gpu
     def test_causal_lm_training_multi_gpu_eetq(self):


### PR DESCRIPTION
See [failing nightly CI tests](https://github.com/huggingface/peft/actions/runs/26615393772/job/78429854421#step:6:1175).

## HiRA

Bnb layers were referencing a non-existing method (copied from LoRA).

## EETQ

EETQ used to be broken because it was not supported after Transformers v5. This is no longer the case but some implementation details changed: 

- uses a different layer type
- requires kernels package

## Testing

As these are GPU tests, they are not covered by PR CI. I ran the tests locally and they passed.