### PR TITLE
FIX AdamssConfig missing validation for degenerate ASA schedule values

### DIFF
--- a/src/peft/tuners/adamss/config.py
+++ b/src/peft/tuners/adamss/config.py
@@ -83,22 +83,24 @@ class AdamssConfig(PeftConfig):
             Target total number of active subspaces across all layers when ASA is enabled. ASA will progressively prune
             subspaces until this target is reached. Lower values result in more aggressive pruning and fewer trainable
             parameters. Should be less than `num_subspaces * num_target_modules`. Typical values range from 20 to 100
-            depending on model size. Default is 50.
+            depending on model size. Default is 50. Must be a positive integer when `use_asa=True`.
 
         init_warmup (`int`):
             Number of training steps to wait before starting ASA pruning. During warmup, all subspaces remain active to
             allow importance scores to stabilize. Higher values give more time for accurate importance estimation but
-            delay pruning. Typical values range from 50 to 200. Default is 50.
+            delay pruning. Typical values range from 50 to 200. Default is 50. Must be smaller than `final_warmup`
+            when `use_asa=True`.
 
         final_warmup (`int`):
             Training step at which ASA completes pruning and reaches `asa_target_subspaces` active subspaces. The
             pruning is distributed between `init_warmup` and `final_warmup`. Should be set based on total training
-            steps; typically 1/3 to 1/2 of total training steps. Default is 1000.
+            steps; typically 1/3 to 1/2 of total training steps. Default is 1000. Must be larger than `init_warmup`
+            when `use_asa=True`.
 
         mask_interval (`int`):
             Number of training steps between ASA mask updates. Lower values allow more frequent adaptation but increase
             overhead. Higher values provide more stable importance estimates between updates. Typical values range from
-            50 to 200. Default is 100.
+            50 to 200. Default is 100. Must be a positive integer when `use_asa=True`.
 
         asa_importance_beta (`float`):
             Exponential moving average (EMA) coefficient for smoothing subspace importance scores. Higher values
@@ -115,7 +117,9 @@ class AdamssConfig(PeftConfig):
             warmup. Higher values result in faster initial pruning (more aggressive early reduction), while lower
             values provide a more gradual, linear-like decay. The formula is: current_active_subspaces =
             asa_target_subspaces + (asa_total_subspaces - asa_target_subspaces) * (progress ** exponent). Typical
-            values range from 1.0 (linear) to 5.0 (aggressive). Default is 3.0.
+            values range from 1.0 (linear) to 5.0 (aggressive). Default is 3.0. Must be a positive number when
+            `use_asa=True` (a zero or negative exponent either degenerates the schedule to a permanent no-op or, once
+            `progress` reaches exactly 0.0, raises a `ZeroDivisionError`).
 
         use_dynamic_rank (`bool`):
             Whether to dynamically determine subspace ranks based on singular value magnitudes. When True, each
@@ -227,7 +231,8 @@ class AdamssConfig(PeftConfig):
             "help": (
                 "Target total number of active subspaces across all layers when ASA is enabled. "
                 "ASA progressively prunes subspaces until this target is reached. Lower values "
-                "result in more aggressive pruning. Typical values: 20-100. Default: 50."
+                "result in more aggressive pruning. Typical values: 20-100. Default: 50. Must be "
+                "a positive integer when use_asa=True."
             )
         },
     )
@@ -237,7 +242,8 @@ class AdamssConfig(PeftConfig):
             "help": (
                 "Training steps to wait before starting ASA pruning. During warmup, all subspaces "
                 "remain active to allow importance scores to stabilize. Higher values give more "
-                "time for accurate estimation. Typical values: 50-200. Default: 50."
+                "time for accurate estimation. Typical values: 50-200. Default: 50. Must be smaller "
+                "than final_warmup when use_asa=True."
             )
         },
     )
@@ -247,7 +253,7 @@ class AdamssConfig(PeftConfig):
             "help": (
                 "Training step at which ASA completes pruning and reaches asa_target_subspaces. "
                 "Should be set based on total training steps; typically 1/3 to 1/2 of total steps. "
-                "Default: 1000."
+                "Default: 1000. Must be larger than init_warmup when use_asa=True."
             )
         },
     )
@@ -257,7 +263,7 @@ class AdamssConfig(PeftConfig):
             "help": (
                 "Training steps between ASA mask updates. Lower values allow more frequent "
                 "adaptation but increase overhead. Higher values provide more stable estimates. "
-                "Typical values: 50-200. Default: 100."
+                "Typical values: 50-200. Default: 100. Must be a positive integer when use_asa=True."
             )
         },
     )
