### PR TITLE
Fix grouped convolutions in LoHa and LoKr

### DIFF
--- a/src/peft/tuners/loha/layer.py
+++ b/src/peft/tuners/loha/layer.py
@@ -142,12 +142,18 @@ class LoHaLayer(nn.Module, LycorisLayer):
             # similar to how Linear layers work. This optimization reduces computational cost
             # without affecting the mathematical equivalence of the operation.
             use_effective_conv2d = use_effective_conv2d and base_layer.kernel_size != (1, 1)
+            # Conv*d weights are shaped (out_channels, in_channels // groups, *kernel_size), not
+            # (out_channels, in_channels, *kernel_size); the latter is only correct for groups == 1. Using the
+            # per-group channel count here keeps `get_delta_weight`'s `reshape(base_layer.weight.shape)` valid for
+            # groups > 1 as well, and `_get_delta_activations` already forwards `groups=base_layer.groups` to
+            # `F.conv2d`, so this is all that's needed to make grouped convolutions work.
+            in_channels = base_layer.in_channels // base_layer.groups
             if use_effective_conv2d:
-                shape = (base_layer.out_channels, base_layer.in_channels, *base_layer.kernel_size)
+                shape = (base_layer.out_channels, in_channels, *base_layer.kernel_size)
             else:
                 shape = (
                     base_layer.out_channels,
-                    base_layer.in_channels * base_layer.kernel_size[0] * base_layer.kernel_size[1],
+                    in_channels * base_layer.kernel_size[0] * base_layer.kernel_size[1],
                 )
         elif isinstance(base_layer, nn.Conv1d):
             # For Conv1d with kernel_size=1, disable effective_conv2d for the same optimization reasons
@@ -155,12 +161,14 @@ class LoHaLayer(nn.Module, LycorisLayer):
             # to a Linear layer applied across the channel dimension. Using flattened representation
             # avoids unnecessary reshaping and improves computational efficiency.
             use_effective_conv2d = use_effective_conv2d and base_layer.kernel_size[0] != 1
+            # See the analogous Conv2d branch above for why this must be divided by `groups`.
+            in_channels = base_layer.in_channels // base_layer.groups
             if use_effective_conv2d:
-                shape = (base_layer.out_channels, base_layer.in_channels, base_layer.kernel_size[0])
+                shape = (base_layer.out_channels, in_channels, base_layer.kernel_size[0])
             else:
                 shape = (
                     base_layer.out_channels,
-                    base_layer.in_channels * base_layer.kernel_size[0],
+                    in_channels * base_layer.kernel_size[0],
                 )
         else:
             raise TypeError(f"LoHa is not implemented for base layers of type {type(base_layer).__name__}")

--- a/src/peft/tuners/loha/layer.py
+++ b/src/peft/tuners/loha/layer.py
@@ -142,11 +142,6 @@ class LoHaLayer(nn.Module, LycorisLayer):
             # similar to how Linear layers work. This optimization reduces computational cost
             # without affecting the mathematical equivalence of the operation.
             use_effective_conv2d = use_effective_conv2d and base_layer.kernel_size != (1, 1)
-            # Conv*d weights are shaped (out_channels, in_channels // groups, *kernel_size), not
-            # (out_channels, in_channels, *kernel_size); the latter is only correct for groups == 1. Using the
-            # per-group channel count here keeps `get_delta_weight`'s `reshape(base_layer.weight.shape)` valid for
-            # groups > 1 as well, and `_get_delta_activations` already forwards `groups=base_layer.groups` to
-            # `F.conv2d`, so this is all that's needed to make grouped convolutions work.
             in_channels = base_layer.in_channels // base_layer.groups
             if use_effective_conv2d:
                 shape = (base_layer.out_channels, in_channels, *base_layer.kernel_size)
