### PR TITLE
Fix app deployment CI issue

### DIFF
--- a/.github/workflows/deploy_method_comparison_app.yml
+++ b/.github/workflows/deploy_method_comparison_app.yml
@@ -46,8 +46,7 @@ jobs:
         run: |
           cd method_comparison
           git init
-          # Spaces expect requirements.txt
-          mv requirements-app.txt requirements.txt
+          # requirements.txt is already present from the previous step
           mv app_embed.py app.py
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The issue is that the previous step is already moving the `requirements.txt` so the next step doesn't need to do this again. Re-initializing the git repo should work, though.

Log: https://github.com/huggingface/peft/actions/runs/27147578991/job/80133890292#step:5:16