@@ -290,7 +296,8 @@ class AdamssConfig(PeftConfig):
                 "asa_target_subspaces. Higher values result in faster initial pruning (aggressive "
                 "early reduction), lower values provide gradual linear-like decay. Formula: "
                 "current_active_subspaces = asa_target_subspaces + (total - target) * (progress ** exponent). "
-                "Typical values: 1.0 (linear) to 5.0 (aggressive). Default: 3.0."
+                "Typical values: 1.0 (linear) to 5.0 (aggressive). Default: 3.0. Must be a positive "
+                "number when use_asa=True."
             )
         },
     )
@@ -341,6 +348,38 @@ class AdamssConfig(PeftConfig):
         # Validate initialization method
         if self.init_weights not in ["orthogonal", None]:
             raise ValueError(f"init_weights must be 'orthogonal' or None, got {self.init_weights}")
+
+        # Validate the ASA (Adaptive Subspace Allocation) scheduling parameters. These fields are only ever read
+        # from `AdamssModel.update_and_allocate` (directly, or via `AdamssAsaCallback`) when `use_asa=True`; when ASA
+        # is disabled they are unused, so skip validation here to preserve the common pattern (see
+        # `examples/adamss_finetuning`) of leaving them at `None` when `use_asa=False`. Without these checks,
+        # degenerate values pass silently at construction time and only surface as a raw `ZeroDivisionError` or
+        # `RuntimeError` deep inside `update_and_allocate`/`_schedule_threshold`/`_global_mask_to_target`, often
+        # several training steps into a run.
+        if self.use_asa:
+            if self.mask_interval is None or self.mask_interval <= 0:
+                raise ValueError(
+                    f"`mask_interval` must be a positive integer when `use_asa=True`, got {self.mask_interval}."
+                )
+
+            if self.init_warmup is None or self.final_warmup is None or self.init_warmup >= self.final_warmup:
+                raise ValueError(
+                    "`init_warmup` must be smaller than `final_warmup` when `use_asa=True` so that ASA has a "
+                    f"non-empty pruning ramp, got init_warmup={self.init_warmup} and "
+                    f"final_warmup={self.final_warmup}."
+                )
+
+            if self.asa_target_subspaces is None or self.asa_target_subspaces <= 0:
+                raise ValueError(
+                    "`asa_target_subspaces` must be a positive integer when `use_asa=True`, got "
+                    f"{self.asa_target_subspaces}."
+                )
+
+            if self.asa_schedule_exponent is None or self.asa_schedule_exponent <= 0:
+                raise ValueError(
+                    "`asa_schedule_exponent` must be a positive number when `use_asa=True`, got "
+                    f"{self.asa_schedule_exponent}."
+                )
 
         # Early check for scikit-learn availability
         try:

