### PR TITLE
FIX GLoRA safe_merge mutating the base layer before the isfinite check

### DIFF
--- a/src/peft/tuners/glora/layer.py
+++ b/src/peft/tuners/glora/layer.py
@@ -204,25 +204,34 @@ class GloraLayer(BaseTunerLayer):
         w0 = weight.data.clone()
         b0 = bias.data.clone() if bias is not None else None
 
+        # Accumulate into separate clones instead of mutating the base layer directly, so that if
+        # safe_merge detects non-finite values below, the base layer's weights/bias are untouched.
+        new_weight = w0.clone()
+        new_bias = b0.clone() if b0 is not None else None
+
         for adapter_name in all_adapters:
             A = self.glora_A[adapter_name]().to(device=device, dtype=dtype)
             B = self.glora_B[adapter_name]().to(device=device, dtype=dtype)
-            base_layer.weight.data += w0 * A + B
+            new_weight += w0 * A + B
             if b0 is not None:
                 C = self.glora_C[adapter_name]().to(device=device, dtype=dtype)
                 D = self.glora_D[adapter_name]().to(device=device, dtype=dtype)
                 E = self.glora_E[adapter_name]().to(device=device, dtype=dtype)
-                base_layer.bias.data += b0 * D + E + torch.matmul(w0, C).squeeze(-1)
+                new_bias += b0 * D + E + torch.matmul(w0, C).squeeze(-1)
 
         if safe_merge:
-            if not torch.isfinite(weight.data).all():
+            if not torch.isfinite(new_weight).all():
                 raise ValueError(
                     f"NaNs detected in the merged weights. The adapter {', '.join(all_adapters)} seems to be broken"
                 )
-            if bias is not None and not torch.isfinite(bias.data).all():
+            if new_bias is not None and not torch.isfinite(new_bias).all():
                 raise ValueError(
                     f"NaNs detected in the merged weights. The adapter {', '.join(all_adapters)} seems to be broken"
                 )
+
+        base_layer.weight.data = new_weight
+        if new_bias is not None:
+            base_layer.bias.data = new_bias
 
         for adapter_name in all_adapters:
             self.merged_adapters.append(adapter_name)

--- a/src/peft/tuners/glora/layer.py
+++ b/src/peft/tuners/glora/layer.py
@@ -199,13 +199,15 @@ class GloraLayer(BaseTunerLayer):
         bias = self.bias
         device, dtype = weight.device, weight.dtype
 
-        # we need a clone of the original weights to compute the merged weights
-        # before they get mutated by the merge process
-        w0 = weight.data.clone()
-        b0 = bias.data.clone() if bias is not None else None
+        # Read the original weights directly as the reference for the merge math. The base layer
+        # is only reassigned at the very end (after the safe_merge check), so it stays untouched
+        # until then and needs no defensive clone here.
+        w0 = weight.data
+        b0 = bias.data if bias is not None else None
 
-        # Accumulate into separate clones instead of mutating the base layer directly, so that if
-        # safe_merge detects non-finite values below, the base layer's weights/bias are untouched.
+        # The accumulator must be a separate tensor from `w0`: each adapter's update reads the
+        # original weights (`w0 * A`), so accumulating in place on `w0` would feed the next adapter
+        # the already-merged weights and corrupt multi-adapter merges.
         new_weight = w0.clone()
         new_bias = b0.clone() if b0 is not None else None
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2394,6 +2394,32 @@ class TestPeftCustomModel(PeftCommonTester):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_safe_merge(model_id, config_cls, config_kwargs)
 
+    def test_glora_safe_merge_does_not_corrupt_base_layer_on_non_finite_adapter(self):
+        # Regression test: GLoRA's merge() used to accumulate the merged weights directly onto
+        # base_layer.weight.data/bias.data *before* the safe_merge isfinite check, so a broken
+        # (non-finite) adapter would permanently corrupt the base layer even though safe_merge
+        # raises -- defeating the whole point of safe_merge ("check for NaNs before merging").
+        torch.manual_seed(0)
+        model = MLP()
+        orig_weight = model.lin0.weight.data.clone()
+        orig_bias = model.lin0.bias.data.clone()
+
+        config = GloraConfig(target_modules=["lin0"])
+        model = get_peft_model(model, config)
+
+        # Deliberately break the adapter (e.g. a corrupted checkpoint or an fp16 overflow) so that
+        # the merged weights would contain non-finite values.
+        glora_b = model.base_model.model.lin0.glora_B["default"]
+        next(glora_b.parameters()).data.fill_(float("inf"))
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged weights"):
+            model.base_model.model.lin0.merge(safe_merge=True)
+
+        # The base layer must be untouched after the failed safe_merge.
+        assert torch.equal(model.base_model.model.lin0.base_layer.weight.data, orig_weight)
+        assert torch.equal(model.base_model.model.lin0.base_layer.bias.data, orig_bias)
+        assert model.base_model.model.lin0.merged_adapters == []
+
     @pytest.mark.parametrize("safe_merge", [False, True])
     @pytest.mark.parametrize("module_type", ["linear", "conv2d"])
     def test_merge_with_lora_bias_when_base_layer_has_no_bias_warns_and_raises(self, safe_merge, module_type):


