### PR TITLE
FIX Accept layers_to_transform=0 together with layers_pattern

### DIFF
--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -88,7 +88,7 @@ class AdaLoraConfig(LoraConfig):
             raise ValueError("`layers_to_transform` cannot be used when `target_modules` is a str.")
 
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
 
         # Check if 'r' has been set to a non-default value

--- a/src/peft/tuners/boft/config.py
+++ b/src/peft/tuners/boft/config.py
@@ -158,7 +158,7 @@ class BOFTConfig(PeftConfig):
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
         if self.boft_block_size == 0 and self.boft_block_num == 0:
             raise ValueError(

--- a/src/peft/tuners/deft/config.py
+++ b/src/peft/tuners/deft/config.py
@@ -205,5 +205,5 @@ class DeftConfig(PeftConfig):
             raise ValueError("`layers_pattern` cannot be used when `target_modules` is a str.")
 
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/delora/config.py
+++ b/src/peft/tuners/delora/config.py
@@ -155,7 +155,7 @@ class DeloraConfig(PeftConfig):
             raise ValueError("`layers_to_transform` cannot be used when `target_modules` is a str.")
 
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
 
         if self.r <= 0:

--- a/src/peft/tuners/fourierft/config.py
+++ b/src/peft/tuners/fourierft/config.py
@@ -202,5 +202,5 @@ class FourierFTConfig(PeftConfig):
         if isinstance(self.target_modules, str) and self.layers_pattern is not None:
             raise ValueError("`layers_pattern` cannot be used when `target_modules` is a str.")
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/frod/config.py
+++ b/src/peft/tuners/frod/config.py
@@ -186,7 +186,7 @@ class FrodConfig(PeftConfig):
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
         )
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
         if self.sparse_rate < 0 or self.sparse_rate > 1:
             raise ValueError(f"`sparse_rate` should be between 0 and 1, got {self.sparse_rate}.")

--- a/src/peft/tuners/hra/config.py
+++ b/src/peft/tuners/hra/config.py
@@ -131,5 +131,5 @@ class HRAConfig(PeftConfig):
             raise ValueError("`layers_pattern` cannot be used when `target_modules` is a str.")
 
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/lily/config.py
+++ b/src/peft/tuners/lily/config.py
@@ -229,7 +229,7 @@ class LilyConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified.")
         if self.stride_A < 1:
             raise ValueError("`stride_A` must be at least 1.")

--- a/src/peft/tuners/loha/config.py
+++ b/src/peft/tuners/loha/config.py
@@ -139,5 +139,5 @@ class LoHaConfig(LycorisConfig):
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/lokr/config.py
+++ b/src/peft/tuners/lokr/config.py
@@ -151,5 +151,5 @@ class LoKrConfig(LycorisConfig):
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -942,7 +942,7 @@ class LoraConfig(PeftConfig):
             raise ValueError("`layers_pattern` cannot be used when `target_modules` is a str.")
 
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
 
         if self.use_dora and self.megatron_config:

--- a/src/peft/tuners/oft/config.py
+++ b/src/peft/tuners/oft/config.py
@@ -184,7 +184,7 @@ class OFTConfig(PeftConfig):
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
         if self.r == 0 and self.oft_block_size == 0:
             raise ValueError(

--- a/src/peft/tuners/peanut/config.py
+++ b/src/peft/tuners/peanut/config.py
@@ -182,7 +182,7 @@ class PeanutConfig(PeftConfig):
         self.exclude_modules = (
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified.")
         if self.r <= 0:
             raise ValueError("`r` must be a positive integer.")

--- a/src/peft/tuners/psoft/config.py
+++ b/src/peft/tuners/psoft/config.py
@@ -277,7 +277,7 @@ class PsoftConfig(PeftConfig):
             raise ValueError("`layers_pattern` cannot be used when `target_modules` is a str.")
 
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
 
         if self.r <= 0:

--- a/src/peft/tuners/pvera/config.py
+++ b/src/peft/tuners/pvera/config.py
@@ -200,7 +200,7 @@ class PveraConfig(PeftConfig):
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
         )
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
         if not self.save_projection:
             warnings.warn(

--- a/src/peft/tuners/tinylora/config.py
+++ b/src/peft/tuners/tinylora/config.py
@@ -184,7 +184,7 @@ class TinyLoraConfig(PeftConfig):
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
         )
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified.")
         if not self.save_projection:
             warnings.warn(

--- a/src/peft/tuners/vblora/config.py
+++ b/src/peft/tuners/vblora/config.py
@@ -192,5 +192,5 @@ class VBLoRAConfig(PeftConfig):
             set(self.exclude_modules) if isinstance(self.exclude_modules, list) else self.exclude_modules
         )
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")

--- a/src/peft/tuners/vera/config.py
+++ b/src/peft/tuners/vera/config.py
@@ -152,7 +152,7 @@ class VeraConfig(PeftConfig):
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
         )
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
         if not self.save_projection:
             warnings.warn(

--- a/src/peft/tuners/waveft/config.py
+++ b/src/peft/tuners/waveft/config.py
@@ -256,7 +256,7 @@ class WaveFTConfig(PeftConfig):
         if isinstance(self.target_modules, str) and self.layers_pattern is not None:
             raise ValueError("`layers_pattern` cannot be used when `target_modules` is a str.")
         # check for layers_to_transform and layers_pattern
-        if self.layers_pattern and not self.layers_to_transform:
+        if self.layers_pattern and self.layers_to_transform is None:
             raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified. ")
 
         if self.wavelet_family not in WAVELET_REDUCTIONS:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import inspect
 import json
 import os
 import pickle
@@ -121,6 +122,14 @@ ALL_CONFIG_CLASSES = (
     (PveraConfig, {}),
     (WaveFTConfig, {}),
 )
+
+# Config classes that support selecting layers by index (`layers_to_transform`) together
+# with a custom `layers_pattern`.
+LAYER_INDEXING_CONFIG_CLASSES = [
+    (config_class, mandatory_kwargs)
+    for config_class, mandatory_kwargs in ALL_CONFIG_CLASSES
+    if {"layers_to_transform", "layers_pattern"} <= set(inspect.signature(config_class).parameters)
+]
 
 
 class TestPeftConfig:
@@ -542,6 +551,19 @@ class TestPeftConfig:
         )
         assert config.layers_to_transform is None
         assert config.layers_pattern is None
