### PR TITLE
docs: clarify subtract_mutated_init

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -243,10 +243,12 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 The path to the initialized adapter, which is obtained after initializing the model with
                 PiSSA/CorDA/OLoRA and before performing any training. When `path_initial_model_for_weight_conversion`
                 is not None, the difference in adapter before and after fine-tuning is calculated. This difference can
-                be represented as the parameters of a standard LoRA adapter. Using this converted adapter does not
-                require changes to the base model, thus conveniently allowing the use of multiple PiSSA/CorDA/OLoRA
-                adapters with LoRA adapters, and the activation or deactivation of any adapters. Note that this
-                conversion is not supported if `rslora` is used in combination with `rank_pattern` or `alpha_pattern`.
+                be represented as the parameters of a standard LoRA adapter. In contrast to PiSSA and friends, using
+                this converted adapter does not require changes to the base model, thus conveniently allowing the use
+                of multiple PiSSA/CorDA/OLoRA adapters with LoRA adapters, and the activation or deactivation of any
+                adapters. Note that this conversion is not supported if `rslora` is used in combination with
+                `rank_pattern` or `alpha_pattern`. See [`peft.tuners.lora.LoraModel.subtract_mutated_init`] for more
+                information.
             kwargs (additional keyword arguments, *optional*):
                 Additional keyword arguments passed along to the `push_to_hub` method.
 

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -907,10 +907,21 @@ class LoraModel(BaseTuner):
         return lora_deltas
 
     def subtract_mutated_init(self, output_state_dict: dict[str, torch.Tensor], adapter_name: str, kwargs=None):
-        """
-        This function can calculate the updates of the PiSSA/CorDA/OLoRA by comparing the parameters of the
+        r"""
+        This function can calculate the updates of PiSSA/CorDA/OLoRA by comparing the parameters of the
         PiSSA/CorDA/OLoRA adapter in `output_state_dict` with the initial values of PiSSA/CorDA/OLoRA in
         `adapter_name`, thus converting PiSSA/CorDA/OLoRA to LoRA.
+
+        Methods like PiSSA remove a portion of the model base weights for training and therefore are not easily
+        swapped. But if you know both the initial pre-training and the post-training weights, you can compute the
+        \Delta W and use that as a LoRA adapter.
+
+        Compute steps:
+
+        - $W = W_{res} + A_0 B_0$ (PiSSA init)
+        - $W + \Delta W = W_{res} + A B$ (PiSSA after training)
+        - $\Delta W = W_{res} + AB - W = W_{res} + AB - W_{res} - A_0 B_0$ (Deriving dW for LoRA)
+        - $\Delta W = AB - A_0 B_0$
         """
         for name, param in self.model.named_parameters():
             if (


### PR DESCRIPTION
I stumbled upon `save_pretrained`'s `path_initial_model_for_weight_conversion` keyword argument and did not understand what it does. I hope that this change helps future readers the same way it helped me.