### PR DESCRIPTION
## What does this PR do?

`GloraLayer.merge(safe_merge=True)` is supposed to check for non-finite values *before* committing the merge, matching the documented contract shared with every other tuner ("If True, the merge operation will be performed in a copy of the original weights and check for NaNs before merging the weights"). For GLoRA specifically, it doesn't: the base layer's weight/bias are corrupted in place *before* the check ever runs.

### Root cause

```python
weight = self.weight          # BaseTunerLayer.weight property -> base_layer.weight (same tensor)
bias = self.bias
...
w0 = weight.data.clone()      # frozen copy used only to compute each adapter's delta
b0 = bias.data.clone() if bias is not None else None

for adapter_name in all_adapters:
    A = self.glora_A[adapter_name]().to(device=device, dtype=dtype)
    B = self.glora_B[adapter_name]().to(device=device, dtype=dtype)
    base_layer.weight.data += w0 * A + B          # <-- mutates the live base layer weight
    ...

if safe_merge:
    if not torch.isfinite(weight.data).all():      # <-- checks AFTER the mutation above
        raise ValueError(...)
```

`self.weight` is `BaseTunerLayer`'s `weight` property, which returns `base_layer.weight` directly — not a clone. So `weight.data` (read at the `isfinite` check) and `base_layer.weight.data` (mutated in the loop) are the exact same tensor. If an adapter's delta is non-finite (a corrupted checkpoint, an fp16 overflow, or an unlucky `init_weights=False` init), the loop already wrote the corrupted values into the base layer before `safe_merge`'s check has a chance to run. The subsequent `ValueError` correctly fires, but by then it's too late — the model is already broken, which is precisely the outcome `safe_merge` exists to prevent.

### Fix

Accumulate into separate `new_weight`/`new_bias` clones instead of mutating `base_layer.weight.data`/`bias.data` directly in the loop, check `isfinite` on those clones, and only commit to the base layer once the check passes:

```python
new_weight = w0.clone()
new_bias = b0.clone() if b0 is not None else None

for adapter_name in all_adapters:
    ...
    new_weight += w0 * A + B
    ...

if safe_merge:
    if not torch.isfinite(new_weight).all():
        raise ValueError(...)
    ...

base_layer.weight.data = new_weight
if new_bias is not None:
    base_layer.bias.data = new_bias
```

`w0`/`b0` (the frozen originals used inside the per-adapter delta math) are left untouched, so the existing multi-adapter "avoid sequential composition" correctness (each adapter's delta computed against the true original weight, not a partially-merged one — see the comment above this code and huggingface/peft#3098's discussion) is preserved exactly. This mirrors the clone→mutate-clone→check→commit pattern already used by `LoraLayer.merge()` (`lora/layer.py`) for the same `safe_merge` contract, and (per a parallel audit of related tuners) `UniLoraLayer.merge()`.

### Why this isn't a duplicate

`gh pr list --repo huggingface/peft --search "glora safe_merge" / "glora merge NaN" --state all` and `gh issue list --search "glora safe_merge"` surface only the original feature PRs that added GLoRA (#3098, #2568). No open PR or issue addresses this.

## Tests

Added `test_glora_safe_merge_does_not_corrupt_base_layer_on_non_finite_adapter` to `TestPeftCustomModel` in `tests/test_custom_models.py`: deliberately fills one parameter of a GLoRA adapter with `inf`, calls `.merge(safe_merge=True)` directly on the wrapped layer, and asserts (a) `ValueError` is raised with the expected message, (b) the base layer's weight *and* bias are unchanged afterward, and (c) `merged_adapters` stays empty. The existing generic `test_safe_merge` (parametrized over `TEST_CASES`, including GLoRA) never catches this because it only exercises the healthy, non-NaN path — it checks logit equivalence before/after `merge_and_unload(safe_merge=True)`, not what happens when the check actually fails.

Verified fail-before / pass-after by running the equivalent code as standalone scripts against the real installed `peft`/`torch` (not synthetic mocks), exercising the same code path as `tests/test_custom_models.py`: before the fix, the regression scenario raises the expected `ValueError` but leaves `base_layer.weight.data` corrupted (`torch.equal(..., orig_weight)` is `False`); after the fix, the error still raises but the base layer is provably untouched. Also verified the healthy (non-corrupted) single-adapter merge path is numerically unaffected by the refactor: `merge_and_unload(safe_merge=True)` output logits match the pre-merge PEFT-model output exactly (`atol=1e-6, rtol=1e-6`), same tolerance the generic `_test_safe_merge` helper uses.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code). There is no pre-existing issue for this bug — it was found while auditing tuner `merge()`/`safe_merge` implementations for consistency with the documented contract. I independently verified the root cause (confirmed `self.weight` aliases `base_layer.weight` via the `BaseTunerLayer.weight` property, traced the mutation-before-check ordering, and cross-checked `LoraLayer.merge()`'s correct clone-based pattern), reproduced the corruption and its fix end-to-end against the real library, and reviewed every changed line before proposing this change.

