### PR TITLE
FIX Save trained bias for bias="lora_only"/"boft_only"

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -178,9 +178,14 @@ def get_peft_model_state_dict(
             for k in state_dict:
                 if "lora_" in k:
                     to_return[k] = state_dict[k]
-                    bias_name = k.split("lora_")[0] + "bias"
-                    if bias_name in state_dict:
-                        to_return[bias_name] = state_dict[bias_name]
+                    # The trained bias lives on the wrapped base layer (e.g. `...base_layer.bias`),
+                    # not next to the adapter. Older code reconstructed `...bias`, which never
+                    # matched and silently dropped the bias on save (#3306). Keep the unwrapped
+                    # name as a fallback for any layer without a `base_layer`.
+                    module_prefix = k.split("lora_")[0]
+                    for bias_name in (module_prefix + "base_layer.bias", module_prefix + "bias"):
+                        if bias_name in state_dict:
+                            to_return[bias_name] = state_dict[bias_name]
         else:
             raise NotImplementedError
         to_return = {k: v for k, v in to_return.items() if (("lora_" in k) or ("bias" in k))}
@@ -215,9 +220,11 @@ def get_peft_model_state_dict(
             for k in state_dict:
                 if "boft_" in k:
                     to_return[k] = state_dict[k]
-                    bias_name = k.split("boft_")[0] + "bias"
-                    if bias_name in state_dict:
-                        to_return[bias_name] = state_dict[bias_name]
+                    # Same as the LoRA branch above: the trained bias lives on the wrapped base layer.
+                    module_prefix = k.split("boft_")[0]
+                    for bias_name in (module_prefix + "base_layer.bias", module_prefix + "bias"):
+                        if bias_name in state_dict:
+                            to_return[bias_name] = state_dict[bias_name]
         else:
             raise NotImplementedError
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2988,6 +2988,44 @@ class TestPeftCustomModel(PeftCommonTester):
             # This is bad, there was a warning about the bias when there should not have been any.
             self.fail("There should be no warning when bias is set to 'none'")
 
+    def test_bias_only_saves_trained_bias(self, tmp_path):
+        # Regression test for https://github.com/huggingface/peft/issues/3306: with bias="lora_only", the trained bias
+        # of the wrapped base layer must be included in the saved adapter, otherwise reloading silently loses it and the
+        # reloaded model produces different outputs.
+        # 1. build model + wrap with bias="lora_only"
+        torch.manual_seed(0)
+        model = MLP(bias=True).to(self.torch_device)
+        config = LoraConfig(target_modules=["lin0", "lin1"], bias="lora_only")
+        model = get_peft_model(model, config)
+
+        # 2. perturb only the bias so it differs from a fresh init (the only variable in the round trip)
+        with torch.no_grad():
+            for name, param in model.named_parameters():
+                if param.requires_grad and "bias" in name:
+                    param += torch.randn_like(param) * 0.1
+
+        # 3. capture the reference output
+        model.eval()
+
+        x = torch.randn(3, 10).to(self.torch_device)
+        with torch.no_grad():
+            out_before = model(x)
+
+        # 4. round trip: save, then load into a FRESH base model
+        model.save_pretrained(tmp_path)
+        torch.manual_seed(0)  # <- same seed: fresh base starts identical
+        reloaded = PeftModel.from_pretrained(MLP(bias=True).to(self.torch_device), tmp_path)
+        reloaded.eval()
+
+        # 5. assertions
+        with torch.no_grad():
+            out_after = reloaded(x)
+
+        saved = safe_load_file(tmp_path / "adapter_model.safetensors")
+
+        assert torch.allclose(out_after, out_before, atol=1e-6)
+        assert any("bias" in key for key in saved)  # the bias survived the save
+
     @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
     def test_active_adapter(self, test_name, model_id, config_cls, config_kwargs):
         _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs)


### PR DESCRIPTION
Fixes #3306

### Problem
With `bias="lora_only"` (and the BOFT `bias="boft_only"` equivalent), the wrapped base layer's bias is marked trainable, but `get_peft_model_state_dict` reconstructed the bias key as `"<module>.bias"`. Since PEFT wraps the original module under `base_layer`, the trained bias actually lives at `"<module>.base_layer.bias"`, so it was silently dropped on save — a reloaded adapter produced different outputs than the trained model.

### Fix
Reconstruct the `"...base_layer.bias"` key, keeping the unwrapped name as a fallback for any layer not wrapped in a `base_layer`. Applied to both the `lora_only` and `boft_only` branches.

### Test
Added `test_bias_only_saves_trained_bias` in `tests/test_custom_models.py`: it perturbs only the bias, round-trips through `save_pretrained`/`from_pretrained`, and asserts the reloaded output matches and the bias is present in the saved file. The test fails on `main` and passes with this fix.