### PR TITLE
FIX Bug in forgetting metric in MetaMathQA

### DIFF
--- a/method_comparison/MetaMathQA/run.py
+++ b/method_comparison/MetaMathQA/run.py
@@ -115,14 +115,15 @@ def calculate_mean_per_token_loss(model, tokenizer, rows: list[str], batch_size:
         sliced = rows[j : j + batch_size]
         batch = tokenizer(sliced, truncation=True, max_length=max_length)
         batch = tokenizer.pad(batch, return_tensors="pt", padding_side="left").to(model.device)
-        outputs = model(**batch, pad_token_id=tokenizer.eos_token_id)
+        outputs = model(**batch)
         logits = outputs.logits
         for logit, target, mask in zip(logits, batch["input_ids"], batch["attention_mask"]):
             # calculate loss per token so that the mean is not skewed by sequence length of sample, padding from left
+            # note: mask correctly calculates the tokens, it does *not* include potential virtual tokens
             num_tokens = mask.sum()
-            token_losses = torch.nn.functional.cross_entropy(
-                logit[-num_tokens:], target[-num_tokens:], reduction="none"
-            )
+            logit = logit[-num_tokens:]
+            target = target[-num_tokens:]
+            token_losses = torch.nn.functional.cross_entropy(logit[:-1], target[1:], reduction="none")
             losses.extend(loss.item() for loss in token_losses)
     return torch.tensor(losses).mean().item()
 
@@ -209,10 +210,27 @@ def train(
 
     rows_wiki = get_wiki_small()
     model.eval()
-    # use small batch_size, not batch_size_eval, to prevent this from taking too much memory and affecting the max memory metric
-    wiki_loss_before = calculate_mean_per_token_loss(
-        model=model, tokenizer=tokenizer, rows=rows_wiki, batch_size=batch_size, max_length=768
-    )
+
+    # Ensure that we calculate the the wiki loss on the base model. Otherwise, PEFT models that are not zero-initialized
+    # (e.g. prompt tuning) will have very bad initial loss, leading to artificially low or negative forgetting. Note: We
+    # could hard-code the value (1.58611) but it would be easy to forget to update the value if we change the
+    # calculation or dataset.
+    is_full_fine_tune = not hasattr(model, "peft_config")
+    base_model_context = nullcontext if is_full_fine_tune else model.disable_adapter
+    with base_model_context():
+        # use small batch_size, not batch_size_eval, to prevent this from taking too much memory and affecting the max
+        # memory metric
+        wiki_loss_before = calculate_mean_per_token_loss(
+            model=model,
+            tokenizer=tokenizer,
+            rows=rows_wiki,
+            batch_size=batch_size,
+            max_length=768,
+        )
+        assert 1 < wiki_loss_before < 2, (
+            "Sanity check failed: The wiki loss before training should be between 1.0 and 2.0"
+        )
+
     model.train()
 
     ds_train, ds_valid, ds_test = get_train_valid_test_datasets(


### PR DESCRIPTION
This PR fixes two bugs in how the forgetting metric in the MetaMathQA benchmark is determined.

## Background

I was revisiting the forgetting metric, which has some weird numbers on some of the MetaMathQA experiments. This revealed two bugs which are fixed in this PR:

1. Beforehand, we were comparing logits vs targets, but we should compare logits vs targets shifted by 1. This is done under the hood in the training loop when passing labels to the forward pass of the model, but when calculating the forgetting metric, we omitted it.

After I fixed that, I re-ran some tests, among others prompt tuning, which had a forgetting metric of 3.673, which is very high. To my surprise, after the fix the metric was -2.475. This prompted me to investigate further and I found the second issue:

2. We calculated the wiki text loss on the PEFT model before training. However, some PEFT methods are not identity transforms at the start of training. For instance, prompt tuning injects (by default) random virtual embeddings, which can severely reduce the loss before training. When, after training, the loss recovers, it appears as if forgetting is negative, when in reality the loss is just back to normal. I verified this by checking the loss before training and it was 3.63. For LoRA, which is an identity transform at the start, the loss was only 1.58.

The solution is to disable the PEFT contribution when calculating the initial wiki loss. Even better would be to calculate the loss before applying PEFT at all, but the way the code is structured, it's currently not possible. I also added a sanity check that the value is between 1 and 2. In theory, we could even hard-code the value, as it must be the same for each model, but then we would have to keep it up-to-date if there are changes.

## Results

With the fixed forgetting metric, I re-ran some experiments: LoRA as the default non-prompt learning PEFT method; adaption prompt, which had the lowest forgetting; and prompt tuning, which had the highest forgetting. The new numbers look much more reasonable:

```
LoRA r32: 0.417 -> 0.501
Adaption prompt lr 0.0005: -0.954 -> 0.221
Prompt tuning lr 0.001 3.673 -> 0.404
```

Of course, if we merge this PR, all forgetting metrics in our results are invalidated, so we would have to re-run all experiments. I think that would be overkill just for this change, but since we have several new PEFT methods, a new PyTorch version, and haven't run the full batch in some time, I would argue we should rerun everything for the upcoming PEFT v0.20.0 release.