### PR TITLE
FIX DEFT's cached merge factor: precision loss and device staleness

### DIFF
--- a/src/peft/tuners/deft/layer.py
+++ b/src/peft/tuners/deft/layer.py
@@ -56,9 +56,8 @@ class DeftLayer(BaseTunerLayer):
         # The residual projection (I - P_proj) @ W is not invertible, so unmerge cannot recover the delta from the
         # merged weight. Rather than cache the full out x in delta, cache only its base-weight-dependent factor
         # right.T @ W (shape r x in_features) per adapter; unmerge recomputes the exact delta from it (~r/out_features
-        # of the memory). A BufferDict (not a plain dict) so it is swept up by `model.to(device)` and by
-        # `_move_adapter_to_device_of_base_layer`, instead of going stale if the model is moved between merge
-        # and unmerge; `persistent=False` since it's a recomputable cache, not real adapter state to checkpoint.
+        # of the memory). A BufferDict so `model.to(device)` and `_move_adapter_to_device_of_base_layer` keep it in
+        # sync with the base layer; `persistent=False` since it's a recomputable cache, not real adapter state.
         self._cached_merge_factor = BufferDict({}, persistent=False)
         # Mark the weight as unmerged
         self._disable_adapters = False
@@ -284,12 +283,9 @@ class DeftLinear(nn.Module, DeftLayer):
                 base_layer.weight.data = new_weight
             else:
                 base_layer.weight.data = base_layer.weight.data + delta_weight
-            # Cache only the small r x in_features factor (not the full out x in delta) for an exact
-            # unmerge. Keep it in float32 (the dtype _merge_factor already returns): downcasting it to
-            # the base weight's dtype here would round it, so unmerge would recompute the delta from a
-            # different (rounded) factor than the one merge used, i.e. a *different* delta than the one
-            # actually applied -- not just the ordinary storage-precision loss every low-rank merge already
-            # has when its dtype is narrower than float32.
+            # Cache only the small r x in_features factor (not the full out x in delta) for an exact unmerge.
+            # Kept in float32 (the dtype _merge_factor already returns) so unmerge recomputes the exact delta
+            # merge applied here, not a rounded approximation of it.
             self._cached_merge_factor[active_adapter] = factor
             self.merged_adapters.append(active_adapter)
 
@@ -302,6 +298,7 @@ class DeftLinear(nn.Module, DeftLayer):
             active_adapter = self.merged_adapters.pop()
             if active_adapter not in self.deft_P.keys():
                 continue
+            # Unlike dict.pop(), BufferDict.pop() takes no default value, so membership is checked first.
             factor = (
                 self._cached_merge_factor.pop(active_adapter) if active_adapter in self._cached_merge_factor else None
             )

--- a/src/peft/tuners/deft/layer.py
+++ b/src/peft/tuners/deft/layer.py
@@ -23,6 +23,7 @@ from transformers.pytorch_utils import Conv1D
 from peft.tuners.tuners_utils import BaseTunerLayer, check_adapters_to_merge
 from peft.utils.other import transpose
 
+from .._buffer_dict import BufferDict
 from .config import DeftConfig
 
 
@@ -37,6 +38,7 @@ class DeftLayer(BaseTunerLayer):
         "deft_para",
         "deft_scaling",
         "deft_dropout",
+        "_cached_merge_factor",
     )
 
     def __init__(self, base_layer: nn.Module, **kwargs) -> None:
@@ -54,8 +56,10 @@ class DeftLayer(BaseTunerLayer):
         # The residual projection (I - P_proj) @ W is not invertible, so unmerge cannot recover the delta from the
         # merged weight. Rather than cache the full out x in delta, cache only its base-weight-dependent factor
         # right.T @ W (shape r x in_features) per adapter; unmerge recomputes the exact delta from it (~r/out_features
-        # of the memory).
-        self._cached_merge_factor = {}
+        # of the memory). A BufferDict (not a plain dict) so it is swept up by `model.to(device)` and by
+        # `_move_adapter_to_device_of_base_layer`, instead of going stale if the model is moved between merge
+        # and unmerge; `persistent=False` since it's a recomputable cache, not real adapter state to checkpoint.
+        self._cached_merge_factor = BufferDict({}, persistent=False)
         # Mark the weight as unmerged
         self._disable_adapters = False
         self.merged_adapters = []
