### PR TITLE
FIX enable_adapters()/disable_adapter() unfreezing adapters loaded with inference_mode=True

### DIFF
--- a/src/peft/tuners/ln_tuning/layer.py
+++ b/src/peft/tuners/ln_tuning/layer.py
@@ -48,16 +48,19 @@ class LNTuningLayer(nn.Module, BaseTunerLayer):
         self.ln_tuning_layers[adapter_name] = deepcopy(layer)
         self.set_adapter(adapter_name, inference_mode=inference_mode)
 
-    def enable_adapters(self, enabled: bool) -> None:
+    def enable_adapters(self, enabled: bool, inference_mode: bool = False) -> None:
         """Toggle the enabling and disabling of adapters
 
         Takes care of setting the requires_grad flag for the adapter weights.
 
         Args:
             enabled (bool): True to enable adapters, False to disable adapters
+            inference_mode (bool, optional): When re-enabling adapters (`enabled=True`), whether the active
+                adapter(s) should be frozen (i.e. `requires_grad=False`) rather than trainable, mirroring the
+                `inference_mode` they were configured with. Ignored when `enabled` is False. Default is False.
         """
         if enabled:
-            self.set_adapter(self.active_adapters)
+            self.set_adapter(self.active_adapters, inference_mode=inference_mode)
             self._disable_adapters = False
         else:
             if self.merged:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -508,7 +508,21 @@ class BaseTuner(nn.Module, ABC):
     def _enable_adapter_layers(self, enabled: bool = True) -> None:
         for module in self.model.modules():
             if isinstance(module, (BaseTunerLayer, AuxiliaryTrainingWrapper)):
-                module.enable_adapters(enabled)
+                if not enabled:
+                    module.enable_adapters(enabled)
+                    continue
+
+                # Re-enabling must restore each of this module's active adapters to their own configured
+                # inference_mode instead of unconditionally marking them trainable again, which would silently
+                # unfreeze an adapter that was loaded/set with inference_mode=True (e.g. a frozen reference
+                # adapter for RLHF-style training). If an active adapter has no entry in peft_config (e.g. it
+                # was already deleted), fall back to treating it as trainable, matching prior behavior.
+                inference_mode = all(
+                    self.peft_config[name].inference_mode
+                    for name in module.active_adapters
+                    if name in self.peft_config
+                )
+                module.enable_adapters(enabled, inference_mode=inference_mode)
 
     def disable_adapter_layers(self) -> None:
         """
@@ -1561,16 +1575,20 @@ class BaseTunerLayer(ABC):
         # is already a list of str
         return self.active_adapter
 
-    def enable_adapters(self, enabled: bool) -> None:
+    def enable_adapters(self, enabled: bool, inference_mode: bool = False) -> None:
         """Toggle the enabling and disabling of adapters
 
         Takes care of setting the requires_grad flag for the adapter weights.
 
         Args:
             enabled (bool): True to enable adapters, False to disable adapters
+            inference_mode (bool, optional): When re-enabling adapters (`enabled=True`), whether the active
+                adapter(s) should be frozen (i.e. `requires_grad=False`) rather than trainable. Should mirror the
+                `inference_mode` that the active adapter(s) were configured with. Ignored when `enabled` is
+                False. Default is False.
         """
         if enabled:
-            self.set_adapter(self.active_adapters)
+            self.set_adapter(self.active_adapters, inference_mode=inference_mode)
             self._disable_adapters = False
         else:
             # disable grads on all adapter layers

--- a/src/peft/tuners/unilora/layer.py
+++ b/src/peft/tuners/unilora/layer.py
@@ -122,8 +122,10 @@ class UniLoraLayer(BaseTunerLayer):
         if target_device is not None:
             self._move_indices_to_device(adapter_name, target_device)
 
-    def enable_adapters(self, enabled: bool) -> None:
-        super().enable_adapters(enabled)
+    def enable_adapters(self, enabled: bool, inference_mode: bool = False) -> None:
+        # Note: when enabled=True, the base class's call to self.set_adapter(..., inference_mode=inference_mode)
+        # dispatches to the override below, which already takes care of unilora_theta_d's requires_grad.
+        super().enable_adapters(enabled, inference_mode=inference_mode)
         if not enabled:
             for theta_d in self.unilora_theta_d.values():
                 theta_d.requires_grad_(False)

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -500,11 +500,15 @@ class AuxiliaryTrainingWrapper(torch.nn.Module):
             return self._forward_wrapped(*args, **kwargs)
         return self._mixed_batch_forward(*args, adapter_names=adapter_names, **kwargs)
 
-    def enable_adapters(self, enabled: bool):
+    def enable_adapters(self, enabled: bool, inference_mode: bool = False):
         """Toggle the enabling and disabling of adapters
 
         Args:
             enabled (bool): True to enable adapters, False to disable adapters
