### PR TITLE
Fix resolving regex/string target_modules in MoE config conversion

### DIFF
--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -14,6 +14,7 @@
 
 # NOTE: don't import from this module unless transformers v5+ is used
 import copy
+import itertools
 import re
 from typing import Any
 
@@ -349,13 +350,78 @@ _MOE_FUSED_TARGETS: dict[str, dict[str, set[str]]] = {
 }
 
 
-def _convert_peft_config_moe(peft_config, model_type: str) -> None:
+def _resolve_string_target_modules(peft_config, model, target_module_mapping: dict[str, str]) -> set[str]:
+    """Resolve a string ``target_modules`` (a regex or the ``"all-linear"`` shorthand) to a concrete set of leaf names.
+
+    Resolving the string up front lets the regular list-based remap downstream work unchanged. The pre-fusion expert
+    projections (e.g. ``gate_proj``, ``up_proj``) no longer exist as submodules on a Transformers v5 model -- they are
+    fused into stacked parameters such as ``gate_up_proj`` -- so they cannot be discovered via
+    ``model.named_modules()``. We therefore match against both real module/parameter keys and v4-style expert keys
+    reconstructed from each fused parameter's container.
+
+    ``"all-linear"`` is matched by module *type* rather than as a regex (see ``_maybe_include_all_linear_layers``). On
+    the original v4 architecture the experts were ``nn.Linear``, so ``"all-linear"`` targeted them; we preserve that by
+    also adding any old projection name whose fused container is present on the model.
+    """
+    from peft.tuners.tuners_utils import _maybe_include_all_linear_layers, check_target_module_exists
+    from peft.utils.constants import INCLUDE_LINEAR_LAYERS_SHORTHAND
+
+    module_keys = [name for name, _ in model.named_modules()]
+    param_keys = [name for name, _ in model.named_parameters()]
+    # new (fused) name -> container paths, used to reconstruct the pre-fusion expert keys
+    new_name_to_containers: dict[str, set[str]] = {}
+    for name in param_keys:
+        container, _, leaf = name.rpartition(".")
+        new_name_to_containers.setdefault(leaf, set()).add(container)
+
+    is_all_linear = peft_config.target_modules.lower() == INCLUDE_LINEAR_LAYERS_SHORTHAND
+    if is_all_linear:
+        # resolve the shorthand to the concrete linear module names (matched by type), then keep only the leaf names
+        resolved = _maybe_include_all_linear_layers(copy.copy(peft_config), model).target_modules
+        matched: set[str] = {name.rsplit(".", 1)[-1] for name in resolved}
+    else:
+        # regex: every real module/parameter whose key matches the pattern (covers the attention projections that stay
+        # in `target_modules` as well as the router `gate` and the `down_proj` parameter, which keep their v5 names)
+        matched = {
+            key.rsplit(".", 1)[-1]
+            for key in itertools.chain(module_keys, param_keys)
+            if check_target_module_exists(peft_config, key)
+        }
+
+    # the pre-fusion expert projections (e.g. `gate_proj`, `up_proj`) were fused and renamed, so they are absent from
+    # the v5 model. Recover them from each fused parameter's container: for "all-linear", a present container means the
+    # projection was an `nn.Linear` in v4 and would have been targeted; for a regex, probe the reconstructed v4 keys.
+    for old_name, new_name in target_module_mapping.items():
+        if old_name in matched:
+            continue
+        containers = new_name_to_containers.get(new_name, ())
+        if not containers:
+            continue
+        if is_all_linear:
+            matched.add(old_name)
+            continue
+        # a representative expert index (0/1) is enough for the regexes seen in practice
+        for container in containers:
+            candidates = (f"{container}.{old_name}", f"{container}.0.{old_name}", f"{container}.1.{old_name}")
+            if any(check_target_module_exists(peft_config, candidate) for candidate in candidates):
+                matched.add(old_name)
+                break
+    return matched
+
+
+def _convert_peft_config_moe(peft_config, model) -> None:
     """
     In-place convert the PEFT config of MoE models whose architecture changed from transformers v4 to v5.
 
     Since the model architecture changed, the targets have to updated accordingly. Moreover, when weights are fused, it
     requires updating the rank and alpha values of those parameters.
+
+    ``target_modules`` may be a list/set of names, the special string ``"all-linear"``, or a regex string (e.g. a
+    pattern produced by an upstream framework like ms-swift). A string is resolved against the model up front (see
+    ``_resolve_string_target_modules``) into the concrete projection names it targets, so the regular list-based remap
+    below applies to all input shapes alike.
     """
