### PR TITLE
fix device mismatch for bnb dequantization

### DIFF
--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -115,10 +115,10 @@ def dequantize_bnb_weight(weight: torch.nn.Parameter, state=None):
 
     if hasattr(bnb.functional, "int8_vectorwise_dequant"):
         # Use bitsandbytes API if available (requires v0.45.0+)
-        dequantized = bnb.functional.int8_vectorwise_dequant(weight.data, state.SCB)
+        dequantized = bnb.functional.int8_vectorwise_dequant(weight.data, state.SCB.to(weight.data.device))
     else:
         # Multiply by (scale/127) to dequantize.
-        dequantized = weight.data * state.SCB.view(-1, 1) * 7.874015718698502e-3
+        dequantized = weight.data * state.SCB.to(weight.data.device).view(-1, 1) * 7.874015718698502e-3
 
     return dequantized
 


### PR DESCRIPTION
Fix failed test case: `tests/test_gpu_examples.py::PeftBnbGPUExampleTests::test_initialize_dora_with_bnb_on_cpu_1_8bit`.
It will fail with error: `untimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`.
The issue happens during 8-bit bnb dequantization. In the DoRA initialization path, the quantized weight data may be temporarily moved to the accelerator device, while the bnb scale tensor state.SCB can remain on CPU. Passing those tensors directly into bnb.functional.int8_vectorwise_dequant causes a device mismatch.

This PR moves state.SCB to weight.data.device before dequantization, and applies the same device alignment in the fallback dequantization path.