### PR TITLE
Fix BdLoraConfig.nblocks default being a tuple instead of an int

### DIFF
--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -215,14 +215,12 @@ class BdLoraConfig:
             "Example: ['out_proj', 'down_proj']"
         },
     )
-    nblocks: int = (
-        field(
-            default=1,
-            metadata={
-                "help": "Number of blocks each block-diagonal matrix has. If using BD-LoRA to speed up inference, "
-                "set it to be equal to the desired sharding degree during serving."
-            },
-        ),
+    nblocks: int = field(
+        default=1,
+        metadata={
+            "help": "Number of blocks each block-diagonal matrix has. If using BD-LoRA to speed up inference, "
+            "set it to be equal to the desired sharding degree during serving."
+        },
     )
     match_strict: bool = field(
         default=True,

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1117,7 +1117,8 @@ TEST_CASES = [
         LoraConfig,
         {
             "target_modules": ["lin0", "lin1"],
-            "use_bdlora": BdLoraConfig(target_modules_bd_a=["lin0"], nblocks=2, match_strict=False),
+            # No `nblocks` here on purpose: exercise the default so the config default is covered.
+            "use_bdlora": BdLoraConfig(target_modules_bd_a=["lin0"], match_strict=False),
         },
     ),
     (


### PR DESCRIPTION
## Problem

`BdLoraConfig.nblocks` is defined with a stray pair of parentheses and a trailing comma:

```python
nblocks: int = (
    field(
        default=1,
        metadata={...},
    ),
)
```

The trailing comma makes the right-hand side a **one-element tuple** `(field(...),)` rather than a `field(...)` call. So the class attribute is a plain `tuple` (not a `dataclasses.Field`), and the dataclass machinery uses the whole tuple as the literal default. `BdLoraConfig().nblocks` is therefore `(<Field object>,)` instead of `1`.

## Impact

`nblocks` is consumed in `lora/variants.py` — `in_features % nblocks` and `in_features // nblocks` (`BlockDiagonalLinear.__init__`) and `torch.chunk(self.weight, self.nblocks, ...)`. With the tuple default, a default-constructed BD-LoRA config raises:

```
TypeError: unsupported operand type(s) for %: 'int' and 'tuple'
```

and the config also fails to serialize (a `Field` object isn't JSON-serializable), so `save_pretrained` on a default BD-LoRA config breaks too. Every user relying on the default `nblocks` is affected.

## Evidence (sibling proves intent)

The field defined immediately below, `match_strict`, uses the correct `name: type = field(...)` form (no wrapping parens/comma) and resolves to `True`. Only `nblocks` has the stray tuple wrapping.

## Fix

```python
nblocks: int = field(
    default=1,
    metadata={...},
)
```

## Reproduction

| | `type(BdLoraConfig().nblocks)` | `in_features % nblocks` |
|---|---|---|
| before | `tuple` — `(<Field ...>,)` ❌ | `TypeError` |
| after | `int` — `1` ✅ | works |
