### PR TITLE
fix(utils): call empty_cache() after fp16→fp32 casts in prepare_model_for_kbit_training

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -186,6 +186,10 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
                 (param.dtype == torch.float16) or (param.dtype == torch.bfloat16)
             ) and param.__class__.__name__ != "Params4bit":
                 param.data = param.data.to(torch.float32)
+        # Release CUDA allocator cache after bulk fp16→fp32 casts to avoid
+        # ~1 GB of reserved-but-unused memory that breaks 8 GB devices (issue #3265)
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     if (
         loaded_in_kbit

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -140,7 +140,9 @@ def infer_device() -> str:
     return "cpu"
 
 
-def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, gradient_checkpointing_kwargs=None):
+def prepare_model_for_kbit_training(
+    model, use_gradient_checkpointing=True, gradient_checkpointing_kwargs=None, auto_clear_cache=True
+):
     r"""
     Note this method only works for `transformers` models.
 
@@ -158,6 +160,10 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
             Keyword arguments to pass to the gradient checkpointing function, please refer to the documentation of
             `torch.utils.checkpoint.checkpoint` for more details about the arguments that you can pass to that method.
             Note this is only available in the latest transformers versions (> 4.34.1).
+        auto_clear_cache (`bool`, *optional*, defaults to `True`):
+            Whether to empty the accelerator cache after upcasting parameters to fp32. This releases memory held by the
+            caching allocator, which is especially helpful on devices that share host and accelerator memory. Set to
+            `False` to skip this step.
     """
     loaded_in_kbit = getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)
     is_gptq_quantized = getattr(model, "quantization_method", None) == "gptq"
@@ -186,10 +192,16 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True, grad
                 (param.dtype == torch.float16) or (param.dtype == torch.bfloat16)
             ) and param.__class__.__name__ != "Params4bit":
                 param.data = param.data.to(torch.float32)
