### PR TITLE
experiment method comparison #2310 : adaptation_prompt

### DIFF
--- a/method_comparison/MetaMathQA/experiments/adaptionprompt/llama-3.2-3B-lr_5e-3/adapter_config.json
+++ b/method_comparison/MetaMathQA/experiments/adaptionprompt/llama-3.2-3B-lr_5e-3/adapter_config.json
@@ -1,0 +1,12 @@
+{
+    "adapter_layers": 28,
+    "adapter_len": 100,
+    "auto_mapping": null,
+    "base_model_name_or_path": null,
+    "inference_mode": false,
+    "peft_type": "ADAPTION_PROMPT",
+    "peft_version": "0.19.2.dev0@UNKNOWN",
+    "revision": null,
+    "target_modules": null,
+    "task_type": null
+}

--- a/method_comparison/MetaMathQA/experiments/adaptionprompt/llama-3.2-3B-lr_5e-3/training_params.json
+++ b/method_comparison/MetaMathQA/experiments/adaptionprompt/llama-3.2-3B-lr_5e-3/training_params.json
@@ -1,0 +1,23 @@
+{
+    "model_id": "meta-llama/Llama-3.2-3B",
+    "dtype": "bfloat16",
+    "max_seq_length": 512,
+    "batch_size": 4,
+    "batch_size_eval": 64,
+    "max_steps": 3000,
+    "eval_steps": 500,
+    "compile": false,
+    "use_gc": true,
+    "use_amp": false,
+    "grad_norm_clip": 1.0,
+    "optimizer_type": "AdamW",
+    "optimizer_kwargs": {
+        "lr": 0.005,
+        "weight_decay": 0.1
+    },
+    "lr_scheduler": "cosine",
+    "generation_kwargs": {
+        "max_new_tokens": 256
+    },
+    "query_template": "Question: {query} Think step by step.\nAnswer:"
+    }


### PR DESCRIPTION
Experiment on Adaptation Prompt (Llama Adaptation) peft method under the #2310 `Comparison of Different Fine-Tuning Techniques for Conversational AI` evaluation suite

## What this PR does

Adds a new experiments to `method_comparison/MetaMathQA/experiments/adaptionprompt/` that demonstrate the existing AdaptionPrompt baseline is significantly undertuned with respect to learning rate. The new experiments use the same adapter capacity as the existing baseline (`adapter_len=100`, `adapter_layers=28`, 8.6M trainable parameters) and the same training recipe (bf16, `use_amp=false`), varying only the learning rate `5e-3`

### Hardware and reproducibility notes

Runs were produced on a single Kaggle T4 (16 GB)

Kaggle notebook: https://www.kaggle.com/code/adyaprasad/peft-comparioson-method-llama-adapter-configured/notebook?scriptVersionId=323825754

### Run command I use in Kaggle:
```bash
!cd peft/method_comparison/MetaMathQA && \
  PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
  python run.py -v experiments/adaptionprompt/llama-3.2-3B-lr_5e-3
```

