### PR TITLE
Fix LN Tuning adapter initialization after merge

### DIFF
--- a/src/peft/tuners/ln_tuning/layer.py
+++ b/src/peft/tuners/ln_tuning/layer.py
@@ -35,6 +35,11 @@ class LNTuningLayer(nn.Module, BaseTunerLayer):
         super().__init__()
         self.base_layer = base_layer
         self.ln_tuning_layers = nn.ModuleDict({})
+        # Keep an untouched copy of the pretrained layer. `merge` repoints `base_layer` to whichever adapter is
+        # currently merged (see `merge`/`unmerge` below), so `base_layer` cannot be relied on to always hold the
+        # pristine pretrained weights. `original_module` is never touched by merge/unmerge and is therefore what
+        # new adapters should be initialized from, regardless of whether another adapter is currently merged.
+        self.original_module = deepcopy(base_layer)
         self.update_layer(self.base_layer, adapter_name, config=config)
         self._active_adapter = adapter_name
         self.merged_adapters = []

--- a/src/peft/tuners/ln_tuning/model.py
+++ b/src/peft/tuners/ln_tuning/model.py
@@ -90,7 +90,10 @@ class LNTuningModel(BaseTuner):
             new_module = LNTuningLayer(target, adapter_name, config=peft_config)
         else:
             new_module = target
-            new_module.update_layer(target.base_layer, adapter_name, config=peft_config)
+            # Use `original_module`, not `base_layer`: if another adapter is currently merged, `base_layer` holds
+            # that adapter's trained weights rather than the pristine pretrained layer (see `LNTuningLayer.merge`),
+            # which would otherwise leak into the newly added adapter's initialization.
+            new_module.update_layer(target.original_module, adapter_name, config=peft_config)
         return new_module
 
     def _unloading_checks(self, adapter_names: Optional[list[str]]):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -6649,6 +6649,35 @@ class TestRequiresGrad:
         assert all(not p.requires_grad for p in model.parameters())
 
 
+class TestLNTuningMerge:
+    """Test that adding a new LN Tuning adapter is not affected by another adapter being merged.
+
+    LN Tuning does not merge by computing a delta, instead it swaps `base_layer` with the trained adapter layer
+    (see `LNTuningLayer.merge`). If a subsequent adapter were initialized from `base_layer`, it would incorrectly
+    start from a previously merged adapter's trained weights instead of the pristine pretrained layer.
+    """
+
+    def test_add_adapter_after_merge_is_initialized_from_pretrained_weights(self):
+        base_model = MLP_LayerNorm()
+        # capture the pristine, pretrained weight independently of any PEFT-internal bookkeeping
+        pretrained_weight = base_model.layernorm0.weight.data.clone()
+
+        config = LNTuningConfig(target_modules=["layernorm0"])
+        model = get_peft_model(base_model, config)
+
+        # simulate training of the "default" adapter, then merge it, as documented for LN Tuning
+        model.base_model.model.layernorm0.ln_tuning_layers["default"].weight.data.fill_(999.0)
+        model.merge_adapter()
+        assert model.base_model.model.layernorm0.merged
+
+        # adding a new adapter while "default" is merged must not leak the merged (trained) weights into it
+        model.add_adapter("adapter2", LNTuningConfig(target_modules=["layernorm0"]))
+        new_adapter_weight = model.base_model.model.layernorm0.ln_tuning_layers["adapter2"].weight.data
+
+        assert torch.allclose(new_adapter_weight, pretrained_weight)
+        assert not torch.allclose(new_adapter_weight, torch.full_like(new_adapter_weight, 999.0))
+
+
 # this is for PEFT methods that support mixed adapter batches.
 MIXED_ADAPTER_TEST_CASES = [
     (


### PR DESCRIPTION
## Status

Closed because this audit change was not coordinated in advance. I will raise an issue first if it needs revisiting.

## AI assistance disclosure

AI assistance was used. I reviewed the change.
