### PR TITLE
Add type hints to rescale_adapter_scale and compute_loss in helpers.py

### DIFF
--- a/src/peft/helpers.py
+++ b/src/peft/helpers.py
@@ -17,7 +17,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from functools import update_wrapper
 from types import MethodType
-from typing import Optional
+from typing import Any, Iterator, Optional, Union
 
 import torch
 from torch import nn
@@ -167,7 +167,7 @@ def check_if_peft_model(model_name_or_path: str) -> bool:
 
 
 @contextmanager
-def rescale_adapter_scale(model, multiplier):
+def rescale_adapter_scale(model: nn.Module, multiplier: Union[float, int]) -> Iterator[None]:
     """
     Context manager to temporarily rescale the scaling of the LoRA adapter in a model.
 
@@ -303,7 +303,9 @@ class MontecloraTrainerMixin:
         ```
     """
 
-    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
+    def compute_loss(
+        self, model: nn.Module, inputs: dict[str, Any], return_outputs: bool = False, **kwargs: Any
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, Any]]:
         """
         Compute loss with Monteclora variational regularization.
 


### PR DESCRIPTION
## What does this PR do?

Adds missing type annotations to two functions in `src/peft/helpers.py`. Follow-up to the merged
#3144 (same author), which added type hints to `src/peft/utils/merge_utils.py` and
`src/peft/utils/other.py`.

The following functions were missing type hints:

**`helpers.py`**
- `rescale_adapter_scale`: added `nn.Module` param type for `model`, `Union[float, int]` param
  type for `multiplier` (matches the existing `isinstance(multiplier, (float, int))` check), and
  `Iterator[None]` return type (it's a `@contextmanager`-decorated generator)
- `MontecloraTrainerMixin.compute_loss`: added `nn.Module` param type for `model`,
  `dict[str, Any]` param type for `inputs`, `bool` param type for `return_outputs`, `Any` for
  `**kwargs`, and `Union[torch.Tensor, tuple[torch.Tensor, Any]]` return type (matches the two
  return paths: `total_loss` alone, or `(total_loss, outputs)`)

I verified each of the 5 functions listed in the original task scope against the live file
before editing. `get_best_targets`, `get_best_target_parameters`, and `find_kappa_target_modules`
already have full parameter and return type hints on `main` (added since #3144), so they were
left unmodified — this PR only touches the two functions that actually lacked hints.

These annotations improve IDE support, static analysis, and code readability without any
behavioral changes.

## Tests

Type-hint only change — no behavioral modification. Test commands:
- `python3 -m py_compile src/peft/helpers.py` — passes
- `npx pyright src/peft/helpers.py` — 11 errors total, all pre-existing (bitsandbytes import
  resolution, dynamic attribute access on `BaseTunerLayer`/`Tensor`, and `object.compute_loss` on
  the mixin's bare superclass since `MontecloraTrainerMixin` is typed standalone); none on the
  lines modified by this PR
- Verified the new hints against actual call sites: `tests/test_helpers.py` calls
  `rescale_adapter_scale(model=..., multiplier=0.5)` with `nn.Module`-typed models (LoRA models,
  diffusers pipeline components) and float multipliers; `compute_loss(model, inputs)` is called
  with `inputs = {"input_ids": ..., "labels": ...}`, a `dict[str, Tensor]`
- No unit test additions required (no behavior change)

## Before submitting
- [x] This PR improves typing/annotations (documentation-adjacent; dismissing docs/test checks
      per the precedent set in #3144 with @BenjaminBossan's guidance).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/peft/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes? (N/A — type hints only)
- [x] Did you write any new necessary tests? (N/A — no behavior change)

## AI assistance disclosure

This PR was developed with the assistance of Claude Code (AI). All changes have been read,
understood, and verified by the human contributor (Rudrendu Paul). The type annotations were
derived by reading the function implementations, checking actual call sites in
`tests/test_helpers.py`, and cross-referencing PyTorch/typing conventions used elsewhere in this
same file (e.g. `KappaTuneSelector`, `find_kappa_target_modules`).
