### PR TITLE
Docs: Improve VeRA conceptual explanation and parameter scaling

### DIFF
--- a/docs/source/package_reference/vera.md
+++ b/docs/source/package_reference/vera.md
@@ -18,6 +18,22 @@ rendered properly in your Markdown viewer.
 
 [VeRA](https://huggingface.co/papers/2310.11454) is a parameter-efficient fine-tuning technique that is similar to LoRA but requires even fewer extra parameters while promising similar or even better performance. As such, it is particularly useful when the parameter budget is very limited, e.g. when scaling to very large models. The reduction of the count of trainable parameters is achieved by sharing the same low-rank matrices across all layers, and only training two additional vectors per layer.
 
+## How VeRA works
+
+LoRA updates a frozen base model by learning two small, low-rank matrices for each adapted layer. The rank is the
+inner dimension of these matrices, and it controls how much capacity the adapter has. Increasing the rank or adapting
+more layers increases the number of trainable LoRA parameters because each layer receives its own pair of matrices.
+
+VeRA keeps the same low-rank adaptation idea but changes which parameters are trained. Instead of learning separate
+low-rank matrices for every layer, VeRA uses one frozen, randomly initialized pair of low-rank matrices, `A` and `B`,
+that is shared across layers. Each adapted layer only learns two scaling vectors, commonly written as `d` and `b`,
+which rescale the shared matrices to produce a layer-specific update.
+
+This is why VeRA can use fewer trainable parameters than LoRA. In the simplified parameter count from the paper, LoRA
+scales with `2 * L_tuned * d_model * r`, where `L_tuned` is the number of adapted layers, `d_model` is the model
+dimension, and `r` is the rank. VeRA scales with `L_tuned * (d_model + r)` because the large low-rank matrices are
+shared and frozen, while only the smaller per-layer vectors are trained.
+
 When saving the adapter parameters, it's possible to eschew storing the low rank matrices by setting `save_projection=False` on the `VeraConfig`. In that case, these matrices will be restored based on the fixed random seed from the `projection_prng_key` argument. This cuts down on the size of the checkpoint, but we cannot guarantee reproducibility on all devices and for all future versions of PyTorch. If you want to ensure reproducibility, set `save_projection=True` (which is the default).
 
 To handle different shapes of adapted layers, VeRA initializes shared A and B matrices with the largest required size for each dimension. During the forward pass, submatrices A and B for a given layer are sliced out from these shared matrices and used as described in the paper. For example, adapting two linear layers of shapes (100, 20) and (80, 50) will create A and B matrices of shapes (rank, 50) and (100, rank) respectively. Then, to adapt a layer of shape (100, 20), submatrices A and B of shapes (rank, 20) and (100, rank) will be extracted.

--- a/docs/source/package_reference/vera.md
+++ b/docs/source/package_reference/vera.md
@@ -21,8 +21,9 @@ rendered properly in your Markdown viewer.
 ## How VeRA works
 
 LoRA updates a frozen base model by learning two small, low-rank matrices for each adapted layer. The rank is the
-inner dimension of these matrices, and it controls how much capacity the adapter has. Increasing the rank or adapting
-more layers increases the number of trainable LoRA parameters because each layer receives its own pair of matrices.
+inner dimension of these matrices, and it controls how much capacity the adapter has. In LoRA, increasing the rank or
+adapting more layers increases the number of trainable parameters quickly because each layer receives its own pair of
+matrices.
 
 VeRA keeps the same low-rank adaptation idea but changes which parameters are trained. Instead of learning separate
 low-rank matrices for every layer, VeRA uses one frozen, randomly initialized pair of low-rank matrices, `A` and `B`,

--- a/docs/source/package_reference/vera.md
+++ b/docs/source/package_reference/vera.md
@@ -21,14 +21,16 @@ rendered properly in your Markdown viewer.
 ## How VeRA works
 
 LoRA updates a frozen base model by learning two small, low-rank matrices for each adapted layer. The rank is the
-inner dimension of these matrices, and it controls how much capacity the adapter has. In LoRA, increasing the rank or
-adapting more layers increases the number of trainable parameters quickly because each layer receives its own pair of
-matrices.
+inner dimension of these matrices, and it controls how much capacity the adapter has. In LoRA, increasing `r` or
+adapting more layers increases the number of trainable parameters quickly because every adapted layer learns its own
+pair of low-rank matrices.
 
 VeRA keeps the same low-rank adaptation idea but changes which parameters are trained. Instead of learning separate
 low-rank matrices for every layer, VeRA uses one frozen, randomly initialized pair of low-rank matrices, `A` and `B`,
-that is shared across layers. Each adapted layer only learns two scaling vectors, commonly written as `d` and `b`,
-which rescale the shared matrices to produce a layer-specific update.
+that is shared across layers. Each adapted layer only learns two scaling vectors, `vera_lambda_d` and `vera_lambda_b`,
+which rescale the shared matrices to produce a layer-specific update. VeRA's trainable parameter count therefore still
+increases with `r` and with the number of adapted layers, but much more slowly than LoRA's because the large `A` and
+`B` matrices are shared and frozen instead of learned separately for each layer.
 
 This is why VeRA can use fewer trainable parameters than LoRA. In the simplified parameter count from the paper, LoRA
 scales with `2 * L_tuned * d_model * r`, where `L_tuned` is the number of adapted layers, `d_model` is the model

--- a/docs/source/package_reference/vera.md
+++ b/docs/source/package_reference/vera.md
@@ -28,9 +28,10 @@ pair of low-rank matrices.
 VeRA keeps the same low-rank adaptation idea but changes which parameters are trained. Instead of learning separate
 low-rank matrices for every layer, VeRA uses one frozen, randomly initialized pair of low-rank matrices, `A` and `B`,
 that is shared across layers. Each adapted layer only learns two scaling vectors, `vera_lambda_d` and `vera_lambda_b`,
-which rescale the shared matrices to produce a layer-specific update. VeRA's trainable parameter count therefore still
-increases with `r` and with the number of adapted layers, but much more slowly than LoRA's because the large `A` and
-`B` matrices are shared and frozen instead of learned separately for each layer.
+which rescale the shared matrices to produce a layer-specific update. Since `vera_lambda_d` has size `r`, VeRA's
+trainable parameter count still increases with `r` and with the number of adapted layers. However, it grows much more
+slowly than LoRA's because the large `A` and `B` matrices are shared and frozen instead of learned separately for each
+layer.
 
 This is why VeRA can use fewer trainable parameters than LoRA. In the simplified parameter count from the paper, LoRA
 scales with `2 * L_tuned * d_model * r`, where `L_tuned` is the number of adapted layers, `d_model` is the model


### PR DESCRIPTION
## Summary

This PR improves the VeRA documentation by adding a beginner-friendly conceptual explanation before the API reference.

It introduces:
- a short explanation of how VeRA differs from LoRA
- an overview of VeRA's parameter-scaling approach
- source-backed context from the original VeRA paper

## Motivation

The current documentation explains that VeRA is similar to LoRA and requires fewer trainable parameters, but it does not clearly explain why this is the case or what components are frozen versus trainable.

This change aims to make the documentation easier for new users to understand while preserving the existing technical content.

## Sources

- VeRA paper, Section 3.1 (method definition)
- VeRA paper, Section 3.2 and Table 1 (parameter scaling and storage comparison)