### Run log:
```bash
config.json: 100%|█████████████████████████████| 844/844 [00:00<00:00, 4.39MB/s]
tokenizer_config.json: 50.5kB [00:00, 87.6MB/s]
tokenizer.json: 9.09MB [00:00, 25.0MB/s]
special_tokens_map.json: 100%|█████████████████| 301/301 [00:00<00:00, 1.21MB/s]
Fetching 2 files: 100%|███████████████████████████| 2/2 [00:23<00:00, 11.76s/it]
Download complete: 100%|████████████████████| 6.43G/6.43G [00:23<00:00, 122MB/s]
Loading weights:   0%| | 1/254 [00:00<00:00, 7423.55it/s, Materializing param=mo
Loading weights:  71%|▋| 181/254 [00:01<00:00, 142.96it/s, Materializing param=m
Loading weights: 100%|█| 254/254 [00:01<00:00, 133.01it/s, Materializing param=m

generation_config.json: 100%|██████████████████| 185/185 [00:00<00:00, 1.27MB/s]
PeftModel(
  (base_model): AdaptionPromptModel(
    (model): LlamaForCausalLM(
      (model): LlamaModel(
        (embed_tokens): Embedding(128256, 3072)
        (layers): ModuleList(
          (0-27): 28 x LlamaDecoderLayer(
            (self_attn): AdaptedAttention(
              (model): LlamaAttention(
                (q_proj): Linear(in_features=3072, out_features=3072, bias=False)
                (k_proj): Linear(in_features=3072, out_features=1024, bias=False)
                (v_proj): Linear(in_features=3072, out_features=1024, bias=False)
                (o_proj): Linear(in_features=3072, out_features=3072, bias=False)
              )
            )
            (mlp): LlamaMLP(
              (gate_proj): Linear(in_features=3072, out_features=8192, bias=False)
              (up_proj): Linear(in_features=3072, out_features=8192, bias=False)
              (down_proj): Linear(in_features=8192, out_features=3072, bias=False)
              (act_fn): SiLUActivation()
            )
            (input_layernorm): LlamaRMSNorm((3072,), eps=1e-05)
            (post_attention_layernorm): LlamaRMSNorm((3072,), eps=1e-05)
          )
        )
        (norm): LlamaRMSNorm((3072,), eps=1e-05)
        (rotary_emb): LlamaRotaryEmbedding()
      )
      (lm_head): Linear(in_features=3072, out_features=128256, bias=False)
    )
  )
)
trainable params: 8,601,628 || all params: 3,221,351,452 || trainable: 0.2670%

README.md: 39.8kB [00:00, 15.8MB/s]
Download complete: 100%|████████████████████| 6.43G/6.43G [00:33<00:00, 122MB/s]
README.md: 4.45kB [00:00, 10.5MB/s]

MetaMathQA-395K.json:   0%|                          | 0.00/396M [00:00<?, ?B/s]
MetaMathQA-395K.json: 100%|███████████████████| 396M/396M [00:01<00:00, 201MB/s]

Generating train split:   0%|                 | 0/395000 [00:00<?, ? examples/s]
Generating train split: 100%|█| 395000/395000 [00:06<00:00, 61329.59 examples/s]
Filtered dataset: 93.8% of the original dataset

README.md: 7.93kB [00:00, 4.02MB/s]

main/train-00000-of-00001.parquet:   0%|            | 0.00/2.31M [00:00<?, ?B/s]
main/train-00000-of-00001.parquet:   0%|            | 0.00/2.31M [00:00<?, ?B/s]
main/train-00000-of-00001.parquet: 100%|███| 2.31M/2.31M [00:00<00:00, 10.4MB/s]
Map:   0%|                       | 1000/370475 [00:00<01:48, 3403.30 examples/s]
Map:   1%|                       | 2000/370475 [00:00<01:39, 3720.13 examples/s]
Map: 100%|█████████████████████████| 1319/1319 [00:00<00:00, 8981.39 examples/s]
  0%|                                                  | 0/3000 [00:00<?, ?it/s]`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.
{"step": "  500", "samples": "   2000", "lr": "4.93e-03", "loss avg": "0.8479", "valid acc": "0.320", "gen valid tokens": 9090, "train time": "4767.7s", "eval time": "146.6s", "train tokens / sec": "88", "mem allocated": "6741926599", "mem reserved": "9346041774", "elapsed time": "88min 16s"}
 33%|███████▉                | 999/3000 [2:42:08<3:14:39,  5.84s/it, loss=0.718]
Example prediction:
    Question: Bob is building raised beds for his vegetable garden. Each bed is 2 feet high, 2 feet wide, and 8 feet long. The sides are going to be built of 1-foot wide planks. If Bob buys his lumber in 8-foot-long boards, planning to cut some of them for the shorter lengths he'll need, how many 8-foot long planks will he need to construct 10 raised beds? Think step by step. Answer:Each bed is 2 feet high, 2 feet wide, and 8 feet long, so the total area of each bed is 2 x 2 x 8 = 32 square feet. The sides of each bed are going to be built of 1-foot wide planks, so each side will be 1 foot wide x 32 square feet = 32 square feet. To construct 10 raised beds, Bob will need a total area of 10 x 32 square feet = 320 square feet. Bob buys his [...]

{"step": " 2000", "samples": "   8000", "lr": "1.51e-03", "loss avg": "0.6598", "valid acc": "0.360", "gen valid tokens": 9271, "train time": "4746.8s", "eval time": "131.8s", "train tokens / sec": "88", "mem allocated": "6740922264", "mem reserved": "9377876541", "elapsed time": "333min 32s"}
 83%|████████████████████▊    | 2499/3000 [6:47:04<50:38,  6.06s/it, loss=0.764]
