### PR TITLE
Fix lora_only bias serialization

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -181,6 +181,10 @@ def get_peft_model_state_dict(
                     bias_name = k.split("lora_")[0] + "bias"
                     if bias_name in state_dict:
                         to_return[bias_name] = state_dict[bias_name]
+                    else:
+                        bias_name = k.split("lora_")[0] + "base_layer.bias"
+                        if bias_name in state_dict:
+                            to_return[bias_name] = state_dict[bias_name]
         else:
             raise NotImplementedError
         to_return = {k: v for k, v in to_return.items() if (("lora_" in k) or ("bias" in k))}


### PR DESCRIPTION
I noticed a bug when using `LoraConfig(bias="lora_only")`. Even though the base layer's bias is correctly marked as trainable during training, it gets dropped when calling `get_peft_model_state_dict()` or `save_pretrained()`.

This happens because the bias parameter of the wrapped layer is named `{prefix}.{module_name}.base_layer.bias` in the state dict. However, the serialization code in `get_peft_model_state_dict()` splits the LoRA weight key on `"lora_"` and appends `"bias"`, looking for `{prefix}.{module_name}.bias`. Since it doesn't find this key, it skips the bias completely.

This PR adds a fallback check for `{prefix}.{module_name}.base_layer.bias` in the `bias == "lora_only"` logic so that these trained biases are saved correctly.

Fixes #3306
