### PR TITLE
Fix state-dict key collisions for modules_to_save

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -384,6 +384,13 @@ def get_peft_model_state_dict(
             module_state_dict = {
                 k.removeprefix(f"{name}."): v for k, v in state_dict.items() if k.startswith(f"{name}.")
             }
+            # A tuner's own key-selection filter above matches keys with a plain substring check (e.g. LoRA collects
+            # every key containing "lora_"), so it can accidentally sweep up this module's raw attributes if its name
+            # happens to contain the tuner's prefix (e.g. a module named "lora_head" listed in `modules_to_save`).
+            # This module is the sole source of truth for which of its own keys should be saved, so any such stale
+            # entries are dropped before being correctly repopulated from `adapter_state_dict` below.
+            for stale_key in [k for k in to_return if k.startswith(f"{name}.")]:
+                del to_return[stale_key]
             to_return.update(
                 {f"{name}.{k}": v for k, v in module.adapter_state_dict(adapter_name, module_state_dict).items()}
             )
@@ -543,6 +550,14 @@ def _insert_adapter_name_into_state_dict(
             _, _, suffix = key.rpartition(parameter_prefix)
             if "." in suffix:
                 suffix_to_replace = ".".join(suffix.split(".")[1:])
+                if "." in suffix_to_replace:
+                    # A genuine adapter parameter attribute (e.g. "lora_A" in "...q_proj.lora_A.weight") is always
+                    # followed by at most one more path component. If more than one remains after the match, the
+                    # occurrence of `parameter_prefix` is part of an unrelated, earlier path segment instead, e.g. a
+                    # `modules_to_save` module whose own name happens to start with the prefix (such as "lora_head"
+                    # in "...lora_head.modules_to_save.default.weight"). Leave such keys untouched.
+                    peft_model_state_dict[key] = val
+                    continue
                 # only replace the substring if the key ends on the substring to avoid accidental replacement inside of
                 # the key if a module happens to have a name that contains the substring
                 key = re.sub(re.escape(suffix_to_replace) + r"$", f"{adapter_name}.{suffix_to_replace}", key)

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -384,11 +384,7 @@ def get_peft_model_state_dict(
             module_state_dict = {
                 k.removeprefix(f"{name}."): v for k, v in state_dict.items() if k.startswith(f"{name}.")
             }
-            # A tuner's own key-selection filter above matches keys with a plain substring check (e.g. LoRA collects
-            # every key containing "lora_"), so it can accidentally sweep up this module's raw attributes if its name
-            # happens to contain the tuner's prefix (e.g. a module named "lora_head" listed in `modules_to_save`).
-            # This module is the sole source of truth for which of its own keys should be saved, so any such stale
-            # entries are dropped before being correctly repopulated from `adapter_state_dict` below.
+            # Remove keys selected only because the module name contains a tuner prefix.
             for stale_key in [k for k in to_return if k.startswith(f"{name}.")]:
                 del to_return[stale_key]
             to_return.update(
@@ -470,7 +466,9 @@ def get_peft_model_state_dict(
             if not embedding_is_targeted or has_valid_embedding_base_layer(layer):
                 embedding_module_name = get_embedding_layer_name(model, layer, embedding_is_targeted)
                 if embedding_module_name:
-                    to_return.update({k: v for k, v in state_dict.items() if embedding_module_name in k})
+                    to_return.update(
+                        {k: v for k, v in state_dict.items() if k.startswith(f"{embedding_module_name}.")}
+                    )
     elif save_embedding_layers:
         warnings.warn("Could not identify embedding layer(s) because the model is not a 🤗 transformers model.")
 
@@ -551,11 +549,7 @@ def _insert_adapter_name_into_state_dict(
             if "." in suffix:
                 suffix_to_replace = ".".join(suffix.split(".")[1:])
                 if "." in suffix_to_replace:
-                    # A genuine adapter parameter attribute (e.g. "lora_A" in "...q_proj.lora_A.weight") is always
-                    # followed by at most one more path component. If more than one remains after the match, the
-                    # occurrence of `parameter_prefix` is part of an unrelated, earlier path segment instead, e.g. a
-                    # `modules_to_save` module whose own name happens to start with the prefix (such as "lora_head"
-                    # in "...lora_head.modules_to_save.default.weight"). Leave such keys untouched.
+                    # Adapter parameters are leaf attributes; a longer suffix means the prefix matched a module name.
                     peft_model_state_dict[key] = val
                     continue
                 # only replace the substring if the key ends on the substring to avoid accidental replacement inside of

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -26,7 +26,14 @@ from transformers import (
     LlavaForConditionalGeneration,
 )
 
-from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
+from peft import (
+    LoraConfig,
+    PeftModel,
+    VeraConfig,
+    get_peft_model,
+    get_peft_model_state_dict,
+    set_peft_model_state_dict,
+)
 from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_ge_v5_6_0
 from peft.utils.other import (
     ModulesToSaveWrapper,
@@ -425,6 +432,67 @@ class TestModulesToSaveNameSubstringBug:
             param_merged = sd_merged[key]
             param_unmerged = sd_unmerged[key]
             assert torch.allclose(param_merged, param_unmerged)
+
+
+class TestModulesToSaveNameContainsPrefixBug:
+    """Test a bug where a `modules_to_save` module's name contains the tuner's own parameter prefix as a substring,
+    e.g. a module named "lora_head" together with a `LoraConfig` (whose parameter prefix is "lora_").
+
+    Two substring checks in the state dict save/load logic used a plain `in` test against the tuner's parameter
+    prefix. Since "lora_head" also contains "lora_", both checks were fooled into treating this module's own
+    attributes as if they were LoRA parameters:
+
+    - On save, the filter that collects LoRA keys (`"lora_" in key`) also picked up this module's raw, unprocessed
+      attributes, alongside the correctly computed key for the module.
+    - On load, `_insert_adapter_name_into_state_dict`'s `parameter_prefix in key` check spliced a second, superfluous
+      adapter name into a key that had already been correctly formed by the `modules_to_save` handling that runs
+      before it.
+
+    The net effect was that the module's trained weight ended up under a key matching nothing in the model, so it
+    silently landed in `unexpected_keys` under non-strict loading, and the untrained weight was kept instead.
+    """
+
+    def get_model(self):
+        class ModelWithLoraNamedModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.body = nn.Linear(2, 2, bias=False)
+                # important: this module's name contains "lora_", the LoRA parameter prefix, as a substring
+                self.lora_head = nn.Linear(2, 2, bias=False)
+                self.plain_head = nn.Linear(2, 2, bias=False)
+
+            def forward(self, x):
+                x = self.body(x)
+                return self.lora_head(x) + self.plain_head(x)
+
+        torch.manual_seed(0)
+        return ModelWithLoraNamedModule()
+
+    def test_save_load_round_trip_restores_weight(self):
+        config = LoraConfig(target_modules=["body"], modules_to_save=["lora_head", "plain_head"])
+        source = get_peft_model(self.get_model(), config)
+        with torch.no_grad():
+            source.base_model.model.lora_head.modules_to_save["default"].weight.fill_(7.0)
+
+        state_dict = get_peft_model_state_dict(source)
+        target = get_peft_model(self.get_model(), copy.deepcopy(config))
+        result = set_peft_model_state_dict(target, state_dict)
+
+        assert not [k for k in result.unexpected_keys if "lora_head" in k]
+        loaded_weight = target.base_model.model.lora_head.modules_to_save["default"].weight
+        assert torch.allclose(loaded_weight, torch.full_like(loaded_weight, 7.0))
+
+    def test_saved_state_dict_matches_non_colliding_name(self):
+        # A `modules_to_save` module whose name contains the adapter prefix should be saved with the exact same key
+        # shape (relative to its own module name) as one whose name does not.
+        config = LoraConfig(target_modules=["body"], modules_to_save=["lora_head", "plain_head"])
+        model = get_peft_model(self.get_model(), config)
+        state_dict = get_peft_model_state_dict(model)
+
+        assert "base_model.model.lora_head.weight" in state_dict
+        assert "base_model.model.plain_head.weight" in state_dict
+        assert not [k for k in state_dict if ("lora_head" in k) and (k != "base_model.model.lora_head.weight")]
+        assert not [k for k in state_dict if ("plain_head" in k) and (k != "base_model.model.plain_head.weight")]
 
 
 class TestTargetingAuxiliaryTrainingWrapper:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -435,46 +435,28 @@ class TestModulesToSaveNameSubstringBug:
 
 
 class TestModulesToSaveNameContainsPrefixBug:
-    """Test a bug where a `modules_to_save` module's name contains the tuner's own parameter prefix as a substring,
-    e.g. a module named "lora_head" together with a `LoraConfig` (whose parameter prefix is "lora_").
-
-    Two substring checks in the state dict save/load logic used a plain `in` test against the tuner's parameter
-    prefix. Since "lora_head" also contains "lora_", both checks were fooled into treating this module's own
-    attributes as if they were LoRA parameters:
-
-    - On save, the filter that collects LoRA keys (`"lora_" in key`) also picked up this module's raw, unprocessed
-      attributes, alongside the correctly computed key for the module.
-    - On load, `_insert_adapter_name_into_state_dict`'s `parameter_prefix in key` check spliced a second, superfluous
-      adapter name into a key that had already been correctly formed by the `modules_to_save` handling that runs
-      before it.
-
-    The net effect was that the module's trained weight ended up under a key matching nothing in the model, so it
-    silently landed in `unexpected_keys` under non-strict loading, and the untrained weight was kept instead.
-    """
-
     def get_model(self):
         class ModelWithLoraNamedModule(nn.Module):
             def __init__(self):
                 super().__init__()
                 self.body = nn.Linear(2, 2, bias=False)
-                # important: this module's name contains "lora_", the LoRA parameter prefix, as a substring
                 self.lora_head = nn.Linear(2, 2, bias=False)
-                self.plain_head = nn.Linear(2, 2, bias=False)
 
             def forward(self, x):
-                x = self.body(x)
-                return self.lora_head(x) + self.plain_head(x)
+                return self.lora_head(self.body(x))
 
         torch.manual_seed(0)
         return ModelWithLoraNamedModule()
 
     def test_save_load_round_trip_restores_weight(self):
-        config = LoraConfig(target_modules=["body"], modules_to_save=["lora_head", "plain_head"])
+        config = LoraConfig(target_modules=["body"], modules_to_save=["lora_head"])
         source = get_peft_model(self.get_model(), config)
         with torch.no_grad():
             source.base_model.model.lora_head.modules_to_save["default"].weight.fill_(7.0)
 
         state_dict = get_peft_model_state_dict(source)
+        assert {k for k in state_dict if "lora_head" in k} == {"base_model.model.lora_head.weight"}
+
         target = get_peft_model(self.get_model(), copy.deepcopy(config))
         result = set_peft_model_state_dict(target, state_dict)
 
@@ -482,17 +464,25 @@ class TestModulesToSaveNameContainsPrefixBug:
         loaded_weight = target.base_model.model.lora_head.modules_to_save["default"].weight
         assert torch.allclose(loaded_weight, torch.full_like(loaded_weight, 7.0))
 
-    def test_saved_state_dict_matches_non_colliding_name(self):
-        # A `modules_to_save` module whose name contains the adapter prefix should be saved with the exact same key
-        # shape (relative to its own module name) as one whose name does not.
-        config = LoraConfig(target_modules=["body"], modules_to_save=["lora_head", "plain_head"])
-        model = get_peft_model(self.get_model(), config)
-        state_dict = get_peft_model_state_dict(model)
+    def test_save_embedding_layers_does_not_include_similarly_named_module(self):
+        class ModelWithEmbedding(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.body = nn.Linear(2, 2)
+                self.embed_tokens = nn.Embedding(4, 2)
+                self.embed_tokens_extra = nn.Embedding(4, 2)
 
-        assert "base_model.model.lora_head.weight" in state_dict
-        assert "base_model.model.plain_head.weight" in state_dict
-        assert not [k for k in state_dict if ("lora_head" in k) and (k != "base_model.model.lora_head.weight")]
-        assert not [k for k in state_dict if ("plain_head" in k) and (k != "base_model.model.plain_head.weight")]
+            def get_input_embeddings(self):
+                return self.embed_tokens
+
+            def get_output_embeddings(self):
+                return None
+
+        model = get_peft_model(ModelWithEmbedding(), LoraConfig(target_modules=["body"]))
+        state_dict = get_peft_model_state_dict(model, save_embedding_layers=True)
+
+        assert "base_model.model.embed_tokens.weight" in state_dict
+        assert not any("embed_tokens_extra" in k for k in state_dict)
 
 
 class TestTargetingAuxiliaryTrainingWrapper:


### PR DESCRIPTION
## What does this PR do?

Fixes state-dict key collisions when a `modules_to_save` module name contains a tuner prefix, such as `lora_head`. Save/load now keeps the wrapper's exact keys instead of treating the module name as an adapter parameter.

It also anchors embedding-layer key selection to a path boundary, preventing a sibling such as `embed_tokens_extra` from being included when saving `embed_tokens`.

## Tests

- `python -m pytest tests/test_other.py -k ModulesToSaveNameContainsPrefixBug -q` — 2 passed
- Ruff check and format check on the changed files

## AI assistance disclosure

AI assistance was used. I reviewed the changes and ran the tests above.