-        # Release CUDA allocator cache after bulk fp16→fp32 casts to avoid
-        # ~1 GB of reserved-but-unused memory that breaks 8 GB devices (issue #3265)
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+
+        # Release CUDA allocator cache after bulk fp16→fp32 casts to reduce
+        # reserved-but-unused memory to free up system memory in devices
+        # that share host and accelerator memory (issue #3265)
+        if auto_clear_cache:
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+            if is_xpu_available():
+                torch.xpu.empty_cache()
 
     if (
         loaded_in_kbit

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -2193,3 +2193,51 @@ class TestSameAdapterDifferentDevices:
         # the rest should be on GPU
         assert model.lin0.base_layer.weight.device.type == self.device
         assert model.lin0.road_theta.other.device.type == self.device
+
+
+class TestPrepareModelForKbitTraining(unittest.TestCase):
+    """Tests for prepare_model_for_kbit_training, including issue #3265 memory fix."""
+
+    def _make_fp16_model(self):
+        model = nn.Sequential(
+            nn.Linear(64, 64),
+            nn.Linear(64, 64),
+            nn.Linear(64, 32),
+        ).to(torch.float16)
+        model.is_loaded_in_8bit = True
+        return model
+
+    def test_prepare_model_for_kbit_training_fp32_cast(self):
+        """CPU-only: all non-Params4bit fp16/bf16 params become fp32 after the call."""
+        model = self._make_fp16_model()
+        for param in model.parameters():
+            self.assertEqual(param.dtype, torch.float16)
+
+        prepare_model_for_kbit_training(model, use_gradient_checkpointing=False)
+
+        for param in model.parameters():
+            if param.__class__.__name__ != "Params4bit":
+                self.assertEqual(param.dtype, torch.float32)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
+    def test_prepare_model_for_kbit_training_no_memory_leak(self):
+        """CUDA: empty_cache() after bulk fp16→fp32 casts keeps reserved memory under 200 MB (issue #3265)."""
+        model = self._make_fp16_model().cuda()
+
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        mem_before = torch.cuda.memory_reserved()
+
+        prepare_model_for_kbit_training(model, use_gradient_checkpointing=False)
+
+        torch.cuda.synchronize()
+        mem_after = torch.cuda.memory_reserved()
+
+        delta_mb = (mem_after - mem_before) / (1024**2)
+        self.assertLess(delta_mb, 200, f"CUDA reserved memory grew by {delta_mb:.1f} MB after prepare_model_for_kbit_training")
+
+        # Confirm empty_cache() was actually called: a second call should not further reduce reserved memory.
+        torch.cuda.empty_cache()
+        mem_after_extra_empty = torch.cuda.memory_reserved()
+        self.assertEqual(mem_after, mem_after_extra_empty,
+                         "Reserved memory changed after a second empty_cache(), meaning the first call was not made")

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -67,6 +67,7 @@ from .testing_utils import (
     require_deterministic_for_xpu,
     require_gptqmodel,
     require_non_cpu,
+    require_torch_gpu,
     require_torch_multi_accelerator,
 )
 
@@ -2195,8 +2196,11 @@ class TestSameAdapterDifferentDevices:
         assert model.lin0.road_theta.other.device.type == self.device
 
 
-class TestPrepareModelForKbitTraining(unittest.TestCase):
-    """Tests for prepare_model_for_kbit_training, including issue #3265 memory fix."""
+class TestPrepareModelForKbitTraining:
+    """Tests for prepare_model_for_kbit_training that require a GPU (issue #3265 memory fix).
+
+    CPU-only tests for this function live in test_other.py.
+    """
 
     def _make_fp16_model(self):
         model = nn.Sequential(
@@ -2207,19 +2211,7 @@ class TestPrepareModelForKbitTraining(unittest.TestCase):
         model.is_loaded_in_8bit = True
         return model
 
-    def test_prepare_model_for_kbit_training_fp32_cast(self):
-        """CPU-only: all non-Params4bit fp16/bf16 params become fp32 after the call."""
-        model = self._make_fp16_model()
-        for param in model.parameters():
-            self.assertEqual(param.dtype, torch.float16)
-
-        prepare_model_for_kbit_training(model, use_gradient_checkpointing=False)
-
-        for param in model.parameters():
-            if param.__class__.__name__ != "Params4bit":
-                self.assertEqual(param.dtype, torch.float32)
-
-    @unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
+    @require_torch_gpu
     def test_prepare_model_for_kbit_training_no_memory_leak(self):
         """CUDA: empty_cache() after bulk fp16→fp32 casts keeps reserved memory under 200 MB (issue #3265)."""
         model = self._make_fp16_model().cuda()
@@ -2234,10 +2226,11 @@ class TestPrepareModelForKbitTraining(unittest.TestCase):
         mem_after = torch.cuda.memory_reserved()
 
         delta_mb = (mem_after - mem_before) / (1024**2)
-        self.assertLess(delta_mb, 200, f"CUDA reserved memory grew by {delta_mb:.1f} MB after prepare_model_for_kbit_training")
+        assert delta_mb < 200, f"CUDA reserved memory grew by {delta_mb:.1f} MB after prepare_model_for_kbit_training"
 
         # Confirm empty_cache() was actually called: a second call should not further reduce reserved memory.
         torch.cuda.empty_cache()
         mem_after_extra_empty = torch.cuda.memory_reserved()
-        self.assertEqual(mem_after, mem_after_extra_empty,
-                         "Reserved memory changed after a second empty_cache(), meaning the first call was not made")
+        assert mem_after == mem_after_extra_empty, (
+            "Reserved memory changed after a second empty_cache(), meaning the first call was not made"
+        )

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -28,7 +28,12 @@ from transformers import (
 
 from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
 from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_ge_v5_6_0
-from peft.utils.other import ModulesToSaveWrapper, _get_module_names_tied_with_embedding, _get_no_split_modules
+from peft.utils.other import (
+    ModulesToSaveWrapper,
+    _get_module_names_tied_with_embedding,
+    _get_no_split_modules,
+    prepare_model_for_kbit_training,
+)
 
 from .testing_utils import hub_online_once
 
@@ -715,6 +720,52 @@ class TestGetModuleNamesTiedWithEmbedding:
 
             modules = _get_module_names_tied_with_embedding(model)
             assert modules == []
+
+
+class TestPrepareModelForKbitTraining:
+    """CPU tests for prepare_model_for_kbit_training.
+
+    GPU tests for this function (issue #3265 memory fix) live in test_common_gpu.py.
+    """
+
+    @pytest.fixture
+    def fp16_model(self):
+        model = nn.Sequential(
+            nn.Linear(64, 64),
+            nn.Linear(64, 64),
+            nn.Linear(64, 32),
+        ).to(torch.float16)
+        model.is_loaded_in_8bit = True
+        return model
+
+    def test_fp32_cast(self, fp16_model):
+        # all non-Params4bit fp16/bf16 params become fp32 after the call
+        for param in fp16_model.parameters():
+            assert param.dtype == torch.float16
+
+        prepare_model_for_kbit_training(fp16_model, use_gradient_checkpointing=False)
+
+        for param in fp16_model.parameters():
+            if param.__class__.__name__ != "Params4bit":
+                assert param.dtype == torch.float32
+
+    def test_auto_clear_cache_default(self, fp16_model):
+        # auto_clear_cache=True (default): empty_cache() is called after the fp32 casts
+        with (
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.empty_cache") as mock_empty_cache,
+        ):
+            prepare_model_for_kbit_training(fp16_model, use_gradient_checkpointing=False)
+        mock_empty_cache.assert_called_once()
+
+    def test_auto_clear_cache_disabled(self, fp16_model):
+        # auto_clear_cache=False: empty_cache() is never called
+        with (
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.empty_cache") as mock_empty_cache,
+        ):
+            prepare_model_for_kbit_training(fp16_model, use_gradient_checkpointing=False, auto_clear_cache=False)
+        mock_empty_cache.assert_not_called()
 
 
 # TODO for PEFT 0.20 remove this


### PR DESCRIPTION
The bulk param.data = param.data.to(torch.float32) loop creates temporary
tensors that PyTorch's CUDA allocator keeps cached even after they are no
longer referenced, resulting in ~1 GB of reserved-but-unused CUDA memory
on return. This breaks training on 8 GB unified-memory devices.

Fix: add a single torch.cuda.empty_cache() call (guarded by
torch.cuda.is_available()) after the cast loop so the allocator releases
those blocks back to the driver immediately.

Fixes #3265