Example prediction:
    Question: Bob gets paid $5 an hour for the regular hours he works and $6 an hour for any overtime hours he works. All hours over 40 in a week are considered overtime. If Bob works 44 hours in the first week and 48 hours in the second week, how much did he make? Think step by step. Answer:Bob works 44 hours in the first week and 48 hours in the second week, so he works a total of 44 + 48 = 92 hours in the two weeks. If all hours over 40 in a week are considered overtime, then Bob works 92 - 40 = 52 overtime hours in the two weeks. Since overtime hours are paid at $6 an hour, Bob makes 52 * $6 = $312 from overtime hours. Therefore, Bob makes a total of $5 * 44 + $6 * 52 = $220 + $312 = $532 in the two weeks. #### 532 The answer is: 532
{"step": " 3000", "samples": "  12000", "lr": "0.00e+00", "loss avg": "0.6518", "valid acc": "0.440", "gen valid tokens": 9080, "train time": "4794.6s", "eval time": "147.6s", "train tokens / sec": "88", "mem allocated": "6743128777", "mem reserved": "9411724575", "elapsed time": "498min 23s"}
100%|█████████████████████████| 3000/3000 [8:12:06<00:00,  9.84s/it, loss=0.788]
Training finished after 3000 steps, evaluation on test set follows.
100%|████████████████████████████████████████| 21/21 [1:03:08<00:00, 180.40s/it]
Test accuracy: 0.377
Saved PEFT checkpoint to /tmp/tmpfiqfayvw
Experiment run was categorized as successful run
accelerator memory max: 11414MB
accelerator memory reserved avg: 8934MB
accelerator memory reserved 99th percentile: 10282MB
train time: 33111.37294706801s
total time: 33992.96s
file size of checkpoint: 16.4MB
Saved log to: /kaggle/working/peft/method_comparison/MetaMathQA/results/adaptionprompt--llama-3.2-3B-lr_5e-3
```

### Saved result `json`:
```
<html><body>
<!--StartFragment--><div id="content"><div class="tabs tabs-tall "><nav class="tabs-navigation"><ul class="tabs-menu" role="tablist"><li class="tabs-menu-item json is-active" role="presentation"><span class="devtools-tab-line"></span></li><li class="tabs-menu-item rawdata " role="presentation"><span class="devtools-tab-line"></span></li><li class="tabs-menu-item headers " role="presentation"><span class="devtools-tab-line"></span></li></ul></nav><div class="panels"><div id="json-panel" style="visibility: visible; height: 100%;" class="tab-panel-box" role="tabpanel" aria-labelledby="json-tab"><div class="tab-panel json"><div class="jsonPanelBox tab-panel-inner"><div class="toolbar"><div class="devtools-separator"></div><div class="devtools-searchbox"><input class="searchBox devtools-filterinput" placeholder="Filter JSON" value=""></div></div><div class="panelContent" id="json-scrolling-panel" tabindex="0">
  |  