@@ -280,8 +284,13 @@ class DeftLinear(nn.Module, DeftLayer):
                 base_layer.weight.data = new_weight
             else:
                 base_layer.weight.data = base_layer.weight.data + delta_weight
-            # cache only the small r x in_features factor (not the full out x in delta) for an exact unmerge
-            self._cached_merge_factor[active_adapter] = factor.to(base_layer.weight.dtype)
+            # Cache only the small r x in_features factor (not the full out x in delta) for an exact
+            # unmerge. Keep it in float32 (the dtype _merge_factor already returns): downcasting it to
+            # the base weight's dtype here would round it, so unmerge would recompute the delta from a
+            # different (rounded) factor than the one merge used, i.e. a *different* delta than the one
+            # actually applied -- not just the ordinary storage-precision loss every low-rank merge already
+            # has when its dtype is narrower than float32.
+            self._cached_merge_factor[active_adapter] = factor
             self.merged_adapters.append(active_adapter)
 
     def unmerge(self) -> None:
@@ -293,7 +302,9 @@ class DeftLinear(nn.Module, DeftLayer):
             active_adapter = self.merged_adapters.pop()
             if active_adapter not in self.deft_P.keys():
                 continue
-            factor = self._cached_merge_factor.pop(active_adapter, None)
+            factor = (
+                self._cached_merge_factor.pop(active_adapter) if active_adapter in self._cached_merge_factor else None
+            )
             if factor is not None:
                 delta_weight = self._delta_from_factor(active_adapter, factor.to(torch.float32))
             else:

--- a/tests/test_deft.py
+++ b/tests/test_deft.py
@@ -17,8 +17,6 @@ from torch import nn
 
 from peft import DeftConfig, get_peft_model
 
-from .testing_utils import require_torch_gpu
-
 
 class MLP(nn.Module):
     def __init__(self, bias=True):
@@ -112,64 +110,35 @@ class TestDeftMerge:
         peft_model.unmerge_adapter()
         assert torch.allclose(layer.base_layer.weight, w0, atol=1e-5)
 
-    def test_merge_caches_factor_in_float32_for_bf16_base_weight(self):
-        # Regression test: the cached factor must stay in float32 regardless of the base layer's dtype.
-        # `_merge_factor` always returns float32 (see its docstring); previously it was downcast to the
-        # base layer's dtype before caching (e.g. bf16), so `unmerge` recomputed the delta from a
-        # *rounded* factor instead of the exact one `merge` used -- the two deltas then differed, breaking
-        # the "unmerge recomputes the exact delta" guarantee this cache exists for. That bug is invisible
-        # with a float32 base layer (downcasting float32 -> float32 loses nothing), which is why the fp32
-        # test above (`test_merge_caches_small_factor_and_unmerges_exactly`) never caught it.
-        torch.manual_seed(0)
-        model = MLP()
-        model.dtype = torch.bfloat16
-        model = model.to(torch.bfloat16)
-        model.eval()
-        x = torch.rand(5, 10)
+    def test_merge_unmerge_roundtrip_precise_for_bf16_base(self):
+        # User-facing guarantee: merging then unmerging a DEFT adapter restores the base weights.
+        # merge() caches its factor in float32; downcasting it to the base dtype (the bug this fixes)
+        # makes unmerge recompute a slightly different delta than merge applied, so the roundtrip
+        # drifts further than the plain bf16 add/subtract rounding. Measure the base-weight roundtrip
+        # error both ways and assert the float32-cached factor is at least as accurate as the
+        # downcast one (in practice strictly better).
+        def roundtrip_max_abs_error(downcast_cached_factor: bool) -> float:
+            torch.manual_seed(0)
+            model = MLP().to(torch.bfloat16)
+            model.eval()
+            config = DeftConfig(target_modules=["lin0"], decomposition_method="relu", r=4)
+            peft_model = get_peft_model(model, config)
+            peft_model.eval()
+            layer = peft_model.base_model.model.lin0
+            with torch.no_grad():
+                layer.deft_R["default"].normal_(std=0.1)
 
