### PR TITLE
DOC Fix incorrect LoRA references in hira and ln_tuning model docstrings

### DIFF
--- a/src/peft/tuners/hira/model.py
+++ b/src/peft/tuners/hira/model.py
@@ -54,13 +54,13 @@ class HiraModel(BaseTuner):
 
     Args:
         model ([`torch.nn.Module`]): The model to be adapted.
-        config ([`LoraConfig`]): The configuration of the Lora model.
+        config ([`HiraConfig`]): The configuration of the HiRA model.
         adapter_name (`str`): The name of the adapter, defaults to `"default"`.
         low_cpu_mem_usage (`bool`, `optional`, defaults to `False`):
             Create empty adapter weights on meta device. Useful to speed up the loading process.
 
     Returns:
-        `torch.nn.Module`: The Lora model.
+        `torch.nn.Module`: The HiRA model.
 
     Example:
 
@@ -113,7 +113,7 @@ class HiraModel(BaseTuner):
 
     **Attributes**:
         - **model** ([`~transformers.PreTrainedModel`]) -- The model to be adapted.
-        - **peft_config** ([`LoraConfig`]): The configuration of the Lora model.
+        - **peft_config** ([`HiraConfig`]): The configuration of the HiRA model.
     """
 
     prefix: str = "hira_"

--- a/src/peft/tuners/ln_tuning/model.py
+++ b/src/peft/tuners/ln_tuning/model.py
@@ -33,7 +33,7 @@ class LNTuningModel(BaseTuner):
 
     Args:
         model ([`torch.nn.Module`]): The model to be adapted.
-        config ([`LNTuningConfig`]): The configuration of the Lora model.
+        config ([`LNTuningConfig`]): The configuration of the LN tuning model.
         adapter_name (`str`): The name of the adapter, defaults to `"default"`.
         low_cpu_mem_usage (`bool`, `optional`, defaults to `False`):
             This option has no effect on LN tuning but exists for consistency with other PEFT methods.
@@ -58,7 +58,7 @@ class LNTuningModel(BaseTuner):
 
     **Attributes**:
         - **model** ([`~transformers.PreTrainedModel`]) -- The model to be adapted.
-        - **peft_config** ([`LNTuningConfig`]): The configuration of the Lora model.
+        - **peft_config** ([`LNTuningConfig`]): The configuration of the LN tuning model.
     """
 
     prefix: str = "ln_tuning_"


### PR DESCRIPTION
Follow-up to #3254. The `HiraModel` and `LNTuningModel` docstrings still describe their config as "the Lora model", copied from `lora/model.py`. #3254 fixed this for `adalora`, `boft`, `ia3`, and `xlora` but missed these two.

- `hira/model.py`: the docstring cross-referenced `LoraConfig`, but `HiraModel` is configured with `HiraConfig`. Updated both references to `HiraConfig` and the "Lora model" wording to "HiRA model".
- `ln_tuning/model.py`: the `LNTuningConfig` references were already correct, only the "Lora model" wording needed fixing.