+    model_type = getattr(getattr(model, "config", None), "model_type", None)
     base_model_type = _MODEL_TO_CONVERSION_PATTERN.get(model_type, None)
     if base_model_type is None:
         return
@@ -368,12 +434,23 @@ def _convert_peft_config_moe(peft_config, model_type: str) -> None:
     if not fused_targets:
         return
 
-    peft_config.target_parameters = set(peft_config.target_parameters or [])
-    peft_config.target_modules = set(peft_config.target_modules or [])
+    # A string `target_modules` (a regex or the "all-linear" shorthand) is resolved against the model into the concrete
+    # projection names it targets. The pre-fusion expert projections don't exist as submodules on a v5 model, so they
+    # can't be recovered by iterating the string -- they are matched against the (reconstructed) model keys instead.
+    if isinstance(peft_config.target_modules, str):
+        resolved = _resolve_string_target_modules(peft_config, model, target_module_mapping)
+        if not resolved:
+            # The string matches nothing on the model (e.g. an invalid bare name like "q_proj", which is a regex here).
+            # Leave it untouched so the regular injection path raises its usual error instead of remapping anything.
+            return
+        peft_config.target_modules = resolved
+
     if not hasattr(peft_config, "rank_pattern") or peft_config.rank_pattern is None:
         peft_config.rank_pattern = {}
     if not hasattr(peft_config, "alpha_pattern") or peft_config.alpha_pattern is None:
         peft_config.alpha_pattern = {}
+    peft_config.target_parameters = set(peft_config.target_parameters or [])
+    peft_config.target_modules = set(peft_config.target_modules or [])
 
     new_target_parameters = peft_config.target_parameters.copy()
     remaining_target_modules = set()