+            inference_mode (bool, optional): When re-enabling adapters (`enabled=True`), whether the active
+                adapter should be frozen (i.e. `requires_grad=False`) rather than trainable. Subclasses that
+                track their own trainable parameters use this to avoid unfreezing an adapter that was
+                configured with `inference_mode=True`. Ignored when `enabled` is False. Default is False.
         """
         if enabled:
             self._disable_adapters = False
@@ -659,15 +663,16 @@ class ModulesToSaveWrapper(AuxiliaryTrainingWrapper):
         if adapter_name == self.active_adapter:
             _set_layer_requires_grad(self.modules_to_save[adapter_name], True)
 
-    def enable_adapters(self, enabled: bool):
+    def enable_adapters(self, enabled: bool, inference_mode: bool = False):
         """Takes care of setting the required_grad flag on the modules_to_save.
-        If adapters are enabled, gradients for the modules_to_save are required as well.
+        If adapters are enabled, gradients for the modules_to_save are required as well, unless the active
+        adapter's own `inference_mode` says it should stay frozen.
         """
-        super().enable_adapters(enabled)
+        super().enable_adapters(enabled, inference_mode=inference_mode)
 
         if enabled:
             for adapter_name in self.active_adapters:
-                _set_layer_requires_grad(self.modules_to_save[adapter_name], True)
+                _set_layer_requires_grad(self.modules_to_save[adapter_name], not inference_mode)
         else:
             for module in self.modules_to_save.values():
                 _set_layer_requires_grad(module, False)
@@ -907,13 +912,13 @@ class TrainableTokensWrapper(AuxiliaryTrainingWrapper):
             f"token_adapter.{k}": state_dict[f"token_adapter.{k}.{adapter_name}"] for k in ["trainable_tokens_delta"]
         }
 
-    def enable_adapters(self, enabled: bool):
+    def enable_adapters(self, enabled: bool, inference_mode: bool = False):
         """Enables/disables the underlying `TrainableTokens` adapter.
         Also handles the internal adapter disable flag.
         """
-        super().enable_adapters(enabled)
+        super().enable_adapters(enabled, inference_mode=inference_mode)
 
-        self.token_adapter.enable_adapters(enabled)
+        self.token_adapter.enable_adapters(enabled, inference_mode=inference_mode)
 
     def check_set_adapter(self, adapter_name: str | list[str]) -> str | None:
         """Helper function to check if the given adapter(s) can be set.

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -3520,6 +3520,34 @@ class TestPeftCustomModel(PeftCommonTester):
         assert all(not module.disable_adapters for module in tuner_modules)
 
     @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
+    def test_disable_adapters_exiting_context_preserves_inference_mode(
+        self, test_name, model_id, config_cls, config_kwargs
+    ):
+        # Exiting the disable_adapter context (or calling enable_adapter_layers directly) must not unfreeze an
+        # adapter that was loaded with inference_mode=True. This complements
+        # test_disable_adapters_exiting_context_restores_previous_state, which only checks the enabled/disabled
+        # state of the adapter layers, not requires_grad.
+        model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            inference_mode=True,
+            **config_kwargs,
+        )
+        model = get_peft_model(model, config)
+        assert all(not p.requires_grad for p in model.parameters())
+
+        with model.disable_adapter():
+            assert all(not p.requires_grad for p in model.parameters())
+        # exiting the context must not unfreeze the adapter
+        assert all(not p.requires_grad for p in model.parameters())
+
+        # same check using the public, non-context-manager API
+        model.base_model.disable_adapter_layers()
+        assert all(not p.requires_grad for p in model.parameters())
+        model.base_model.enable_adapter_layers()
+        assert all(not p.requires_grad for p in model.parameters())
+
+    @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
     def test_delete_adapter(self, test_name, model_id, config_cls, config_kwargs):
         _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs)
         self._test_delete_adapter(model_id, config_cls, config_kwargs)
