### PR TITLE
FEAT Add git dirty flag to method_comparison benchmark results

### DIFF
--- a/method_comparison/MetaMathQA/utils.py
+++ b/method_comparison/MetaMathQA/utils.py
@@ -580,7 +580,7 @@ def get_peft_branch() -> str:
     )
 
 
-def get_git_is_dirty() -> bool:
+def get_peft_worktree_is_dirty() -> bool:
     """Check if the PEFT git worktree has uncommitted changes."""
     peft_dir = os.path.dirname(peft.__file__)
     # Exit code 0 means clean, non-zero means dirty (or error, which we treat as dirty)
@@ -708,7 +708,7 @@ def log_results(
             "total_time": time_total,
             "experiment_name": experiment_name,
             "peft_branch": peft_branch,
-            "peft_is_dirty": get_git_is_dirty(),
+            "peft_worktree_is_dirty": get_peft_worktree_is_dirty(),
             "train_config": asdict(train_config),
             "peft_config": peft_config_dict,
             "error_msg": train_result.error_msg,

--- a/method_comparison/MetaMathQA/utils.py
+++ b/method_comparison/MetaMathQA/utils.py
@@ -580,6 +580,15 @@ def get_peft_branch() -> str:
     )
 
 
+def get_git_is_dirty() -> bool:
+    """Check if the PEFT git worktree has uncommitted changes."""
+    peft_dir = os.path.dirname(peft.__file__)
+    # Exit code 0 means clean, non-zero means dirty (or error, which we treat as dirty)
+    result = subprocess.run(["git", "diff", "--quiet"], cwd=peft_dir)
+    result_cached = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=peft_dir)
+    return result.returncode != 0 or result_cached.returncode != 0
+
+
 class TrainStatus(enum.Enum):
     FAILED = "failed"
     SUCCESS = "success"
@@ -699,6 +708,7 @@ def log_results(
             "total_time": time_total,
             "experiment_name": experiment_name,
             "peft_branch": peft_branch,
+            "peft_is_dirty": get_git_is_dirty(),
             "train_config": asdict(train_config),
             "peft_config": peft_config_dict,
             "error_msg": train_result.error_msg,

--- a/method_comparison/image-gen/utils.py
+++ b/method_comparison/image-gen/utils.py
@@ -412,6 +412,15 @@ def get_peft_branch() -> str:
     )
 
 
+def get_git_is_dirty() -> bool:
+    """Check if the PEFT git worktree has uncommitted changes."""
+    peft_dir = os.path.dirname(peft.__file__)
+    # Exit code 0 means clean, non-zero means dirty (or error, which we treat as dirty)
+    result = subprocess.run(["git", "diff", "--quiet"], cwd=peft_dir)
+    result_cached = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=peft_dir)
+    return result.returncode != 0 or result_cached.returncode != 0
+
+
 class TrainStatus(enum.Enum):
     FAILED = "failed"
     SUCCESS = "success"
@@ -568,6 +577,7 @@ def log_results(
             "total_time": time_total,
             "experiment_name": experiment_name,
             "peft_branch": peft_branch,
+            "peft_is_dirty": get_git_is_dirty(),
             "train_config": asdict(train_config),
             "peft_config": peft_config_dict,
             "error_msg": train_result.error_msg,

--- a/method_comparison/image-gen/utils.py
+++ b/method_comparison/image-gen/utils.py
@@ -412,7 +412,7 @@ def get_peft_branch() -> str:
     )
 
 
-def get_git_is_dirty() -> bool:
+def get_peft_worktree_is_dirty() -> bool:
     """Check if the PEFT git worktree has uncommitted changes."""
     peft_dir = os.path.dirname(peft.__file__)
     # Exit code 0 means clean, non-zero means dirty (or error, which we treat as dirty)
@@ -577,7 +577,7 @@ def log_results(
             "total_time": time_total,
             "experiment_name": experiment_name,
             "peft_branch": peft_branch,
-            "peft_is_dirty": get_git_is_dirty(),
+            "peft_worktree_is_dirty": get_peft_worktree_is_dirty(),
             "train_config": asdict(train_config),
             "peft_config": peft_config_dict,
             "error_msg": train_result.error_msg,


### PR DESCRIPTION
## Description

The result files of the MetaMathQA and image-gen benchmarks in `method_comparison/` currently record the PEFT branch name and commit hash, but not whether the git worktree was dirty (i.e. had uncommitted changes) at the time the benchmark was run.

This adds a `peft_is_dirty` boolean field to the `run_info` section of the result JSON files. This is important for reproducibility — a dirty worktree means the recorded commit hash does not fully describe the code that produced the result.

### Changes

- Added `get_git_is_dirty()` helper function to both `method_comparison/MetaMathQA/utils.py` and `method_comparison/image-gen/utils.py`. This function checks `git diff --quiet` and `git diff --cached --quiet` in the PEFT source directory, following the same pattern as the existing `get_git_hash()` and `get_peft_branch()` functions.
- Added `peft_is_dirty` field to the `run_info` dict in `log_results()` in both benchmarks.

The `text_generation_benchmark` benchmark is left untouched as it was not part of the request, but the same pattern could be applied there in a follow-up if desired.

## Issue

Closes #3384

## Tests

No unit tests are needed for this change since it only affects benchmark result logging (not the PEFT library itself). `make style` was run and passes cleanly:

```
ruff check --fix src tests examples docs scripts docker
All checks passed!
ruff format src tests examples docs scripts docker
412 files left unchanged
```

## AI assistance

This PR was created with AI assistance by the PEFT Jambot agent, directed by @BenjaminBossan. The submitting human (Benjamin) is responsible for reviewing every changed line.