### PR TITLE
Validate GraLoRA, AdaLoRA, WaveFT, and AdaMSS configs

### DIFF
--- a/src/peft/tuners/adalora/config.py
+++ b/src/peft/tuners/adalora/config.py
@@ -101,6 +101,11 @@ class AdaLoraConfig(LoraConfig):
         if self.total_step is None or self.total_step <= 0:
             raise ValueError("AdaLoRA does not work when `total_step` is None, supply a value > 0.")
 
+        if self.orth_reg_weight < 0:
+            raise ValueError(
+                f"`orth_reg_weight` should be greater than or equal to 0, but the value passed is {self.orth_reg_weight}"
+            )
+
         if self.tinit >= (self.total_step - self.tfinal):
             raise ValueError(
                 "The supplied schedule values don't allow for a budgeting phase. Decrease `tfinal`/`tinit` or "

--- a/src/peft/tuners/adalora/model.py
+++ b/src/peft/tuners/adalora/model.py
@@ -233,8 +233,8 @@ class AdaLoraModel(LoraModel):
             # Calculate the orthogonal regularization
             orth_reg_weight = self.peft_config[self.trainable_adapter_name].orth_reg_weight
 
-            if orth_reg_weight <= 0:
-                raise ValueError("orth_reg_weight should be greater than 0. ")
+            if orth_reg_weight < 0:
+                raise ValueError("orth_reg_weight should be greater than or equal to 0. ")
 
             regu_loss = 0
             num_param = 0

--- a/src/peft/tuners/adamss/config.py
+++ b/src/peft/tuners/adamss/config.py
@@ -83,22 +83,24 @@ class AdamssConfig(PeftConfig):
             Target total number of active subspaces across all layers when ASA is enabled. ASA will progressively prune
             subspaces until this target is reached. Lower values result in more aggressive pruning and fewer trainable
             parameters. Should be less than `num_subspaces * num_target_modules`. Typical values range from 20 to 100
-            depending on model size. Default is 50.
+            depending on model size. Default is 50. Must be a positive integer when `use_asa=True`.
 
         init_warmup (`int`):
             Number of training steps to wait before starting ASA pruning. During warmup, all subspaces remain active to
             allow importance scores to stabilize. Higher values give more time for accurate importance estimation but
-            delay pruning. Typical values range from 50 to 200. Default is 50.
+            delay pruning. Typical values range from 50 to 200. Default is 50. Must be smaller than `final_warmup`
+            when `use_asa=True`.
 
         final_warmup (`int`):
             Training step at which ASA completes pruning and reaches `asa_target_subspaces` active subspaces. The
             pruning is distributed between `init_warmup` and `final_warmup`. Should be set based on total training
-            steps; typically 1/3 to 1/2 of total training steps. Default is 1000.
+            steps; typically 1/3 to 1/2 of total training steps. Default is 1000. Must be larger than `init_warmup`
+            when `use_asa=True`.
 
         mask_interval (`int`):
             Number of training steps between ASA mask updates. Lower values allow more frequent adaptation but increase
             overhead. Higher values provide more stable importance estimates between updates. Typical values range from
-            50 to 200. Default is 100.
+            50 to 200. Default is 100. Must be a positive integer when `use_asa=True`.
 
         asa_importance_beta (`float`):
             Exponential moving average (EMA) coefficient for smoothing subspace importance scores. Higher values
@@ -115,7 +117,9 @@ class AdamssConfig(PeftConfig):
             warmup. Higher values result in faster initial pruning (more aggressive early reduction), while lower
             values provide a more gradual, linear-like decay. The formula is: current_active_subspaces =
             asa_target_subspaces + (asa_total_subspaces - asa_target_subspaces) * (progress ** exponent). Typical
-            values range from 1.0 (linear) to 5.0 (aggressive). Default is 3.0.
+            values range from 1.0 (linear) to 5.0 (aggressive). Default is 3.0. Must be a positive number when
+            `use_asa=True` (a zero or negative exponent either degenerates the schedule to a permanent no-op or, once
+            `progress` reaches exactly 0.0, raises a `ZeroDivisionError`).
 
         use_dynamic_rank (`bool`):
             Whether to dynamically determine subspace ranks based on singular value magnitudes. When True, each
@@ -227,7 +231,8 @@ class AdamssConfig(PeftConfig):
             "help": (
                 "Target total number of active subspaces across all layers when ASA is enabled. "
                 "ASA progressively prunes subspaces until this target is reached. Lower values "
-                "result in more aggressive pruning. Typical values: 20-100. Default: 50."
+                "result in more aggressive pruning. Typical values: 20-100. Default: 50. Must be "
+                "a positive integer when use_asa=True."
             )
         },
     )
