### PR TITLE
FIX Crash when unloading a model whose active adapter does not use modules_to_save

### DIFF
--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -257,12 +257,9 @@ class MixedModel(BaseTuner):
                 self._replace_module(parent, target_name, target.get_base_layer(), target)
             elif isinstance(target, ModulesToSaveWrapper):
                 # save any additional trainable modules part of `modules_to_save`
-                new_module = target.modules_to_save[target.active_adapter]
-                if hasattr(new_module, "base_layer"):
-                    # check if the module is itself a tuner layer
-                    if merge:
-                        new_module.merge(safe_merge=safe_merge, adapter_names=adapter_names)
-                    new_module = new_module.get_base_layer()
+                new_module = target.unload_and_optionally_merge_module(
+                    merge=merge, safe_merge=safe_merge, adapter_names=adapter_names
+                )
                 setattr(parent, target_name, new_module)
 
         # Clean up peft_config from the model since all PEFT modules have been removed.

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -797,6 +797,11 @@ class ModulesToSaveWrapper(AuxiliaryTrainingWrapper):
 
         However, if the wrapped module is itself a tuner, we'll call merge on it before.
         """
+        if not self.active_adapters:
+            # none of the modules_to_save adapters of this module are active, e.g. because the model's active adapter
+            # does not use modules_to_save on this module; like in forward, the original module is used in this case
+            return self.original_module
+
         new_module = self.modules_to_save[self.active_adapter]
 
         # TODO: not sure if this is still a sensible thing to do. We would basically have to

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -664,6 +664,41 @@ class TestMixedAdapterTypes(unittest.TestCase):
         with pytest.raises(ValueError, match="Only one adapter can be set at a time for ModulesToSaveWrapper"):
             peft_model.set_adapter(["adapter0", "adapter1"])
 
+    def test_unload_modules_to_save_when_active_adapter_does_not_use_it(self):
+        # Unloading used to crash when the active adapter did not use modules_to_save on a wrapped module; see
+        # TestModulesToSaveUnloadNoActiveAdapter in test_other.py. This covers MixedModel's separate unload path.
+        atol = 1e-5
+        rtol = 1e-5
+        input = torch.arange(90).reshape(9, 10).to(self.torch_device)
+
+        config0 = LoraConfig(target_modules=["lin0"], modules_to_save=["lin1"])
+        peft_model = self._get_model(SimpleNet, config0, "adapter0")
+        torch.manual_seed(1)
+        config1 = LoHaConfig(target_modules=["lin0"], init_weights=False)
+        peft_model.add_adapter("adapter1", config1)
+        peft_model.set_adapter(["adapter1"])
+
+        # modify the modules_to_save copy of adapter0 to ensure that unloading does not use it
+        lin1_weight_before = peft_model.base_model.model.lin1.original_module.weight.data.clone()
+        peft_model.base_model.model.lin1.modules_to_save["adapter0"].weight.data.fill_(42.0)
+        output_peft = peft_model(input)
+
+        model_merged = copy.deepcopy(peft_model).merge_and_unload()
+        assert isinstance(model_merged.lin1, nn.Linear)
+        assert torch.equal(model_merged.lin1.weight.data, lin1_weight_before)
+        output_merged = model_merged(input)
+        # merging must reproduce the output of the model with adapter1 active; merging requires a bit higher
+        # tolerance, like in _check_merging
+        assert torch.allclose(output_peft, output_merged, atol=1e-4, rtol=1e-4)
+
+        model_unloaded = peft_model.unload()
+        assert isinstance(model_unloaded.lin1, nn.Linear)
+        assert torch.equal(model_unloaded.lin1.weight.data, lin1_weight_before)
+        output_unloaded = model_unloaded(input)
+        # unloading without merging must restore the base model output
+        output_base = self._get_model(SimpleNet)(input)
+        assert torch.allclose(output_base, output_unloaded, atol=atol, rtol=rtol)
+
     def test_get_nb_trainable_parameters(self):
         model = SimpleNet().eval().to(self.torch_device)
         params_base = sum(p.numel() for p in model.parameters())

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -330,6 +330,61 @@ class TestModulesToSaveKwargsOnlyForward:
         assert out.shape == (2, 8)
 
 
+class TestModulesToSaveUnloadNoActiveAdapter:
+    """Regression test for unloading when a ModulesToSaveWrapper has no active adapter.
+
+    When the model's active adapter does not use modules_to_save on a given module (e.g. adapter "other" below), the
+    wrapper's list of active adapters is empty. Unloading used to crash with `TypeError: unhashable type: 'list'`
+    because the empty list was used to index the ModuleDict of saved modules. Instead, unloading should restore the
+    original module, which is also what forward uses when no adapter is active on the wrapper.
+    """
+
+    @pytest.fixture
+    def mlp(self):
+        class MLP(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin0 = nn.Linear(8, 8)
+                self.lin1 = nn.Linear(8, 8)
+
+            def forward(self, x):
+                return self.lin1(self.lin0(x))
+
+        torch.manual_seed(0)
+        return MLP()
+
+    @pytest.mark.parametrize("unload_method", ["unload", "merge_and_unload"])
+    def test_unload_with_inactive_modules_to_save(self, mlp, unload_method):
+        x = torch.randn(4, 8)
+        out_base = mlp(x)
+        lin1_weight_before = mlp.lin1.weight.data.clone()
+
+        # adapter "default" uses modules_to_save for lin1 but adapter "other", which is active, does not
+        config_default = LoraConfig(target_modules=["lin0"], modules_to_save=["lin1"])
+        model = get_peft_model(mlp, config_default)
+        config_other = LoraConfig(target_modules=["lin0"], init_lora_weights=False)
+        model.add_adapter("other", config_other)
+        model.set_adapter("other")
+
+        # modify the modules_to_save copy of adapter "default" to ensure that unloading does not use it
+        model.base_model.model.lin1.modules_to_save["default"].weight.data.fill_(42.0)
+        out_peft = model(x)
+
+        unloaded = getattr(model, unload_method)()
+
+        assert isinstance(unloaded.lin1, nn.Linear)
+        # the original module is restored, not the modules_to_save copy of the inactive adapter "default"
+        assert torch.equal(unloaded.lin1.weight.data, lin1_weight_before)
+
+        out_unloaded = unloaded(x)
+        if unload_method == "merge_and_unload":
+            # merging must reproduce the output of the model with adapter "other" active
+            assert torch.allclose(out_unloaded, out_peft, atol=1e-6, rtol=1e-6)
+        else:
+            # unloading without merging must restore the base model output
+            assert torch.allclose(out_unloaded, out_base, atol=1e-6, rtol=1e-6)
+
+
 class TestModulesToSaveNameSubstringBug:
     """Test a bug that could occur with multiple modules to save where one adapter's name is a substring of another
     adapter's name.


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `unload()` / `merge_and_unload()`: `TypeError: unhashable type: 'list'` when the model's active adapter does not use `modules_to_save` on a module that another adapter wraps.