--- a/tests/test_adamss_asa.py
+++ b/tests/test_adamss_asa.py
@@ -7,6 +7,7 @@ Tests cover:
 - update_and_allocate: full ASA flow (accumulate → global mask → reset)
 """
 
+import pytest
 import torch
 from torch import nn
 
@@ -270,3 +271,39 @@ class TestAdamssAsa:
         for layer in layers:
             for p in layer.adamss_A["default"]:
                 assert p.requires_grad
+
+    # -- config validation (regression tests for ZeroDivisionError bugs) ----
+
+    def test_zero_mask_interval_fails_at_construction_not_training(self):
+        """`mask_interval=0` must raise ValueError as soon as AdamssConfig is constructed (inside
+        `_make_asa_model`), before a model is ever built or `update_and_allocate` is called. Previously this raised
+        a raw `ZeroDivisionError` deep inside `update_and_allocate` instead."""
+        with pytest.raises(ValueError, match="mask_interval"):
+            _make_asa_model(mask_interval=0)
+
+    def test_equal_warmup_bounds_fails_at_construction_not_training(self):
+        """`init_warmup == final_warmup` must raise ValueError at AdamssConfig construction, before a model is ever
+        built. Previously this raised a raw `ZeroDivisionError` deep inside `_schedule_threshold`."""
+        with pytest.raises(ValueError, match="final_warmup"):
+            _make_asa_model(init_warmup=10, final_warmup=10, mask_interval=1)
+
+    def test_full_schedule_range_trains_without_error(self):
+        """A valid ASA config must still train cleanly across the *entire* warmup -> final_warmup range, including
+        the exact step where step == final_warmup (where `mul_coeff` is exactly 0.0) and beyond -- the boundary
+        conditions the ZeroDivisionError bugs used to hit -- and should still end up masking some subspaces."""
+        model = _make_asa_model(
+            num_subspaces=4, asa_target_subspaces=2, init_warmup=0, final_warmup=10, mask_interval=1
+        )
+        optimizer = torch.optim.AdamW(model.parameters(), lr=0.1)
+        layers = _get_adamss_layers(model)
+        initial_active = sum(1 for layer in layers for p in layer.adamss_A["default"] if p.requires_grad)
+
+        for step in range(12):  # runs past final_warmup=10, touching every schedule boundary
+            x = torch.randn(4, 20)
+            model(x).sum().backward()
+            optimizer.step()
+            model.base_model.update_and_allocate(step)  # must not raise
+            optimizer.zero_grad()
+
+        final_active = sum(1 for layer in layers for p in layer.adamss_A["default"] if p.requires_grad)
+        assert final_active < initial_active, f"Active params should decrease: {initial_active} → {final_active}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -442,6 +442,64 @@ class TestPeftConfig:
 
         assert "The supplied schedule values don't allow for a budgeting phase" in str(e)
 
+    @pytest.mark.parametrize(
+        "adamss_kwargs",
+        [
+            {"use_asa": True, "init_warmup": 0, "final_warmup": 100, "mask_interval": 10},
+            {"use_asa": True, "init_warmup": 50, "final_warmup": 1000, "mask_interval": 100},
+            {"use_asa": True, "init_warmup": 0, "final_warmup": 1, "mask_interval": 1},
+            {"use_asa": True, "asa_target_subspaces": 1, "init_warmup": 0, "final_warmup": 100},
+            {"use_asa": True, "asa_schedule_exponent": 1.0, "init_warmup": 0, "final_warmup": 100},
+            # ASA disabled: these fields are never read by `update_and_allocate`, so degenerate or `None` values
+            # must be tolerated. `None` mirrors the pattern used by examples/adamss_finetuning/*.py, which pass
+            # `None` for all of these fields whenever `use_asa=False`.
+            {"use_asa": False},
+            {"use_asa": False, "mask_interval": 0, "init_warmup": 10, "final_warmup": 10, "asa_target_subspaces": -1},
+            {
+                "use_asa": False,
+                "mask_interval": None,
+                "init_warmup": None,
+                "final_warmup": None,
+                "asa_target_subspaces": None,
+                "asa_schedule_exponent": None,
+            },
+        ],
+    )
+    def test_adamss_config_valid_asa_schedule_works(self, adamss_kwargs):
+        # Make sure that passing correct ASA scheduling values -- or any values at all when ASA is disabled -- is
+        # not prevented by faulty config checks.
+        AdamssConfig(**adamss_kwargs)  # does not raise
+
+    @pytest.mark.parametrize(
+        "adamss_kwargs,match",
+        [
+            # mask_interval is used as `global_step % config.mask_interval` in `update_and_allocate`; 0 used to
+            # raise a raw ZeroDivisionError deep in training instead of failing fast at construction.
+            ({"mask_interval": 0}, "mask_interval"),
+            ({"mask_interval": -5}, "mask_interval"),
+            # `final_warmup - init_warmup` is a denominator in `_schedule_threshold`; equal values used to raise
+            # ZeroDivisionError, and `init_warmup > final_warmup` silently disabled ASA masking for the whole run
+            # (the `init_warmup <= step <= final_warmup` window is never entered).
+            ({"init_warmup": 10, "final_warmup": 10}, "init_warmup"),
+            ({"init_warmup": 50, "final_warmup": 10}, "init_warmup"),
+            # asa_target_subspaces is used as `k` in `torch.kthvalue` in `_global_mask_to_target`; non-positive
+            # values used to raise a confusing "kthvalue(): selected number k out of range" RuntimeError mid-run.
+            ({"asa_target_subspaces": 0}, "asa_target_subspaces"),
+            ({"asa_target_subspaces": -1}, "asa_target_subspaces"),
+            # asa_schedule_exponent is the exponent of `mul_coeff ** exponent` in `_schedule_threshold`, where
+            # `mul_coeff` reaches exactly 0.0 at `step == final_warmup`; negative values used to raise
+            # ZeroDivisionError ("0.0 cannot be raised to a negative power") and 0.0 silently froze the schedule at
+            # the full subspace count for the entire warmup range.
+            ({"asa_schedule_exponent": 0.0}, "asa_schedule_exponent"),
+            ({"asa_schedule_exponent": -1.0}, "asa_schedule_exponent"),
+        ],
+    )
+    def test_adamss_config_invalid_asa_schedule_raises(self, adamss_kwargs, match):
+        kwargs = {"use_asa": True, "init_warmup": 0, "final_warmup": 100, "mask_interval": 10}
+        kwargs.update(adamss_kwargs)
+        with pytest.raises(ValueError, match=match):
+            AdamssConfig(**kwargs)
+
     @pytest.mark.parametrize("config_class, mandatory_kwargs", ALL_CONFIG_CLASSES)
     def test_from_pretrained_forward_compatible(self, config_class, mandatory_kwargs, tmp_path, recwarn):
         """


