### PR TITLE
CI Skip EETQ test if kernel not found

### DIFF
--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4246,9 +4246,12 @@ class PeftEetqGPUTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             quantization_config = EetqConfig("int8")
 
-            model = AutoModelForCausalLM.from_pretrained(
-                self.causal_lm_model_id, device_map="auto", quantization_config=quantization_config
-            )
+            try:
+                model = AutoModelForCausalLM.from_pretrained(
+                    self.causal_lm_model_id, device_map="auto", quantization_config=quantization_config
+                )
+            except FileNotFoundError:
+                pytest.skip("There is no kernel for EETQ on this architecture, skipping this test.")
 
             model = prepare_model_for_kbit_training(model)
 


### PR DESCRIPTION
EETQ now uses kernels from the HF kernel hub. However, for the CUDA version used in the Docker image, [there is no corresponding kernel](https://huggingface.co/kernels-community/quantization-eetq/tree/main/build) at this time (we use CUDA 13), in which case a `FileNotFoundError` is raised. We now intercept that error and skip the test.