@@ -237,7 +242,8 @@ class AdamssConfig(PeftConfig):
             "help": (
                 "Training steps to wait before starting ASA pruning. During warmup, all subspaces "
                 "remain active to allow importance scores to stabilize. Higher values give more "
-                "time for accurate estimation. Typical values: 50-200. Default: 50."
+                "time for accurate estimation. Typical values: 50-200. Default: 50. Must be smaller "
+                "than final_warmup when use_asa=True."
             )
         },
     )
@@ -247,7 +253,7 @@ class AdamssConfig(PeftConfig):
             "help": (
                 "Training step at which ASA completes pruning and reaches asa_target_subspaces. "
                 "Should be set based on total training steps; typically 1/3 to 1/2 of total steps. "
-                "Default: 1000."
+                "Default: 1000. Must be larger than init_warmup when use_asa=True."
             )
         },
     )
@@ -257,7 +263,7 @@ class AdamssConfig(PeftConfig):
             "help": (
                 "Training steps between ASA mask updates. Lower values allow more frequent "
                 "adaptation but increase overhead. Higher values provide more stable estimates. "
-                "Typical values: 50-200. Default: 100."
+                "Typical values: 50-200. Default: 100. Must be a positive integer when use_asa=True."
             )
         },
     )
@@ -290,7 +296,8 @@ class AdamssConfig(PeftConfig):
                 "asa_target_subspaces. Higher values result in faster initial pruning (aggressive "
                 "early reduction), lower values provide gradual linear-like decay. Formula: "
                 "current_active_subspaces = asa_target_subspaces + (total - target) * (progress ** exponent). "
-                "Typical values: 1.0 (linear) to 5.0 (aggressive). Default: 3.0."
+                "Typical values: 1.0 (linear) to 5.0 (aggressive). Default: 3.0. Must be a positive "
+                "number when use_asa=True."
             )
         },
     )
@@ -341,6 +348,32 @@ class AdamssConfig(PeftConfig):
         # Validate initialization method
         if self.init_weights not in ["orthogonal", None]:
             raise ValueError(f"init_weights must be 'orthogonal' or None, got {self.init_weights}")
+
+        # Validate ASA scheduling parameters only when ASA is enabled.
+        if self.use_asa:
+            if self.mask_interval <= 0:
+                raise ValueError(
+                    f"`mask_interval` must be a positive integer when `use_asa=True`, got {self.mask_interval}."
+                )
+
+            if self.init_warmup >= self.final_warmup:
+                raise ValueError(
+                    "`init_warmup` must be smaller than `final_warmup` when `use_asa=True` so that ASA has a "
+                    f"non-empty pruning ramp, got init_warmup={self.init_warmup} and "
+                    f"final_warmup={self.final_warmup}."
+                )
+
+            if self.asa_target_subspaces <= 0:
+                raise ValueError(
+                    "`asa_target_subspaces` must be a positive integer when `use_asa=True`, got "
+                    f"{self.asa_target_subspaces}."
+                )
+
+            if self.asa_schedule_exponent <= 0:
+                raise ValueError(
+                    "`asa_schedule_exponent` must be a positive number when `use_asa=True`, got "
+                    f"{self.asa_schedule_exponent}."
+                )
 
         # Early check for scikit-learn availability
         try:

