### PR TITLE
Fix hotswapping for LoRA adapters targeting grouped Conv2d

### DIFF
--- a/src/peft/utils/hotswap.py
+++ b/src/peft/utils/hotswap.py
@@ -148,7 +148,9 @@ def _get_padded_linear(lora_module: torch.nn.Module, target_rank: int, is_lora_A
     return new_layer
 
 
-def _get_padded_conv2d(lora_module: torch.nn.Module, target_rank: int, is_lora_A: bool) -> torch.nn.Conv2d:
+def _get_padded_conv2d(
+    lora_module: torch.nn.Module, target_rank: int, is_lora_A: bool, groups: int = 1
+) -> torch.nn.Conv2d:
     """
     Get a new Conv2d layer for LoRA with padded weights according to the target rank.
 
@@ -159,6 +161,8 @@ def _get_padded_conv2d(lora_module: torch.nn.Module, target_rank: int, is_lora_A
             The desired rank to pad to.
         is_lora_A (bool):
             True if this is the LoRA A matrix, False if LoRA B.
+        groups (int):
+            The number of groups of the targeted base Conv2d layer.
 
     Returns:
         nn.Conv2d:
@@ -167,7 +171,8 @@ def _get_padded_conv2d(lora_module: torch.nn.Module, target_rank: int, is_lora_A
     weight = lora_module.weight
     # For Conv2d: [out_channels, in_channels, kernel_height, kernel_width]
     out_channels, in_channels, kh, kw = weight.shape
-    original_rank = out_channels if is_lora_A else in_channels
+    # LoRA B is a grouped conv, so it stores rank // groups input channels; LoRA A is always groups=1
+    original_rank = out_channels if is_lora_A else in_channels * groups
 
     if original_rank == target_rank:
         return lora_module
@@ -178,11 +183,22 @@ def _get_padded_conv2d(lora_module: torch.nn.Module, target_rank: int, is_lora_A
             f"({original_rank}). This is not possible."
         )
 
+    if target_rank % groups != 0:
+        raise ValueError(
+            f"Trying to pad the adapter to the target rank {target_rank}, which is not divisible by the number of "
+            f"groups ({groups}) of the targeted Conv2d layer."
+        )
+
     # lora_A and lora_B are always nn.Conv2d
     if is_lora_A:
-        # LoRA A affects out_channels
+        # LoRA A affects out_channels; place each group's rank at the start of its slice so that the grouped
+        # LoRA B reads the padding zeros from the right channels
+        rank_per_group = out_channels // groups
+        target_per_group = target_rank // groups
         padded = torch.zeros(target_rank, in_channels, kh, kw, device=weight.device, dtype=weight.dtype)
-        padded[:out_channels, :, :, :] = weight
+        for g in range(groups):
+            src = weight[g * rank_per_group : (g + 1) * rank_per_group]
+            padded[g * target_per_group : g * target_per_group + rank_per_group] = src
         new_layer = torch.nn.Conv2d(
             in_channels,
             target_rank,
@@ -193,8 +209,8 @@ def _get_padded_conv2d(lora_module: torch.nn.Module, target_rank: int, is_lora_A
             groups=lora_module.groups,
         )
     else:
-        # LoRA B affects in_channels
-        padded = torch.zeros(out_channels, target_rank, kh, kw, device=weight.device, dtype=weight.dtype)
+        # LoRA B affects in_channels, stored as rank // groups per group for grouped convs
+        padded = torch.zeros(out_channels, target_rank // groups, kh, kw, device=weight.device, dtype=weight.dtype)
         padded[:, :in_channels, :, :] = weight
         new_layer = torch.nn.Conv2d(
             target_rank,
@@ -247,20 +263,22 @@ def _pad_lora_weights(model: torch.nn.Module, target_rank: int) -> bool:
         # Decide which pad function to call based on module type
         if isinstance(module, Linear):
             pad_fn = _get_padded_linear
+            pad_kwargs = {}
         elif isinstance(module, Conv2d):
             pad_fn = _get_padded_conv2d
+            pad_kwargs = {"groups": module.get_base_layer().groups}
         else:
             # Skip any other module types
             continue
 
         # Pad LoRA A
         for adapter_name, lora_A_module in module.lora_A.items():
-            new_layer = pad_fn(lora_A_module, target_rank=target_rank, is_lora_A=True)
+            new_layer = pad_fn(lora_A_module, target_rank=target_rank, is_lora_A=True, **pad_kwargs)
             module.lora_A[adapter_name] = new_layer
 
         # Pad LoRA B
         for adapter_name, lora_B_module in module.lora_B.items():
-            new_layer = pad_fn(lora_B_module, target_rank=target_rank, is_lora_A=False)
+            new_layer = pad_fn(lora_B_module, target_rank=target_rank, is_lora_A=False, **pad_kwargs)
             module.lora_B[adapter_name] = new_layer
 
         found_adapter = True
@@ -490,7 +508,17 @@ def hotswap_adapter_from_state_dict(
             # Linear or Conv2d: the check for dim 0 or 1 works for both of these layer types
             if old_val.shape[0] > new_val.shape[0]:
                 old_val.data.fill_(0)
-                old_val.data[: new_val.shape[0]].copy_(new_val.data)
+                # For LoRA A of a grouped conv, the rank dimension is split into `groups` blocks, one per group, so
+                # each block of the new weight must be copied to the start of the corresponding block of the old
+                # weight (matching the layout created by prepare_model_for_compiled_hotswap). For everything else,
+                # groups == 1 and this is a single contiguous copy.
+                groups = getattr(module.get_base_layer(), "groups", 1)
+                old_block = old_val.shape[0] // groups
+                new_block = new_val.shape[0] // groups
+                for g in range(groups):
+                    old_val.data[g * old_block : g * old_block + new_block].copy_(
+                        new_val.data[g * new_block : (g + 1) * new_block]
+                    )
             elif old_val.shape[1] > new_val.shape[1]:
                 old_val.data.fill_(0)
                 old_val.data[:, : new_val.shape[1]].copy_(new_val.data)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -4077,6 +4077,18 @@ class TestHotSwapping:
         torch.manual_seed(0)
         return ConvModel().to(self.torch_device)
 
+    def get_model_conv2d_grouped(self):
+        class ConvModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(4, 4, kernel_size=3, groups=2)
+
+            def forward(self, X):
+                return self.conv(X)
+
+        torch.manual_seed(0)
+        return ConvModel().to(self.torch_device)
+
     @pytest.mark.parametrize(
         "config",
         [
@@ -4366,6 +4378,65 @@ class TestHotSwapping:
         # real check: model now behaves again like adapter 0
         assert torch.allclose(output0, output_loaded_back0, atol=atol, rtol=rtol)
 
+    def test_hotswap_works_different_ranks_grouped_conv2d(self, tmp_path):
+        # same as previous test, but for a grouped Conv2d (groups > 1); the model is padded to a larger target rank
+        # first, then an adapter with a smaller rank is hotswapped in, see #3416
+        atol, rtol = 1e-4, 1e-4
+        inputs = torch.rand(3, 4, 10, 10).to(self.torch_device)
+
+        # create adapter 0
+        config0 = LoraConfig(target_modules=["conv"], r=4, init_lora_weights=False)
+        model = self.get_model_conv2d_grouped()
+        torch.manual_seed(0)
+        model = get_peft_model(model, config0)
+        model.eval()
+        with torch.inference_mode():
+            output0 = model(inputs)
+        model.save_pretrained(tmp_path / "adapter0")
+
+        del model
+
+        # create adapter 1
+        config1 = LoraConfig(target_modules=["conv"], r=2, init_lora_weights=False)
+        model = self.get_model_conv2d_grouped()
+        torch.manual_seed(1)
+        model = get_peft_model(model, config1)
+        model.eval()
+        with torch.inference_mode():
+            output1 = model(inputs)
+        model.save_pretrained(tmp_path / "adapter1")
+
+        # sanity check: they're not the same
+        assert not torch.allclose(output0, output1, atol=atol, rtol=rtol)
+
+        del model
+
+        # load adapter 0 and pad it to the target rank
+        model = self.get_model_conv2d_grouped()
+        model = PeftModel.from_pretrained(model, tmp_path / "adapter0")
+        prepare_model_for_compiled_hotswap(model, target_rank=8)
+        with torch.inference_mode():
+            output_loaded0 = model(inputs)
+
+        # sanity check: same output after padding for adapter 0
+        assert torch.allclose(output0, output_loaded0, atol=atol, rtol=rtol)
+
+        # hotswap with adapter 1, whose rank is smaller than the target rank
+        hotswap_adapter(model, tmp_path / "adapter1", adapter_name="default")
+        with torch.inference_mode():
+            output_loaded1 = model(inputs)
+
+        # real check: model now behaves like adapter 1
+        assert torch.allclose(output1, output_loaded1, atol=atol, rtol=rtol)
+
+        # hotswap back to adapter 0
+        hotswap_adapter(model, tmp_path / "adapter0", adapter_name="default")
+        with torch.inference_mode():
+            output_loaded_back0 = model(inputs)
+
+        # real check: model now behaves again like adapter 0
+        assert torch.allclose(output0, output_loaded_back0, atol=atol, rtol=rtol)
+
     def test_prepare_model_for_compiled_hotswap_scalings_are_tensors(self):
         config = LoraConfig(target_modules=["lin0", "lin1"])
         model = self.get_model()
@@ -4461,6 +4532,18 @@ class TestHotSwapping:
         msg = re.escape("Trying to pad the adapter to the target rank 9, but the original rank is larger (10)")
         with pytest.raises(ValueError, match=msg):
             prepare_model_for_compiled_hotswap(model, target_rank=new_rank)
+
+    def test_prepare_model_for_compiled_hotswap_grouped_conv2d_indivisible_target_rank_raises(self):
+        # when the target rank is not divisible by the groups of the base layer, raise an error, see #3416
+        config = LoraConfig(target_modules=["conv"], r=4)
+        model = self.get_model_conv2d_grouped()
+        model = get_peft_model(model, config)
+
+        msg = re.escape(
+            "Trying to pad the adapter to the target rank 7, which is not divisible by the number of groups (2)"
+        )
+        with pytest.raises(ValueError, match=msg):
+            prepare_model_for_compiled_hotswap(model, target_rank=7)
 
     def test_prepare_model_for_compiled_hotswap_with_rank_pattern(self):
         old_rank0 = 8
@@ -4621,6 +4704,37 @@ class TestHotSwapping:
 
         new_rank = 13
         prepare_model_for_compiled_hotswap(model, target_rank=new_rank)
+        with torch.inference_mode():
+            output_after = model(inputs)
+
+        assert torch.allclose(output_before, output_after)
+
+    def test_prepare_model_for_compiled_hotswap_does_not_change_output_grouped_conv2d(self):
+        # same as previous test, but for a grouped Conv2d (groups > 1), see #3416
+        inputs = torch.rand(3, 4, 10, 10).to(self.torch_device)
+        model = self.get_model_conv2d_grouped().eval()
+        with torch.inference_mode():
+            output_base = model(inputs)
+
+        old_rank = 4
+        config = LoraConfig(target_modules=["conv"], r=old_rank, init_lora_weights=False)
+        model = get_peft_model(model, config).eval()
+        with torch.inference_mode():
+            output_before = model(inputs)
+
+        # sanity check: LoRA changed output
+        assert not torch.allclose(output_base, output_before)
+
+        new_rank = 8
+        prepare_model_for_compiled_hotswap(model, target_rank=new_rank)
+
+        # for grouped convs, LoRA B stores rank // groups input channels
+        for name, param in model.named_parameters():
+            if "lora_A" in name:
+                assert param.shape[0] == new_rank
+            elif "lora_B" in name:
+                assert param.shape[1] == new_rank // 2
+
         with torch.inference_mode():
             output_after = model(inputs)
 


### PR DESCRIPTION
Fixes #3416

`prepare_model_for_compiled_hotswap` raises a shape mismatch for LoRA adapters that target a grouped `Conv2d`. For these layers, LoRA B is itself a grouped conv, so its weight stores `rank // groups` input channels, but `_get_padded_conv2d` treated that dimension as the full rank.

This PR:

- computes LoRA B's original rank as `in_channels * groups` and sizes its padded weight with `target_rank // groups` input channels
- lays out each group's LoRA A output channels at the start of that group's slice of the padded weight, so the grouped LoRA B multiplies the padding zeros with the right channels and the model output is unchanged
- rejects a target rank that is not divisible by the layer's groups

While testing the full flow, I found the same layout problem in `hotswap_adapter_from_state_dict`: when the incoming adapter has a smaller rank than the loaded (or padded) one, the contiguous copy of LoRA A silently produces wrong outputs for grouped convs (max abs diff vs. the adapter loaded directly was ~1.8 in my repro; this also reproduces on main without calling `prepare_model_for_compiled_hotswap`). The copy is now done per group block; with `groups == 1` it reduces to the previous single contiguous copy.

Tests run (CPU):

- new `test_prepare_model_for_compiled_hotswap_does_not_change_output_grouped_conv2d`: padding a grouped conv adapter preserves the output; without the fix it fails with the `ValueError` from the issue
- new `test_hotswap_works_different_ranks_grouped_conv2d`: pad to a larger target rank, hotswap in a smaller-rank adapter, output must match that adapter loaded directly; without the swap-path fix it fails (wrong output, no error)
- new `test_prepare_model_for_compiled_hotswap_grouped_conv2d_indivisible_target_rank_raises` for the new guard
- `pytest tests/test_initialization.py -k TestHotSwapping`: 35 passed
- `ruff check` and `ruff format --check` pass on the touched files

Coordination: reported in #3416, @BenjaminBossan gave the go-ahead in https://github.com/huggingface/peft/issues/3416#issuecomment-4934017022.

AI assistance was used for this PR (Claude Code). The change was reviewed and the tests were run before submitting.