-        config = DeftConfig(target_modules=["lin0"], decomposition_method="relu", r=4)
-        peft_model = get_peft_model(model, config)
-        peft_model.eval()
-        layer = peft_model.base_model.model.lin0
+            w0 = layer.base_layer.weight.detach().clone()
+            peft_model.merge_adapter()
+            if downcast_cached_factor:
+                # Reproduce the pre-fix behaviour: the cached factor rounded to the base dtype, so
+                # unmerge recomputes the delta from the rounded factor instead of the exact one.
+                dtype = layer.base_layer.weight.dtype
+                rounded = layer._cached_merge_factor["default"].to(dtype).to(torch.float32)
+                layer._cached_merge_factor["default"] = rounded
+            peft_model.unmerge_adapter()
+            return (layer.base_layer.weight.float() - w0.float()).abs().max().item()
 
-        with torch.no_grad():
-            layer.deft_R["default"].normal_(std=0.1)
-
-        # Capture the delta merge() is about to apply, from the pristine (not-yet-cached) factor.
-        factor_before_merge = layer._merge_factor("default")
-        delta_at_merge = layer._delta_from_factor("default", factor_before_merge)
-
-        peft_model.merge_adapter()
-
-        cached_factor = layer._cached_merge_factor["default"]
-        assert cached_factor.dtype == torch.float32, (
-            f"cached merge factor must stay float32, got {cached_factor.dtype} "
-            f"(base layer weight dtype is {layer.base_layer.weight.dtype})"
-        )
-        assert torch.equal(cached_factor, factor_before_merge)
-
-        # This mirrors exactly what unmerge() does with the cached factor.
-        delta_at_unmerge = layer._delta_from_factor("default", cached_factor.to(torch.float32))
-        assert torch.equal(delta_at_merge, delta_at_unmerge), (
-            "delta recomputed at unmerge time must be bit-identical to the delta merge() applied"
-        )
-
-    @require_torch_gpu
-    def test_cached_merge_factor_follows_model_to_device(self):
-        # Regression test: `_cached_merge_factor` was a plain dict, so `model.to(device)` never moved its
-        # tensors (unlike deft_P/deft_R, which are ParameterDicts and are moved automatically). Merging on
-        # one device, moving the model, then unmerging used to raise a device-mismatch RuntimeError.
-        torch.manual_seed(0)
-        model = MLP()
-        model.eval()
-        config = DeftConfig(target_modules=["lin0"], decomposition_method="relu", r=4)
-        peft_model = get_peft_model(model, config)
-        layer = peft_model.base_model.model.lin0
-
-        peft_model.merge_adapter()
-        assert layer._cached_merge_factor["default"].device.type == "cpu"
-
-        peft_model = peft_model.to("cuda")
-        assert layer._cached_merge_factor["default"].device.type == "cuda"
-
-        peft_model.unmerge_adapter()  # must not raise
+        err_float32 = roundtrip_max_abs_error(downcast_cached_factor=False)
+        err_downcast = roundtrip_max_abs_error(downcast_cached_factor=True)
+        assert err_float32 <= err_downcast

--- a/tests/test_deft.py
+++ b/tests/test_deft.py
@@ -16,7 +16,6 @@ import torch
 from torch import nn
 
 from peft import DeftConfig, get_peft_model
-from peft.tuners._buffer_dict import BufferDict
 
 
 class MLP(nn.Module):
@@ -116,15 +115,10 @@ class TestDeftMerge:
         # merge() caches its factor in float32; downcasting it to the base dtype (the bug this fixes)
         # makes unmerge recompute a slightly different delta than merge applied, so the roundtrip
         # drifts further than the plain bf16 add/subtract rounding. Measure the base-weight roundtrip
-        # error both ways and assert the float32-cached factor is strictly more accurate.
+        # error both ways and assert the float32-cached factor is meaningfully more accurate.
         #
-        # `deft_P` (hence the cached factor `right.T @ W`) is deliberately scaled well above its
-        # default init (std=0.02): the factor's own magnitude has to be large enough that rounding
-        # it to bf16 shifts the recomputed delta by more than the base weight's own bf16 storage
-        # quantization step -- otherwise the discrepancy this bug introduces is silently absorbed by
-        # that ordinary rounding and this test can't observe it (verified empirically: at the default
-        # init scale, `err_float32 == err_downcast` every time, which would make this test pass
-        # whether the bug is present or not).
+        # `deft_P` is scaled well above its default init so the effect is large enough to observe
+        # over ordinary bf16 storage rounding (see #3412 for the empirical detail).
         def roundtrip_max_abs_error(downcast_cached_factor: bool) -> float:
             torch.manual_seed(0)
             model = MLP().to(torch.bfloat16)
