### PR TITLE
FIX AdaMSS: register adamss_newB in other_param_names (delete_adapter leak)

### DIFF
--- a/src/peft/tuners/adamss/layer.py
+++ b/src/peft/tuners/adamss/layer.py
@@ -35,11 +35,13 @@ class AdamssLayer(BaseTunerLayer):
 
     # All names of layers that may contain adapter weights (trainable or frozen)
     # Use ModuleDict for proper state_dict key format that PEFT's save/load can handle
-    # Only include trainable parameter containers here (not buffers)
-    # adamss_newB is a buffer (frozen), not a trainable parameter
+    # adapter_layer_names holds the trainable parameter containers (not buffers)
     adapter_layer_names = ("adamss_A", "adamss_B")
-    # other_param_names specifies additional non-tensor metadata
+    # other_param_names holds the remaining per-adapter state, so the generic tuner machinery
+    # (delete_adapter, per-adapter device moves, ...) handles it. adamss_newB is a frozen
+    # per-adapter buffer (BufferDict), so it belongs here -- like vera_A/vera_B in VeRA.
     other_param_names = (
+        "adamss_newB",
         "num_subspaces",
         "train_subspace_index",
         "seg_result",

--- a/tests/test_adamss_asa.py
+++ b/tests/test_adamss_asa.py
@@ -64,6 +64,23 @@ def _get_adamss_layers(model):
     return [m for m in model.modules() if isinstance(m, AdamssLayer)]
 
 
+def test_delete_adapter_removes_newB_buffer():
+    # adamss_newB is a frozen per-adapter BufferDict, so it must be registered in other_param_names for the
+    # generic delete_adapter() to remove it (like vera_A / vera_B in VeRA). Otherwise the deleted adapter's
+    # projection buffer leaks.
+    cfg = {"target_modules": ["lin0", "lin1"], "r": 8, "num_subspaces": 4, "subspace_rank": 1, "init_weights": None}
+    model = get_peft_model(SimpleMLP(), AdamssConfig(**cfg), adapter_name="a1")
+    model.add_adapter("a2", AdamssConfig(**cfg))
+    model.delete_adapter("a1")
+
+    layers = _get_adamss_layers(model)
+    assert layers
+    for layer in layers:
+        assert "a1" not in layer.adamss_newB  # the deleted adapter's frozen buffer is gone
+        assert "a1" not in layer.adamss_A  # sanity: trainable params are cleaned too
+        assert "a2" in layer.adamss_newB  # the remaining adapter is untouched
+
+
 class TestAdamssAsa:
     # -- update_importance --------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

`AdamssLayer.adamss_newB` is a per-adapter frozen projection buffer (`BufferDict(persistent=True)`), but it is listed in **neither** `adapter_layer_names` **nor** `other_param_names`. The generic `BaseTunerLayer` machinery iterates `adapter_layer_names + other_param_names`, so it never touches `adamss_newB`:

- `delete_adapter(name)` removes `name` from `adamss_A` / `adamss_B` but leaves it in `adamss_newB` — the deleted adapter's projection buffer leaks.
- per-adapter device moves (`_move_adapter_to_device_of_base_layer`) skip it. (In the common `get_peft_model(...).to(device)` flow `nn.Module.to()` still moves the registered submodule, so that only bites exotic multi-device-base setups; the delete leak is the concrete issue.)

Frozen per-adapter buffers belong in `other_param_names` — this is exactly what VeRA does with its `vera_A` / `vera_B` `BufferDict`s. The existing comment shows the author correctly kept `adamss_newB` out of `adapter_layer_names` (it isn't trainable) but missed that it still needs registering in `other_param_names`.

### How it was verified

- Repro: with two AdaMSS adapters, `delete_adapter("a1")` leaves `"a1"` in every layer's `adamss_newB` on `main` (while `adamss_A` is correctly cleaned); with the fix it's removed.
- Added `test_delete_adapter_removes_newB_buffer` — it fails on `main` and passes with the fix.
- `delete_adapter` still works with no crash (the `adamss_` prefix means the module-level delete already filters these keys), and forward / `merge_and_unload` are unaffected. `tests/test_adamss_asa.py` passes (9 passed); `ruff check` / `ruff format --check` clean.

### AI assistance

AI assistance was used to prepare this change. I reviewed every changed line, verified the behavior as described above, and take responsibility for the patch.
