### PR TITLE
FIX PVeRA reparameterization crash from invalid randn_like generator argument

### DIFF
--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -152,7 +152,13 @@ class PveraLayer(BaseTunerLayer):
     def _reparametrize(self, mu, logvar, sample_at_inference):
         if self.training or (not self.training and sample_at_inference):
             std = torch.exp(0.5 * logvar)
-            eps = torch.randn_like(std, generator=self.generator)
+            if self.generator is None:
+                eps = torch.randn_like(std)
+            else:
+                # torch.randn_like does not accept a `generator` argument, so torch.randn is used instead. The
+                # generator is a CPU torch.Generator (see update_layer), hence the noise is sampled on CPU for
+                # reproducible, device-independent results and then moved to std's device and dtype.
+                eps = torch.randn(std.shape, generator=self.generator).to(device=std.device, dtype=std.dtype)
             z = mu + eps * std
         else:
             z = mu

--- a/tests/test_pvera.py
+++ b/tests/test_pvera.py
@@ -242,3 +242,45 @@ class TestPVeRA:
         inputs = torch.randn(5, 10).to(dtype)
         output = peft_model(inputs)  # should not raise
         assert output.dtype == dtype
+
+    def test_pvera_forward_in_training_mode(self):
+        # Regression test: in training mode, PVeRA samples noise via the reparameterization trick in
+        # PveraLayer._reparametrize. This must not raise and must allow gradients to flow back to mu/logvar.
+        config = PveraConfig(target_modules=["lin1", "lin2"], init_weights=False)
+        peft_model = get_peft_model(MLP(), config)
+        peft_model.train()
+        output = peft_model(torch.randn(5, 10))  # should not raise
+        output.sum().backward()  # gradients should flow
+        assert output.shape == (5, 2)
+
+    def test_pvera_sample_at_inference(self):
+        # Regression test: with sample_at_inference=True, the noise is also sampled in eval mode (same code path
+        # in PveraLayer._reparametrize as the training-mode case), which must not raise.
+        config = PveraConfig(target_modules=["lin1", "lin2"], init_weights=False, sample_at_inference=True)
+        peft_model = get_peft_model(MLP(), config)
+        peft_model.eval()
+        peft_model(torch.randn(5, 10))  # should not raise
+
+    def test_pvera_generator_seed_reproducible(self):
+        # With a fixed generator_seed, the sampled noise (and therefore the output) must be reproducible across two
+        # identically initialized models, while a different seed must yield a different output.
+        inputs = torch.randn(5, 10)
+
+        def build(seed):
+            config = PveraConfig(target_modules=["lin1", "lin2"], init_weights=False, generator_seed=seed)
+            torch.manual_seed(0)
+            return get_peft_model(MLP(), config)
+
+        model_a = build(123)
+        model_b = build(123)
+        model_c = build(456)
+
+        model_a.train()
+        model_b.train()
+        model_c.train()
+        output_a = model_a(inputs)
+        output_b = model_b(inputs)
+        output_c = model_c(inputs)
+
+        assert torch.allclose(output_a, output_b)
+        assert not torch.allclose(output_a, output_c)


### PR DESCRIPTION
## What does this PR do?