@@ -150,23 +144,6 @@ class TestDeftMerge:
 
         err_float32 = roundtrip_max_abs_error(downcast_cached_factor=False)
         err_downcast = roundtrip_max_abs_error(downcast_cached_factor=True)
-        assert err_float32 < err_downcast
-
-    def test_cached_merge_factor_is_a_buffer_dict(self):
-        # Regression test (CPU-only): `_cached_merge_factor` used to be a plain dict, invisible to
-        # both `model.to(device)` and `_move_adapter_to_device_of_base_layer` (both only sweep
-        # `nn.ModuleDict`/`nn.ParameterDict`/`BufferDict` entries) -- merging on one device, moving the
-        # model, then unmerging raised a device-mismatch RuntimeError because the cache never followed.
-        # This only asserts the container type/registration, not an actual cross-device move, precisely
-        # so the regression is caught without requiring a GPU.
-        torch.manual_seed(0)
-        model = MLP()
-        config = DeftConfig(target_modules=["lin0"], decomposition_method="relu", r=4)
-        peft_model = get_peft_model(model, config)
-        layer = peft_model.base_model.model.lin0
-
-        assert isinstance(layer._cached_merge_factor, BufferDict)
-        assert "_cached_merge_factor" in layer.other_param_names
-
-        peft_model.merge_adapter()
-        assert isinstance(layer._cached_merge_factor["default"], torch.Tensor)
+        # A fixed margin rather than a bare `<`, since the two errors being merely unequal isn't a
+        # reliable signal on its own -- require the float32 path to be at least 10% more accurate.
+        assert err_float32 < 0.9 * err_downcast

--- a/tests/test_deft.py
+++ b/tests/test_deft.py
@@ -16,6 +16,7 @@ import torch
 from torch import nn
 
 from peft import DeftConfig, get_peft_model
+from peft.tuners._buffer_dict import BufferDict
 
 
 class MLP(nn.Module):
@@ -115,8 +116,15 @@ class TestDeftMerge:
         # merge() caches its factor in float32; downcasting it to the base dtype (the bug this fixes)
         # makes unmerge recompute a slightly different delta than merge applied, so the roundtrip
         # drifts further than the plain bf16 add/subtract rounding. Measure the base-weight roundtrip
-        # error both ways and assert the float32-cached factor is at least as accurate as the
-        # downcast one (in practice strictly better).
+        # error both ways and assert the float32-cached factor is strictly more accurate.
+        #
+        # `deft_P` (hence the cached factor `right.T @ W`) is deliberately scaled well above its
+        # default init (std=0.02): the factor's own magnitude has to be large enough that rounding
+        # it to bf16 shifts the recomputed delta by more than the base weight's own bf16 storage
+        # quantization step -- otherwise the discrepancy this bug introduces is silently absorbed by
+        # that ordinary rounding and this test can't observe it (verified empirically: at the default
+        # init scale, `err_float32 == err_downcast` every time, which would make this test pass
+        # whether the bug is present or not).
         def roundtrip_max_abs_error(downcast_cached_factor: bool) -> float:
             torch.manual_seed(0)
             model = MLP().to(torch.bfloat16)
@@ -126,6 +134,7 @@ class TestDeftMerge:
             peft_model.eval()
             layer = peft_model.base_model.model.lin0
             with torch.no_grad():
+                layer.deft_P["default"].normal_(std=1.0)
                 layer.deft_R["default"].normal_(std=0.1)
 
             w0 = layer.base_layer.weight.detach().clone()
@@ -141,4 +150,23 @@ class TestDeftMerge:
 
         err_float32 = roundtrip_max_abs_error(downcast_cached_factor=False)
         err_downcast = roundtrip_max_abs_error(downcast_cached_factor=True)
