### PR TITLE
Fix broken link in GLoRA docs

### DIFF
--- a/docs/source/package_reference/glora.md
+++ b/docs/source/package_reference/glora.md
@@ -103,6 +103,5 @@ model.merge_and_unload()
 - GLoRA supports all standard PEFT adapter management features (add, delete, switch, merge, etc).
 
 ## See Also
-- [Adapter conceptual guide](../conceptual_guides/adapter.md)
 - [LoRA reference](./lora.md)
 - [Paper: https://huggingface.co/papers/2306.07967](https://huggingface.co/papers/2306.07967)


### PR DESCRIPTION
## What does this PR do?

The GLoRA docs' "See Also" section links to `../conceptual_guides/adapter.md`, which no longer exists — the conceptual guides were folded into the package reference (`_redirects.yml` maps `conceptual_guides/adapter` → `package_reference/lora`), so this link is dead in the built docs.

The bullet right below it already points to the LoRA reference (`./lora.md`), which is exactly where that adapter/LoRA conceptual content now lives, so the dead bullet is redundant. Removed it rather than re-pointing it to avoid duplicating the LoRA reference line.

Docs-only. `glora.md` is the only file with this stale path.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/peft/blob/main/PHILOSOPHY.md)?
