### PR TITLE
FIX Pin huggingface_hub to <1.22

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]
+          # TODO see internal discussions about Diffusers/HFH issue, check around ~2025-09-01 if issue is resolved and
+          # pin can be removed
+          pip install huggingface_hub 1.22
       - name: Check quality
         run: |
           make quality

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,9 +35,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]
-          # TODO see internal discussions about Diffusers/HFH issue, check around ~2025-09-01 if issue is resolved and
-          # pin can be removed
-          pip install huggingface_hub 1.22
       - name: Check quality
         run: |
           make quality
@@ -132,6 +129,9 @@ jobs:
           pip install setuptools
           # cpu version of pytorch
           pip install -e .[test]
+          # TODO see internal discussions about Diffusers/HFH issue, check around ~2025-09-01 if issue is resolved and
+          # pin can be removed
+          pip install "huggingface_hub<1.22"
       - name: Test with pytest
         shell: bash
         env:

--- a/tests/test_stablediffusion.py
+++ b/tests/test_stablediffusion.py
@@ -15,9 +15,7 @@
 import copy
 from dataclasses import asdict, replace
 
-import diffusers
 import numpy as np
-import packaging.version
 import pytest
 import torch
 from diffusers import AutoModel, StableDiffusionPipeline
@@ -39,10 +37,6 @@ from peft.tuners.tuners_utils import BaseTunerLayer
 
 from .testing_common import PeftCommonTester
 from .testing_utils import hub_online_once, set_init_weights_false, temp_seed
-
-
-# TODO: remove once Diffusers 0.40 is released
-is_diffusers_ge_v040 = packaging.version.parse(diffusers.__version__) >= packaging.version.parse("0.40.0.dev0")
 
 
 PEFT_DIFFUSERS_SD_MODELS_TO_TEST = ["hf-internal-testing/tiny-sd-pipe"]
@@ -354,9 +348,6 @@ class TestStableDiffusionModel(PeftCommonTester):
     @pytest.mark.parametrize("model_id", PEFT_DIFFUSERS_SD_MODELS_TO_TEST)
     @pytest.mark.parametrize("config_cls,config_kwargs", DIFFUSERS_CONFIGS)
     def test_disable_adapter(self, model_id, config_cls, config_kwargs):
-        # TODO: remove once Diffusers 0.40 is released
-        if not is_diffusers_ge_v040:
-            pytest.skip("This test fails with Diffusers < 0.40 due to a change in huggingface_hub")
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_disable_adapter(model_id, config_cls, config_kwargs)
 

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -15,8 +15,6 @@ import dataclasses
 import re
 from copy import deepcopy
 
-import diffusers
-import packaging.version
 import pytest
 import torch
 from diffusers import StableDiffusionPipeline
@@ -60,9 +58,6 @@ from peft.utils.quantization_utils import Bnb8bitBackend
 
 from .testing_utils import hub_online_once, require_bitsandbytes, require_non_cpu
 
-
-# TODO: remove once Diffusers 0.40 is released
-is_diffusers_ge_v040 = packaging.version.parse(diffusers.__version__) >= packaging.version.parse("0.40.0.dev0")
 
 # Implements tests for regex matching logic common for all BaseTuner subclasses, and
 # tests for correct behaviour with different config kwargs for BaseTuners (Ex: feedforward for IA3, etc) and
@@ -345,10 +340,6 @@ class TestPeftCustomKwargs:
             assert new_config.target_modules == expected_target_modules
 
     def test_maybe_include_all_linear_layers_diffusion(self):
-        # TODO: remove once Diffusers 0.40 is released
-        if not is_diffusers_ge_v040:
-            pytest.skip("This test fails with Diffusers < 0.40 due to a change in huggingface_hub")
-
         model_id = "hf-internal-testing/tiny-sd-pipe"
         with hub_online_once(model_id):
             model = StableDiffusionPipeline.from_pretrained(model_id)


### PR DESCRIPTION
See internal Slack discussion, #3394, #3399, #3404.

There are several issues since the huggingface_hub 1.22 release with loading Diffusers models on Windows. For the time being, we need to pin the version to < 1.22 and wait if/how this is resolved in hfh and Diffusers.

Reverting #3394, as it's not needed with hfh < 1.22.