### PR TITLE
DOC Expand contributing installation guide with fork and setup steps

### DIFF
--- a/docs/source/developer_guides/contributing.md
+++ b/docs/source/developer_guides/contributing.md
@@ -20,7 +20,43 @@ We are happy to accept contributions to PEFT. If you plan to contribute, please 
 
 ## Installation
 
-For code contributions to PEFT, you should choose the ["source"](../install#source) installation method.
+Follow these steps to start contributing:
+
+1. Fork the [repository](https://github.com/huggingface/peft) by clicking on the 'Fork' button on the repository's page. This creates a copy of the code under your GitHub user account.
+
+2. Clone your fork to your local disk, and add the base repository as a remote. The following command assumes you have your public SSH key uploaded to GitHub. See the following guide for more [information](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
+
+   ```bash
+   git clone git@github.com:<your Github handle>/peft.git
+   cd peft
+   git remote add upstream https://github.com/huggingface/peft.git
+   ```
+
+3. Create a new branch to hold your development changes, and do this for every new PR you work on.
+
+   Start by synchronizing your `main` branch with the `upstream/main` branch (more details in the [GitHub Docs](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork)):
+
+   ```bash
+   git checkout main
+   git fetch upstream
+   git merge upstream/main
+   ```
+
+   Once your `main` branch is synchronized, create a new branch from it:
+
+   ```bash
+   git checkout -b a-descriptive-name-for-my-changes
+   ```
+
+   **Do not** work on the `main` branch.
+
+4. Set up a development environment by running the following command in a conda or a virtual environment you've created for working on this library:
+
+   ```bash
+   pip install -e ".[test]"
+   ```
+
+   (If PEFT was already installed in the virtual environment, remove it with `pip uninstall peft` before reinstalling it.)
 
 If you are new to creating a pull request, follow the [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) guide by GitHub.
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -36,12 +36,13 @@ New features that haven't been released yet are added every day, which also mean
 pip install git+https://github.com/huggingface/peft
 ```
 
-If you're working on contributing to the library or wish to play with the source code and see live 
-results as you run the code, an editable version can be installed from a locally-cloned version of the 
-repository:
+If you wish to play with the source code and see live results as you run the code, an editable version
+can be installed from a locally-cloned version of the repository:
 
 ```bash
 git clone https://github.com/huggingface/peft
 cd peft
-pip install -e .[test]
+pip install -e ".[test]"
 ```
+
+If you're planning to contribute to PEFT, follow the [contributing guide](../developer_guides/contributing#installation) instead, which also covers forking, adding the upstream remote, and creating a working branch.

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -45,4 +45,4 @@ cd peft
 pip install -e ".[test]"
 ```
 
-If you're planning to contribute to PEFT, follow the [contributing guide](../developer_guides/contributing#installation) instead, which also covers forking, adding the upstream remote, and creating a working branch.
+If you're planning to contribute to PEFT, follow the [contributing guide](developer_guides/contributing#installation) instead, which also covers forking, adding the upstream remote, and creating a working branch.


### PR DESCRIPTION
## What this does

- Rewrites the **Installation** section of the contributing guide so a new contributor can go from zero to an editable dev install without leaving the page. Adds explicit fork -> clone -> add-upstream -> branch -> `pip install -e ".[test]"`
steps, and removes the old `../install#source` link.

- Updates `docs/source/install.md`: quotes `pip install -e ".[test]"` for the same zsh reason, and points would-be contributors from the **Source** section to the contributing guide (dropping the half-covered "contributing" wording there so the two pages don't overlap).

## Motivation

I was about to fork the repo to start working on a new PEFT method, and the first thing I hit was the installation link in the contributing guide leading to a **404** on GitHub: `https://github.com/huggingface/peft/tree/install#source`.

The reason is that `../install#source` is a doc-builder relative link that only resolves on the rendered docs site -- on GitHub  it points at a nonexistent repo path. After finding the real page myself (https://huggingface.co/docs/peft/install#source), I realized a few steps that would have eased my onboarding were missing (forking, adding the upstream remote, syncing `main`, creating a work branch). So I adapted the
established [TRL](https://github.com/huggingface/trl?tab=contributing-ov-file#submitting-a-pull-request-pr) contributing-guide structure for PEFT to make the section self-contained regardless of where it's viewed.

I quoted `pip install -e ".[test]"` so it doesn't fail under zsh and works for bash (just a little more convenient way instead of hitting `zsh: no matches found: .[test]` and manually adding quotes).

## Tests

Docs-only change -- no unit tests required or run.

## Notes

AI assistance was used while preparing this change to polish the grammar. I reviewed every line and can explain and defend it.