--- a/src/peft/tuners/adamss/config.py
+++ b/src/peft/tuners/adamss/config.py
@@ -88,8 +88,8 @@ class AdamssConfig(PeftConfig):
         init_warmup (`int`):
             Number of training steps to wait before starting ASA pruning. During warmup, all subspaces remain active to
             allow importance scores to stabilize. Higher values give more time for accurate importance estimation but
-            delay pruning. Typical values range from 50 to 200. Default is 50. Must be smaller than `final_warmup`
-            when `use_asa=True`.
+            delay pruning. Typical values range from 50 to 200. Default is 50. Must be smaller than `final_warmup` when
+            `use_asa=True`.
 
         final_warmup (`int`):
             Training step at which ASA completes pruning and reaches `asa_target_subspaces` active subspaces. The

--- a/src/peft/tuners/gralora/config.py
+++ b/src/peft/tuners/gralora/config.py
@@ -182,5 +182,9 @@ class GraloraConfig(PeftConfig):
         self.target_modules = (
             set(self.target_modules) if isinstance(self.target_modules, list) else self.target_modules
         )
+        if self.gralora_k <= 0:
+            raise ValueError(
+                f"`gralora_k` should be a positive integer value but the value passed is {self.gralora_k}"
+            )
         if self.r % self.gralora_k != 0:
             raise ValueError(f"r should be divisible by gralora_k, but got {self.r} and {self.gralora_k}")

--- a/src/peft/tuners/waveft/model.py
+++ b/src/peft/tuners/waveft/model.py
@@ -65,7 +65,9 @@ class WaveFTModel(BaseTuner):
         n_frequency_dict = {}
         for name, input_dim, output_dim in target_modules_info:
             layer_ratio = (input_dim * output_dim) / total_sum