### PR DESCRIPTION
## What does this PR do?

`AdamssConfig` (the config for the AdaMSS tuner's Adaptive Subspace Allocation / ASA feature) accepts several ASA scheduling values that are silently invalid at construction time and only crash much later, deep inside `AdamssModel.update_and_allocate` — sometimes many training steps into a run, always with a raw, non-obvious exception rather than a message that points at the actual misconfigured field. This PR is a validation-completeness pass over the ASA-scheduling half of `AdamssConfig`: I went through every numeric field the class defines, reproduced the crash (or confirmed there isn't one) for degenerate values of each, and added `__post_init__` validation for every field where a real gap existed, not just the two originally-suspected ones.

### Bugs fixed

All five reproduced on current `main` with a minimal 2-layer model before this fix; all five now raise a clear `ValueError` at `AdamssConfig(...)` construction instead.

1. **`mask_interval=0`** → `ZeroDivisionError: integer division or modulo by zero` from `global_step % config.mask_interval` in `update_and_allocate` (`src/peft/tuners/adamss/model.py`). `mask_interval=0` reads as a plausible (if wrong) attempt at "apply the mask every step."

2. **`init_warmup == final_warmup`** → `ZeroDivisionError: division by zero` from the `config.final_warmup - config.init_warmup` denominator in `_schedule_threshold`. Setting both to the same value reads as a plausible attempt at "prune immediately, skip the ramp."

   I also checked `init_warmup > final_warmup`: it doesn't crash, but `within_warmup = init_warmup <= global_step <= final_warmup` is then an empty range for every possible `global_step`, so ASA masking silently never triggers for the entire run despite `use_asa=True` — arguably worse than a crash since it fails silently. Both the equal and inverted cases are rejected by the same check (`init_warmup >= final_warmup`).

3. **`asa_schedule_exponent <= 0`** (found during the field-by-field sweep, not in the original report): the schedule computes `mul_coeff ** exponent` where `mul_coeff` is clamped to `[0.0, 1.0]` and reaches *exactly* `0.0` whenever `global_step == final_warmup` — a perfectly normal step to hit during training, not an edge case a user has to contrive. `0.0 ** (negative exponent)` raises `ZeroDivisionError: 0.0 cannot be raised to a negative power`. An exponent of exactly `0.0` doesn't crash (`0.0 ** 0.0 == 1.0` in Python) but makes `mul_coeff ** exponent` constant `1.0` for every step, so the interpolated target is permanently pinned at the full subspace count — ASA silently never prunes anything for the whole warmup window.

4. **`asa_target_subspaces <= 0`** (also found during the sweep): once the interpolated schedule reaches the raw target value (at `step == final_warmup`), it's passed as `k` to `torch.kthvalue(-all_scores, k)` in `_global_mask_to_target`. `k <= 0` raises `RuntimeError: kthvalue(): selected number k out of range for dimension 0`, again with nothing in the message pointing at `asa_target_subspaces`.

Validation is gated on `use_asa=True`: these fields are documented as ASA-only and are never read when ASA is disabled. This also matters for backward compatibility — `examples/adamss_finetuning/glue_adamss_asa_example.py`, `glue_adamss_asa_manual_example.py`, and `image_classification_adamss_asa.py` all pass `None` for every one of these fields whenever `--use_asa` is off, which would otherwise now raise `TypeError` on an unconditional `None <= 0` check. Confirmed this exact pattern still constructs cleanly after the fix.

### Other numeric fields checked, no gap found