@@ -4840,6 +4868,29 @@ class TestRequiresGrad:
             "base_model.model.lin0.lora_B.default.weight",
         )
 
+    def test_requires_grad_modules_to_save_disabling_inference_mode(self):
+        # Same as test_requires_grad_modules_to_save_disabling, but for an adapter that was created with
+        # inference_mode=True. Disabling/re-enabling adapter layers must not unfreeze modules_to_save for an
+        # adapter that is supposed to stay frozen throughout.
+        config = LoraConfig(target_modules=["lin0"], modules_to_save=["lin1"], inference_mode=True)
+        peft_model = get_peft_model(MLP(), config)
+
+        # inference_mode=True from the start: nothing should require grad
+        self.check_requires_grad(peft_model)
+
+        peft_model.disable_adapter_layers()
+        self.check_requires_grad(peft_model)
+
+        # re-enabling must not unfreeze modules_to_save, since the adapter is in inference_mode
+        peft_model.enable_adapter_layers()
+        self.check_requires_grad(peft_model)
+
+        with peft_model.disable_adapter():
+            self.check_requires_grad(peft_model)
+
+        # exiting the context must not unfreeze it either
+        self.check_requires_grad(peft_model)
+
     def test_requires_grad_modules_to_save_multiple_adapters(self):
         config0 = LoraConfig(target_modules=["lin0"], modules_to_save=["lin1"])
         peft_model = get_peft_model(MLP(), config0)
@@ -4969,6 +5020,29 @@ class TestRequiresGrad:
 
         # set config1 as active but in inference mode, should result in no module requiring grad
         peft_model.set_adapter("adapter1", inference_mode=True)
+        self.check_requires_grad(peft_model)
+
+    def test_requires_grad_trainable_token_indices_disabling_inference_mode(self):
+        # Same idea as test_requires_grad_modules_to_save_disabling_inference_mode, but for
+        # trainable_token_indices. TrainableTokensWrapper.enable_adapters delegates to its BaseTunerLayer-based
+        # token_adapter, which has the same requires_grad-vs-inference_mode gap as modules_to_save.
+        config = LoraConfig(target_modules=["conv1d"], trainable_token_indices={"emb": [0, 1, 2]}, inference_mode=True)
+        peft_model = get_peft_model(ModelEmbConv1D(), config)
+
+        # inference_mode=True from the start: nothing should require grad
+        self.check_requires_grad(peft_model)
+
+        peft_model.disable_adapter_layers()
+        self.check_requires_grad(peft_model)
+
+        # re-enabling must not unfreeze the trainable tokens, since the adapter is in inference_mode
+        peft_model.enable_adapter_layers()
+        self.check_requires_grad(peft_model)
+
+        with peft_model.disable_adapter():
+            self.check_requires_grad(peft_model)
+
+        # exiting the context must not unfreeze it either
         self.check_requires_grad(peft_model)
 
     def test_requires_grad_lora_different_targets(self):


### PR DESCRIPTION
## What does this PR do?

Fixes #3447.

`BaseTunerLayer.enable_adapters` — invoked by `PeftModel.disable_adapter()`'s context-manager exit and by the public `enable_adapter_layers()`/`disable_adapter_layers()` methods — calls:

```python
self.set_adapter(self.active_adapters)
```

with no `inference_mode` argument, so it defaults to `False`. This unconditionally sets `requires_grad=True` on every active adapter, silently unfreezing an adapter that was explicitly loaded or set with `inference_mode=True` (e.g. a frozen reference adapter for RLHF-style training, or any adapter loaded with `is_trainable=False`).

### Reproduction (from the issue)

```python
model = get_peft_model(
    SmallModel(),
    LoraConfig(target_modules=["lin"], r=4, lora_alpha=8, inference_mode=True),
)
print([p.requires_grad for n, p in model.named_parameters() if "lora_" in n])  # [False, False]
with model.disable_adapter():
    pass
print([p.requires_grad for n, p in model.named_parameters() if "lora_" in n])  # [True, True] -- bug
```

