### PR TITLE
FIX PEFT Shop deployment workflow error 2

### DIFF
--- a/.github/workflows/deploy_peft_shop_app.yml
+++ b/.github/workflows/deploy_peft_shop_app.yml
@@ -42,7 +42,7 @@ jobs:
           # data.json is generated at deploy time so that it always matches the deployed PEFT commit (see
           # method_comparison/peft-shop/README.md); the app reads method_capabilities.json from the CWD and
           # writes data.json into its own directory, where the deploy step below picks it up
-          python scripts/generate_method_capabilities.py --output method_comparison/peft-shop/method_capabilities.json
+          python scripts/generate_method_capabilities.py --output method_capabilities.json
           python method_comparison/peft-shop/app.py --rebuild --build-only
 
       - name: Ensure Space exists
@@ -71,5 +71,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote add gradio-app https://huggingface.co/spaces/peft-internal-testing/PEFT-shop
           git add .
+          # data.json is gitignored (see .gitignore) so it doesn't get committed into the PEFT repo during local
+          # dev; force-add it here so the self-contained data file actually ships with the Space
+          git add -f data.json
           git commit -m "🚀 Deploy PEFT shop app from GH action"
           git push -f gradio-app HEAD:main


### PR DESCRIPTION
Unfortunately, the fix in #3332 was incorrect. The file was not missing because it was in the wrong location, it was missing because it is `.gitignore`-d (which we want, as it shouldn't be part of the repo). That led to the file not being pushed to the Space. Now the file is force added.