### PR TITLE
Fix inject_adapter_in_model not exposing AdaLora's update_and_allocate

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -73,6 +73,10 @@ def inject_adapter_in_model(
             This can be useful when the exact `target_modules` of the PEFT method is unknown, for instance because the
             checkpoint was created without meta data. Note that the values from the `state_dict` are not used, only the
             keys are used to determine the correct layers that should be adapted.
+
+    Note:
+        For AdaLora, the returned model will have an ``update_and_allocate`` method bound to it. This method must be
+        called after each backward pass and before ``optimizer.zero_grad()`` to dynamically reallocate rank budgets.
     """
     if peft_config.is_prompt_learning or peft_config.is_adaption_prompt:
         raise ValueError("`create_and_replace` does not support prompt learning and adaption prompt yet.")
@@ -89,4 +93,13 @@ def inject_adapter_in_model(
         model, peft_config, adapter_name=adapter_name, low_cpu_mem_usage=low_cpu_mem_usage, state_dict=state_dict
     )
 
-    return peft_model.model
+    returned_model = peft_model.model
+
+    # Some tuner types expose training-time methods that are only present on the tuner wrapper, not on the inner
+    # model. Bind those methods onto the returned model so callers do not need to hold a separate reference to the
+    # tuner. For example, AdaLoraModel.update_and_allocate must be called after each backward pass to dynamically
+    # reallocate rank budgets; without this binding the method is unreachable after inject_adapter_in_model returns.
+    if hasattr(peft_model, "update_and_allocate"):
+        returned_model.update_and_allocate = peft_model.update_and_allocate
+
+    return returned_model

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -121,6 +121,32 @@ class TestLowLevelFunctional:
         assert hasattr(model.linear2, "weight")
         assert hasattr(model.linear2, "bias")
 
+    def test_adalora_update_and_allocate_after_inject(self):
+        # Regression test for https://github.com/huggingface/peft/issues/3373.
+        # After inject_adapter_in_model, AdaLora's update_and_allocate must be callable on the returned model.
+        model = DummyModel()
+
+        adalora_config = AdaLoraConfig(
+            target_modules=["linear"],
+            total_step=10,
+        )
+
+        model = inject_adapter_in_model(adalora_config, model)
+
+        assert hasattr(model, "update_and_allocate"), (
+            "update_and_allocate must be accessible on the model returned by inject_adapter_in_model "
+            "when using AdaLoraConfig"
+        )
+        assert callable(model.update_and_allocate)
+
+        # Verify the method actually executes: gradients must exist before calling update_and_allocate,
+        # matching the expected training loop ordering (loss.backward → update_and_allocate → zero_grad).
+        dummy_inputs = torch.LongTensor([[0, 1, 2, 3, 4, 5, 6, 7]])
+        output = model(dummy_inputs)
+        output.sum().backward()
+        # Should not raise; step 0 is inside the budgeting window and exercises update_ipt + mask_to_budget.
+        model.update_and_allocate(0)
+
 
 class TestInjectAdapterFromStateDict:
     # The inject_adapter_in_model function can determine the target modules based on the LoraConfig (default) or based


### PR DESCRIPTION
## Summary

Fixes #3373.

After `inject_adapter_in_model()` returns, the caller holds the bare inner `torch.nn.Module`, not the `AdaLoraModel` tuner wrapper. `update_and_allocate` lives on `AdaLoraModel`, so it was silently dropped, and any training loop following the documented pattern:

```python
loss.backward()
model.update_and_allocate(global_step)
optimizer.zero_grad()
```

would raise `AttributeError: 'DummyModel' object has no attribute 'update_and_allocate'`.

**Root cause** — `inject_adapter_in_model` (`src/peft/mapping.py`) ends with:

```python
return peft_model.model   # tuner wrapper discarded here
```

**Fix** — after extracting the inner model, check whether the tuner exposes `update_and_allocate` and, if so, bind the bound method onto the returned model:

```python
returned_model = peft_model.model
if hasattr(peft_model, "update_and_allocate"):
    returned_model.update_and_allocate = peft_model.update_and_allocate
return returned_model
```

Because `peft_model.update_and_allocate` is already a bound method, `self` inside it remains the `AdaLoraModel` instance (with its `RankAllocator`, `peft_config`, and `trainable_adapter_name` intact). The bound method also keeps the tuner alive via a reference, so no state is lost.

The guard is written generically (`hasattr`) so it will apply to any future tuner that adds a similar training-time method without requiring changes to `inject_adapter_in_model` again.

## Changes

- `src/peft/mapping.py` — bind `update_and_allocate` onto the returned model when the tuner exposes it; add a `Note:` to the docstring documenting this behaviour for AdaLora users.
- `tests/test_low_level_api.py` — add `test_adalora_update_and_allocate_after_inject` to `TestLowLevelFunctional`: injects AdaLora into a `DummyModel`, asserts `update_and_allocate` is present and callable, then runs a complete forward → backward → `update_and_allocate(0)` cycle to verify end-to-end correctness.

## Test plan

- [x] New test `TestLowLevelFunctional::test_adalora_update_and_allocate_after_inject` passes
- [x] All existing `TestLowLevelFunctional` tests continue to pass (`test_inject_adapter_in_model`, `test_get_peft_model_state_dict`, `test_modules_to_save`)
- [x] The existing `TestInjectAdapterFromStateDict` parametrised test that passes `AdaLoraConfig(total_step=5)` through `inject_adapter_in_model` is unaffected