```python
import torch.nn as nn
from peft import LoraConfig, get_peft_model

class MLP(nn.Module):
    def __init__(self):
        super().__init__()
        self.lin0 = nn.Linear(8, 8)
        self.lin1 = nn.Linear(8, 8)

    def forward(self, x):
        return self.lin1(self.lin0(x))

model = get_peft_model(MLP(), LoraConfig(target_modules=["lin0"], modules_to_save=["lin1"]))
model.add_adapter("other", LoraConfig(target_modules=["lin0"]))
model.set_adapter("other")
model.unload()  # TypeError: unhashable type: 'list'
```

### Root cause

When the active adapter does not use `modules_to_save` on a wrapped module, the wrapper's list of active adapters is empty. `ModulesToSaveWrapper.unload_and_optionally_merge_module` then executes

```python
new_module = self.modules_to_save[self.active_adapter]
```

with `active_adapter == []`, and indexing an `nn.ModuleDict` with a list raises `TypeError: unhashable type: 'list'`. The forward path already handles this state gracefully: `_forward_wrapped` passes through to `self.original_module` when `not self.active_adapters`.

### Fix

`unload_and_optionally_merge_module` now returns `self.original_module` when the wrapper has no active adapter, mirroring the forward passthrough (there is also nothing to merge on this module in that case).

The same crash existed independently in `PeftMixedModel`: `MixedModel._unload_and_optionally_merge` duplicated the wrapper's unload logic inline, including the crashing indexing. That branch now delegates to `unload_and_optionally_merge_module`, the same method the main unload path already uses via `BaseTuner._unload_and_optionally_merge`, so both paths share the fix.

### Why this isn't a duplicate

`gh pr list --repo huggingface/peft --search "unload modules_to_save" / "unhashable" --state all` and the corresponding issue searches surface no open PR or issue for this crash. Open PR #3431 touches the same files but fixes a different bug (delete_adapter-then-add_adapter crash in `check_set_adapter`); it does not touch the unload path.

## Tests

- `tests/test_other.py::TestModulesToSaveUnloadNoActiveAdapter`, parametrized over `unload` / `merge_and_unload`: builds a model where adapter "default" uses `modules_to_save` on `lin1` but the active adapter "other" does not, poisons the inactive adapter's `modules_to_save` copy with a sentinel value, and asserts that the original module (not the copy) is restored and that outputs match (base model output for `unload`, active-adapter output for `merge_and_unload`).
- `tests/test_mixed.py::TestMixedAdapterTypes::test_unload_modules_to_save_when_active_adapter_does_not_use_it`: same scenario (including the sentinel check that the original module, not the inactive adapter's copy, is restored) through `PeftMixedModel`'s separate unload path, which had the crash duplicated inline.

Both tests fail on main with `TypeError: unhashable type: 'list'` and pass with this fix.
