### PR TITLE
Add UniLoraConfig to ALL_CONFIG_CLASSES test matrix

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,7 @@ from peft import (
     TaskType,
     TinyLoraConfig,
     TrainableTokensConfig,
+    UniLoraConfig,
     VBLoRAConfig,
     VeraConfig,
     WaveFTConfig,
@@ -118,6 +119,7 @@ ALL_CONFIG_CLASSES = (
     (OFTConfig, {}),
     (PveraConfig, {}),
     (WaveFTConfig, {}),
+    (UniLoraConfig, {}),
 )
 
 


### PR DESCRIPTION
## What does this PR do?

`UniLoraConfig` (added in #3257) is missing from `ALL_CONFIG_CLASSES` in `tests/test_config.py`, so it isn't covered by the config test matrix (`to_dict` / `save_pretrained` / `from_pretrained` / `from_json_file`, copy/pickle, etc.).

This is the same kind of gap that #3365 addressed for `CPTConfig`/`RandLoraConfig` (and the four others I added there). `UniLoraConfig` landed afterwards without being registered. It's a public `PeftConfig` subclass with no mandatory init kwargs, so it's added as `(UniLoraConfig, {})`, consistent with the other entries.

I re-checked the full matrix against every public `PeftConfig`/`PromptLearningConfig` subclass — `UniLoraConfig` is the only one currently missing.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/peft/blob/main/PHILOSOPHY.md)?
