### PR TITLE
CI Tests: Extend ignored paths

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,13 @@ on:
     branches: [main]
     paths-ignore:
       - 'docs/**'
+      - 'method_comparison/**'
+      - '**.md'
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'method_comparison/**'
+      - '**.md'
 
 env:
   HF_HOME: .cache/huggingface


### PR DESCRIPTION
Right now, the standard CI tests, which take quite some time to finish, run on many PRs that don't need them, e.g. when just adding a new experiment in the method comparison benchmark. This PR now adds `method_comparison` and `**.md` files to the ignored paths.

Initially, I also wanted to add `examples/` but they are currently being linted by ruff, which we want to keep. This means we could still skip the expensive `pytest` run but AFAICT, there is no simple way to tell GH actions to only run one job for `examples/` but not the other.

(Of course it's possible to achieve but I wanted to keep it simple here, so that's left for the future.)