-- | --
run_info |  
created_at | "2026-06-02T04:10:59+00:00"
total_time | 33992.963994196994
experiment_name | "adaptionprompt/llama-3.2-3B-configured"
peft_branch | "main"
train_config |  
model_id | "meta-llama/Llama-3.2-3B"
dtype | "bfloat16"
max_seq_length | 512
batch_size | 4
batch_size_eval | 64
max_steps | 3000
eval_steps | 500
compile | false
use_gc | true
query_template | "Question: {query} Think step by step.\nAnswer:"
seed | 0
grad_norm_clip | 1.0JS:1
optimizer_type | "AdamW"
optimizer_kwargs |  
lr | 0.005
weight_decay | 0.1
lr_scheduler | "cosine"
use_amp | false
autocast_adapter_dtype | true
generation_kwargs |  
max_new_tokens | 256
attn_implementation | null
init_kv_cache_prefix | null
peft_config |  
task_type | null
peft_type | "ADAPTION_PROMPT"
auto_mapping | null
peft_version | "0.19.2.dev0@UNKNOWN"
base_model_name_or_path | "meta-llama/Llama-3.2-3B"
revision | null
inference_mode | false
target_modules | "self_attn"
adapter_len | 100
adapter_layers | 28
error_msg | ""
train_info |  
accelerator_memory_reserved_avg | 9368998597
accelerator_memory_max | 11968446464
accelerator_memory_reserved_99th | 10781458432
train_time | 33111.37294706801
file_size | 17210384
num_trainable_params | 8601628
num_total_params | 3221351452
status | "success"
metrics |  
0 |  
step | 500
valid accuracy | 0.32
train loss | 0.8479486206769943
train samples | 2000
train time | 4767.722330723
eval time | 146.64939873799995
tokens / sec | 88.00533481075693
mem allocated avg | 6741926598.656
mem reserved avg | 9346041774.08
elapsed time | 5295.628022369
1 |  
step | 1000
valid accuracy | 0.44
train loss | 0.6820464489459992
train samples | 4000
train time | 4804.922728980969
eval time | 133.16406877499867
tokens / sec | 87.94709589213744
mem allocated avg | 6743754570.752
mem reserved avg | 9342141071.36
elapsed time | 10238.550218003
2 |  
step | 1500
valid accuracy | 0.4
train loss | 0.6678970144987106
train samples | 6000
train time | 4747.8348737079905
eval time | 137.71595469099702
tokens / sec | 88.0013755983244
mem allocated avg | 6741236243.456
mem reserved avg | 9363154534.4
elapsed time | 15128.994178331
3 |  
step | 2000
valid accuracy | 0.36
train loss | 0.6598022002577781
train samples | 8000
train time | 4746.774001920985
eval time | 131.79883610199977
tokens / sec | 87.80468584165341
mem allocated avg | 6740922263.552
mem reserved avg | 9377876541.44
elapsed time | 20012.454066637
4 |  
step | 2500
valid accuracy | 0.38
train loss | 0.6588010110259056
train samples | 10000
train time | 4783.2564902700105
eval time | 154.9148787510021
tokens / sec | 87.96454901715894
mem allocated avg | 6742758867.968
mem reserved avg | 9373053091.84
elapsed time | 24955.516532625003
5 |  
step | 3000
valid accuracy | 0.44
train loss | 0.6517807692289352
train samples | 12000
train time | 4794.645083146002
eval time | 147.5877438819989
tokens / sec | 87.68115109870757
mem allocated avg | 6743128776.704
mem reserved avg | 9411724574.72
elapsed time | 29902.717915877
6 |  
step | 3000
test accuracy | 0.37680060652009095
train loss | 0.6517807692289352
train samples | 12000
train total tokens | 2517926
forgetting | 0.11155319213867188
meta_info |  
model_info |  
sha | "13afe5124825b4f3751f836b40dafda64c1ed062"
created_at | "2024-09-18T15:23:48+00:00"
dataset_info |  
metamath |  
sha | "aa4f34d3d2d3231299b5b03d9b3e5a20da45aa18"
created_at | "2023-09-21T17:22:46+00:00"
gsm8k |  
sha | "740312add88f781978c0658806c59bc2815b9866"
created_at | "2022-04-12T10:22:10+00:00"
package_info |  
transformers-version | "5.0.0"
transformers-commit-hash | null
peft-version | "0.19.2.dev0"
peft-commit-hash | "dc2e5b2d9fdbcea900ae8c2bad120eab035ed41b"
datasets-version | "4.8.3"
datasets-commit-hash | null
bitsandbytes-version | "0.49.2"
bitsandbytes-commit-hash | null
torch-version | "2.10.0+cu128"
torch-commit-hash | null
system_info |  
system | "Linux"
release | "6.6.122+"
version | "#1 SMP Thu Apr 30 18:17:14 UTC 2026"
machine | "x86_64"
processor | "x86_64"
accelerator | "Tesla T4"
pytorch_info | "PyTorch built with:\n  - GCC 13.3\n  - C++ Version: 201703\n  - Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v3.7.1 (Git Hash 8d263e693366ef8db40acc569cc7d8edf644556d)\n  - OpenMP 201511 (a.k.a. OpenMP 4.5)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: AVX512\n  - CUDA Runtime 12.8\n  - NVCC architecture flags: -gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_90,code=sm_90;-gencode;arch=compute_100,code=sm_100;-gencode;arch=compute_120,code=sm_120\n  - CuDNN 91.0.2  (built against CUDA 12.9)\n  - Magma 2.6.1\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, COMMIT_SHA=449b1768410104d3ed79d3bcfe4ba1d65c7f22c0, CUDA_VERSION=12.8, CUDNN_VERSION=9.10.2, CXX_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/c++, CXX_FLAGS= -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOROCTRACER -DLIBKINETO_NOXPUPTI=ON -DUSE_FBGEMM -DUSE_FBGEMM_GENAI -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -DC10_NODEPRECATED -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Werror=range-loop-construct -Werror=bool-operation -Wnarrowing -Wno-missing-field-initializers -Wno-unknown-pragmas -Wno-unused-parameter -Wno-strict-overflow -Wno-strict-aliasing -Wno-stringop-overflow -Wsuggest-override -Wno-psabi -Wno-error=old-style-cast -faligned-new -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-dangling-reference -Wno-error=dangling-reference -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, TORCH_VERSION=2.10.0, USE_CUDA=ON, USE_CUDNN=ON, USE_CUSPARSELT=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_GLOO=ON, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=1, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, USE_ROCM_KERNEL_ASSERT=OFF, USE_XCCL=OFF, USE_XPU=OFF, \n"

</div></div></div></div></div></div></div><!--EndFragment-->
</body>
</html>
```

### How can review
@BenjaminBossan 