@@ -161,7 +156,6 @@ class LoHaLayer(nn.Module, LycorisLayer):
             # to a Linear layer applied across the channel dimension. Using flattened representation
             # avoids unnecessary reshaping and improves computational efficiency.
             use_effective_conv2d = use_effective_conv2d and base_layer.kernel_size[0] != 1
-            # See the analogous Conv2d branch above for why this must be divided by `groups`.
             in_channels = base_layer.in_channels // base_layer.groups
             if use_effective_conv2d:
                 shape = (base_layer.out_channels, in_channels, base_layer.kernel_size[0])

--- a/src/peft/tuners/lokr/layer.py
+++ b/src/peft/tuners/lokr/layer.py
@@ -204,11 +204,6 @@ class LoKrLayer(nn.Module, LycorisLayer):
             use_w2 = not (r < max(shape[0][1], shape[1][1]) / 2)
             use_effective_conv2d = False
         elif isinstance(base_layer, nn.Conv2d):
-            # Conv*d weights are shaped (out_channels, in_channels // groups, *kernel_size), not
-            # (out_channels, in_channels, *kernel_size); the latter is only correct for groups == 1. Using the
-            # per-group channel count here keeps `get_delta_weight`'s `reshape(base_layer.weight.shape)` valid for
-            # groups > 1 as well, and `_get_delta_activations` already forwards `groups=base_layer.groups` to
-            # `F.conv2d`, so this is all that's needed to make grouped convolutions work.
             in_dim, out_dim = base_layer.in_channels // base_layer.groups, base_layer.out_channels
             k_size = base_layer.kernel_size
 
@@ -225,7 +220,6 @@ class LoKrLayer(nn.Module, LycorisLayer):
             # without affecting the mathematical equivalence of the operation.
             use_effective_conv2d = use_effective_conv2d and base_layer.kernel_size != (1, 1)
         elif isinstance(base_layer, nn.Conv1d):
-            # See the analogous Conv2d branch above for why this must be divided by `groups`.
             in_dim, out_dim = base_layer.in_channels // base_layer.groups, base_layer.out_channels
             k_size = (base_layer.kernel_size[0],)  # Convert to a tuple with single element
 

--- a/src/peft/tuners/lokr/layer.py
+++ b/src/peft/tuners/lokr/layer.py
@@ -204,7 +204,12 @@ class LoKrLayer(nn.Module, LycorisLayer):
             use_w2 = not (r < max(shape[0][1], shape[1][1]) / 2)
             use_effective_conv2d = False
         elif isinstance(base_layer, nn.Conv2d):
-            in_dim, out_dim = base_layer.in_channels, base_layer.out_channels
+            # Conv*d weights are shaped (out_channels, in_channels // groups, *kernel_size), not
+            # (out_channels, in_channels, *kernel_size); the latter is only correct for groups == 1. Using the
+            # per-group channel count here keeps `get_delta_weight`'s `reshape(base_layer.weight.shape)` valid for
+            # groups > 1 as well, and `_get_delta_activations` already forwards `groups=base_layer.groups` to
+            # `F.conv2d`, so this is all that's needed to make grouped convolutions work.
+            in_dim, out_dim = base_layer.in_channels // base_layer.groups, base_layer.out_channels
             k_size = base_layer.kernel_size
 
             in_m, in_n = factorization(in_dim, decompose_factor)
@@ -220,7 +225,8 @@ class LoKrLayer(nn.Module, LycorisLayer):
             # without affecting the mathematical equivalence of the operation.
             use_effective_conv2d = use_effective_conv2d and base_layer.kernel_size != (1, 1)
         elif isinstance(base_layer, nn.Conv1d):
