### PR TITLE
FIX Upcast bf16 adapters to fp32 on CPU in MultiheadAttention and VBLoRA delta weight

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2069,9 +2069,9 @@ class MultiheadAttention(nn.Module, LoraLayer):
         dtype = self.lora_B[adapter].weight.dtype
 
         # In case users wants to merge the adapter weights that are in
-        # float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
-        # float16 because the `@` and matmul operation in general is not supported in torch + cpu + fp16.
-        cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
+        # (b)float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
+        # (b)float16 because some CPUs have slow bf16/fp16 matmuls.
+        cast_to_fp32 = device.type == "cpu" and (dtype == torch.float16 or dtype == torch.bfloat16)
 
         weight_A = self.lora_A[adapter].weight
         weight_B = self.lora_B[adapter].weight

--- a/src/peft/tuners/vblora/layer.py
+++ b/src/peft/tuners/vblora/layer.py
@@ -222,7 +222,10 @@ class Linear(nn.Linear, VBLoRALayer):
         """
         device = self.vblora_logits_A[adapter].device
         dtype = self.vblora_logits_A[adapter].dtype
-        cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
+        # In case users wants to merge the adapter weights that are in
+        # (b)float16 while being on CPU, we need to cast the weights to float32, perform the merge and then cast back to
+        # (b)float16 because some CPUs have slow bf16/fp16 matmuls.
+        cast_to_fp32 = device.type == "cpu" and (dtype == torch.float16 or dtype == torch.bfloat16)
         A, B = self._get_lora_matrices(adapter, cast_to_fp32)
         output_tensor = transpose(B @ A, self.fan_in_fan_out)
         return output_tensor


### PR DESCRIPTION
## What does this PR do?

`MultiheadAttention.get_delta_weight` (LoRA, `lora/layer.py`) and `VBLoRA`'s `Linear.get_delta_weight` (`vblora/layer.py`) only upcast **fp16** adapters to fp32 before the CPU matmul:

```python
cast_to_fp32 = device.type == "cpu" and dtype == torch.float16
```

Every other tuner layer's `get_delta_weight` upcasts **both** fp16 and bf16. For example, the canonical `lora.Linear` (`lora/layer.py`):

```python
# ... because some CPUs have slow bf16/fp16 matmuls.
cast_to_fp32 = device.type == "cpu" and (dtype == torch.float16 or dtype == torch.bfloat16)
```

So merging a **bf16** adapter on CPU (e.g. `merge_and_unload()` after bf16 training, before moving weights to GPU) computes the delta `weight_B @ weight_A` in bf16 for these two layer types, while ~25 other layer types upcast to fp32 first. The `MultiheadAttention` comment is also stale ("not supported in torch + cpu + fp16"), predating the bf16 handling that was later added to the other layers.

This PR aligns both outliers with the canonical guard and refreshes the `MultiheadAttention` comment to the canonical wording.

### How it was verified

- Confirmed these are the only two `cast_to_fp32` sites still using the fp16-only form; the other ~25 sites already include `bfloat16`.
- Empirical (CPU, tiny model): for a bf16 VBLoRA adapter, the pre-fix code computes the delta via a bf16 matmul (`cast_to_fp32 == False`); with the fix it computes in fp32, matching the fp32 reference (the bf16 matmul differed from the fp32 result by ~0.6% relative on the test tensor).
- Functional merge round-trip on CPU with bf16 adapters passes for both VBLoRA and LoRA-`MultiheadAttention`: the merged-weight forward matches the unmerged adapter forward.
- `ruff check` and `ruff format --check` pass on both changed files.

No prior issue; this is a small, self-contained correctness/consistency fix (no behavior change outside the bf16-on-CPU `get_delta_weight` path). Happy to open a tracking issue if preferred.

### AI assistance

AI assistance was used to prepare this change. I reviewed every changed line, verified the behavior empirically as described above, and take responsibility for the patch.
