### PR TITLE
CI Pin kernels version

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -53,7 +53,7 @@ RUN \
     # Add eetq for quantization testing; needs to run without build isolation since the setup
     # script directly imports torch from the environment which would fail with isolation.
     # Ninja should speed up build time.
-    conda run -n peft pip install ninja kernels && conda run -n peft pip install --no-build-isolation git+https://github.com/NetEase-FuXi/EETQ.git
+    conda run -n peft pip install ninja && conda run -n peft pip install --no-build-isolation git+https://github.com/NetEase-FuXi/EETQ.git
 
 # TODO: Importing TE results in: undefined symbol: cublasLtGroupedMatrixLayoutInit_internal, version libcublasLt.so.13
 # Reinstate TE when the issue is resolved (probably this one: https://github.com/NVIDIA/TransformerEngine/issues/2504)
@@ -75,7 +75,8 @@ RUN conda run -n peft pip install -U --no-cache-dir \
         aqlm[gpu]>=1.0.2 \
         # Add HQQ for quantization testing
         hqq \
-        deepspeed
+        deepspeed \
+        "kernels<0.16"
 
 RUN conda run -n peft pip freeze | grep transformers
 


### PR DESCRIPTION
Our Dockerfile currently has no constraints on the version of kernels, resulting in installing 0.16.0. However, both EETQ and fp8 in Transformers require 0.15.2 <= version < 0.16

https://github.com/huggingface/transformers/blob/36778030cba4bccfcb15366d7ad860ca30f47417/src/transformers/utils/import_utils.py#L145C1-L145C20

This PR fixes the kernels version to <0.16, which should resolve the error in the nightly CI run.

https://github.com/huggingface/peft/actions/runs/28490551267/job/84446073432#step:6:1192

The investigation was conducted by jambot.