### PR TITLE
Fix X-LoRA adapter lifecycle validation

### DIFF
--- a/src/peft/tuners/xlora/model.py
+++ b/src/peft/tuners/xlora/model.py
@@ -101,7 +101,7 @@ def _load_adapter_into_lora_model(
     This method emulates the behavior of `PeftModel.from_pretrained`. Updates to `PeftModel.from_pretrained` may need
     to be reflected here.
 
-    All params pertain to the adapter (adapter name, model id, `i` is the adapter number in 0 indexing).
+    All params pertain to the adapter (adapter name, model id).
     """
     from peft.peft_model import PeftModel
     from peft.tuners.lora.config import LoraConfig
@@ -241,6 +241,12 @@ class XLoraModel(BaseTuner):
         else:
             conf = config
 
+        if adapter_name in conf.adapters:
+            raise ValueError(
+                f"X-LoRA expert name {adapter_name!r} conflicts with the outer adapter name. "
+                "Use a different name for the expert."
+            )
+
         # Create an empty LoraModel
         base_lora_config = copy.copy(conf)
         base_lora_config.target_modules = DUMMY_TARGET_MODULES
@@ -264,10 +270,10 @@ class XLoraModel(BaseTuner):
             adapters_items = peft_config.adapters.items()
 
         if hasattr(self.xlora_config, "_subfolders"):
-            for i, (_adapter_name, model_id), subfolder in enumerate(adapters_items):
+            for (_adapter_name, model_id), subfolder in adapters_items:
                 _load_adapter_into_lora_model(
                     lora_model=self.lora_model,
-                    adapter_name=str(i),
+                    adapter_name=_adapter_name,
                     model_id=model_id,
                     torch_device=torch_device,
                     ephemeral_gpu_offload=ephemeral_gpu_offload,
@@ -276,10 +282,10 @@ class XLoraModel(BaseTuner):
                     **kwargs,
                 )
         else:
-            for i, (_adapter_name, model_id) in enumerate(adapters_items):
+            for _adapter_name, model_id in adapters_items:
                 _load_adapter_into_lora_model(
                     lora_model=self.lora_model,
-                    adapter_name=str(i),
+                    adapter_name=_adapter_name,
                     model_id=model_id,
                     torch_device=torch_device,
                     ephemeral_gpu_offload=ephemeral_gpu_offload,
@@ -401,6 +407,33 @@ class XLoraModel(BaseTuner):
             if name == "lora_model":  # see #1892: prevent infinite recursion if class is not initialized
                 raise
             return getattr(self.lora_model, name)
+
+    @property
+    def active_adapter(self) -> str | list[str]:
+        """Forward active-adapter state to the wrapped LoRA model."""
+        return self.lora_model.active_adapter
+
+    @active_adapter.setter
+    def active_adapter(self, value: str | list[str]) -> None:
+        self.lora_model.active_adapter = value
+
+    def delete_adapter(self, adapter_name: str) -> None:
+        """This method is not supported for X-LoRA."""
+        raise TypeError(
+            f"{self.__class__.__name__} does not support `delete_adapter` because its classifier output is fixed "
+            "at construction time."
+        )
+
+    def set_adapter(self, adapter_name: str | list[str], inference_mode: bool = False) -> None:
+        """Activate the complete expert set in its original order."""
+        adapter_names = [adapter_name] if isinstance(adapter_name, str) else list(adapter_name)
+        full_adapter_names = list(self.xlora_config.adapters.keys())
+        if adapter_names != full_adapter_names:
+            raise ValueError(
+                f"{self.__class__.__name__} only supports the original expert order {full_adapter_names}, "
+                f"but received {adapter_names}."
+            )
+        super().set_adapter(adapter_name, inference_mode=inference_mode)
 
     @staticmethod
     def _prepare_adapter_config(peft_config, _model_config):

--- a/tests/test_xlora.py
+++ b/tests/test_xlora.py
@@ -143,6 +143,21 @@ class TestXlora:
         return model
 
     @pytest.fixture(scope="function")
+    def model_named_adapters(self, base_model, saved_lora_adapters):
+        base_model.config.use_cache = False
+        adapters = {f"adapter_{i}": file_name for i, file_name in enumerate(saved_lora_adapters, start=1)}
+
+        peft_config = XLoraConfig(
+            task_type=TaskType.CAUSAL_LM,
+            peft_type=PeftType.XLORA,
+            hidden_size=base_model.config.hidden_size,
+            xlora_depth=8,
+            adapters=adapters,
+        )
+        model = get_peft_model(base_model, peft_config).to(self.torch_device)
+        return model
+
+    @pytest.fixture(scope="function")
     def model_layerwise(self, base_model, saved_lora_adapters):
         base_model.config.use_cache = False
         adapters = {str(i): file_name for i, file_name in enumerate(saved_lora_adapters)}
@@ -478,3 +493,55 @@ class TestXlora:
             orig_embedding.embed_scale.fill_(0)
             embedding_output = xlora_embedding(x)
             assert (embedding_output == 0.0).all()
+
+    def test_non_numeric_adapter_names_forward(self, tokenizer, model_named_adapters):
+        inputs = tokenizer.encode("Python is a", add_special_tokens=False, return_tensors="pt")
+        outputs = model_named_adapters.generate(
+            input_ids=inputs.to(self.torch_device),
+            max_new_tokens=8,
+        )
+        assert torch.isfinite(outputs[: inputs.shape[1] :]).all()
+
+    def test_delete_adapter(self, tokenizer, model):
+        inputs = tokenizer.encode("Python is a", add_special_tokens=False, return_tensors="pt")
+        outputs_before = model.generate(input_ids=inputs.to(self.torch_device), max_new_tokens=8)
+        assert torch.isfinite(outputs_before[: inputs.shape[1] :]).all()
+
+        with pytest.raises(TypeError, match="does not support `delete_adapter`"):
+            model.delete_adapter("1")
+
+        assert model.active_adapters == ["0", "1", "2", "3"]
+        outputs_after = model.generate(input_ids=inputs.to(self.torch_device), max_new_tokens=8)
+        assert torch.isfinite(outputs_after[: inputs.shape[1] :]).all()
+
+    def test_expert_name_collides_with_adapter_name(self, base_model, saved_lora_adapters):
+        base_model.config.use_cache = False
+        adapters = {str(i): file_name for i, file_name in enumerate(saved_lora_adapters)}
+        adapters["default"] = saved_lora_adapters[0]
+
+        peft_config = XLoraConfig(
+            task_type=TaskType.CAUSAL_LM,
+            peft_type=PeftType.XLORA,
+            hidden_size=base_model.config.hidden_size,
+            xlora_depth=8,
+            adapters=adapters,
+        )
+        with pytest.raises(ValueError, match="conflicts with the outer adapter name"):
+            get_peft_model(base_model, peft_config)
+
+    def test_set_adapter_rejects_subset_or_reorder(self, tokenizer, model):
+        with pytest.raises(ValueError, match="only supports the original expert order"):
+            model.base_model.set_adapter(["0", "2"])
+
+        with pytest.raises(ValueError, match="only supports the original expert order"):
+            model.base_model.set_adapter(["1", "0", "2", "3"])
+
+        with pytest.raises(ValueError, match="only supports the original expert order"):
+            model.base_model.set_adapter("0")
+
+        model.base_model.set_adapter(["0", "1", "2", "3"])
+        assert model.active_adapters == ["0", "1", "2", "3"]
+
+        inputs = tokenizer.encode("Python is a", add_special_tokens=False, return_tensors="pt")
+        outputs = model.generate(input_ids=inputs.to(self.torch_device), max_new_tokens=8)
+        assert torch.isfinite(outputs[: inputs.shape[1] :]).all()


### PR DESCRIPTION
## Summary

- preserve user-provided expert names when registering X-LoRA adapters
- reject outer/expert name collisions with a clear error
- reject deletion, subsets, and reordering because classifier columns are fixed at construction

## Tests

- `python -m pytest tests/test_xlora.py -q --no-cov` (20 passed)
- `python -m ruff check src/peft/tuners/xlora tests/test_xlora.py`
- `python -m ruff format --check src/peft/tuners/xlora tests/test_xlora.py`

## AI assistance disclosure

AI assistance was used. I reviewed the changes and ran the tests above.