### PR TITLE
fix(lora): include base_layer.bias in saved state dict when bias='lora_only'

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -121,7 +121,7 @@ def get_peft_model_state_dict(
         save_embedding_layers (`Union[bool, str]`, , *optional*, defaults to `auto`):
             If `True`, save the embedding layers in addition to adapter weights. If `auto`, checks the common embedding
             layers `peft.utils.other.EMBEDDING_LAYER_NAMES` in config's `target_modules` when available. Based on it
-            sets the boolean flag. This only works for 🤗 transformers models.
+            sets the boolean flag. This only works for ð¤ transformers models.
 
     """
     if unwrap_compiled:
@@ -181,6 +181,11 @@ def get_peft_model_state_dict(
                     bias_name = k.split("lora_")[0] + "bias"
                     if bias_name in state_dict:
                         to_return[bias_name] = state_dict[bias_name]
+                    # LoRA layers wrap the original module as base_layer; the trained
+                    # bias lives at base_layer.bias rather than directly under bias.
+                    base_layer_bias_name = k.split("lora_")[0] + "base_layer.bias"
+                    if base_layer_bias_name in state_dict:
+                        to_return[base_layer_bias_name] = state_dict[base_layer_bias_name]
         else:
             raise NotImplementedError
         to_return = {k: v for k, v in to_return.items() if (("lora_" in k) or ("bias" in k))}
@@ -465,7 +470,7 @@ def get_peft_model_state_dict(
                 if embedding_module_name:
                     to_return.update({k: v for k, v in state_dict.items() if embedding_module_name in k})
     elif save_embedding_layers:
-        warnings.warn("Could not identify embedding layer(s) because the model is not a 🤗 transformers model.")
+        warnings.warn("Could not identify embedding layer(s) because the model is not a ð¤ transformers model.")
 
     # REMOVE ADAPTER NAME
     # Ensure not to replace in the middle of the key because a module happens to have the same name as the adapter.


### PR DESCRIPTION
## Summary

`LoraConfig(bias="lora_only")` correctly marks `base_layer.bias` as trainable during fine-tuning, but `get_peft_model_state_dict()` and `save_pretrained()` silently drop it — so loading the saved adapter produces different outputs than the trained model.

**Root cause** in `src/peft/utils/save_and_load.py`, `lora_only` branch:

```python
bias_name = k.split("lora_")[0] + "bias"
```

For a LoRA key like `base_model.model.proj.lora_A.default.weight` this yields:
```
base_model.model.proj.bias      ← does not exist
```

But the trained parameter lives at:
```
base_model.model.proj.base_layer.bias   ← the actual key, silently missed
```

## Fix

After the existing `bias_name` lookup, also probe the `base_layer.bias` variant:

```python
base_layer_bias_name = k.split("lora_")[0] + "base_layer.bias"
if base_layer_bias_name in state_dict:
    to_return[base_layer_bias_name] = state_dict[base_layer_bias_name]
```

Both the legacy key pattern and the wrapped `base_layer` key are now handled.

## Reproduction (before fix)

```python
import torch
from torch import nn
from peft import LoraConfig, get_peft_model, PeftModel
from peft.utils import get_peft_model_state_dict

class Toy(nn.Module):
    def __init__(self):
        super().__init__()
        self.proj = nn.Linear(4, 4)

model = get_peft_model(Toy(), LoraConfig(r=2, lora_alpha=2, target_modules=["proj"], bias="lora_only"))

# After simulating training:
state_dict = get_peft_model_state_dict(model)
bias_keys = [k for k in state_dict if "bias" in k]
# Before: bias_keys == []   ← trained bias is missing
# After:  bias_keys == ['base_model.model.proj.base_layer.bias']
```

Fixes #3306