### PR TITLE
FIX Image benchmark dataset wrong prompt order

### DIFF
--- a/method_comparison/MetaMathQA/README.md
+++ b/method_comparison/MetaMathQA/README.md
@@ -47,9 +47,7 @@ without modifying it. For example:
 
 to run the VBLoRA default experiment again.
 
-If you set `UPLOAD_BUCKET="your_user/bucket_name"` as an environment variable prior to starting experiments
-via `make`, all experiments will be called with the `--bucket_name $UPLOAD_BUCKET` parameter and therefore
-store the checkpoints in that bucket.
+If you set `UPLOAD_BUCKET="your_user/bucket_name"` as an environment variable prior to starting experiments via `make`, all experiments will be called with the `--bucket_name $UPLOAD_BUCKET` parameter and therefore store the checkpoints in that bucket. _For maintainers_: The default bucket name should be `"peft-internal-testing/metamathqa-checkpoints"`.
 
 ### `adapter_config.json`
 

--- a/method_comparison/image-gen/README.md
+++ b/method_comparison/image-gen/README.md
@@ -45,7 +45,7 @@ The Makefile checks which experiments are missing a corresponding results file a
 make
 ```
 
-If you set `UPLOAD_BUCKET="your_user/bucket_name"` as an environment variable prior to starting experiments via `make`, all experiments will be called with the `--bucket_name $UPLOAD_BUCKET` parameter and therefore store the checkpoints and sample images in that bucket.
+If you set `UPLOAD_BUCKET_IMAGEGEN="your_user/bucket_name"` as an environment variable prior to starting experiments via `make`, all experiments will be called with the `--bucket_name $UPLOAD_BUCKET_IMAGEGEN` parameter and therefore store the checkpoints and sample images in that bucket. _For maintainers_: The default bucket name should be `"peft-internal-testing/image-gen-benchmark"`.
 
 List experiments to run:
 

--- a/method_comparison/image-gen/default_training_params.json
+++ b/method_comparison/image-gen/default_training_params.json
@@ -37,14 +37,6 @@
   "instance_prompts": [
     "sks cat sitting on a chair in front of a box of chocolates",
     "sks cat playing on the Steam Deck",
-    "sks cat reading the newspaper with the title \"DIE BOX\"",
-    "sks cat being fed sushi",
-    "sks cat in front of a box of tomatoes",
-    "a gingerbread house in front of sks cat",
-    "sks cat is wearing a Wednesday Addams costume",
-    "sks cat looks skeptical as he reads a magazine depicting a black cat",
-    "sks cat wearing a striped scarf",
-    "sleepy sks cat lying in bed covered by a blue blanket",
     "sks cat wearing a necklace while sitting in a box on a sofa",
     "a box with four donuts in front of sks cat",
     "sks cat wearing a pink veil with flowers on it and a dagger made out of yellow cardboard",
@@ -54,7 +46,15 @@
     "sks cat opens a white door",
     "sks cat with a VIP \"all access\" pass",
     "sks cat in front of a monitor showing the video game \"RimWorld\"",
-    "sks cat reads a newspaper about cannabis"
+    "sks cat reads a newspaper about cannabis",
+    "sks cat reading the newspaper with the title \"DIE BOX\"",
+    "sks cat being fed sushi",
+    "sks cat in front of a box of tomatoes",
+    "a gingerbread house in front of sks cat",
+    "sks cat is wearing a Wednesday Addams costume",
+    "sks cat looks skeptical as he reads a magazine depicting a black cat",
+    "sks cat wearing a striped scarf",
+    "sleepy sks cat lying in bed covered by a blue blanket"
   ],
   "sample_image_prompts": [
     "a photo of sks cat",


### PR DESCRIPTION
For some reason, the order of the prompts and the images of the [cat plushy dataset](https://huggingface.co/datasets/peft-internal-testing/cat-image-dataset) don't align.

I also updated the README of the MetaMath and image gen benchmarks to point to the checkpoint files.

This PR fixes the order. The dataset iself needs to be updated separately.