### PR TITLE
Add decoupled weight-decay one-step update test

### DIFF
--- a/tests/test_lorafa.py
+++ b/tests/test_lorafa.py
@@ -150,3 +150,115 @@ def test_LoraFAOptimizer_step():
     for name, param in model.named_parameters():
         if "lora_B" in name:
             assert torch.any(param != 0), f"lora_B weights are still zero for {name}"
+
+
+def test_lorafa_weight_decay_decoupled_update():
+    """
+    Test that one optimizer step applies decoupled weight decay with the expected parameter scaling.
+    """
+    lora_rank = 16
+    lora_alpha = 32
+    # Stronger lr and weight_decay to make the decay effect more pronounced for testing
+    lr = 1e-2
+    weight_decay = 1.0
+    seed = 42
+
+    config = LoraConfig(
+        r=lora_rank,
+        lora_alpha=lora_alpha,
+        target_modules=["lin0", "lin1"],
+        bias="all",
+    )
+    torch.manual_seed(seed)
+    model_no_wd = get_peft_model(SimpleNet(), config).to(torch_device)
+    torch.manual_seed(seed)
+    model_wd = get_peft_model(SimpleNet(), config).to(torch_device)
+
+    # Sanity check: both models start from the same parameters
+    for (name_no_wd, param_no_wd), (name_wd, param_wd) in zip(
+        model_no_wd.named_parameters(), model_wd.named_parameters()
+    ):
+        assert name_no_wd == name_wd
+        assert torch.equal(param_no_wd, param_wd)
+
+    optimizer_no_wd = create_lorafa_optimizer(
+        model=model_no_wd,
+        r=lora_rank,
+        lora_alpha=lora_alpha,
+        lr=lr,
+        weight_decay=0.0,
+    )
+    optimizer_wd = create_lorafa_optimizer(
+        model=model_wd,
+        r=lora_rank,
+        lora_alpha=lora_alpha,
+        lr=lr,
+        weight_decay=weight_decay,
+    )
+    loss = torch.nn.CrossEntropyLoss()
+
+    # Save initial weights of lora_A with and without weight decay
+    initial_lora_A_weights_no_wd = {
+        name: param.clone() for name, param in model_no_wd.named_parameters() if "lora_A" in name
+    }
+    initial_lora_A_weights_wd = {
+        name: param.clone() for name, param in model_wd.named_parameters() if "lora_A" in name
+    }
+
+    # Generate random input and label using different seeds
+    torch.manual_seed(seed + 1)
+    x = torch.randint(100, (2, 4, 10)).to(torch_device)
+    output_no_wd = model_no_wd(x).permute(0, 3, 1, 2)
+    output_wd = model_wd(x).permute(0, 3, 1, 2)
+    torch.manual_seed(seed + 2)
+    label = torch.randint(16, (2, 4, 10)).to(torch_device)
+
+    # Calculate both losses and perform backward passes
+    loss_value_no_wd = loss(output_no_wd, label)
+    loss_value_no_wd.backward()
+    loss_value_wd = loss(output_wd, label)
+    loss_value_wd.backward()
+
+    params_no_wd = dict(model_no_wd.named_parameters())
+    params_wd = dict(model_wd.named_parameters())
+
+    non_lora_trainable_names = [
+        name
+        for name, param in params_no_wd.items()
+        if "lora" not in name and param.requires_grad and param.grad is not None
+    ]
+    # Sanity check: non-LoRA trainable parameters
+    assert non_lora_trainable_names, "Expected at least one non-LoRA trainable parameter with gradients"
+
+    # Perform both optimizer steps
+    optimizer_no_wd.step()
+    optimizer_wd.step()
+
+    params_no_wd = dict(model_no_wd.named_parameters())
+    params_wd = dict(model_wd.named_parameters())
+
+    # Check if lora_A weights have not changed
+    for name, param in params_no_wd.items():
+        if "lora_A" in name:
+            assert torch.equal(param, initial_lora_A_weights_no_wd[name]), f"lora_A weights changed for {name}"
+            assert torch.equal(params_wd[name], initial_lora_A_weights_wd[name]), f"lora_A weights changed for {name}"
+
+    # Compute the scaling factor for the expected relation of with and without weight decay
+    scale = 1.0 - lr * weight_decay
+
+    # Check if lora_B weights are non-zero and if they follow the expected relation
+    for name, param_no_wd in params_no_wd.items():
+        if "lora_B" in name:
+            assert torch.any(param_no_wd != 0), f"lora_B weights are still zero for {name}"
+            assert torch.allclose(params_wd[name], param_no_wd * scale, rtol=1e-5, atol=1e-6), (
+                f"lora_B weights for {name} do not match decoupled weight decay scaling"
+            )
+
+    # Check if all non-LoRA params also follow the expected relation
+    for name in non_lora_trainable_names:
+        assert torch.allclose(
+            params_wd[name],
+            params_no_wd[name] * scale,
+            rtol=1e-5,
+            atol=1e-6,
+        ), f"{name} does not match decoupled weight decay scaling"

