### PR TITLE
Add type hints to hotswap utility functions in hotswap.py

### DIFF
--- a/src/peft/utils/hotswap.py
+++ b/src/peft/utils/hotswap.py
@@ -33,7 +33,7 @@ from .save_and_load import _insert_adapter_name_into_state_dict, load_peft_weigh
 CONFIG_KEYS_TO_CHECK = {PeftType.LORA: ["use_rslora", "lora_dropout", "alpha_pattern", "use_dora"]}
 
 
-def _update_scaling(lora_module, adapter_name, scaling=None):
+def _update_scaling(lora_module: LoraLayer, adapter_name: str, scaling: Optional[float] = None) -> None:
     """
     Update the value of the scalings of the LoRA module.
 
@@ -374,7 +374,7 @@ def hotswap_adapter_from_state_dict(
     adapter_name: str,
     config: LoraConfig,
     parameter_prefix: str = "lora_",
-):
+) -> None:
     """
     Swap out the adapter weights from the model with the weights from state_dict.
 
@@ -555,7 +555,13 @@ def check_hotswap_configs_compatible(config0: PeftConfig, config1: PeftConfig) -
             raise ValueError(f"Configs are incompatible: for {key}, {val0} != {val1}")
 
 
-def hotswap_adapter(model, model_name_or_path, adapter_name, torch_device=None, **kwargs):
+def hotswap_adapter(
+    model: torch.nn.Module,
+    model_name_or_path: str,
+    adapter_name: str,
+    torch_device: Optional[str] = None,
+    **kwargs,
+) -> None:
     """Substitute old adapter data with new adapter data, keeping the rest the same.
 
     As of now, only LoRA is supported.


### PR DESCRIPTION
## What does this PR do?

Adds missing type annotations to utility functions in `src/peft/utils/hotswap.py`, following the same pattern as the already-merged type-hint cleanup in #3144.

The following functions were missing type hints:

**`hotswap.py`**
- `_update_scaling`: added `LoraLayer` (param `lora_module`), `str` (param `adapter_name`), `Optional[float] = None` (param `scaling`), and `None` return type
- `hotswap_adapter_from_state_dict`: added `None` return type (params were already annotated)
- `hotswap_adapter`: added `torch.nn.Module` (param `model`), `str` (param `model_name_or_path`), `str` (param `adapter_name`), `Optional[str] = None` (param `torch_device`), and `None` return type

`prepare_model_for_compiled_hotswap` was also checked per the task scope, but it already had complete type hints on every parameter and the return type, so it was left unchanged — no genuinely missing hints there.

Type choices were verified against real call sites, not just docstrings:
- `_update_scaling`'s `lora_module` param is typed as `LoraLayer` (not the more generic `torch.nn.Module` used elsewhere in this file) because the function body accesses `lora_module.scaling`, a dict attribute defined on `LoraLayer`, not on `torch.nn.Module`. Typing it as `torch.nn.Module` produced 14 new pyright errors inside the function body (subscript/attribute access on an untyped `Module.__getattr__` fallback); typing it as `LoraLayer` eliminates all of them while accurately describing the real runtime objects passed in (`Linear`/`Conv2d` LoRA layers, both of which subclass `LoraLayer`).
- `hotswap_adapter`'s `model_name_or_path` param is typed as `str` (matching the declared signatures of `PeftConfig.from_pretrained` and `load_peft_weights`, both of which it's passed into) rather than `str | os.PathLike`, even though some tests pass `pathlib.Path` objects — widening the annotation to include `os.PathLike` caused a new pyright error at the `load_peft_weights(model_name_or_path, ...)` call site, since that function's own parameter is declared as `str` only.

## Tests

Type-hint only change — no behavioral modification.
- `python -m py_compile src/peft/utils/hotswap.py` — passes
- `ruff check` / `ruff format --check` (pinned version 0.15.12) — both pass with no findings
- `npx pyright src/peft/utils/hotswap.py` — error count and messages are byte-for-byte identical before and after this change (56 errors both times, all pre-existing, in code untouched by this PR, or due to import resolution in a bare env without torch/accelerate fully installed — none introduced by the newly annotated functions)

## Before submitting
- [x] This PR improves typing/annotations (documentation-adjacent; no test/doc updates needed per the precedent set in #3144)
- [x] Did you read the [contributor guideline](https://github.com/huggingface/peft/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes? (N/A — type hints only)
- [x] Did you write any new necessary tests? (N/A — no behavior change)

## AI assistance disclosure

This PR was developed with the assistance of Claude Code (AI). All changes have been read, understood, and verified by the human contributor (Rudrendu Paul), including cross-referencing every added type against the function's real call sites and confirming via pyright that no new type errors were introduced.
