### PR TITLE
FIX DeLoRA crash with UnboundLocalError on unsupported layers

### DIFF
--- a/src/peft/tuners/delora/model.py
+++ b/src/peft/tuners/delora/model.py
@@ -100,5 +100,9 @@ class DeloraModel(BaseTuner):
 
         if isinstance(target_base_layer, torch.nn.Linear):
             new_module = DeloraLinear(target, adapter_name, config=delora_config, **kwargs)
+        else:
+            raise TypeError(
+                f"Target module {target} is not supported. Currently, only `torch.nn.Linear` is supported."
+            )
 
         return new_module

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -2471,26 +2471,6 @@ class TestDeLoRAInitialization:
         y_peft = model(data)
         assert not torch.allclose(y_base, y_peft, atol=1e-6, rtol=1e-6)
 
-    def get_embedding_model(self):
-        class ModelEmbedding(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.emb = nn.Embedding(100, 10)
-
-            def forward(self, X):
-                return self.emb(X)
-
-        return ModelEmbedding().to(self.torch_device).eval()
-
-    def test_delora_with_embedding_layer_raises(self):
-        # DeLoRA only supports nn.Linear, targeting any other layer type should raise a clear error instead of
-        # crashing with an UnboundLocalError
-        model = self.get_embedding_model()
-        config = DeloraConfig(target_modules=["emb"])
-        msg = "Target module Embedding(100, 10) is not supported. Currently, only `torch.nn.Linear` is supported."
-        with pytest.raises(TypeError, match=re.escape(msg)):
-            get_peft_model(model, config)
-
 
 class TestGraLoRAInitialization:
     """Basic sanity tests for the GraLoRA tuner."""

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -2471,6 +2471,26 @@ class TestDeLoRAInitialization:
         y_peft = model(data)
         assert not torch.allclose(y_base, y_peft, atol=1e-6, rtol=1e-6)
 
+    def get_embedding_model(self):
+        class ModelEmbedding(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.emb = nn.Embedding(100, 10)
+
+            def forward(self, X):
+                return self.emb(X)
+
+        return ModelEmbedding().to(self.torch_device).eval()
+
+    def test_delora_with_embedding_layer_raises(self):
+        # DeLoRA only supports nn.Linear, targeting any other layer type should raise a clear error instead of
+        # crashing with an UnboundLocalError
+        model = self.get_embedding_model()
+        config = DeloraConfig(target_modules=["emb"])
+        msg = "Target module Embedding(100, 10) is not supported. Currently, only `torch.nn.Linear` is supported."
+        with pytest.raises(TypeError, match=re.escape(msg)):
+            get_peft_model(model, config)
+
 
 class TestGraLoRAInitialization:
     """Basic sanity tests for the GraLoRA tuner."""


### PR DESCRIPTION
## What does this PR do?

`DeloraModel._create_new_module` only assigns `new_module` inside the `if isinstance(target_base_layer, torch.nn.Linear)` branch, with no `else`. Targeting any non-`Linear` module (e.g. an `nn.Embedding` layer, or `"all-linear"` on a GPT-2-style model) raises `UnboundLocalError` at `return new_module` instead of a clear error.

This adds the missing `else: raise TypeError(...)` branch, matching the pattern already used by every other tuner with this same structure (e.g. `c3a`, `beft`).

I checked `_create_new_module` (and equivalent dispatch methods) across all other tuners: DeLoRA was the only one missing this fallback, so this fix doesn't need to extend to other methods.

## AI disclosure

AI assistance (Claude) was used to help investigate this bug and draft the fix. I reviewed the change, understand it, and verified it myself.