-            n_freq = round(layer_ratio * total_budget)
+            # A plain round() can floor a small layer's proportional share of the budget down to 0.
+            # Guarantee every target layer gets at least 1 frequency component.
+            n_freq = max(1, round(layer_ratio * total_budget))
             n_frequency_dict[name] = n_freq
 
         return n_frequency_dict

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1307,7 +1307,7 @@ TEST_CASES = [
         "Vanilla MLP 1 AdaLoRA",
         "MLP",
         AdaLoraConfig,
-        {"target_modules": ["lin0"], "init_lora_weights": False, "total_step": 1},
+        {"target_modules": ["lin0"], "init_lora_weights": False, "total_step": 1, "orth_reg_weight": 0},
     ),
     (
         "Vanilla MLP 2 AdaLoRA",

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -31,6 +31,7 @@ from transformers import AutoModelForCausalLM
 
 from peft import (
     AdaLoraConfig,
+    AdamssConfig,
     BeftConfig,
     C3AConfig,
     DeloraConfig,
@@ -1895,6 +1896,11 @@ class TestAdaLoraInitialization:
         with pytest.raises(ValueError, match="ADALORA does not support LOFTQ"):
             AdaLoraConfig(init_lora_weights="loftq", loftq_config={"loftq": "config"}, total_step=1)
 
+    def test_adalora_negative_orth_reg_weight_raises(self):
+        msg = "`orth_reg_weight` should be greater than or equal to 0, but the value passed is -0.5"
+        with pytest.raises(ValueError, match=re.escape(msg)):
+            AdaLoraConfig(target_modules=["linear"], total_step=1, orth_reg_weight=-0.5)
+
     def get_model(self):
         class MyModule(nn.Module):
             def __init__(self):
@@ -1922,6 +1928,36 @@ class TestAdaLoraInitialization:
         model = get_peft_model(model, config)
         output_after = model(data)
         assert torch.allclose(output_before, output_after)
+
+
+class TestAdamssInitialization:
+    @pytest.mark.parametrize(
+        "adamss_kwargs,message",
+        [
+            (
+                {"mask_interval": 0},
+                "`mask_interval` must be a positive integer when `use_asa=True`, got 0.",
+            ),
+            (
+                {"init_warmup": 10, "final_warmup": 10},
+                "`init_warmup` must be smaller than `final_warmup` when `use_asa=True` so that ASA has a "
+                "non-empty pruning ramp, got init_warmup=10 and final_warmup=10.",
+            ),
+            (
+                {"asa_target_subspaces": 0},
+                "`asa_target_subspaces` must be a positive integer when `use_asa=True`, got 0.",
+            ),
+            (
+                {"asa_schedule_exponent": 0.0},
+                "`asa_schedule_exponent` must be a positive number when `use_asa=True`, got 0.0.",
+            ),
+        ],
+    )
+    def test_invalid_asa_schedule_raises(self, adamss_kwargs, message):
+        kwargs = {"use_asa": True, "init_warmup": 0, "final_warmup": 100, "mask_interval": 10}
+        kwargs.update(adamss_kwargs)
+        with pytest.raises(ValueError, match=re.escape(message)):
+            AdamssConfig(**kwargs)
 
 
 class TestPromptTuningInitialization:
@@ -2334,6 +2370,25 @@ class TestWaveFTInitialization:
         with pytest.raises(ValueError, match=re.escape(msg)):
             WaveFTConfig(target_modules=["linear"], wavelet_family=invalid_family)
 
+    def test_waveft_proportional_parameters_does_not_zero_out_small_layer(self):
+        class Imbalanced(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.big = nn.Linear(4096, 4096)
+                self.tiny = nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.tiny(x[:, :4])
+
+        model = Imbalanced().eval().to(self.torch_device)
+        config = WaveFTConfig(target_modules=["big", "tiny"], n_frequency=1, proportional_parameters=True)
+        model = get_peft_model(model, config)
+
+        tiny_layer = model.base_model.model.tiny
+        big_layer = model.base_model.model.big
+        assert tiny_layer.waveft_n_frequency["default"] >= 1
+        assert big_layer.waveft_n_frequency["default"] >= 1
+
 
 class TestRoadInitialization:
     torch_device = infer_device()
@@ -2504,6 +2559,13 @@ class TestGraLoRAInitialization:
         gralora_k = 4
         # msg = f"r should be divisible by gralora_k, but got {config.r} and {config.gralora_k}"
         msg = f"r should be divisible by gralora_k, but got {r} and {gralora_k}"
+        with pytest.raises(ValueError, match=re.escape(msg)):
+            GraloraConfig(target_modules=["lin0"], r=r, gralora_k=gralora_k)
+
+    @pytest.mark.parametrize("gralora_k", [0, -1])
+    def test_gralora_with_non_positive_gralora_k_raises(self, gralora_k):
+        r = 32
+        msg = f"`gralora_k` should be a positive integer value but the value passed is {gralora_k}"
         with pytest.raises(ValueError, match=re.escape(msg)):
             GraloraConfig(target_modules=["lin0"], r=r, gralora_k=gralora_k)
 


### PR DESCRIPTION
## Summary

- reject invalid GraLoRA and AdaLoRA configuration values at construction time
- keep zero as a valid AdaLoRA orthogonal regularization weight
- prevent WaveFT proportional allocation from assigning zero frequencies
- validate AdaMSS scheduling values when ASA is enabled

## Tests

- `python -m pytest tests/test_initialization.py -k "adamss or adalora or waveft or gralora" -q --no-cov` (25 passed)
- `python -m pytest tests/test_custom_models.py -k "AdaLoRA" -q --disable-warnings --no-cov` (164 passed, 40 skipped, 2 xfailed)
- Ruff check and format check on the changed files

## AI assistance disclosure

AI assistance was used. I reviewed the changes and ran the tests above.