### PR TITLE
Sync function docstrings with their signatures

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1208,10 +1208,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         - `quantization_backend` (`str` or `None`):
            The name of the quantization backend, e.g. `"bnb 4bit"`, or `None` if not quantized.
 
-        Args:
-            model ([`~PeftModel`]):
-                The model to get the adapter layer status from.
-
         Returns:
             list[`peft.peft_model.TunerLayerStatus`]:
                 A list of dataclasses, each containing the status of the corresponding adapter layer.
@@ -1250,10 +1246,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         - `quantization_backend` (`str`, `None`, `Literal["irregular"]`):
            The name of the quantization backend, e.g. `"bnb 4bit"`, or `None` if not quantized. If the backend is not
            consistent across all layers, this will be `"irregular"`.
-
-        Args:
-            model ([`~PeftModel`]):
-                The model to get the adapter layer status from.
 
         Returns:
             `peft.peft_model.TunerModelStatus`:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1597,7 +1597,7 @@ class BaseTunerLayer(ABC):
         inference_mode is True.
 
         Args:
-            adapter_name (`str` or `list[str]`):
+            adapter_names (`str` or `list[str]`):
                  The name(s) of the adapter(s) to set as active.
             inference_mode (bool, optional):
                  Whether the activated adapter should be frozen (i.e. `requires_grad=False`). Default is False.


### PR DESCRIPTION
## What does this PR do?

Fixes function docstrings that drifted from their actual signatures (no functional changes).

**1. Wrong parameter name (`adapter_name` → `adapter_names`).** `set_requires_grad` (in `AuxiliaryTrainingWrapper`, `BaseTuner`, `BaseTunerLayer`, `PeftModel`, and the module-level helper) and `BaseTunerLayer.set_adapter` all take a parameter named `adapter_names` (plural), but their `Args:` sections documented `adapter_name`. Following the docs (`set_requires_grad(adapter_name=...)`) raises `TypeError`. Renamed the docstring entry to match the signature.

**2. Spurious `Args: model` on delegating methods.** `PeftModel.get_layer_status(self)` and `PeftModel.get_model_status(self)` take no `model` argument — they delegate to the module-level `get_layer_status(model)` / `get_model_status(model)` functions. Their docstrings had an `Args: model (...)` block (copied from those functions) describing a parameter the methods don't accept. Removed it from the two methods; the module-level functions (which do take `model`) keep their `Args` unchanged.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/peft/blob/main/PHILOSOPHY.md)?
- [x] This PR fixes docstrings.