Per the field-by-field sweep, I also exercised degenerate values (`0`, negative, and out-of-typical-range) for `r`, `num_subspaces`, `subspace_rank`, `svd_threshold`, `asa_importance_beta`, and `asa_uncertainty_beta`:

- `subspace_rank=0` is already handled gracefully (explicit "ensure at least rank 1" fallback in `AdamssLayer.update_layer`).
- `svd_threshold` at an extreme value (e.g. `100.0`) is likewise absorbed by that same rank-1 fallback — no crash.
- `asa_importance_beta` / `asa_uncertainty_beta` outside `[0, 1]` don't crash (the EMA update is a plain `mul_`/`add_`, well-defined for any float); they'd just be numerically unusual, which isn't something this PR tries to police.
- `r`, `num_subspaces`, and negative `subspace_rank` do crash (in `KMeans`/`slice_pca`/tensor-shape errors), but only at layer-construction time (`get_peft_model`), with reasonably specific messages already (e.g. `RuntimeError: slice_pca raised an exception for layer default (...)`, which already names the layer and shape). These are structural/capacity parameters, analogous to `LoraConfig.r`, which peft also doesn't validate for positivity — so leaving them alone matches existing convention rather than being a gap this PR should invent new policy for.

## Why this isn't a duplicate

Searched `huggingface/peft` PRs and issues (`gh search prs/issues`) for `adamss`, `ZeroDivisionError`, `mask_interval`, `init_warmup`, `asa_target_subspaces`, and `asa_schedule_exponent`. All `adamss`-matching PRs are the original tuner PRs (#2987, #2967) or unrelated fixes (#3367 delete_adapter leak, #3310 SVD determinism) — none touch config validation. My own open PR #3438 ("Add missing config validation across GraLoRA, AdaLoRA, WaveFT") is the same *kind* of fix but touches a disjoint set of files (`adalora/config.py`, `gralora/config.py`, `waveft/model.py`) and doesn't mention AdaMSS anywhere. No existing PR or issue addresses any of the five gaps above.

## Tests

Added regression tests in two places, next to the existing analogous tests:

- `tests/test_config.py::TestPeftConfig` — `test_adamss_config_valid_asa_schedule_works` (parametrized, 8 cases: valid `use_asa=True` schedules across all four fields, plus `use_asa=False` with degenerate/`None` values to lock in the backward-compat behavior) and `test_adamss_config_invalid_asa_schedule_raises` (parametrized, 8 cases: both zero and negative variants of all four fields, plus both the equal and inverted `init_warmup`/`final_warmup` cases). Mirrors the existing `test_adalora_config_valid_timing_works` / `test_adalora_config_timing_bounds_error` pattern for AdaLoRA's analogous `tinit`/`tfinal`/`total_step` schedule.
- `tests/test_adamss_asa.py::TestAdamssAsa` — `test_zero_mask_interval_fails_at_construction_not_training` and `test_equal_warmup_bounds_fails_at_construction_not_training` confirm the fix using the file's existing `_make_asa_model` end-to-end helper (i.e. the ValueError fires before a model is even built), and `test_full_schedule_range_trains_without_error` trains a valid config across the *entire* warmup→final_warmup boundary (the exact region the bugs lived in) to confirm masking still works correctly post-fix.

**Fail-before / pass-after**: isolated the `src/peft/tuners/adamss/config.py` fix into a standalone patch, reverted it with the new tests left in place, and reran — all 8 "invalid" parametrized cases plus both `test_..._fails_at_construction_not_training` tests failed exactly as expected (construction silently succeeded, no `ValueError`), while the "valid config" tests still passed. Reapplied the patch and reran — all tests passed.

Ran, all passing:
- `tests/test_adamss_asa.py` (full file): 11/11
- `tests/test_config.py` (full file): 1209 passed, 12 skipped (unrelated, pre-existing)

`ruff check` and `ruff format --check` (ruff 0.15.17, matching the `~=0.15.12` pin) are clean on all three changed files; my added lines are all within the 119-char line length.

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code). There is no pre-existing issue — I found the `asa_schedule_exponent` and `asa_target_subspaces` gaps myself while systematically sweeping every numeric field in `AdamssConfig` for the same class of problem after being pointed at the two originally-known `mask_interval`/`init_warmup` crashes. I independently reproduced each of the five crashes against `main` with a minimal repro script, reviewed and understand every changed line, and validated the fail-before/pass-after behavior via patch-revert before proposing this change.
