### PR TITLE
TST Skip failing Diffusers tests until v0.40.0

### DIFF
--- a/tests/test_stablediffusion.py
+++ b/tests/test_stablediffusion.py
@@ -15,7 +15,9 @@
 import copy
 from dataclasses import asdict, replace
 
+import diffusers
 import numpy as np
+import packaging.version
 import pytest
 import torch
 from diffusers import AutoModel, StableDiffusionPipeline
@@ -37,6 +39,10 @@ from peft.tuners.tuners_utils import BaseTunerLayer
 
 from .testing_common import PeftCommonTester
 from .testing_utils import hub_online_once, set_init_weights_false, temp_seed
+
+
+# TODO: remove once Diffusers 0.40 is released
+is_diffusers_ge_v040 = packaging.version.parse(diffusers.__version__) >= packaging.version.parse("0.40.0.dev0")
 
 
 PEFT_DIFFUSERS_SD_MODELS_TO_TEST = ["hf-internal-testing/tiny-sd-pipe"]
@@ -344,6 +350,9 @@ class TestStableDiffusionModel(PeftCommonTester):
     @pytest.mark.parametrize("model_id", PEFT_DIFFUSERS_SD_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", DIFFUSERS_CONFIGS)
     def test_disable_adapter(self, model_id, config_cls, config_kwargs):
+        # TODO: remove once Diffusers 0.40 is released
+        if not is_diffusers_ge_v040:
+            pytest.skip("This test fails with Diffusers < 0.40 due to a change in huggingface_hub")
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_disable_adapter(model_id, config_cls, config_kwargs)
 

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -15,6 +15,8 @@ import dataclasses
 import re
 from copy import deepcopy
 
+import diffusers
+import packaging.version
 import pytest
 import torch
 from diffusers import StableDiffusionPipeline
@@ -58,6 +60,9 @@ from peft.utils.quantization_utils import Bnb8bitBackend
 
 from .testing_utils import hub_online_once, require_bitsandbytes, require_non_cpu
 
+
+# TODO: remove once Diffusers 0.40 is released
+is_diffusers_ge_v040 = packaging.version.parse(diffusers.__version__) >= packaging.version.parse("0.40.0.dev0")
 
 # Implements tests for regex matching logic common for all BaseTuner subclasses, and
 # tests for correct behaviour with different config kwargs for BaseTuners (Ex: feedforward for IA3, etc) and
@@ -340,6 +345,10 @@ class TestPeftCustomKwargs:
             assert new_config.target_modules == expected_target_modules
 
     def test_maybe_include_all_linear_layers_diffusion(self):
+        # TODO: remove once Diffusers 0.40 is released
+        if not is_diffusers_ge_v040:
+            pytest.skip("This test fails with Diffusers < 0.40 due to a change in huggingface_hub")
+
         model_id = "hf-internal-testing/tiny-sd-pipe"
         with hub_online_once(model_id):
             model = StableDiffusionPipeline.from_pretrained(model_id)


### PR DESCRIPTION
Due to a recent change in huggingface-hub, loading Diffusers pipelines in offline mode can fail. Since the PEFT caching mechanism works by setting offline mode, several PEFT tests are affected by this.

There is a fix on the way in Diffusers, but there won't be a patch release:

https://github.com/huggingface/diffusers/pull/14118

Therefore, we skip these tests for now. Once Diffusers 0.40.0 releases, the tests will run again, but we can also remove the skipping logic completely.