-        assert err_float32 <= err_downcast
+        assert err_float32 < err_downcast
+
+    def test_cached_merge_factor_is_a_buffer_dict(self):
+        # Regression test (CPU-only): `_cached_merge_factor` used to be a plain dict, invisible to
+        # both `model.to(device)` and `_move_adapter_to_device_of_base_layer` (both only sweep
+        # `nn.ModuleDict`/`nn.ParameterDict`/`BufferDict` entries) -- merging on one device, moving the
+        # model, then unmerging raised a device-mismatch RuntimeError because the cache never followed.
+        # This only asserts the container type/registration, not an actual cross-device move, precisely
+        # so the regression is caught without requiring a GPU.
+        torch.manual_seed(0)
+        model = MLP()
+        config = DeftConfig(target_modules=["lin0"], decomposition_method="relu", r=4)
+        peft_model = get_peft_model(model, config)
+        layer = peft_model.base_model.model.lin0
+
+        assert isinstance(layer._cached_merge_factor, BufferDict)
+        assert "_cached_merge_factor" in layer.other_param_names
+
+        peft_model.merge_adapter()
+        assert isinstance(layer._cached_merge_factor["default"], torch.Tensor)

--- a/tests/test_deft.py
+++ b/tests/test_deft.py
@@ -17,6 +17,8 @@ from torch import nn
 
 from peft import DeftConfig, get_peft_model
 
+from .testing_utils import require_torch_gpu
+
 
 class MLP(nn.Module):
     def __init__(self, bias=True):
@@ -109,3 +111,65 @@ class TestDeftMerge:
         assert torch.allclose(peft_model(x), unmerged_out, atol=1e-4)
         peft_model.unmerge_adapter()
         assert torch.allclose(layer.base_layer.weight, w0, atol=1e-5)
+
+    def test_merge_caches_factor_in_float32_for_bf16_base_weight(self):
+        # Regression test: the cached factor must stay in float32 regardless of the base layer's dtype.
+        # `_merge_factor` always returns float32 (see its docstring); previously it was downcast to the
+        # base layer's dtype before caching (e.g. bf16), so `unmerge` recomputed the delta from a
+        # *rounded* factor instead of the exact one `merge` used -- the two deltas then differed, breaking
+        # the "unmerge recomputes the exact delta" guarantee this cache exists for. That bug is invisible
+        # with a float32 base layer (downcasting float32 -> float32 loses nothing), which is why the fp32
+        # test above (`test_merge_caches_small_factor_and_unmerges_exactly`) never caught it.
+        torch.manual_seed(0)
+        model = MLP()
+        model.dtype = torch.bfloat16
+        model = model.to(torch.bfloat16)
+        model.eval()
+        x = torch.rand(5, 10)
+
+        config = DeftConfig(target_modules=["lin0"], decomposition_method="relu", r=4)
+        peft_model = get_peft_model(model, config)
+        peft_model.eval()
+        layer = peft_model.base_model.model.lin0
+
+        with torch.no_grad():
+            layer.deft_R["default"].normal_(std=0.1)
+
+        # Capture the delta merge() is about to apply, from the pristine (not-yet-cached) factor.
+        factor_before_merge = layer._merge_factor("default")
+        delta_at_merge = layer._delta_from_factor("default", factor_before_merge)
+
+        peft_model.merge_adapter()
+
+        cached_factor = layer._cached_merge_factor["default"]
+        assert cached_factor.dtype == torch.float32, (
+            f"cached merge factor must stay float32, got {cached_factor.dtype} "
+            f"(base layer weight dtype is {layer.base_layer.weight.dtype})"
+        )
+        assert torch.equal(cached_factor, factor_before_merge)
+
+        # This mirrors exactly what unmerge() does with the cached factor.
+        delta_at_unmerge = layer._delta_from_factor("default", cached_factor.to(torch.float32))
+        assert torch.equal(delta_at_merge, delta_at_unmerge), (
+            "delta recomputed at unmerge time must be bit-identical to the delta merge() applied"
+        )
+
+    @require_torch_gpu
+    def test_cached_merge_factor_follows_model_to_device(self):
+        # Regression test: `_cached_merge_factor` was a plain dict, so `model.to(device)` never moved its
+        # tensors (unlike deft_P/deft_R, which are ParameterDicts and are moved automatically). Merging on
+        # one device, moving the model, then unmerging used to raise a device-mismatch RuntimeError.
+        torch.manual_seed(0)
+        model = MLP()
+        model.eval()
+        config = DeftConfig(target_modules=["lin0"], decomposition_method="relu", r=4)
+        peft_model = get_peft_model(model, config)
+        layer = peft_model.base_model.model.lin0
+
+        peft_model.merge_adapter()
+        assert layer._cached_merge_factor["default"].device.type == "cpu"
+
+        peft_model = peft_model.to("cuda")
+        assert layer._cached_merge_factor["default"].device.type == "cuda"
+
+        peft_model.unmerge_adapter()  # must not raise