-            in_dim, out_dim = base_layer.in_channels, base_layer.out_channels
+            # See the analogous Conv2d branch above for why this must be divided by `groups`.
+            in_dim, out_dim = base_layer.in_channels // base_layer.groups, base_layer.out_channels
             k_size = (base_layer.kernel_size[0],)  # Convert to a tuple with single element
 
             in_m, in_n = factorization(in_dim, decompose_factor)

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -3091,7 +3091,7 @@ class TestPeftCustomModel(PeftCommonTester):
         if issubclass(config_cls, (LoHaConfig, LoKrConfig)) and model_id in ("Conv2dGroups", "Conv2dGroups2"):
             # LoHa/LoKr recombine their delta weight from several low-rank factors (Hadamard/Kronecker products)
             # before merging into a grouped conv's weight, which accumulates more floating-point rounding than a
-            # plain LoRA `B @ A` merge, similar in spirit to the "more instability with Conv" case above.
+            # plain LoRA `B @ A` merge
             atol, rtol = 1e-3, 1e-3
 
         if issubclass(config_cls, OFTConfig):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -389,6 +389,8 @@ TEST_CASES = [
         {"target_modules": ["conv1d"], "r": 2, "use_effective_conv2d": False},
     ),
     ("Conv2d 1x1 LOHA", "Conv2d1x1", LoHaConfig, {"target_modules": ["conv2d"]}),
+    ("Conv2d Groups LOHA", "Conv2dGroups", LoHaConfig, {"target_modules": ["conv2d"]}),
+    ("Conv2d Groups2 LOHA", "Conv2dGroups2", LoHaConfig, {"target_modules": ["conv2d"]}),
     # LoKr
     ("Vanilla MLP 1 LOKR", "MLP", LoKrConfig, {"target_modules": "lin0"}),
     ("Vanilla MLP 2 LOKR", "MLP", LoKrConfig, {"target_modules": ["lin0"]}),
@@ -449,6 +451,8 @@ TEST_CASES = [
             "decompose_factor": 4,
         },
     ),
+    ("Conv2d Groups LOKR", "Conv2dGroups", LoKrConfig, {"target_modules": ["conv2d"]}),
+    ("Conv2d Groups2 LOKR", "Conv2dGroups2", LoKrConfig, {"target_modules": ["conv2d"]}),
     ########
     # OFT #
     ########
@@ -3082,6 +3086,12 @@ class TestPeftCustomModel(PeftCommonTester):
 
         conv_ids = ["Conv2d", "Conv3d", "Conv2d2"]
         if issubclass(config_cls, (IA3Config, LoraConfig)) and model_id in conv_ids:  # more instability with Conv
