### PR TITLE
docs: sync PEFT config docstrings with their fields

### DIFF
--- a/src/peft/tuners/gralora/config.py
+++ b/src/peft/tuners/gralora/config.py
@@ -57,6 +57,10 @@ class GraloraConfig(PeftConfig):
             Bias type for gralora. Can be 'none', 'all' or 'gralora_only'. If 'all' or 'gralora_only', the
             corresponding biases will be updated during training. Be aware that this means that, even when disabling
             the adapters, the model will not produce the same output as the base model would have without adaptation.
+        modules_to_save (`Optional[list[str]]`):
+            List of modules apart from gralora layers to be set as trainable and saved in the final checkpoint. For
+            example, in Sequence Classification or Token Classification tasks, the final layer `classifier/score` are
+            randomly initialized and as such need to be trainable and saved.
         init_weights (`bool`):
             Whether to initialize the weights of the GraLoRA layers with their default initialization. Don't change
             this setting, except if you know exactly what you're doing.

--- a/src/peft/tuners/hira/config.py
+++ b/src/peft/tuners/hira/config.py
@@ -49,6 +49,12 @@ class HiraConfig(PeftConfig):
             `Conv1D` which stores weights like (fan_in, fan_out) and hence this should be set to `True`.
         modules_to_save (`List[str]`):
             List of modules apart from adapter layers to be set as trainable and saved in the final checkpoint.
+        init_weights (`bool` | `Literal["gaussian"]`):
+            How to initialize the weights of the HiRA layers. Passing True (default) results in the default
+            initialization, with the HiRA B weight being set to 0. This means that without further training, the HiRA
+            adapter will be a no-op. Setting the initialization to False leads to random initialization of HiRA A and
+            B, meaning that HiRA is not a no-op before training; this setting is intended for debugging purposes.
+            Passing `'gaussian'` results in Gaussian initialization scaled by the HiRA rank for linear and layers.
         layers_to_transform (`Union[List[int], int]`):
             The layer indices to transform. If a list of ints is passed, it will apply the adapter to the layer indices
             that are specified in this list. If a single integer is passed, it will apply the transformations on the

--- a/src/peft/tuners/hra/config.py
+++ b/src/peft/tuners/hra/config.py
@@ -53,6 +53,8 @@ class HRAConfig(PeftConfig):
         layers_pattern (`Optional[Union[List[str], str]]`):
             The layer pattern name, used only if `layers_to_transform` is different from `None`. This should target the
             `nn.ModuleList` of the model, which is often called `'layers'` or `'h'`.