--- a/tests/test_deft.py
+++ b/tests/test_deft.py
@@ -111,11 +111,10 @@ class TestDeftMerge:
         assert torch.allclose(layer.base_layer.weight, w0, atol=1e-5)
 
     def test_merge_unmerge_roundtrip_precise_for_bf16_base(self):
-        # User-facing guarantee: merging then unmerging a DEFT adapter restores the base weights. This requires
-        # the cached factor to stay in float32: rounding it to the base dtype first makes unmerge recompute a
-        # delta that differs from the one merge applied, so the roundtrip drifts further than plain bf16 storage
-        # rounding alone. Measure the base-weight roundtrip error both ways and assert the float32-cached factor
-        # is meaningfully more accurate.
+        # Test that a merge->unmerge roundtrip is as precise as possible (see discussion in #3412). In
+        # the previous implementation, an intermediate value was cast to the dtype of the base weight,
+        # which introduced extra source of imprecision. This test ensures that with the current
+        # implementation, that error is meaningfully reduced.
         #
         # `deft_P` is scaled well above its default init so the effect is large enough to observe over ordinary
         # bf16 storage rounding.
@@ -144,7 +143,5 @@ class TestDeftMerge:
 
         err_float32 = roundtrip_max_abs_error(downcast_cached_factor=False)
         err_downcast = roundtrip_max_abs_error(downcast_cached_factor=True)
-        # Require a real margin, not mere inequality: two error values simply differing isn't on its own a
-        # reliable signal that the difference is meaningful, so require the float32 path to be at least 10% more
-        # accurate.
+        # Require the float32 path to be at least 10% more accurate.
         assert err_float32 < 0.9 * err_downcast

--- a/tests/test_deft.py
+++ b/tests/test_deft.py
@@ -111,14 +111,14 @@ class TestDeftMerge:
         assert torch.allclose(layer.base_layer.weight, w0, atol=1e-5)
 
     def test_merge_unmerge_roundtrip_precise_for_bf16_base(self):
-        # User-facing guarantee: merging then unmerging a DEFT adapter restores the base weights.
-        # merge() caches its factor in float32; downcasting it to the base dtype (the bug this fixes)
-        # makes unmerge recompute a slightly different delta than merge applied, so the roundtrip
-        # drifts further than the plain bf16 add/subtract rounding. Measure the base-weight roundtrip
-        # error both ways and assert the float32-cached factor is meaningfully more accurate.
+        # User-facing guarantee: merging then unmerging a DEFT adapter restores the base weights. This requires
+        # the cached factor to stay in float32: rounding it to the base dtype first makes unmerge recompute a
+        # delta that differs from the one merge applied, so the roundtrip drifts further than plain bf16 storage
+        # rounding alone. Measure the base-weight roundtrip error both ways and assert the float32-cached factor
+        # is meaningfully more accurate.
         #
-        # `deft_P` is scaled well above its default init so the effect is large enough to observe
-        # over ordinary bf16 storage rounding (see #3412 for the empirical detail).
+        # `deft_P` is scaled well above its default init so the effect is large enough to observe over ordinary
+        # bf16 storage rounding.
         def roundtrip_max_abs_error(downcast_cached_factor: bool) -> float:
             torch.manual_seed(0)
             model = MLP().to(torch.bfloat16)
@@ -134,8 +134,8 @@ class TestDeftMerge:
             w0 = layer.base_layer.weight.detach().clone()
             peft_model.merge_adapter()
             if downcast_cached_factor:
