### PR TITLE
FIX Mixed: honor bias='<prefix>_only' for all compatible tuners (not just lora_only)

### DIFF
--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -164,8 +164,7 @@ class MixedModel(BaseTuner):
                 for n, p in model.named_parameters():
                     if "bias" in n:
                         p.requires_grad = True
-            elif bias == "lora_only":
-                # TODO: check if this is needed for other supported types
+            elif bias.endswith("_only"):  # e.g. "lora_only" or "oft_only"
                 for m in model.modules():
                     if isinstance(m, Layers) and hasattr(m, "bias") and m.bias is not None:
                         m.bias.requires_grad = True

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -31,6 +31,7 @@ from peft import (
     LoHaConfig,
     LoKrConfig,
     LoraConfig,
+    OFTConfig,
     PeftMixedModel,
     PrefixTuningConfig,
     get_peft_model,
@@ -691,6 +692,17 @@ class TestMixedAdapterTypes(unittest.TestCase):
         # remove 2 params because we need to exclude "ranknum" for AdaLora trainable params
         assert trainable_params2 == (((params_lora + params_loha) + params_adalora) - 2)
         assert all_param2 == (((params_base + params_lora) + params_loha) + params_adalora)
+
+    def test_bias_only_honored_for_non_lora_tuner(self):
+        # `bias="<prefix>_only"` should be honored for any mixed-compatible tuner, not just LoRA. Previously the
+        # mixed model hardcoded `bias == "lora_only"` and raised `ValueError: Requested bias: oft_only, is not
+        # implemented.` for e.g. OFT, even though standalone OFT supports `bias="oft_only"`.
+        model = SimpleNet().eval().to(self.torch_device)
+        config = OFTConfig(target_modules=["lin1"], oft_block_size=8, bias="oft_only")
+        peft_model = get_peft_model(model, config, "adapter0", mixed=True)
+
+        trainable_biases = [n for n, p in peft_model.named_parameters() if n.endswith("bias") and p.requires_grad]
+        assert trainable_biases, "expected at least one trainable bias with bias='oft_only'"
 
     def test_incompatible_config_raises(self):
         model = SimpleNet().eval().to(self.torch_device)


### PR DESCRIPTION
## What does this PR do?

`PeftMixedModel`'s `_mark_only_adapters_as_trainable` hardcodes `bias == "lora_only"`:

```python
elif bias == "lora_only":
    ...
else:
    raise ValueError(f"Requested bias: {bias}, is not implemented.")
```

But `MixedModel.COMPATIBLE_TUNER_TYPES` includes OFT, and `OFTConfig` accepts `bias="oft_only"` (a valid `Literal["none", "all", "oft_only"]`). So a mixed model with an OFT adapter and `bias="oft_only"` raises `ValueError: Requested bias: oft_only, is not implemented.`, even though the identical config trains fine in a standalone OFT model.

The body of that branch is already generic — it marks the bias of every compatible `Layers` instance trainable, not just LoRA — so only the guard was too narrow. This aligns it with `BaseTuner._mark_only_adapters_as_trainable`, which uses `bias.endswith("_only")` (and removes the now-resolved `# TODO: check if this is needed for other supported types`).

### How it was verified

- Repro (CPU): a `SimpleNet` mixed model with `OFTConfig(target_modules=["lin1"], oft_block_size=8, bias="oft_only")` raises the `ValueError` on `main` and trains its bias after the fix; standalone OFT with the same config already works.
- Added `test_bias_only_honored_for_non_lora_tuner` — it fails on `main` with the `ValueError` above and passes with this change.
- `tests/test_mixed.py` passes (33 passed); `ruff check` / `ruff format --check` clean.

### AI assistance

AI assistance was used to prepare this change. I reviewed every changed line, verified the behavior as described above, and take responsibility for the patch.
