### PR TITLE
Fix typos in examples, tests, and docs

### DIFF
--- a/examples/boft_dreambooth/boft_dreambooth.md
+++ b/examples/boft_dreambooth/boft_dreambooth.md
@@ -49,7 +49,7 @@ conda install xformers -c xformers
 pip install -r requirements.txt
 pip install git+https://github.com/huggingface/peft
 ```
-The follwing environment setuo is validated work on Intel XPU:
+The following environment setup is validated work on Intel XPU:
 
 ### Intel XPU
 ```bash

--- a/examples/deft_finetuning/deft_finetuning.py
+++ b/examples/deft_finetuning/deft_finetuning.py
@@ -95,7 +95,7 @@ def train_model(
         num_train_epochs=num_epochs,
         per_device_train_batch_size=batch_size,
         per_device_eval_batch_size=batch_size,
-        warmup_steps=int(max_steps * 0.1),  # 10% of total trainig steps
+        warmup_steps=int(max_steps * 0.1),  # 10% of total training steps
         weight_decay=0.0,
         logging_steps=eval_step,
         save_steps=save_step,

--- a/examples/delora_finetuning/delora_finetuning.py
+++ b/examples/delora_finetuning/delora_finetuning.py
@@ -93,7 +93,7 @@ def train_model(
         num_train_epochs=num_epochs,
         per_device_train_batch_size=batch_size,
         per_device_eval_batch_size=batch_size,
-        warmup_steps=int(max_steps * 0.1),  # 10% of total trainig steps
+        warmup_steps=int(max_steps * 0.1),  # 10% of total training steps
         weight_decay=0.0,
         logging_steps=eval_step,
         save_steps=save_step,

--- a/examples/eva_finetuning/README.md
+++ b/examples/eva_finetuning/README.md
@@ -135,7 +135,7 @@ def prepare_model_inputs_fn_language_modeling(model_input, peft_config: LoraConf
 ### prepare_layer_inputs_fn
 
 `prepare_layer_inputs_fn` can be used to preprocess the layer inputs before passing them to the SVD algorithm. `prepare_layer_inputs_fn` receives three arguments: `layer_input`, `model_input` and `layer_name`. It can either be a callable or a dictionary where the keys are the layer names and the values are callables. If it is a dictionary, functions are assigned to adapter layers based on the layer names. By default a language modeling setting is assumed where model_inputs are the outputs of `prepare_model_inputs_fn_language_modeling` which is a mask of indices. If this parameter is set to None, only two modifications are made to the layer inputs
-- take the first element incase of a tuple or list. 
+- take the first element in case of a tuple or list. 
 - if the input has more than 2 dimensions, we flatten all but the last dimension.
 
 Must always return a tensor. The default logic is:

--- a/examples/miss_finetuning/miss_finetuning.py
+++ b/examples/miss_finetuning/miss_finetuning.py
@@ -35,7 +35,7 @@ class ScriptArguments(SFTConfig):
         default=True,
         metadata={
             "help": (
-                "True -> MiSS efficience and balance; `bat` -> Bat, `mini` -> smaller MiSS efficience and balance"
+                "True -> MiSS efficiency and balance; `bat` -> Bat, `mini` -> smaller MiSS efficiency and balance"
             ),
         },
     )

--- a/examples/randlora_finetuning/README.md
+++ b/examples/randlora_finetuning/README.md
@@ -80,7 +80,7 @@ python randlora_finetuning.py \
 ```
 
 ## RandLora vs. LoRA
-RandLora differs from LoRA and other related low rank approximation algorithms by chanllenging the low rank paradigm. RandLora adapters learn **full-rank** updates as the [paper](https://huggingface.co/papers/2502.00987) shows that the low rank constraint of LoRA can constrain performance gains as trainable parameters increase (with higher ranks). As a result, using RandLora is specifically recommended for difficult tasks that are underfit by LoRA. RandLoRA however also often improves performance for common tasks. If increasing LoRA's rank improves performance for your task, RandLora will most likely outperform.
+RandLora differs from LoRA and other related low rank approximation algorithms by challenging the low rank paradigm. RandLora adapters learn **full-rank** updates as the [paper](https://huggingface.co/papers/2502.00987) shows that the low rank constraint of LoRA can constrain performance gains as trainable parameters increase (with higher ranks). As a result, using RandLora is specifically recommended for difficult tasks that are underfit by LoRA. RandLoRA however also often improves performance for common tasks. If increasing LoRA's rank improves performance for your task, RandLora will most likely outperform.
 
 RandLora is expected to increase performance over LoRA for equivalent amounts of trainable parameters, mostly for larger equivalent amounts (> LoRA rank 4).
 

--- a/examples/randlora_finetuning/randlora_finetuning.py
+++ b/examples/randlora_finetuning/randlora_finetuning.py
@@ -124,7 +124,7 @@ def train_model(
         num_train_epochs=num_epochs,
         per_device_train_batch_size=batch_size,
         per_device_eval_batch_size=batch_size,
-        warmup_steps=int(max_steps * 0.1),  # 10% of total trainig steps
+        warmup_steps=int(max_steps * 0.1),  # 10% of total training steps
         weight_decay=0.01,
         logging_dir="./logs",
         logging_steps=eval_step,

--- a/examples/stable_diffusion/inc_flux_lora_hpu.py
+++ b/examples/stable_diffusion/inc_flux_lora_hpu.py
@@ -1,5 +1,5 @@
 """
-This exampe demonstrates loading of LoRA adapter (via PEFT) into an FP8 INC-quantized FLUX model.
+This example demonstrates loading of LoRA adapter (via PEFT) into an FP8 INC-quantized FLUX model.
 
 More info on Intel Neural Compressor (INC) FP8 quantization is available at:
 https://github.com/intel/neural-compressor/tree/master/examples/helloworld/fp8_example

--- a/examples/stable_diffusion/train_dreambooth.py
+++ b/examples/stable_diffusion/train_dreambooth.py
@@ -1173,7 +1173,7 @@ def main(args):
                     pipeline = pipeline.to(accelerator.device)
                     pipeline.set_progress_bar_config(disable=True)
 
-                    # Set evaliation mode
+                    # Set evaluation mode
                     pipeline.unet.eval()
                     pipeline.text_encoder.eval()
 
@@ -1203,7 +1203,7 @@ def main(args):
                                 }
                             )
 
-                    # Set evaliation mode
+                    # Set evaluation mode
                     pipeline.unet.train()
                     pipeline.text_encoder.train()
 

--- a/examples/xlora/xlora_inference_mistralrs.py
+++ b/examples/xlora/xlora_inference_mistralrs.py
@@ -6,7 +6,7 @@ runner = Runner(
         tok_model_id=None,  # Automatically determine from ordering file
         model_id=...,  # Model ID of the base model (local path of HF model ID)
         xlora_model_id=...,  # X-LoRA Model ID of the base model (local path of HF model ID)
-        order=...,  # Ordering file to ensure compatability with PEFT
+        order=...,  # Ordering file to ensure compatibility with PEFT
         tgt_non_granular_index=3,  # Only generate scalings for the first 3 decoding tokens, and then use the last generated one
     )
 )

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -1769,7 +1769,7 @@ class PeftGPUCommonTests(unittest.TestCase):
     @require_non_cpu
     @pytest.mark.single_gpu_tests
     def test_r_odd_hra_inference(self):
-        # check that an untrained HRA adapter can't be initialized as an identity tranformation
+        # check that an untrained HRA adapter can't be initialized as an identity transformation
         # when r is an odd number
         model = AutoModelForCausalLM.from_pretrained(
             "peft-internal-testing/opt-125m",

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -4914,7 +4914,7 @@ class TestAutoCast(unittest.TestCase):
     device = infer_device()
 
     # This test makes sure, that Lora dtypes are consistent with the types
-    # infered by torch.autocast under tested PRECISIONS
+    # inferred by torch.autocast under tested PRECISIONS
     @parameterized.expand(PRECISIONS)
     def test_simple_model(self, *args, **kwargs):
         self._test_model(SimpleModel(), *args, **kwargs)
@@ -5271,7 +5271,7 @@ class TestEvaInitializationGPU:
             model = AutoModelForCausalLM.from_pretrained(
                 model_id,
                 quantization_config=bnb_config,
-                attn_implementation="eager",  # gpt2 doesnt support flash attention
+                attn_implementation="eager",  # gpt2 doesn't support flash attention
             )
             model.transformer.h = model.transformer.h[:2]  # truncate to 2 layers
             model = prepare_model_for_kbit_training(model)
@@ -5825,7 +5825,7 @@ class TestHotSwapping:
             model = get_peft_model(model, config)
             strong_init(model)
             # Note: For compilation, use eager backend, as the parameter targeting, which uses nn.utils.parametrize,
-            # leads to recompiles/graph breaks, which can signficantly affect the outputs, even if weights are correctly
+            # leads to recompiles/graph breaks, which can significantly affect the outputs, even if weights are correctly
             # loaded.
             model = torch.compile(model, backend="eager")
             with torch.inference_mode():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -149,7 +149,7 @@ class TestScalingAdapters:
 
         model = get_peft_model(model, lora_config)
 
-        # we expect a type error here becuase of wrong datatpye of multiplier
+        # we expect a type error here because of wrong datatype of multiplier
         multiplier = "a"
         with pytest.raises(TypeError, match=f"Argument multiplier should be of type float, got {type(multiplier)}"):
             with rescale_adapter_scale(model=model, multiplier=multiplier):
@@ -289,7 +289,7 @@ class TestScalingAdapters:
         model = get_peft_model(model, lora_config)
         inputs = tokenizer("hello world", return_tensors="pt")
 
-        # add another adaper and activate it
+        # add another adapter and activate it
         model.add_adapter("other", lora_config)
         model.set_adapter("other")
 
@@ -491,7 +491,7 @@ class TestDoraCaching:
 
     @pytest.fixture(autouse=True)
     def disable_dora_caching(self):
-        # auto-fixture to ensure that no test accidentically permanently enables DoRA caching
+        # auto-fixture to ensure that no test accidentally permanently enables DoRA caching
         DoraCaching()(enabled=False)
 
     def get_caches(self, model):

--- a/tests/test_lora_conversion.py
+++ b/tests/test_lora_conversion.py
@@ -165,7 +165,7 @@ class TestLoraConversion:
         assert not lora_config.alpha_pattern
 
     def test_dynamic_rank_lora_config(self, lokr_model):
-        # with a dynmaic rank, we expect rank_pattern and alpha_pattern to be set
+        # with a dynamic rank, we expect rank_pattern and alpha_pattern to be set
         lora_config, state_dict = convert_to_lora(lokr_model, rank=0.5)
         assert lora_config.r == 1  # dummy value
         assert lora_config.lora_alpha == 1  # dummy value
@@ -178,7 +178,7 @@ class TestLoraConversion:
         assert 2 * len(lora_config.rank_pattern) == len(state_dict)
 
     def test_dynamic_rank_1_lora_config(self, lokr_model):
-        # with a dynmaic rank, we expect rank_pattern and alpha_pattern to be set
+        # with a dynamic rank, we expect rank_pattern and alpha_pattern to be set
         lora_config, state_dict = convert_to_lora(lokr_model, rank=1.0)
         assert lora_config.r == 1  # dummy value
         assert lora_config.lora_alpha == 1  # dummy value

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -168,7 +168,7 @@ class TestInjectAdapterFromStateDict:
 
             sd_after = get_peft_model_state_dict(model)
 
-            # We exepct the same keys and the same shapes of the weights. Don't check the values: injection is only
+            # We expect the same keys and the same shapes of the weights. Don't check the values: injection is only
             # about creating the PEFT adapter, not about loading the actual weights
             assert len(sd_before) > 0
             assert sd_before.keys() == sd_after.keys()
@@ -189,7 +189,7 @@ class TestInjectAdapterFromStateDict:
             model = inject_adapter_in_model(config, model, state_dict=sd_before)
             sd_after = get_peft_model_state_dict(model)
 
-            # We exepct the same keys and the same shapes of the weights. Don't check the values: injection is only
+            # We expect the same keys and the same shapes of the weights. Don't check the values: injection is only
             # about creating the PEFT adapter, not about loading the actual weights
             assert len(sd_before) > 0
             assert sd_before.keys() == sd_after.keys()
@@ -213,7 +213,7 @@ class TestInjectAdapterFromStateDict:
             model = inject_adapter_in_model(config, model, state_dict=sd_before)
             sd_after = get_peft_model_state_dict(model)
 
-            # We exepct the same keys and the same shapes of the weights. Don't check the values: injection is only
+            # We expect the same keys and the same shapes of the weights. Don't check the values: injection is only
             # about creating the PEFT adapter, not about loading the actual weights
             assert len(sd_before) > 0
             assert sd_before.keys() == sd_after.keys()
@@ -303,7 +303,7 @@ class TestInjectAdapterFromStateDict:
             sd_te_after = get_peft_model_state_dict(pipe.text_encoder)
             sd_unet_after = get_peft_model_state_dict(pipe.unet)
 
-            # We exepct the same keys and the same shapes of the weights. Don't check the values: injection is only
+            # We expect the same keys and the same shapes of the weights. Don't check the values: injection is only
             # about creating the PEFT adapter, not about loading the actual weights
             assert len(sd_te_before) > 0
             assert sd_te_before.keys() == sd_te_after.keys()
@@ -332,7 +332,7 @@ class TestInjectAdapterFromStateDict:
             assert {p.device.type for p in get_peft_model_state_dict(model).values()} == {"meta"}
 
     def test_inject_from_state_dict_missing_keys_warning(self):
-        # check that if the PEFT config specifies **more** taget modules than the state_dict, we get a warning for that
+        # check that if the PEFT config specifies **more** target modules than the state_dict, we get a warning for that
         model_id = "peft-internal-testing/opt-125m"
         config = LoraConfig()
 
@@ -366,7 +366,7 @@ class TestInjectAdapterFromStateDict:
                 assert sd_before[key].shape == sd_after[key].shape
 
     def test_inject_from_state_dict_extra_keys_warning(self):
-        # check that if the PEFT config specifies **fewer** taget modules than the state_dict, we get a warning for that
+        # check that if the PEFT config specifies **fewer** target modules than the state_dict, we get a warning for that
         model_id = "peft-internal-testing/opt-125m"
         config = LoraConfig()
 
@@ -425,7 +425,7 @@ class TestInjectAdapterFromStateDict:
                 # work
                 sd_after = {k.removeprefix("_orig_mod."): v for k, v in sd_after.items()}
 
-            # We exepct the same keys and the same shapes of the weights. Don't check the values: injection is only
+            # We expect the same keys and the same shapes of the weights. Don't check the values: injection is only
             # about creating the PEFT adapter, not about loading the actual weights
             assert len(sd_before) > 0
             assert sd_before.keys() == sd_after.keys()

--- a/tests/test_trainable_tokens.py
+++ b/tests/test_trainable_tokens.py
@@ -346,7 +346,7 @@ class TestTrainableTokens:
         ],
     )
     def test_load_multiple_adapters(self, model, peft_config, tmp_path):
-        # tests if having more than one adpater (even with just the same config) works
+        # tests if having more than one adapter (even with just the same config) works
         original_model = copy.deepcopy(model)
         model = get_peft_model(model, peft_config)
 

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -431,7 +431,7 @@ class TestPeftCustomKwargs:
                 layer.mlp.down_proj,
             )
             for proj in projs:
-                # the targted layer itself, which in the base model was the nn.Linear layer, is now a LoraLayer
+                # the targeted layer itself, which in the base model was the nn.Linear layer, is now a LoraLayer
                 assert isinstance(proj, LoraLayer)
                 # all children of that layer are still normal nn.Linear layers
                 assert isinstance(proj.base_layer, nn.Linear)

--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -191,7 +191,7 @@ class TestXlora:
         assert torch.isfinite(outputs[: inputs.shape[1] :]).all()
 
         _ = model.get_latest_scalings()
-        # 32 is the numeber of max scalings. 3 is the number of prompt tokens.
+        # 32 is the number of max scalings. 3 is the number of prompt tokens.
         assert 32 + 3 >= len(model.get_scalings_log()) > 0
 
         model.disable_scalings_logging()
@@ -358,7 +358,7 @@ class TestXlora:
         assert torch.isfinite(outputs[: inputs.shape[1] :]).all()
 
     def test_xlora_loading_valid(self):
-        # This test also simulatenously tests the loading-from-hub functionality!
+        # This test also simultaneously tests the loading-from-hub functionality!
         torch.manual_seed(123)
 
         model_id = "peft-internal-testing/opt-125m"

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -623,7 +623,7 @@ class PeftCommonTester:
             if self.torch_device in ["mlu"]:
                 atol, rtol = 1e-3, 1e-3  # MLU
             if model_id == "trl-internal-testing/tiny-GptOssForCausalLM":
-                # this tolerance issue with the target_parameters test only occurrs on CI with transformers v5
+                # this tolerance issue with the target_parameters test only occurs on CI with transformers v5
                 atol, rtol = 1e-3, 1e-3
             if config.peft_type in ("ADALORA", "OFT"):
                 # these methods require a bit higher tolerance


### PR DESCRIPTION
## What does this PR do?

Fixes a handful of spelling typos found with `codespell`. All changes are in comments / prose (example scripts, example READMEs, and test comments) — no code or behavior changes:

- `examples/deft_finetuning/deft_finetuning.py`, `examples/delora_finetuning/delora_finetuning.py`: `trainig` → `training`
- `examples/boft_dreambooth/boft_dreambooth.md`: `follwing` → `following`, `setuo` → `setup`
- `examples/eva_finetuning/README.md`: `incase` → `in case`
- `tests/test_tuners_utils.py`: `targted` → `targeted`
- `tests/testing_common.py`: `occurrs` → `occurs`

*This PR was written with AI assistance; the changes were human-reviewed.*