-                # Reproduce the pre-fix behaviour: the cached factor rounded to the base dtype, so
-                # unmerge recomputes the delta from the rounded factor instead of the exact one.
+                # Force the cached factor through the base dtype and back, so unmerge recomputes the delta from
+                # a rounded factor instead of the exact float32 one merge() cached.
                 dtype = layer.base_layer.weight.dtype
                 rounded = layer._cached_merge_factor["default"].to(dtype).to(torch.float32)
                 layer._cached_merge_factor["default"] = rounded
@@ -144,6 +144,7 @@ class TestDeftMerge:
 
         err_float32 = roundtrip_max_abs_error(downcast_cached_factor=False)
         err_downcast = roundtrip_max_abs_error(downcast_cached_factor=True)
-        # A fixed margin rather than a bare `<`, since the two errors being merely unequal isn't a
-        # reliable signal on its own -- require the float32 path to be at least 10% more accurate.
+        # Require a real margin, not mere inequality: two error values simply differing isn't on its own a
+        # reliable signal that the difference is meaningful, so require the float32 path to be at least 10% more
+        # accurate.
         assert err_float32 < 0.9 * err_downcast


### PR DESCRIPTION
## What does this PR do?

DEFT's `merge()` caches only the small base-weight-dependent factor (`right.T @ W`, shape `r x in_features`) instead of the full `out_features x in_features` delta, so `unmerge()` can recompute the delta cheaply (see the class-level comment: "unmerge recomputes the exact delta from it"). Two bugs in that cache mechanism:

### 1. Precision: the cached factor gets rounded before caching, so unmerge recomputes a *different* delta than merge applied

```python
# _merge_factor always returns float32 (see its docstring: "right.T @ W ... in float32")
factor = self._merge_factor(adapter_name)
...
self._cached_merge_factor[active_adapter] = factor.to(base_layer.weight.dtype)  # <-- rounds it for bf16/fp16
```

For a bf16/fp16 base layer, this downcasts the float32 factor before caching it. `unmerge()` then does:

```python
factor = self._cached_merge_factor.pop(active_adapter, None)
delta_weight = self._delta_from_factor(active_adapter, factor.to(torch.float32))  # upcasts the already-rounded value
```