--- a/tests/test_lorafa.py
+++ b/tests/test_lorafa.py
@@ -41,20 +41,9 @@ class SimpleNet(nn.Module):
         return X
 
 
-def _run_lorafa_weight_decay_step():
-    lora_rank = 16
-    lora_alpha = 32
-    # Stronger lr and weight_decay to make the decay effect more pronounced for testing
-    lr = 1e-2
-    weight_decay = 1.0
+def _run_lorafa_weight_decay_step(config: LoraConfig, lr: float, weight_decay: float):
     seed = 42
 
-    config = LoraConfig(
-        r=lora_rank,
-        lora_alpha=lora_alpha,
-        target_modules=["lin0", "lin1"],
-        bias="all",  # Include bias to also check non-LoRA trainable parameters
-    )
     torch.manual_seed(seed)
     model_no_wd = get_peft_model(SimpleNet(), config).to(torch_device)
     torch.manual_seed(seed)
@@ -69,15 +58,15 @@ def _run_lorafa_weight_decay_step():
 
     optimizer_no_wd = create_lorafa_optimizer(
         model=model_no_wd,
-        r=lora_rank,
-        lora_alpha=lora_alpha,
+        r=config.r,
+        lora_alpha=config.lora_alpha,
         lr=lr,
         weight_decay=0.0,
     )
     optimizer_wd = create_lorafa_optimizer(
         model=model_wd,
-        r=lora_rank,
-        lora_alpha=lora_alpha,
+        r=config.r,
+        lora_alpha=config.lora_alpha,
         lr=lr,
         weight_decay=weight_decay,
     )
@@ -112,15 +101,11 @@ def _run_lorafa_weight_decay_step():
     optimizer_no_wd.step()
     optimizer_wd.step()
 
-    # Compute the scaling factor for the expected relation of with and without weight decay
-    scale = 1.0 - lr * weight_decay
-
     return (
         dict(model_no_wd.named_parameters()),
         dict(model_wd.named_parameters()),
         initial_lora_A_weights,
         non_lora_trainable_names,
-        scale,
     )
 
 
@@ -239,7 +224,21 @@ def test_lorafa_weight_decay_decoupled_update_lora_b():
     """
     Test that one optimizer step applies decoupled weight decay to LoRA B weights.
     """
-    params_no_wd, params_wd, initial_lora_A_weights, _, scale = _run_lorafa_weight_decay_step()
+    lora_rank = 16
+    lora_alpha = 32
+    # Stronger lr and weight_decay to make the decay effect more pronounced for testing
+    lr = 1e-2
+    weight_decay = 1.0
+    config = LoraConfig(
+        r=lora_rank,
+        lora_alpha=lora_alpha,
+        target_modules=["lin0", "lin1"],
+        bias="none",
+    )
+    params_no_wd, params_wd, initial_lora_A_weights, _ = _run_lorafa_weight_decay_step(config, lr, weight_decay)
+
+    # Compute the scaling factor for the expected relation of with and without weight decay
+    scale = 1.0 - lr * weight_decay
 
     # Check if lora_A weights have not changed
     for name, param in params_no_wd.items():
@@ -259,7 +258,21 @@ def test_lorafa_weight_decay_decoupled_update_non_lora_params():
     """
     Test that one optimizer step applies decoupled weight decay to non-LoRA trainable parameters.
     """
-    params_no_wd, params_wd, _, non_lora_trainable_names, scale = _run_lorafa_weight_decay_step()
+    lora_rank = 16
+    lora_alpha = 32
+    # Stronger lr and weight_decay to make the decay effect more pronounced for testing
+    lr = 1e-2
+    weight_decay = 1.0
+    config = LoraConfig(
+        r=lora_rank,
+        lora_alpha=lora_alpha,
+        target_modules=["lin0", "lin1"],
+        bias="all",  # Include bias to check non-LoRA trainable parameters
+    )
+    params_no_wd, params_wd, _, non_lora_trainable_names = _run_lorafa_weight_decay_step(config, lr, weight_decay)
+
+    # Compute the scaling factor for the expected relation of with and without weight decay
+    scale = 1.0 - lr * weight_decay
 
     # Sanity check: non-LoRA trainable parameters
     assert non_lora_trainable_names, "Expected at least one non-LoRA trainable parameter with gradients"

--- a/tests/test_lorafa.py
+++ b/tests/test_lorafa.py
@@ -41,6 +41,89 @@ class SimpleNet(nn.Module):
         return X
 
 