While tracing the root cause (see [comment](https://github.com/huggingface/peft/issues/3447#issuecomment-5010032441)), I found the identical unconditional-unfreeze pattern independently duplicated in two more places, so this bundles fixes for all of them per this repo's `.ai/AGENTS.md` ("If an issue is small and affects multiple PEFT methods... fix all of them in the same PR"):

- `ModulesToSaveWrapper.enable_adapters` (`utils/other.py`) — same bug for `modules_to_save`.
- `LNTuningLayer.enable_adapters` (`tuners/ln_tuning/layer.py`) — a separate, full reimplementation with the same bug for LN Tuning.
- `TrainableTokensWrapper` and `UniLoraLayer` delegate their `enable_adapters` to a `BaseTunerLayer`-derived object, so they're fixed by the base-class change, but their signatures needed updating to accept and forward the new parameter.

Not a duplicate of #2928/PR #2936 (fixes `_set_adapter`/`ModulesToSaveWrapper.set_adapter`, a different function, and its test never constructs an adapter with `inference_mode=True`) or of PR #3290 (fixes `BaseTuner.inject_adapter`'s housekeeping call, a different, model-level method).

### Fix

`BaseTuner._enable_adapter_layers` now derives each module's active adapter(s)' own `inference_mode` from `peft_config` when re-enabling, instead of unconditionally marking them trainable, and passes it through `enable_adapters` -> `set_adapter`, which already handles `inference_mode` correctly (this mirrors the same `peft_config[name].inference_mode` lookup already used by `inject_adapter`'s housekeeping call). The two duplicated implementations (`ModulesToSaveWrapper`, `LNTuningLayer`) are fixed the same way, and `enable_adapters`'s signature gained an optional `inference_mode: bool = False` parameter (default preserves prior behavior for any external caller that doesn't pass it).

### Tests

Added one test parametrized over the existing `TEST_CASES` matrix (`test_disable_adapters_exiting_context_preserves_inference_mode`, covering every tuner type in that suite — LoRA, LoHa, LoKr, AdaLoRA, HiRA, BOFT, GLoRA, LN Tuning, UniLoRA, VeRA, WaveFT, VBLoRA, X-LoRA, TinyLoRA, etc.), plus two dedicated tests for `modules_to_save` and `trainable_token_indices` mirroring the existing `test_requires_grad_modules_to_save_disabling`/`test_requires_grad_follows_inference_mode_trainable_token_indices` tests but with `inference_mode=True`.

Per the contribution guide, implemented as a failing test first: all three new tests fail on `main` (321 failures total across the parametrized matrix) and pass after the fix.

Ran the following locally (CPU, Python 3.12):
- `pytest tests/test_custom_models.py` (full file): 15347 passed, 676 skipped, 4 xfailed (the 4 xfail are pre-existing, unrelated known limitations, e.g. `test_loading_model_requires_grad_set_correctly_switch_inference_mode`). One `TestDynamicDispatch::test_training_works` failure appeared under `-n auto`; it does not touch `enable_adapters`/`inference_mode` at all and passes consistently in isolation (both single-process and under xdist scoped to just that class), so it looks like a pre-existing xdist test-isolation flake (the suite already emits a `PytestRemovedIn10Warning: Class-scoped fixture defined as instance method is deprecated` for that class) rather than a regression from this change.
- `pytest tests/test_custom_models.py::TestRequiresGrad`: 175 passed, 2 skipped, 4 xfailed.
- `pytest tests/test_tuners_utils.py`: 219 passed, 16 skipped.
- `pytest tests/test_other.py tests/test_trainable_tokens.py`: 107 passed.
- `pytest tests/test_mixed.py`: 32 passed, 1 skipped.
- `make style` (`ruff check` + `ruff format --check`, pinned `ruff~=0.15.12`): clean.

## AI disclosure

I used AI assistance (Claude) to help trace the root cause, identify the two duplicated occurrences of the same bug, and draft the fix and tests. I reviewed every changed line, understand the fix and why it's needed, and ran all tests listed above myself.

## Coordination

Posted [this comment](https://github.com/huggingface/peft/issues/3447#issuecomment-5010032441) on the issue confirming the repro and stating intent before opening this PR, per `.ai/AGENTS.md`.