+            atol, rtol = 1e-3, 1e-3
+
+        if issubclass(config_cls, (LoHaConfig, LoKrConfig)) and model_id in ("Conv2dGroups", "Conv2dGroups2"):
+            # LoHa/LoKr recombine their delta weight from several low-rank factors (Hadamard/Kronecker products)
+            # before merging into a grouped conv's weight, which accumulates more floating-point rounding than a
+            # plain LoRA `B @ A` merge, similar in spirit to the "more instability with Conv" case above.
             atol, rtol = 1e-3, 1e-3
 
         if issubclass(config_cls, OFTConfig):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -376,6 +376,7 @@ TEST_CASES = [
     ("Conv1d LOHA", "Conv1d", LoHaConfig, {"target_modules": ["conv1d"]}),
     ("Conv1d LOHA 1", "Conv1d", LoHaConfig, {"target_modules": ["conv1d"]}),
     ("Conv1d LOHA 2", "Conv1d", LoHaConfig, {"target_modules": ["conv1d"], "r": 2}),
+    ("Conv1d Groups LOHA", "Conv1dGroups", LoHaConfig, {"target_modules": ["conv1d"], "r": 4}),
     (
         "Conv1d LOHA 3",
         "Conv1dBigger",
@@ -411,6 +412,7 @@ TEST_CASES = [
     ("Vanilla MLP 8 LOKR", "MLP", LoKrConfig, {"target_modules": "lin0", "decompose_both": True, "r": 1, "alpha": 1}),
     ("Conv1d LOKR 1", "Conv1d", LoKrConfig, {"target_modules": ["conv1d"]}),
     ("Conv1d LOKR 2", "Conv1d", LoKrConfig, {"target_modules": ["conv1d"], "r": 2}),
+    ("Conv1d Groups LOKR", "Conv1dGroups", LoKrConfig, {"target_modules": ["conv1d"], "r": 4}),
     (
         "Conv1d LOKR 3",
         "Conv1dBigger",
@@ -2039,6 +2041,26 @@ class ModelConv1DBigger(nn.Module):
         return X
 
 
+class ModelConv1DGroups(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1d = nn.Conv1d(8, 8, 3, groups=2)
+        self.relu = nn.ReLU()
+        self.flat = nn.Flatten()
+        self.lin0 = nn.Linear(64, 2)
+        self.sm = nn.LogSoftmax(dim=-1)
+        self.dtype = torch.float
+
+    def forward(self, X):
+        X = X.to(self.dtype).reshape(-1, 1, 10)
+        X = torch.concat([X] * 8, dim=1)
+        X = self.conv1d(X)
+        X = self.relu(X)
+        X = self.flat(X)
+        X = self.lin0(X)
+        return self.sm(X)
+
+
 class ModelConv2D(nn.Module):
     def __init__(self, bias=True):
         super().__init__()
@@ -2274,6 +2296,9 @@ class MockTransformerWrapper:
 
         if model_id == "Conv1dBigger":
             return ModelConv1DBigger().to(dtype)
+
+        if model_id == "Conv1dGroups":
+            return ModelConv1DGroups().to(dtype)
 
         if model_id == "Conv2d":
             return ModelConv2D().to(dtype)
@@ -3088,10 +3113,12 @@ class TestPeftCustomModel(PeftCommonTester):
         if issubclass(config_cls, (IA3Config, LoraConfig)) and model_id in conv_ids:  # more instability with Conv
             atol, rtol = 1e-3, 1e-3
 
-        if issubclass(config_cls, (LoHaConfig, LoKrConfig)) and model_id in ("Conv2dGroups", "Conv2dGroups2"):
-            # LoHa/LoKr recombine their delta weight from several low-rank factors (Hadamard/Kronecker products)
-            # before merging into a grouped conv's weight, which accumulates more floating-point rounding than a
-            # plain LoRA `B @ A` merge
+        if issubclass(config_cls, (LoHaConfig, LoKrConfig)) and model_id in (
+            "Conv1dGroups",
+            "Conv2dGroups",
+            "Conv2dGroups2",
+        ):
+            # Grouped LoHa/LoKr merges need a wider tolerance than a LoRA `B @ A` merge.
             atol, rtol = 1e-3, 1e-3
 
         if issubclass(config_cls, OFTConfig):

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1881,7 +1881,7 @@ class TestLokrInitialization:
 
 class TestLoHaLoKrGroupedConv:
     """Regression tests for LoHa and LoKr crashing on a plain (unmerged) forward pass whenever the wrapped
-    Conv1d/Conv2d layer has `groups > 1` (e.g. depthwise/grouped convolutions, common in vision models).
+    Conv1d layer has `groups > 1` (e.g. depthwise/grouped convolutions, common in vision models).
 
     Both tuners built their low-rank adapter parameters using the base layer's full `in_channels` instead of
     `in_channels // groups`, so `get_delta_weight`'s `reshape(base_layer.weight.shape)` raised a `RuntimeError`
@@ -1890,6 +1890,10 @@ class TestLoHaLoKrGroupedConv:
     LoHa/LoKr use their delta weight as an independent conv kernel (`F.conv2d(input, delta_weight,
     groups=base_layer.groups)`, already present before this fix), so sizing the low-rank factors with
     `in_channels // groups` is sufficient to fully support grouped convolutions, not just reject them.
+
+    Only Conv1d is covered here: Conv2d + groups > 1 for LoHa/LoKr is already exercised by the "Conv2d
+    Groups(2) LOHA/LOKR" entries in `test_custom_models.py`'s shared `TEST_CASES` battery (forward, merge,
+    disable/enable, save/load, etc.), so a duplicate Conv2d check here would add nothing.
     """
 
     torch_device = infer_device()
@@ -1897,7 +1901,6 @@ class TestLoHaLoKrGroupedConv:
     # (conv_cls, input_shape), input_shape excludes the batch and channel dims
     conv_cases = [
         pytest.param(nn.Conv1d, (9,), id="Conv1d"),
-        pytest.param(nn.Conv2d, (9, 9), id="Conv2d"),
     ]
 
     def get_model_conv_groups(self, conv_cls, groups):
@@ -1954,19 +1957,6 @@ class TestLoHaLoKrGroupedConv:
         assert not torch.allclose(out_unmerged, torch.zeros_like(out_unmerged))
         assert torch.allclose(out_unmerged, out_merged, atol=1e-5, rtol=1e-5)
         assert torch.allclose(out_unmerged, out_unmerged_again, atol=1e-6, rtol=1e-6)
-
-    @pytest.mark.parametrize("config_cls", [LoHaConfig, LoKrConfig])
-    @pytest.mark.parametrize("conv_cls, input_shape", conv_cases)
-    def test_no_regression_for_groups_equal_to_one(self, config_cls, conv_cls, input_shape):
-        # sanity check: the default groups=1 case must keep working correctly after the groups>1 fix, since
-        # `update_layer` now always divides by `groups` (which is 1 here, a no-op).
-        base_model = self.get_model_conv_groups(conv_cls, groups=1)
-        config = config_cls(target_modules=["conv"], r=4)
-        peft_model = get_peft_model(base_model, config)  # does not raise
-
-        x = torch.randn(2, 8, *input_shape).to(self.torch_device)
-        output = peft_model(x)  # does not raise
-        assert output.shape[:2] == (2, 8)
 
 
 class TestAdaLoraInitialization:

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -40,7 +40,6 @@ from peft import (
     IA3Config,
     LilyConfig,
     LoftQConfig,
-    LoHaConfig,
     LoKrConfig,
     LoraConfig,
     PeanutConfig,
@@ -1877,86 +1876,6 @@ class TestLokrInitialization:
         output_after = model(data)[1]
 
         assert torch.allclose(output_before, output_after)
-
-
-class TestLoHaLoKrGroupedConv:
-    """Regression tests for LoHa and LoKr crashing on a plain (unmerged) forward pass whenever the wrapped
-    Conv1d layer has `groups > 1` (e.g. depthwise/grouped convolutions, common in vision models).
-
-    Both tuners built their low-rank adapter parameters using the base layer's full `in_channels` instead of
-    `in_channels // groups`, so `get_delta_weight`'s `reshape(base_layer.weight.shape)` raised a `RuntimeError`
-    (numel mismatch) the first time `forward` was called -- merging was never even reached. Unlike HiRA's
-    analogous `groups > 1` restriction (a Hadamard product against the base weight, see `TestHiraInitialization`),
-    LoHa/LoKr use their delta weight as an independent conv kernel (`F.conv2d(input, delta_weight,
-    groups=base_layer.groups)`, already present before this fix), so sizing the low-rank factors with
-    `in_channels // groups` is sufficient to fully support grouped convolutions, not just reject them.
-
-    Only Conv1d is covered here: Conv2d + groups > 1 for LoHa/LoKr is already exercised by the "Conv2d
-    Groups(2) LOHA/LOKR" entries in `test_custom_models.py`'s shared `TEST_CASES` battery (forward, merge,
-    disable/enable, save/load, etc.), so a duplicate Conv2d check here would add nothing.
-    """
-
-    torch_device = infer_device()
-
-    # (conv_cls, input_shape), input_shape excludes the batch and channel dims
-    conv_cases = [
-        pytest.param(nn.Conv1d, (9,), id="Conv1d"),
-    ]
-
-    def get_model_conv_groups(self, conv_cls, groups):
-        class ModelConvGroups(nn.Module):
-            """For testing when the groups argument is used in a conv layer"""
-
-            def __init__(self):
-                super().__init__()
-                self.conv = conv_cls(8, 8, kernel_size=3, groups=groups)
-
-            def forward(self, X):
-                return self.conv(X)
-
-        return ModelConvGroups().eval().to(self.torch_device)
-
-    @pytest.mark.parametrize("config_cls", [LoHaConfig, LoKrConfig])
-    @pytest.mark.parametrize("conv_cls, input_shape", conv_cases)
-    @pytest.mark.parametrize("groups", [2, 4, 8])
-    def test_forward_works_for_groups_greater_than_one(self, config_cls, conv_cls, input_shape, groups):
-        # Before the fix: constructing the adapter "succeeded" but the very first forward pass crashed with a
-        # confusing RuntimeError (shape '[...]' is invalid for input of size ...), even though no merge was
-        # involved. After the fix: forward runs cleanly and produces a correctly-shaped output.
-        base_model = self.get_model_conv_groups(conv_cls, groups=groups)
-        config = config_cls(target_modules=["conv"], r=4, init_weights=False)
-        peft_model = get_peft_model(base_model, config)  # does not raise
-
-        x = torch.randn(2, 8, *input_shape).to(self.torch_device)
-        output = peft_model(x)  # does not raise
-        assert output.shape[:2] == (2, 8)
-
-    @pytest.mark.parametrize("config_cls", [LoHaConfig, LoKrConfig])
-    @pytest.mark.parametrize("conv_cls, input_shape", conv_cases)
-    def test_merge_unmerge_correct_for_groups_greater_than_one(self, config_cls, conv_cls, input_shape):
-        # Beyond "does not crash": verify the grouped-conv delta weight is actually correct, not just
-        # coincidentally reshape-compatible, by checking that merging it into the base layer's weight
-        # (base_layer.weight.data += delta_weight) reproduces exactly the same output as the unmerged forward pass
-        # (base_layer(x) + conv(x, delta_weight, groups=...)), and that unmerging restores it again. A wrong
-        # channel-to-group assignment would still crash or diverge here even if the raw element count happened to
-        # match.
-        groups = 2
-        base_model = self.get_model_conv_groups(conv_cls, groups=groups)
-        config = config_cls(target_modules=["conv"], r=4, init_weights=False)
-        peft_model = get_peft_model(base_model, config).eval()
-
-        x = torch.randn(2, 8, *input_shape).to(self.torch_device)
-        with torch.no_grad():
-            out_unmerged = peft_model(x)
-            peft_model.merge_adapter()
-            out_merged = peft_model(x)
-            peft_model.unmerge_adapter()
-            out_unmerged_again = peft_model(x)
-
-        # sanity check: the adapter is actually contributing something non-trivial
-        assert not torch.allclose(out_unmerged, torch.zeros_like(out_unmerged))
-        assert torch.allclose(out_unmerged, out_merged, atol=1e-5, rtol=1e-5)
-        assert torch.allclose(out_unmerged, out_unmerged_again, atol=1e-6, rtol=1e-6)
 
 
 class TestAdaLoraInitialization:

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -40,6 +40,7 @@ from peft import (
     IA3Config,
     LilyConfig,
     LoftQConfig,
+    LoHaConfig,
     LoKrConfig,
     LoraConfig,
     PeanutConfig,
@@ -1876,6 +1877,96 @@ class TestLokrInitialization:
         output_after = model(data)[1]
 
         assert torch.allclose(output_before, output_after)
+
+
+class TestLoHaLoKrGroupedConv:
+    """Regression tests for LoHa and LoKr crashing on a plain (unmerged) forward pass whenever the wrapped
+    Conv1d/Conv2d layer has `groups > 1` (e.g. depthwise/grouped convolutions, common in vision models).
+
+    Both tuners built their low-rank adapter parameters using the base layer's full `in_channels` instead of
+    `in_channels // groups`, so `get_delta_weight`'s `reshape(base_layer.weight.shape)` raised a `RuntimeError`
+    (numel mismatch) the first time `forward` was called -- merging was never even reached. Unlike HiRA's
+    analogous `groups > 1` restriction (a Hadamard product against the base weight, see `TestHiraInitialization`),
+    LoHa/LoKr use their delta weight as an independent conv kernel (`F.conv2d(input, delta_weight,
+    groups=base_layer.groups)`, already present before this fix), so sizing the low-rank factors with
+    `in_channels // groups` is sufficient to fully support grouped convolutions, not just reject them.
+    """
+
+    torch_device = infer_device()
+
+    # (conv_cls, input_shape), input_shape excludes the batch and channel dims
+    conv_cases = [
+        pytest.param(nn.Conv1d, (9,), id="Conv1d"),
+        pytest.param(nn.Conv2d, (9, 9), id="Conv2d"),
+    ]
+
+    def get_model_conv_groups(self, conv_cls, groups):
+        class ModelConvGroups(nn.Module):
+            """For testing when the groups argument is used in a conv layer"""
+
+            def __init__(self):
+                super().__init__()
+                self.conv = conv_cls(8, 8, kernel_size=3, groups=groups)
+
+            def forward(self, X):
+                return self.conv(X)
+
+        return ModelConvGroups().eval().to(self.torch_device)
+
+    @pytest.mark.parametrize("config_cls", [LoHaConfig, LoKrConfig])
+    @pytest.mark.parametrize("conv_cls, input_shape", conv_cases)
+    @pytest.mark.parametrize("groups", [2, 4, 8])
+    def test_forward_works_for_groups_greater_than_one(self, config_cls, conv_cls, input_shape, groups):
+        # Before the fix: constructing the adapter "succeeded" but the very first forward pass crashed with a
+        # confusing RuntimeError (shape '[...]' is invalid for input of size ...), even though no merge was
+        # involved. After the fix: forward runs cleanly and produces a correctly-shaped output.
+        base_model = self.get_model_conv_groups(conv_cls, groups=groups)
+        config = config_cls(target_modules=["conv"], r=4, init_weights=False)
+        peft_model = get_peft_model(base_model, config)  # does not raise
+
+        x = torch.randn(2, 8, *input_shape).to(self.torch_device)
+        output = peft_model(x)  # does not raise
+        assert output.shape[:2] == (2, 8)
+
+    @pytest.mark.parametrize("config_cls", [LoHaConfig, LoKrConfig])
+    @pytest.mark.parametrize("conv_cls, input_shape", conv_cases)
+    def test_merge_unmerge_correct_for_groups_greater_than_one(self, config_cls, conv_cls, input_shape):
+        # Beyond "does not crash": verify the grouped-conv delta weight is actually correct, not just
+        # coincidentally reshape-compatible, by checking that merging it into the base layer's weight
+        # (base_layer.weight.data += delta_weight) reproduces exactly the same output as the unmerged forward pass
+        # (base_layer(x) + conv(x, delta_weight, groups=...)), and that unmerging restores it again. A wrong
+        # channel-to-group assignment would still crash or diverge here even if the raw element count happened to
+        # match.
+        groups = 2
+        base_model = self.get_model_conv_groups(conv_cls, groups=groups)
+        config = config_cls(target_modules=["conv"], r=4, init_weights=False)
+        peft_model = get_peft_model(base_model, config).eval()
+
+        x = torch.randn(2, 8, *input_shape).to(self.torch_device)
+        with torch.no_grad():
+            out_unmerged = peft_model(x)
+            peft_model.merge_adapter()
+            out_merged = peft_model(x)
+            peft_model.unmerge_adapter()
+            out_unmerged_again = peft_model(x)
+
+        # sanity check: the adapter is actually contributing something non-trivial
+        assert not torch.allclose(out_unmerged, torch.zeros_like(out_unmerged))
+        assert torch.allclose(out_unmerged, out_merged, atol=1e-5, rtol=1e-5)
+        assert torch.allclose(out_unmerged, out_unmerged_again, atol=1e-6, rtol=1e-6)
+
+    @pytest.mark.parametrize("config_cls", [LoHaConfig, LoKrConfig])
+    @pytest.mark.parametrize("conv_cls, input_shape", conv_cases)
+    def test_no_regression_for_groups_equal_to_one(self, config_cls, conv_cls, input_shape):
+        # sanity check: the default groups=1 case must keep working correctly after the groups>1 fix, since
+        # `update_layer` now always divides by `groups` (which is 1 here, a no-op).
+        base_model = self.get_model_conv_groups(conv_cls, groups=1)
+        config = config_cls(target_modules=["conv"], r=4)
+        peft_model = get_peft_model(base_model, config)  # does not raise
+
+        x = torch.randn(2, 8, *input_shape).to(self.torch_device)
+        output = peft_model(x)  # does not raise
+        assert output.shape[:2] == (2, 8)
 
 
 class TestAdaLoraInitialization:

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -817,10 +817,11 @@ class PeftCommonTester:
                 atol, rtol = 1e-3, 1e-3
             elif issubclass(config_cls, PveraConfig):
                 atol, rtol = 1e-5, 1e-5
-            elif issubclass(config_cls, (LoHaConfig, LoKrConfig)) and model_id in ("Conv2dGroups", "Conv2dGroups2"):
-                # LoHa/LoKr recombine their delta weight from several low-rank factors (Hadamard/Kronecker products)
-                # before merging into a grouped conv's weight, which accumulates more floating-point rounding than a
-                # plain LoRA `B @ A` merge
+            elif issubclass(config_cls, (LoHaConfig, LoKrConfig)) and model_id in (
+                "Conv1dGroups",
+                "Conv2dGroups",
+                "Conv2dGroups2",
+            ):
                 atol, rtol = 1e-3, 1e-3
 
             if config.peft_type == "ADAMSS":

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -817,6 +817,11 @@ class PeftCommonTester:
                 atol, rtol = 1e-3, 1e-3
             elif issubclass(config_cls, PveraConfig):
                 atol, rtol = 1e-5, 1e-5
+            elif issubclass(config_cls, (LoHaConfig, LoKrConfig)) and model_id in ("Conv2dGroups", "Conv2dGroups2"):
+                # LoHa/LoKr recombine their delta weight from several low-rank factors (Hadamard/Kronecker products)
+                # before merging into a grouped conv's weight, which accumulates more floating-point rounding than a
+                # plain LoRA `B @ A` merge
+                atol, rtol = 1e-3, 1e-3
 
             if config.peft_type == "ADAMSS":
                 # AdaMSS merges via B @ A @ newB (triple matmul), which accumulates more FP32


### PR DESCRIPTION
## What does this PR do?

Fixes grouped `Conv1d` and `Conv2d` support in LoHa and LoKr. Adapter shapes now use `in_channels // groups`, matching the base convolution weight layout.

Grouped-convolution cases are part of the shared custom-model matrix, covering forward passes, merge/unmerge, and save/load behavior without a separate test-only model.

## Tests

- `python -m pytest tests/test_custom_models.py -k "Conv1d and (LOHA or LOKR)" -q` — 495 passed, 22 skipped
- Ruff check and format check on the changed files

## AI assistance disclosure

AI assistance was used. I reviewed the changes and ran the tests above.
