### PR TITLE
FIX PVeRA reparameterization crash from invalid randn_like generator argument

### DIFF
--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -152,7 +152,13 @@ class PveraLayer(BaseTunerLayer):
     def _reparametrize(self, mu, logvar, sample_at_inference):
         if self.training or (not self.training and sample_at_inference):
             std = torch.exp(0.5 * logvar)
-            eps = torch.randn_like(std, generator=self.generator)
+            if self.generator is None:
+                eps = torch.randn_like(std)
+            else:
+                # torch.randn_like does not accept a `generator` argument, so torch.randn is used instead. The
+                # generator is a CPU torch.Generator (see update_layer), hence the noise is sampled on CPU for
+                # reproducible, device-independent results and then moved to std's device and dtype.
+                eps = torch.randn(std.shape, generator=self.generator).to(device=std.device, dtype=std.dtype)
             z = mu + eps * std
         else:
             z = mu

--- a/tests/test_pvera.py
+++ b/tests/test_pvera.py
@@ -242,3 +242,44 @@ class TestPVeRA:
         inputs = torch.randn(5, 10).to(dtype)
         output = peft_model(inputs)  # should not raise
         assert output.dtype == dtype
+
+    def test_pvera_forward_in_training_mode(self):
+        # Regression test: in training mode PVeRA samples noise via the reparameterization trick, which must not
+        # raise and must allow gradients to flow.
+        config = PveraConfig(target_modules=["lin1", "lin2"], init_weights=False)
+        peft_model = get_peft_model(MLP(), config)
+        peft_model.train()
+        output = peft_model(torch.randn(5, 10))  # should not raise
+        output.sum().backward()  # gradients should flow
+        assert output.shape == (5, 2)
+
+    def test_pvera_sample_at_inference(self):
+        # With sample_at_inference=True the noise is also sampled in eval mode, which must not raise.
+        config = PveraConfig(target_modules=["lin1", "lin2"], init_weights=False, sample_at_inference=True)
+        peft_model = get_peft_model(MLP(), config)
+        peft_model.eval()
+        peft_model(torch.randn(5, 10))  # should not raise
+
+    def test_pvera_generator_seed_reproducible(self):
+        # With a fixed generator_seed the sampled noise - and therefore the output - must be reproducible across two
+        # identically initialized models, while a different seed must yield a different output.
+        inputs = torch.randn(5, 10)
+
+        def build(seed):
+            config = PveraConfig(target_modules=["lin1", "lin2"], init_weights=False, generator_seed=seed)
+            torch.manual_seed(0)
+            return get_peft_model(MLP(), config)
+
+        model_a = build(123)
+        model_b = build(123)
+        model_c = build(456)
+
+        model_a.train()
+        model_b.train()
+        model_c.train()
+        output_a = model_a(inputs)
+        output_b = model_b(inputs)
+        output_c = model_c(inputs)
+
+        assert torch.allclose(output_a, output_b)
+        assert not torch.allclose(output_a, output_c)


### PR DESCRIPTION
## What does this PR do?

`PveraLayer._reparametrize` calls `torch.randn_like(std, generator=self.generator)`,
but `torch.randn_like` does not accept a `generator` argument (only `torch.randn`
does). As a result, the call raises `TypeError: randn_like() got an unexpected
keyword argument 'generator'` whenever the sampling branch is taken — i.e. on every
forward pass in training mode, and in eval mode when `sample_at_inference=True`.
PVeRA training is therefore broken.

This was introduced in #3200 (seeded PVeRA RNG) and went unnoticed because the
existing tests only run the model in eval mode with the default
`sample_at_inference=False`, which takes the deterministic `z = mu` branch and never
reaches the offending line.

## Fix

Sample the noise with `torch.randn`, which supports `generator`. Because
`self.generator` is a CPU `torch.Generator` (created in `update_layer`), the noise is
sampled on CPU for reproducible, device-independent results and then moved to `std`'s
device and dtype. When no `generator_seed` is set the behavior is unchanged
(`torch.randn_like(std)`).

## Tests

Added regression tests to `tests/test_pvera.py`:
- `test_pvera_forward_in_training_mode`: forward + backward in train mode no longer raises.
- `test_pvera_sample_at_inference`: eval-mode sampling no longer raises.
- `test_pvera_generator_seed_reproducible`: a fixed `generator_seed` yields reproducible
  output, and a different seed yields a different output.

Before this PR, all three fail (the first two with `TypeError`); after, they pass.
