### PR TITLE
MetaMathQA: Optimized configs for IA3

### DIFF
--- a/method_comparison/MetaMathQA/experiments/ia3/llama-3.2-3B-all-attn-5k-lr0.005/adapter_config.json
+++ b/method_comparison/MetaMathQA/experiments/ia3/llama-3.2-3B-all-attn-5k-lr0.005/adapter_config.json
@@ -1,0 +1,14 @@
+{
+  "auto_mapping": null,
+  "base_model_name_or_path": null,
+  "exclude_modules": null,
+  "fan_in_fan_out": false,
+  "feedforward_modules": ["down_proj", "gate_proj", "up_proj"],
+  "inference_mode": false,
+  "init_ia3_weights": true,
+  "modules_to_save": null,
+  "peft_type": "IA3",
+  "revision": null,
+  "target_modules": ["q_proj", "k_proj", "v_proj", "o_proj", "down_proj", "gate_proj", "up_proj"],
+  "task_type": null
+}

--- a/method_comparison/MetaMathQA/experiments/ia3/llama-3.2-3B-all-attn-5k-lr0.005/training_params.json
+++ b/method_comparison/MetaMathQA/experiments/ia3/llama-3.2-3B-all-attn-5k-lr0.005/training_params.json
@@ -1,0 +1,6 @@
+{
+  "optimizer_kwargs": {
+    "lr": 5e-3,
+    "weight_decay": 0.0
+  }
+}


### PR DESCRIPTION
From the temporary results with this configuration:

```
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.005--2026-04-09T11-26-16+00-00.json:      "max_steps": 5000,
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.005--2026-04-09T11-26-16+00-00.json:    "accelerator_memory_max": 26153582592,
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.005--2026-04-09T11-26-16+00-00.json:        "test accuracy": 0.46626231993934797,
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.005--2026-04-09T11-26-16+00-00.json:        "forgetting": -0.5505256652832031
```

Full log of this experiment: https://gist.github.com/githubnemo/c9bbc7fd1a86f42409407c133ddfe2ae

Of note is that IA3 is relatively stable across learning rates:

```
 # lr 0.002
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.002--2026-04-09T10-35-21+00-00.json:      "max_steps": 5000,
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.002--2026-04-09T10-35-21+00-00.json:        "test accuracy": 0.46474601971190294,
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.002--2026-04-09T10-35-21+00-00.json:        "forgetting": -0.10045337677001953
 # lr 0.003
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.003--2026-04-09T11-02-37+00-00.json:      "max_steps": 5000,
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.003--2026-04-09T11-02-37+00-00.json:        "test accuracy": 0.46474601971190294,
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.003--2026-04-09T11-02-37+00-00.json:        "forgetting": -0.24126625061035156
 # lr 0.005
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.005--2026-04-09T11-26-16+00-00.json:      "max_steps": 5000,
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.005--2026-04-09T11-26-16+00-00.json:        "test accuracy": 0.46626231993934797,
method_comparison/MetaMathQA/temporary_results/ia3--llama-3.2-3B-all-attn-5k-lr0.005--2026-04-09T11-26-16+00-00.json:        "forgetting": -0.5505256652832031
```