### PR TITLE
DOC Fix LoRA-GA 'Usage Tips' subsection

### DIFF
--- a/docs/source/package_reference/lora.md
+++ b/docs/source/package_reference/lora.md
@@ -218,7 +218,7 @@ def train_step():
 preprocess_loraga(model, lora_config, train_step)
 ```
 
-#### Usage Tips
+**Usage Tips**
 
 - **Gradient Estimation**: LoRA-GA requires a gradient estimation phase before model initialization. Use `preprocess_loraga()` with a `train_step` callback to compute gradients over a small number of training batches (typically 64-128 batches).
 


### PR DESCRIPTION
In the doc navigation, under "LoRA > Initialization", there is a "Usage Tips" section but clicking it doesn't work. The reason is that it's a subsection of LoRA-GA, but LoRA-GA is not open by default as the initialization options are formatted as different tabs.

My proposal is to remove the section title so that it no longer appears in the navigation.

<img width="1242" height="622" alt="image" src="https://github.com/user-attachments/assets/ff4919db-dc59-4c93-bd50-ca9f9c5f0a50" />
