### PR TITLE
FIX PEFT Shop deployment workflow error

### DIFF
--- a/.github/workflows/deploy_peft_shop_app.yml
+++ b/.github/workflows/deploy_peft_shop_app.yml
@@ -42,7 +42,7 @@ jobs:
           # data.json is generated at deploy time so that it always matches the deployed PEFT commit (see
           # method_comparison/peft-shop/README.md); the app reads method_capabilities.json from the CWD and
           # writes data.json into its own directory, where the deploy step below picks it up
-          python scripts/generate_method_capabilities.py --output method_capabilities.json
+          python scripts/generate_method_capabilities.py --output method_comparison/peft-shop/method_capabilities.json
           python method_comparison/peft-shop/app.py --rebuild --build-only
 
       - name: Ensure Space exists


### PR DESCRIPTION
For the PEFT shop, we create a file that contains the capabilities of the different PEFT methods, e.g. if it supports quantization. That file is required to run the shop. However, it was created in the wrong location and was thus missing in the deployed Space. This fix creates it in the correct location.