`PveraLayer._reparametrize` calls `torch.randn_like(std, generator=self.generator)`, but `torch.randn_like` does not accept a `generator` argument on the torch versions PEFT commits to supporting (only `torch.randn` does). This raises `TypeError: randn_like() got an unexpected keyword argument 'generator'` on every forward pass in training mode (`nn.Module`'s default `training=True` state), and in eval mode when the documented `sample_at_inference=True` config option is used. PVeRA training is broken on these torch versions.

This was introduced in #3200 (seeded PVeRA RNG).

### Root cause

```python
def _reparametrize(self, mu, logvar, sample_at_inference):
    if self.training or (not self.training and sample_at_inference):
        std = torch.exp(0.5 * logvar)
        eps = torch.randn_like(std, generator=self.generator)  # generator kwarg unsupported here
```

Verified directly against the installed `torch==2.6.0+cu124`:

```python
>>> torch.randn_like(torch.ones(3), generator=torch.Generator())
TypeError: randn_like() got an unexpected keyword argument 'generator'
>>> torch.randn(3, generator=torch.Generator())  # torch.randn does support it
tensor([...])
```

### Relation to #3294

This exact bug, with an equivalent fix, was previously reported in #3294. It was closed after review feedback stating that `torch.randn_like` gained `generator` support in torch 2.10, that requiring `torch>=2.10` for PVeRA seemed reasonable, and that "if this call really failed, our tests would have caught it."

Re-checking that against PEFT's own stated policy and the currently installed environment surfaces two things that weren't in front of that review:

- `.ai/AGENTS.md` ("Development" > "Backwards compatibility") states: *"Generally strive to keep the changes compatible with all PyTorch releases of the last two years."* `setup.py` correspondingly declares `torch>=1.13.0` as the floor — PEFT doesn't currently require `torch>=2.10` anywhere. `torch==2.6.0+cu124` (the version this was tested against) falls inside that two-year window.
- The "our tests would have caught it" premise is correct, but doesn't show up in CI: on fresh `main`, with `torch==2.6.0+cu124`, **5 of the 10 existing tests in `tests/test_pvera.py` already fail** with this exact `TypeError` before this PR's changes (`test_multiple_adapters_same_prng_weights`, `test_pvera_different_shapes`, and all 3 `test_pvera_dtypes` parametrizations) — their fixtures never call `.eval()`, so they exercise the default `training=True` branch and hit the offending line. This doesn't surface in CI because `.github/workflows/tests.yml` installs torch unpinned (`pip install -e .[test]`), so CI only ever exercises whichever torch is newest at run time, not the older-but-still-in-window versions `setup.py`/`AGENTS.md` commit to supporting.

Not reopening this to relitigate the prior review — just adding the data point (declared minimum torch version, and reproduction on an in-window version) that wasn't available at the time.

### Fix

Same approach as #3294: sample with `torch.randn`, which accepts `generator` on all supported torch versions. `self.generator` is a CPU `torch.Generator` (created in `update_layer`), so when a `generator_seed` is configured, the noise is sampled on CPU for reproducible, device-independent results and then moved to `std`'s device and dtype. When no `generator_seed` is set, behavior is unchanged (`torch.randn_like(std)`, sampled directly on `std`'s device, as before).

### Why this isn't a duplicate

`gh pr list --repo huggingface/peft --search "pvera" --state all` and `gh issue list --repo huggingface/peft --search "pvera randn" / "pvera" --state all` surface only #3294 (closed, same bug) plus the unrelated PVeRA feature/benchmark PRs. No open PR or issue currently addresses this.

## Tests

Added to `tests/test_pvera.py`:
- `test_pvera_forward_in_training_mode`: forward + backward in train mode no longer raises.
- `test_pvera_sample_at_inference`: eval-mode sampling with `sample_at_inference=True` no longer raises.
- `test_pvera_generator_seed_reproducible`: a fixed `generator_seed` yields reproducible output across two independently constructed models, while a different seed yields a different output.

Verified fail-before / pass-after by isolating the source fix (`src/peft/tuners/pvera/layer.py` only) into a patch file and reverse-applying it against the finished test file, rather than editing back and forth:
- With the tests added but the one-line `randn_like` regression reinstated: `pytest tests/test_pvera.py` -> **8 failed, 5 passed** (the 3 new tests, plus the 5 pre-existing ones listed above — all failing with the same `TypeError`).
- Re-applying the fix: `pytest tests/test_pvera.py` -> **13 passed**.

Run with `PYTHONPATH=<worktree>/src` against the real installed `peft`/`torch` (`torch==2.6.0+cu124`), not a synthetic mock; confirmed `peft.__file__` resolved to the worktree before each run.

Lint: `ruff check --line-length 119` and `ruff format --check --line-length 119` both clean on the changed files (ruff 0.15.17, matching `setup.py`'s `ruff~=0.15.12` pin).

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code). The bug and its fix approach were already established by #3294; I independently re-verified the crash and the fix against the real installed library rather than trusting the prior PR's description alone, confirmed PEFT's actual declared torch-compatibility policy (`.ai/AGENTS.md`, `setup.py`) before reopening it, and reviewed every changed line before proposing this change.
