### PR TITLE
Forward revision and token in AutoPeftModel loading

### DIFF
--- a/src/peft/auto.py
+++ b/src/peft/auto.py
@@ -155,14 +155,14 @@ class _BaseAutoPeftModel:
 
         base_model = target_class.from_pretrained(base_model_path, revision=base_model_revision, **kwargs)
 
+        token = kwargs.get("token", None)
+        if token is None:
+            token = kwargs.get("use_auth_token", None)
+
         tokenizer_exists = False
         if os.path.exists(os.path.join(pretrained_model_name_or_path, TOKENIZER_CONFIG_NAME)):
             tokenizer_exists = True
         else:
-            token = kwargs.get("token", None)
-            if token is None:
-                token = kwargs.get("use_auth_token", None)
-
             tokenizer_exists = check_file_exists_on_hf_hub(
                 repo_id=pretrained_model_name_or_path,
                 filename=TOKENIZER_CONFIG_NAME,
@@ -173,7 +173,10 @@ class _BaseAutoPeftModel:
 
         if tokenizer_exists and hasattr(base_model, "get_input_embeddings"):
             tokenizer = AutoTokenizer.from_pretrained(
-                pretrained_model_name_or_path, trust_remote_code=kwargs.get("trust_remote_code", False)
+                pretrained_model_name_or_path,
+                revision=revision,
+                token=token,
+                trust_remote_code=kwargs.get("trust_remote_code", False),
             )
             embedding_size = base_model.get_input_embeddings().weight.shape[0]
             if len(tokenizer) > embedding_size:
@@ -186,6 +189,7 @@ class _BaseAutoPeftModel:
             adapter_name=adapter_name,
             is_trainable=is_trainable,
             config=config,
+            revision=revision,
             **kwargs,
         )
 

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -16,7 +16,7 @@ import copy
 import pytest
 import torch
 from huggingface_hub import ModelCard
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from peft import AutoPeftModelForCausalLM, LoraConfig, PeftConfig, PeftModel, TaskType, get_peft_model
 
@@ -113,6 +113,14 @@ class TestBaseModelRevision:
 
         assert peft_model.peft_config["default"].base_model_name_or_path == base_model_id
         assert peft_model.peft_config["default"].revision == base_model_revision
+
+    def test_auto_peft_model_forwards_revision_to_tokenizer(self):
+        model_id = "peft-internal-testing/opt-tokenizer-revision"
+        revision = "my-revision"
+
+        model = AutoPeftModelForCausalLM.from_pretrained(model_id, revision=revision)
+        tokenizer = AutoTokenizer.from_pretrained(model_id, revision=revision)
+        assert model.get_input_embeddings().weight.shape[0] == len(tokenizer)
 
 
 class TestModelCard:

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -115,6 +115,8 @@ class TestBaseModelRevision:
         assert peft_model.peft_config["default"].revision == base_model_revision
 
     def test_auto_peft_model_forwards_revision_to_tokenizer(self):
+        # Regression test for #3442: revision was not forwarded when loading the tokenizer, so the adapter's
+        # saved embeddings could be incompatible with the tokenizer loaded from the default revision.
         model_id = "peft-internal-testing/opt-tokenizer-revision"
         revision = "my-revision"
 


### PR DESCRIPTION
## Summary

Forward `revision` and `token` when `AutoPeftModel*.from_pretrained` loads tokenizer and adapter files, keeping them on the caller-selected revision.

The regression test uses `peft-internal-testing/opt-tokenizer-revision` and verifies that the revision-specific tokenizer and model load with matching embedding sizes.

## Tests

- `python -m pytest tests/test_auto.py tests/test_hub_features.py -q --no-cov` (28 passed)
- Ruff check and format check on the changed files

## AI assistance disclosure

AI assistance was used. I reviewed the changes and ran the tests above.