+def _run_lorafa_weight_decay_step():
+    lora_rank = 16
+    lora_alpha = 32
+    # Stronger lr and weight_decay to make the decay effect more pronounced for testing
+    lr = 1e-2
+    weight_decay = 1.0
+    seed = 42
+
+    config = LoraConfig(
+        r=lora_rank,
+        lora_alpha=lora_alpha,
+        target_modules=["lin0", "lin1"],
+        bias="all",  # Include bias to also check non-LoRA trainable parameters
+    )
+    torch.manual_seed(seed)
+    model_no_wd = get_peft_model(SimpleNet(), config).to(torch_device)
+    torch.manual_seed(seed)
+    model_wd = get_peft_model(SimpleNet(), config).to(torch_device)
+
+    # Shared setup invariant: both models must start from the same parameters.
+    for (name_no_wd, param_no_wd), (name_wd, param_wd) in zip(
+        model_no_wd.named_parameters(), model_wd.named_parameters()
+    ):
+        assert name_no_wd == name_wd
+        assert torch.equal(param_no_wd, param_wd)
+
+    optimizer_no_wd = create_lorafa_optimizer(
+        model=model_no_wd,
+        r=lora_rank,
+        lora_alpha=lora_alpha,
+        lr=lr,
+        weight_decay=0.0,
+    )
+    optimizer_wd = create_lorafa_optimizer(
+        model=model_wd,
+        r=lora_rank,
+        lora_alpha=lora_alpha,
+        lr=lr,
+        weight_decay=weight_decay,
+    )
+    loss = torch.nn.CrossEntropyLoss()
+
+    # Save initial lora_A weights. Only from one model since both models params are identical
+    initial_lora_A_weights = {
+        name: param.clone() for name, param in model_no_wd.named_parameters() if "lora_A" in name
+    }
+
+    # Generate random input and label using different seeds
+    torch.manual_seed(seed + 1)
+    x = torch.randint(100, (2, 4, 10)).to(torch_device)
+    output_no_wd = model_no_wd(x).permute(0, 3, 1, 2)
+    output_wd = model_wd(x).permute(0, 3, 1, 2)
+    torch.manual_seed(seed + 2)
+    label = torch.randint(16, (2, 4, 10)).to(torch_device)
+
+    # Calculate both losses and perform backward passes
+    loss_value_no_wd = loss(output_no_wd, label)
+    loss_value_no_wd.backward()
+    loss_value_wd = loss(output_wd, label)
+    loss_value_wd.backward()
+
+    non_lora_trainable_names = [
+        name
+        for name, param in model_no_wd.named_parameters()
+        if "lora" not in name and param.requires_grad and param.grad is not None
+    ]
+
+    # Perform both optimizer steps
+    optimizer_no_wd.step()
+    optimizer_wd.step()
+
+    # Compute the scaling factor for the expected relation of with and without weight decay
+    scale = 1.0 - lr * weight_decay
+
+    return (
+        dict(model_no_wd.named_parameters()),
+        dict(model_wd.named_parameters()),
+        initial_lora_A_weights,
+        non_lora_trainable_names,
+        scale,
+    )
+
+
 def test_lorafa_init_default():
     """
     Test if the optimizer is correctly created
@@ -152,99 +235,16 @@ def test_LoraFAOptimizer_step():
             assert torch.any(param != 0), f"lora_B weights are still zero for {name}"
 
 
-def test_lorafa_weight_decay_decoupled_update():
+def test_lorafa_weight_decay_decoupled_update_lora_b():
     """