+
+    @pytest.mark.parametrize("config_class, mandatory_kwargs", LAYER_INDEXING_CONFIG_CLASSES)
+    def test_config_layers_to_transform_index_zero(self, config_class, mandatory_kwargs):
+        # `layers_to_transform=0` selects the first layer and is a valid index. Because 0
+        # is falsy, a truthiness check on `layers_to_transform` wrongly rejected it when
+        # combined with `layers_pattern`; the guard must compare against None instead.
+        config = config_class(
+            layers_to_transform=0,
+            layers_pattern="model.layers",
+            **mandatory_kwargs,
+        )
+        assert config.layers_to_transform == 0
+        assert config.layers_pattern == "model.layers"
 
     @pytest.mark.parametrize("version", ["0.10", "0.17.0", "1"])
     @pytest.mark.parametrize("config_class, mandatory_kwargs", ALL_CONFIG_CLASSES)


### PR DESCRIPTION
No linked issue — found by reading the code.

### What this fixes

Every tuner config validates the `layers_pattern` / `layers_to_transform` pairing in `__post_init__` with:

```python
if self.layers_pattern and not self.layers_to_transform:
    raise ValueError("When `layers_pattern` is specified, `layers_to_transform` must also be specified.")
```

Because `0` is falsy, passing the **valid first-layer index** `layers_to_transform=0` together with a `layers_pattern` wrongly raises — even though `layers_to_transform` *was* specified:

```python
from peft import LoraConfig

LoraConfig(target_modules=["q_proj"], layers_to_transform=0, layers_pattern="blocks")
# ValueError: When `layers_pattern` is specified, `layers_to_transform` must also be specified.

LoraConfig(target_modules=["q_proj"], layers_to_transform=1,  layers_pattern="blocks")  # OK
LoraConfig(target_modules=["q_proj"], layers_to_transform=[0], layers_pattern="blocks")  # OK
```

Only index `0` is affected — `1` and `[0]` (the same logical request) are accepted.

### Why `is None` is the correct check

- The consuming matcher already treats `0` as a valid index — `check_target_module_exists` in `src/peft/tuners/tuners_utils.py` gates on `layer_indexes is not None`, and the sibling check a few lines above in the same `__post_init__` also uses `self.layers_to_transform is not None`.
- The docstring states the pattern is *"used only if `layers_to_transform` is different from `None`."*

So the guard should compare against `None`, not truthiness. The check was added in #2159 and its message improved in #2169, but the falsy-`0` case remained.

### Scope

The identical guard is duplicated across **all 19 tuner configs** that support layer indexing (lora, adalora, boft, deft, delora, fourierft, frod, hra, lily, loha, lokr, oft, peanut, psoft, pvera, tinylora, vblora, vera, waveft), so the one-line fix is applied to every one.

### Testing

Added `test_config_layers_to_transform_index_zero`, parametrized over every config in `ALL_CONFIG_CLASSES` that supports `layers_to_transform` (25 configs), asserting `layers_to_transform=0` + `layers_pattern` is accepted. It fails before this change (19 of the configs raise) and passes after. `ruff check` / `ruff format --check` are clean and `tests/test_config.py` passes (1218 passed).