@@ -441,7 +518,7 @@ def convert_peft_config_for_transformers(peft_config, model: torch.nn.Module, co
 
     model_type = getattr(model.config, "model_type", None)
     if get_checkpoint_conversion_mapping(model_type) is not None:
-        _convert_peft_config_moe(peft_config, model_type)
+        _convert_peft_config_moe(peft_config, model)
 
 
 def _convert_to_peft_serialized_keys(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,7 +64,7 @@ from peft import (
 )
 
 
-class TestingCommitHashError(Exception):
+class CommitHashTestingError(Exception):
     pass
 
 
@@ -601,7 +601,7 @@ class TestPeftConfig:
         monkeypatch.setattr(config, "__version__", version)
 
         def fake_commit_hash_raises(pkg_name):
-            raise TestingCommitHashError("Error for testing purpose")
+            raise CommitHashTestingError("Error for testing purpose")
 
         monkeypatch.setattr(config, "_get_commit_hash", fake_commit_hash_raises)
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -391,3 +391,149 @@ class TestTransformersV5:
             # target up_proj and gate_proj
             config = LoraConfig(target_modules=["gate_proj", "up_proj", "down_proj", "score"])
             get_peft_model(model, config)  # does not raise
+
+    @pytest.mark.parametrize(
+        "regex",
+        [
+            # The shape ms-swift's `get_multimodal_target_regex` helper produces (anchored, lookahead on the prefix);
+            # see https://github.com/huggingface/peft/issues/3229 and https://github.com/modelscope/ms-swift/issues/9321.
+            r"^(model(?=\.).*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj))$",
+            # A plain "ends with one of these projections" pattern.
+            r".*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj)",
+        ],
+    )
+    def test_qwen3_moe_regex_target_modules_works(self, regex):
+        # Regression test for https://github.com/huggingface/peft/issues/3229. The MoE config conversion did
+        # `set(peft_config.target_modules)`, which for a regex `target_modules` splits the string into its characters
+        # (`{'^', '(', 'q', '_', ...}`) and fails downstream with "Target modules ... not found in the base model".
+        # The fused expert projections (`gate_proj`/`up_proj`) don't exist as submodules on a v5 model, so a string
+        # `target_modules` is resolved against the model into concrete projection names before the usual remap runs:
+        # the fused experts move to `target_parameters` and the attention projections stay in `target_modules`.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            peft_model = get_peft_model(model, LoraConfig(target_modules=regex))  # does not raise
+
+        config = peft_model.peft_config["default"]
+        # the regex is resolved to the concrete non-fused targets (q/k/v_proj)
+        assert config.target_modules == {"q_proj", "k_proj", "v_proj"}
+        # the fused experts are moved to target_parameters, with the rank/alpha doubled for the 2-way `gate_up_proj`
+        assert {"gate_up_proj", "down_proj"} <= set(config.target_parameters)
+        assert config.rank_pattern == {r".*\.gate_up_proj": config.r * 2}
+        assert config.alpha_pattern == {r".*\.gate_up_proj": config.lora_alpha * 2}
+        # the experts are actually adapted, not just recorded in the config
+        assert any("experts" in name for name, _ in peft_model.named_modules() if name.endswith("lora_A.default"))
+
+    def test_qwen3_moe_single_attention_regex_target_modules_works(self):
+        # A string `target_modules` that resolves to a single attention projection (no experts) must convert cleanly:
+        # the conversion resolves the string against the model rather than splitting it into characters.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            peft_model = get_peft_model(model, LoraConfig(target_modules=r".*\.q_proj"))  # does not raise
+
+        config = peft_model.peft_config["default"]
+        assert config.target_modules == {"q_proj"}
+        # a bare attention projection touches no experts, so nothing is moved to target_parameters
+        assert not config.target_parameters
+        assert not config.rank_pattern
+        adapted = {
+            name.rsplit(".lora_A", 1)[0].rsplit(".", 1)[-1]
+            for name, _ in peft_model.named_modules()
+            if name.endswith("lora_A.default")
+        }
+        assert adapted == {"q_proj"}
+
+    def test_qwen3_moe_unresolvable_string_target_modules_raises_standard_error(self):
+        # A string `target_modules` is matched as a regex (`re.fullmatch`), so a bare leaf name like "q_proj" matches
+        # nothing and is invalid on *any* model -- the MoE conversion must not turn this into a different/confusing
+        # error (previously `set("q_proj")` split it into characters). The standard "not found" error is expected.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+
+            with pytest.raises(ValueError, match="Target modules q_proj not found in the base model"):
+                get_peft_model(model, LoraConfig(target_modules="q_proj"))
+
+    def test_qwen3_moe_regex_partial_fusion_raises(self):
+        # A regex that targets `up_proj` but not `gate_proj` cannot be converted, because the two are fused into
+        # `gate_up_proj` -- same contract as the list path in `test_qwen3_moe_error_message`.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            msg = re.escape(
+                "Cannot convert PEFT target(s) up_proj without also targeting gate_proj because they are fused into "
+                "gate_up_proj."
+            )
+            with pytest.raises(ValueError, match=msg):
+                get_peft_model(model, LoraConfig(target_modules=r".*\.(up_proj|down_proj)"))
+
+    def test_qwen3_moe_regex_attention_only_no_moe_conversion(self):
+        # A regex that only matches attention projections must not trigger any MoE remap (no fused parameters added).
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            peft_model = get_peft_model(model, LoraConfig(target_modules=r".*\.(q_proj|v_proj)"))
+
+        config = peft_model.peft_config["default"]
+        assert not config.target_parameters
+        assert not config.rank_pattern
+
+    def test_qwen3_moe_all_linear_target_modules_works(self):
+        # `"all-linear"` is a special shorthand matched by module *type*, not a regex (previously `set("all-linear")`
+        # corrupted it into a set of characters and injection failed). On the original v4 architecture the experts were
+        # `nn.Linear`, so `"all-linear"` targeted them; on the converted v5 model they are fused `nn.Parameter`s. To
+        # preserve that intent across the conversion, `"all-linear"` must still pull the experts into
+        # `target_parameters` -- in addition to resolving the attention projections.
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            peft_model = get_peft_model(model, LoraConfig(target_modules="all-linear"))  # does not raise
+
+        config = peft_model.peft_config["default"]
+        adapted = {
+            name.rsplit(".lora_A", 1)[0].rsplit(".", 1)[-1]
+            for name, _ in peft_model.named_modules()
+            if name.endswith("lora_A.default")
+        }
+        # resolved to the actual linear modules (attention projections)
+        assert {"q_proj", "k_proj", "v_proj", "o_proj"} <= adapted
+        # the experts (linear in v4) are carried over to target_parameters with the rank/alpha doubled for `gate_up_proj`
+        assert {"gate_up_proj", "down_proj"} <= set(config.target_parameters)
+        assert config.rank_pattern == {r".*\.gate_up_proj": config.r * 2}
+        assert config.alpha_pattern == {r".*\.gate_up_proj": config.lora_alpha * 2}
+        assert any("experts" in name for name, _ in peft_model.named_modules() if name.endswith("lora_A.default"))
+
+    def test_qwen3_moe_regex_target_modules_save_load_roundtrip(self, tmp_path):
+        # Full lifecycle for a regex `target_modules` on a v5 MoE model: create the adapter, save it, and load it back.
+        # Reloading runs the config conversion a second time (now on the already-converted config), so this also guards
+        # against the conversion not being idempotent.
+        inputs = torch.arange(10).view(1, -1).to(self.torch_device)
+        model_id = "trl-internal-testing/tiny-Qwen3MoeForCausalLM"
+        regex = r"^(model(?=\.).*\.(q_proj|k_proj|v_proj|gate_proj|up_proj|down_proj))$"
+
+        with hub_online_once(model_id):
+            model = AutoModelForCausalLM.from_pretrained(model_id).to(self.torch_device)
+            peft_model = get_peft_model(model, LoraConfig(target_modules=regex))
+            # perturb the (zero-initialized) LoRA B weights so the adapter actually changes the output
+            with torch.no_grad():
+                for name, param in peft_model.named_parameters():
+                    if "lora_B" in name:
+                        param.add_(0.02)
+
+            with torch.inference_mode():
+                logits_before = peft_model(inputs).logits
+            peft_model.save_pretrained(tmp_path)
+            del model, peft_model
+
+            model = AutoModelForCausalLM.from_pretrained(model_id).to(self.torch_device)
+            reloaded = PeftModel.from_pretrained(model, tmp_path)
+            with torch.inference_mode():
+                logits_after = reloaded(inputs).logits
+
+        assert torch.allclose(logits_before, logits_after, atol=1e-5, rtol=1e-5)
+        # the second conversion (on load) is idempotent: the regex was already resolved to concrete names on save
+        reloaded_config = reloaded.peft_config["default"]
+        assert reloaded_config.target_modules == {"q_proj", "k_proj", "v_proj"}
+        assert {"gate_up_proj", "down_proj"} <= set(reloaded_config.target_parameters)
+        assert reloaded_config.rank_pattern == {r".*\.gate_up_proj": reloaded_config.r * 2}


### PR DESCRIPTION
Fix resolving regex/string target_modules in MoE config conversion

Hey,

I ran into this issue while trying to use a regex pattern (like the ones produced by ms-swift) for `target_modules` on a Mixtral / Qwen-Moe type model in PEFT.

Currently, `_convert_peft_config_moe` tries to convert `target_modules` to a set, which ends up splitting the regex string (or `"all-linear"`) into a set of characters. This causes downstream module matching to completely fail with a module not found error.

This PR fixes this by resolving the string `target_modules` against the model's named modules and parameters up front, so that the regular list-based conversion logic runs correctly. I've also added integration tests covering various cases (regex, attention-only, all-linear, save/load idempotency).

Also, I noticed a pytest collection warning on `TestingCommitHashError` during my local testing due to class naming, so I renamed it to `CommitHashTestingError` to clean that up.

Let me know if this looks good! Closes #3229.