+        bias (`str`):
+            Bias type for HRA. Can be `'none'`, `'all'` or `'hra_only'`.
         modules_to_save (`List[str]`):
             List of modules apart from adapter layers to be set as trainable and saved in the final checkpoint.
     """

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -193,9 +193,9 @@ class BdLoraConfig:
             `pattern is in target_name`. Example: ['out_proj', 'down_proj']
         nblocks: Number of blocks in block-diagonal matrices
         match_strict:
-            If set to true, requires each target_module to have either a block-diagonal LoRA-A or LoRA-B, and raises
-            an error otherwise. You can set this to False to mix LoRA and BD-LoRA training, e.g. if some layers in
-            your module do not benefit from BD-LoRA.
+            If set to true, requires each target_module to have either a block-diagonal LoRA-A or LoRA-B, and raises an
+            error otherwise. You can set this to False to mix LoRA and BD-LoRA training, e.g. if some layers in your
+            module do not benefit from BD-LoRA.
     """
 
     target_modules_bd_a: Optional[list[str]] = field(
@@ -500,12 +500,12 @@ class LoraConfig(PeftConfig):
         qalora_group_size (`int`):
             Group size parameter for QALoRA pooling, controlling the dimension reduction factor. Input dimensions are
             pooled into groups of this size, reducing the computational cost. Higher values provide more compression
-            but may reduce model quality. This parameter determines how many original features are averaged together
-            to create one pooled feature. Only used when `use_qalora=True`.
+            but may reduce model quality. This parameter determines how many original features are averaged together to
+            create one pooled feature. Only used when `use_qalora=True`.
         monteclora_config (`Optional[MontecloraConfig]`):
             The configuration of Monteclora (Monte Carlo Low-Rank Adaptation). If passed, Monteclora will be used to
-            add variational Monte Carlo sampling on top of the LoRA adapters. See `MontecloraConfig` for details on
-            the individual hyperparameters.
+            add variational Monte Carlo sampling on top of the LoRA adapters. See `MontecloraConfig` for details on the
+            individual hyperparameters.
         layer_replication (`List[Tuple[int, int]]`):
             Build a new stack of layers by stacking the original model layers according to the ranges specified. This
             allows expanding (or shrinking) the model without duplicating the base model weights. The new layers will

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -108,13 +108,8 @@ class LoftQConfig:
     This is the sub-configuration class to store the configuration of a [`LoraModel`].
 
     Args:
-        bits_pattern (`dict`): The mapping from layer names or regexp expression to bits which are different from the
-            default bits specified by `bits`. For example, `{model.decoder.layers.0.encoder_attn.k_proj: 2`}.
-        bits (`int`): Quantization bits for LoftQ.
-        iter (`int`): Alternating iterations for LoftQ.
-        fake (`bool`): True: use fp16/fp32; used for first time to save weights. False: use bitsandbytes 4bit linear
-            models. weights can't be saved. Recommend to set to True, save the weights and load the saved weights in 4
-            bits.
+        loftq_bits (`int`): Quantization bits for LoftQ.
+        loftq_iter (`int`): Alternating iterations for LoftQ.
     """
 
     loftq_bits: int = field(default=4, metadata={"help": "Quantization bits for LoftQ"})
@@ -197,6 +192,10 @@ class BdLoraConfig:
             Modules where the LoRA-B is block-diagonal. Matches each pattern in the list against the module name via
             `pattern is in target_name`. Example: ['out_proj', 'down_proj']
         nblocks: Number of blocks in block-diagonal matrices
+        match_strict:
+            If set to true, requires each target_module to have either a block-diagonal LoRA-A or LoRA-B, and raises
+            an error otherwise. You can set this to False to mix LoRA and BD-LoRA training, e.g. if some layers in
+            your module do not benefit from BD-LoRA.
     """
 
     target_modules_bd_a: Optional[list[str]] = field(
@@ -468,6 +467,9 @@ class LoraConfig(PeftConfig):
         corda_config (`Optional[CordaConfig]`):
             The configuration of CorDA. If this is not None, then CorDA will be used to build the adapter layers. Also
             pass `init_lora_weights='corda'`.
+        lora_ga_config (`Optional[LoraGAConfig]`):
+            The configuration of LoRA-GA. If this is passed, then LoRA-GA will be used to initialize the adapter
+            layers. Also set `init_lora_weights='lora_ga'` in this case.
         use_dora (`bool`):
             Enable 'Weight-Decomposed Low-Rank Adaptation' (DoRA). This technique decomposes the updates of the weights
             into two parts, magnitude and direction. Direction is handled by normal LoRA, whereas the magnitude is
@@ -489,6 +491,21 @@ class LoraConfig(PeftConfig):
             operations. Overall adapter inference speedups of an order of magnitude or more can occur on vLLM,
             depending on the length of the shared context. Note that merging is not possible due to the selective
             application of the weights.
+        use_qalora (`bool`):
+            It is only implemented in GPTQ for now. Enable <a
+            href='https://huggingface.co/papers/2309.14717'>Quantization-Aware Low-Rank Adaptation (QALoRA)</a>. This
+            technique combines quantization-aware training with LoRA to improve performance for quantized models. This
+            can improve the performance of LoRA, especially at low ranks. Right now, QALoRA only supports linear
+            layers.
+        qalora_group_size (`int`):
+            Group size parameter for QALoRA pooling, controlling the dimension reduction factor. Input dimensions are
+            pooled into groups of this size, reducing the computational cost. Higher values provide more compression
+            but may reduce model quality. This parameter determines how many original features are averaged together
+            to create one pooled feature. Only used when `use_qalora=True`.
+        monteclora_config (`Optional[MontecloraConfig]`):
+            The configuration of Monteclora (Monte Carlo Low-Rank Adaptation). If passed, Monteclora will be used to
+            add variational Monte Carlo sampling on top of the LoRA adapters. See `MontecloraConfig` for details on
+            the individual hyperparameters.
         layer_replication (`List[Tuple[int, int]]`):
             Build a new stack of layers by stacking the original model layers according to the ranges specified. This
             allows expanding (or shrinking) the model without duplicating the base model weights. The new layers will
@@ -509,6 +526,12 @@ class LoraConfig(PeftConfig):
             `target_parameters`. As an example, for Llama4, you can pass:
             `target_parameters=['feed_forward.experts.gate_up_proj', 'feed_forward.experts.down_proj]`. Passing a
             string for regex matching is not implemented yet.
+        use_bdlora (`Optional[BdLoraConfig]`):
+            Enable BD-LoRA (Block-Diagonal LoRA) by providing a BdLoraConfig. This technique uses block-diagonal
+            matrices for LoRA-A or LoRA-B factors to enable faster multi-LoRA serving by eliminating communication
+            overheads in distributed settings.
+        arrow_config (`Optional[ArrowConfig]`):
+            The necessary config to apply arrow routing on the model.
         ensure_weight_tying (`bool`, *optional*)
             Whether to tie weights or not after peft initialization. This will ensure that the adapters added to the
             tied layers are also tied. This is only applicable for layers passed via `modules_to_save` and

--- a/src/peft/tuners/miss/config.py
+++ b/src/peft/tuners/miss/config.py
@@ -60,6 +60,8 @@ class MissConfig(PeftConfig):
             layer at this index.
         layers_pattern (`str`):
             The layer pattern name, used only if `layers_to_transform` is different from `None`.
+        bias (`str`):
+            Bias type for MiSS. Can be `'none'`, `'all'` or `'MiSS_only'`.
         modules_to_save (`List[str]`):
             List of modules apart from adapter layers to be set as trainable and saved in the final checkpoint.
     """


### PR DESCRIPTION
## What does this PR do?

Audits the tuner config classes against their actual dataclass fields and fixes both directions of drift. All wording mirrors each field's existing `help` text; field order determines docstring placement.

### Docstring documents parameters that don't exist (TypeError if followed)

- **`LoftQConfig`**: the Args section documented `bits_pattern`, `bits`, `iter` and `fake` — none of which exist; the real fields are `loftq_bits` and `loftq_iter`. A user following the docstring (`LoftQConfig(bits=2, fake=True)`) gets a `TypeError`. Rewrote the Args section to match the actual fields.

### Fields with `help` text but no docstring entry

| Config | Added entries |
|---|---|
| `LoraConfig` | `lora_ga_config`, `use_qalora`, `qalora_group_size`, `monteclora_config`, `use_bdlora`, `arrow_config` |
| `BdLoraConfig` | `match_strict` |
| `HiraConfig` | `init_weights` |
| `HRAConfig` | `bias` |
| `MissConfig` | `bias` |
| `GraloraConfig` | `modules_to_save` |

### Deliberately excluded

`OFTConfig.num_cayley_neumann_terms` and `BOFTConfig.init_weights` have the same gap, but #3300 rewrites those two docstrings as part of the doc restructure — left untouched here to avoid conflicts (cc @BenjaminBossan, same reasoning as huggingface/peft#3311 → githubnemo/peft#5).

Docstring-only; +44 / −7 across 5 files, no behavior change.