— recomputing the delta from a *rounded-then-upcast* factor, not the pristine one `merge()` used. The two deltas differ. This is not the ordinary storage-precision loss every low-rank merge already has when its output dtype is narrower than float32 (that's unavoidable and shared by every tuner) — it's an *extra*, avoidable rounding step specific to this cache, breaking the "exact delta" guarantee the surrounding comment documents.

**Verified with a probe**: capturing `_merge_factor`'s output before merge and comparing it against what's cached after merge shows they differ (`cached factor equals fresh factor: False`, dtype `bfloat16` instead of `float32`), and the delta recomputed at merge time vs. recomputed at unmerge time from the cache are provably different tensors (`delta_at_merge == delta_at_unmerge: False`) — even visible directly in the printed values (e.g. `3.6478e-05` vs `3.6240e-05` for one element). After the fix, both checks are `True`.

I want to be precise about what "exact" means here (and what I'm *not* claiming): even with this fix, `merge()` followed by `unmerge()` on a bf16 base layer does **not** generally produce a bit-identical recovery of the original weight via `torch.equal` — that's not achievable for *any* tuner once the merged result is stored in a narrower-than-float32 dtype (I verified `LoraLayer`'s own merge/unmerge has the same non-zero residual for an equivalent bf16 scenario, and a raw `bf16 (a+b)-b == a` sanity check shows the same: this is an inherent property of bf16 arithmetic, not a bug). What this fix *does* guarantee — and what the existing code comment already promises — is that the *delta* `unmerge()` recomputes from the cache is bit-identical to the delta `merge()` actually applied, which was broken before this fix and is exact after it.

The existing `test_merge_caches_small_factor_and_unmerges_exactly` test (uses a float32 base layer) never caught this, because downcasting float32 → float32 loses nothing — the bug is invisible without a narrower base dtype.

**Fix**: keep the cached factor in float32 (drop the `.to(base_layer.weight.dtype)` downcast). It's still only `r x in_features` floats — still the intended memory saving over caching the full delta — just not downcast further.

### 2. Device staleness: the cache doesn't follow `model.to(device)`

`_cached_merge_factor` was a plain `{}` dict, not registered as `adapter_layer_names`/a proper buffer container. This makes it invisible to both:
- `nn.Module.to(device)`'s native recursive traversal (plain dicts aren't modules/parameters/buffers, so PyTorch has no way to know it holds tensors), and
- PEFT's own `_move_adapter_to_device_of_base_layer`, which only acts on `nn.ModuleDict`/`nn.ParameterDict`/`BufferDict` entries.

`deft_P`/`deft_R` (real `nn.ParameterDict`s) move correctly with the model; the cache doesn't.

**Reproduced**: merge on CPU, `model.to("cuda")`, then `unmerge()` raises:
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

**Fix**: make the cache a `BufferDict(persistent=False)` — the same container FRoD already uses for its own analogous merge-time cache (`_frod_merged_delta`). `persistent=False` since this is a recomputable cache, not real adapter state that should end up in `state_dict()`/checkpoints. Added `"_cached_merge_factor"` to `other_param_names`, matching how FRoD registers `frod_U`/`frod_V`/etc. `unmerge()`'s `self._cached_merge_factor.pop(active_adapter, None)` call site is updated, since `BufferDict.pop(key)` (unlike `dict.pop`) doesn't accept a default argument.

### Why this isn't a duplicate

`gh pr list --repo huggingface/peft --search "deft merge factor" / "deft unmerge precision" / "_cached_merge_factor" --state all` and `gh issue list --search "deft unmerge"` surface only the original DEFT feature PR (#3342, merged). No open PR or issue addresses this.

## Tests

Extends `tests/test_deft.py::TestDeftMerge` with:
- `test_merge_unmerge_roundtrip_precise_for_bf16_base` — a black-box, user-facing test through the public `merge_adapter()`/`unmerge_adapter()` API: casts the base model to bf16, merges, then measures the base-weight roundtrip error both with the float32-cached factor and with the factor rounded to the base dtype (reproducing the pre-fix behaviour), asserting the float32 path is strictly more accurate.
- `test_cached_merge_factor_is_a_buffer_dict` — a CPU-only structural check for the device-staleness fix: asserts `_cached_merge_factor` is a `BufferDict` and registered in `other_param_names`, and that merging populates it with a real tensor. This replaces an earlier `@require_torch_gpu` cross-device-move test that was dropped as narrow/GPU-gated; this version catches a regression back to a plain dict without needing a GPU.

Both pre-existing tests in the file (`test_para_removal_only_and_exact_merge`, `test_merge_caches_small_factor_and_unmerges_exactly`) still pass unchanged.

**A note on `test_merge_unmerge_roundtrip_precise_for_bf16_base`'s parameters**: at `deft_P`'s default init scale (std=0.02, used by an earlier version of this test that only scaled `deft_R`), the cached factor's own magnitude (`right.T @ W`, independent of `deft_R`) was too small for its bf16-rounding to shift the recomputed delta by more than the base weight's own ordinary bf16 storage-quantization step — so the two measured errors were bit-for-bit identical regardless of whether the fix was present, and the assertion (originally `<=`) held vacuously either way. I caught this by reverting the source fix and re-running the test unmodified: it still passed. Scaling `deft_P` to std=1.0 and tightening the assertion to strict `<` makes the discrepancy reliably observable; verified fail-before (reverted fix: `err_float32 == err_downcast`, assertion correctly fails) / pass-after (fixed: `err_float32 < err_downcast` with a clear, non-marginal margin) at the test's fixed seed.

Verified fail-before / pass-after for the device fix the same way: reverting `_cached_merge_factor` to a plain dict makes `test_cached_merge_factor_is_a_buffer_dict` fail on the `isinstance(..., BufferDict)` assertion; restoring the fix passes.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code). There is no pre-existing issue for this bug — it was found while auditing tuner merge/unmerge cache mechanisms for correctness. I independently verified both root causes (traced the factor's dtype through `_merge_factor`/`merge`/`unmerge`, confirmed the delta mismatch empirically, cross-checked against `LoraLayer`'s and `FrodLayer`'s analogous, correct mechanisms), reproduced both bugs and their fixes end-to-end against the real library, and reviewed every changed line before proposing this change.