-    Test that one optimizer step applies decoupled weight decay with the expected parameter scaling.
+    Test that one optimizer step applies decoupled weight decay to LoRA B weights.
     """
-    lora_rank = 16
-    lora_alpha = 32
-    # Stronger lr and weight_decay to make the decay effect more pronounced for testing
-    lr = 1e-2
-    weight_decay = 1.0
-    seed = 42
-
-    config = LoraConfig(
-        r=lora_rank,
-        lora_alpha=lora_alpha,
-        target_modules=["lin0", "lin1"],
-        bias="all",
-    )
-    torch.manual_seed(seed)
-    model_no_wd = get_peft_model(SimpleNet(), config).to(torch_device)
-    torch.manual_seed(seed)
-    model_wd = get_peft_model(SimpleNet(), config).to(torch_device)
-
-    # Sanity check: both models start from the same parameters
-    for (name_no_wd, param_no_wd), (name_wd, param_wd) in zip(
-        model_no_wd.named_parameters(), model_wd.named_parameters()
-    ):
-        assert name_no_wd == name_wd
-        assert torch.equal(param_no_wd, param_wd)
-
-    optimizer_no_wd = create_lorafa_optimizer(
-        model=model_no_wd,
-        r=lora_rank,
-        lora_alpha=lora_alpha,
-        lr=lr,
-        weight_decay=0.0,
-    )
-    optimizer_wd = create_lorafa_optimizer(
-        model=model_wd,
-        r=lora_rank,
-        lora_alpha=lora_alpha,
-        lr=lr,
-        weight_decay=weight_decay,
-    )
-    loss = torch.nn.CrossEntropyLoss()
-
-    # Save initial weights of lora_A with and without weight decay
-    initial_lora_A_weights_no_wd = {
-        name: param.clone() for name, param in model_no_wd.named_parameters() if "lora_A" in name
-    }
-    initial_lora_A_weights_wd = {
-        name: param.clone() for name, param in model_wd.named_parameters() if "lora_A" in name
-    }
-
-    # Generate random input and label using different seeds
-    torch.manual_seed(seed + 1)
-    x = torch.randint(100, (2, 4, 10)).to(torch_device)
-    output_no_wd = model_no_wd(x).permute(0, 3, 1, 2)
-    output_wd = model_wd(x).permute(0, 3, 1, 2)
-    torch.manual_seed(seed + 2)
-    label = torch.randint(16, (2, 4, 10)).to(torch_device)
-
-    # Calculate both losses and perform backward passes
-    loss_value_no_wd = loss(output_no_wd, label)
-    loss_value_no_wd.backward()
-    loss_value_wd = loss(output_wd, label)
-    loss_value_wd.backward()
-
-    params_no_wd = dict(model_no_wd.named_parameters())
-    params_wd = dict(model_wd.named_parameters())
-
-    non_lora_trainable_names = [
-        name
-        for name, param in params_no_wd.items()
-        if "lora" not in name and param.requires_grad and param.grad is not None
-    ]
-    # Sanity check: non-LoRA trainable parameters
-    assert non_lora_trainable_names, "Expected at least one non-LoRA trainable parameter with gradients"
-
-    # Perform both optimizer steps
-    optimizer_no_wd.step()
-    optimizer_wd.step()
-
-    params_no_wd = dict(model_no_wd.named_parameters())
-    params_wd = dict(model_wd.named_parameters())
+    params_no_wd, params_wd, initial_lora_A_weights, _, scale = _run_lorafa_weight_decay_step()
 
     # Check if lora_A weights have not changed
     for name, param in params_no_wd.items():
         if "lora_A" in name:
-            assert torch.equal(param, initial_lora_A_weights_no_wd[name]), f"lora_A weights changed for {name}"
-            assert torch.equal(params_wd[name], initial_lora_A_weights_wd[name]), f"lora_A weights changed for {name}"
-
-    # Compute the scaling factor for the expected relation of with and without weight decay
-    scale = 1.0 - lr * weight_decay
+            assert torch.equal(param, initial_lora_A_weights[name]), f"lora_A weights changed for {name}"
 
     # Check if lora_B weights are non-zero and if they follow the expected relation
     for name, param_no_wd in params_no_wd.items():
@@ -253,6 +253,16 @@ def test_lorafa_weight_decay_decoupled_update():
             assert torch.allclose(params_wd[name], param_no_wd * scale, rtol=1e-5, atol=1e-6), (
                 f"lora_B weights for {name} do not match decoupled weight decay scaling"
             )
+
+
+def test_lorafa_weight_decay_decoupled_update_non_lora_params():
+    """
+    Test that one optimizer step applies decoupled weight decay to non-LoRA trainable parameters.
+    """
+    params_no_wd, params_wd, _, non_lora_trainable_names, scale = _run_lorafa_weight_decay_step()
+
+    # Sanity check: non-LoRA trainable parameters
+    assert non_lora_trainable_names, "Expected at least one non-LoRA trainable parameter with gradients"
 
     # Check if all non-LoRA params also follow the expected relation
     for name in non_lora_trainable_names:


### PR DESCRIPTION
## Summary
This PR adds a deterministic LoRAFA test that validates decoupled weight-decay behavior in a one-step update setting

## Why
Current LoRAFA tests in test_lorafa.py cover initialization and general optimizer-step behavior, but do not explicitly validate non-zero weight-decay update paths

## What Changed
- Added test_lorafa_weight_decay_decoupled_update in test_lorafa.py
- The test creates two seeded identical models and runs the same one-step forward/backward pass on both
- It compares optimizer updates for:
1. weight_decay = 0
2. weight_decay > 0
- It asserts:
1. LoRA A remains unchanged
2. LoRA B is updated and follows the expected decoupled scaling relation
3. Non-LoRA trainable parameters with gradients follow the same decoupled scaling relation

## Relation Checked
param_with_decay ≈ param_without_decay × (1 - lr × weight_decay)

## Notes
- Test-only change, no functional change to LoRAFA behavior
- The test is intentionally one-step and seed-fixed to keep it deterministic
- High learning rate and weight_decay to make the decay effect more pronounced for testing