### PR TITLE
FIX Crash in reduce_intruder_dimension on fp16/bf16 adapters with autocast_adapter_dtype=False

### DIFF
--- a/src/peft/tuners/lora/intruders.py
+++ b/src/peft/tuners/lora/intruders.py
@@ -96,6 +96,7 @@ def reduce_intruder_dimension(
         if cast_to_fp32:
             W_dtype = W.dtype
             W = W.float()
+            W_merged = W_merged.float()
 
         # compare base weights and adapter weights using cosine similarity.
         # based on this similarity we can find intruder dimensions using threshold_epsilon
@@ -145,16 +146,18 @@ def reduce_intruder_dimension(
         B_new = U_dW[:, :effective_rank] @ torch.diag(S_dW[:effective_rank]).sqrt()
         A_new = torch.diag(S_dW[:effective_rank]).sqrt() @ V_dW[:effective_rank]
 
+        # cast the new adapter weights back from float32 to whatever the base layer's weights
+        # were before, so the new adapter's dtype matches the old adapter's and the base model's
+        if cast_to_fp32:
+            B_new = B_new.to(W_dtype)
+            A_new = A_new.to(W_dtype)
+
         if is_embedding:
             layer.lora_embedding_B[new_adapter_name].data = B_new
             layer.lora_embedding_A[new_adapter_name].data = A_new
         else:
             layer.lora_B[new_adapter_name].weight.data = B_new
             layer.lora_A[new_adapter_name].weight.data = A_new
-
-        # cast W back from float32 to whatever it was before to save memory in the long run
-        if cast_to_fp32:
-            W = W.to(W_dtype)
 
     logging_sink(f"Enabling new adapter {new_adapter_name}")
     peft_model.set_adapter(new_adapter_name)

--- a/src/peft/tuners/lora/intruders.py
+++ b/src/peft/tuners/lora/intruders.py
@@ -91,6 +91,8 @@ def reduce_intruder_dimension(
         W_merged = W + dW
         is_embedding = old_adapter_name not in layer.lora_B
 
+        # torch.linalg.svd below does not support half precision, so upcast fp16/bf16 inputs to
+        # fp32 for the decomposition; the resulting factors are cast back to W_dtype at the end.
         cast_to_fp32 = W.dtype in (torch.float16, torch.bfloat16)
 
         if cast_to_fp32:

--- a/tests/test_lora_intruders.py
+++ b/tests/test_lora_intruders.py
@@ -35,6 +35,19 @@ class TestLoraIntruders:
         return peft_model
 
     @pytest.fixture
+    def model_lin_bf16_no_autocast(self):
+        model_id = "trl-internal-testing/tiny-random-LlamaForCausalLM"
+        with hub_online_once(model_id):
+            base_model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.bfloat16)
+
+        cfg = LoraConfig(target_modules=["q_proj"])
+        # autocast_adapter_dtype=False keeps the adapter weights in the base model's dtype
+        # (bf16) instead of upcasting them to fp32.
+        peft_model = get_peft_model(base_model, cfg, autocast_adapter_dtype=False)
+
+        return peft_model
+
+    @pytest.fixture
     def model_lin_non_lora(self):
         model_id = "trl-internal-testing/tiny-random-LlamaForCausalLM"
         with hub_online_once(model_id):
@@ -74,6 +87,30 @@ class TestLoraIntruders:
                 # Since the epsilon is really low, we should modify every layer so the weights should differ
                 new_weight = module.lora_B["intruder_reduced"].weight.detach()
                 assert not torch.equal(new_weight, original_weights[name])
+
+    def test_lora_intruders_linear_bf16_no_autocast(self, model_lin_bf16_no_autocast):
+        # Regression test: with autocast_adapter_dtype=False, the base layer's weights (and thus
+        # W_merged = W + dW) are bf16. torch.linalg.svd does not support half-precision dtypes, so
+        # W_merged must be upcast to fp32 for the SVD calls just like W already is. Without that,
+        # this call used to raise a RuntimeError.
+        model_lin = model_lin_bf16_no_autocast
+
+        original_dtypes = {}
+        for name, module in model_lin.named_modules():
+            if "q_proj" in name and hasattr(module, "lora_B"):
+                original_dtypes[name] = module.lora_B["default"].weight.dtype
+
+        # use a high epsilon to make sure that we get a match to see whether layers get modified
+        reduce_intruder_dimension(model_lin, threshold_epsilon=999)
+
+        assert model_lin.active_adapters == ["intruder_reduced"]
+
+        for name, module in model_lin.named_modules():
+            if name in original_dtypes:
+                # The new adapter's dtype must match the old adapter's (and the base model's) dtype,
+                # not be left as the float32 the SVD internally computed in.
+                assert module.lora_B["intruder_reduced"].weight.dtype == original_dtypes[name]
+                assert original_dtypes[name] == torch.bfloat16
 
     def test_lora_intruders_embedding(self, model_emb):
         original_weights = {}

--- a/tests/test_lora_intruders.py
+++ b/tests/test_lora_intruders.py
@@ -108,7 +108,9 @@ class TestLoraIntruders:
         for name, module in model_lin.named_modules():
             if name in original_dtypes:
                 # The new adapter's dtype must match the old adapter's (and the base model's) dtype,
-                # not be left as the float32 the SVD internally computed in.
+                # not be left as the float32 the SVD internally computed in. Both LoRA factors are
+                # rebuilt from the SVD, so check A and B.
+                assert module.lora_A["intruder_reduced"].weight.dtype == original_dtypes[name]
                 assert module.lora_B["intruder_reduced"].weight.dtype == original_dtypes[name]
                 assert original_dtypes[name] == torch.bfloat16
 


### PR DESCRIPTION
## What does this PR do?

`reduce_intruder_dimension` (added in #2999) crashes with `RuntimeError: "linalg_svd_cpu" not implemented for 'BFloat16'` (or the CUDA equivalent) when the base model is loaded in fp16/bf16 with `get_peft_model(..., autocast_adapter_dtype=False)`.

### Root cause

```python
W = layer.get_base_layer().weight.data
dW = layer.get_delta_weight(old_adapter_name)
W_merged = W + dW                      # inherits W's original dtype
...
cast_to_fp32 = W.dtype in (torch.float16, torch.bfloat16)
if cast_to_fp32:
    W_dtype = W.dtype
    W = W.float()                      # only W is upcast
...
U_base, _S_base, _V_base = torch.linalg.svd(W, full_matrices=False)          # fine, W is fp32
U_merged, S_merged, V_merged = torch.linalg.svd(W_merged, full_matrices=False)  # W_merged is still fp16/bf16
```

`W_merged` is computed *before* the fp32 cast and is never itself cast, so the second SVD call runs on a half-precision tensor. `torch.linalg.svd` doesn't support fp16/bf16, hence the crash.

This only reproduces with `autocast_adapter_dtype=False` (a documented, first-class option — "If set to False, the dtypes will stay the same as those of the corresponding layer," `peft_model.py`). With the default `autocast_adapter_dtype=True`, PEFT's own adapter-fp32-upcast masks the bug, which is why the existing `tests/test_lora_intruders.py` suite (which loads the test model with no explicit dtype, i.e. fp32) never caught it.

### Secondary issue exposed by the fix

Once `W_merged` is upcast, the whole downstream SVD chain runs in fp32, so `B_new`/`A_new` come out as fp32. They were being written directly onto `layer.lora_B`/`layer.lora_embedding_B`, leaving the newly created adapter in a different dtype than the "old" adapter and the base model (in the `autocast_adapter_dtype=False` scenario). The existing tail of the function already gestured at "cast back to save memory":

```python
# cast W back from float32 to whatever it was before to save memory in the long run
if cast_to_fp32:
    W = W.to(W_dtype)
```

but this only reassigns the local `W` variable, which is immediately overwritten at the top of the next loop iteration and never read again — it has no effect. I replaced it with casting `B_new`/`A_new` back to `W_dtype` right before they're assigned onto the layer, which is what the comment's intent actually required.

### Why this isn't a duplicate

`gh pr list --repo huggingface/peft --search "reduce_intruder_dimension" / "intruder" / "svd bfloat16" --state all` surfaces only the original feature PR #2999 (merged). No open PR or issue addresses this.

## Tests

Added `model_lin_bf16_no_autocast` fixture and `test_lora_intruders_linear_bf16_no_autocast` to `tests/test_lora_intruders.py`: loads the tiny test model in bf16 with `autocast_adapter_dtype=False`, calls `reduce_intruder_dimension`, and asserts it does not raise and that the new adapter's weight dtype matches the old adapter's (bf16).

Verified fail-before / pass-after by running the equivalent code as a standalone script against the real installed `peft`/`transformers`/`torch` (not a synthetic mock), exercising the same code path as `tests/test_lora_intruders.py`: before the fix, it raises `RuntimeError: "linalg_svd_cpu" not implemented for 'BFloat16'`; after the fix it passes and the new adapter is confirmed to be bf16. Also re-ran the existing fp32 `test_lora_intruders_linear` / `test_lora_intruders_embedding` scenarios the same way to confirm the fp32 path (the common case, `autocast_adapter_dtype=True` default) is unaffected — both pass.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code). There is no pre-existing issue for this bug — I found it myself while auditing recently-added LoRA utilities for correctness issues. I independently verified the root cause (read the exact call sequence, confirmed `torch.linalg.svd` rejects fp16/bf16), reproduced the crash and its fix end-to-end against the real library, and reviewed every changed line before proposing this change.

