### PR TITLE
Fix bias="lora_only"/"boft_only" dropping the trained bias on save

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -178,7 +178,7 @@ def get_peft_model_state_dict(
             for k in state_dict:
                 if "lora_" in k:
                     to_return[k] = state_dict[k]
-                    bias_name = k.split("lora_")[0] + "bias"
+                    bias_name = k.split("lora_")[0] + "base_layer.bias"
                     if bias_name in state_dict:
                         to_return[bias_name] = state_dict[bias_name]
         else:
@@ -215,7 +215,7 @@ def get_peft_model_state_dict(
             for k in state_dict:
                 if "boft_" in k:
                     to_return[k] = state_dict[k]
-                    bias_name = k.split("boft_")[0] + "bias"
+                    bias_name = k.split("boft_")[0] + "base_layer.bias"
                     if bias_name in state_dict:
                         to_return[bias_name] = state_dict[bias_name]
         else:


### PR DESCRIPTION
## Problem

`get_peft_model_state_dict` with `bias="lora_only"` (and the analogous BOFT `bias="boft_only"` branch) is meant to also persist each adapted layer's base bias:

```python
elif bias == "lora_only":
    to_return = {}
    for k in state_dict:
        if "lora_" in k:
            to_return[k] = state_dict[k]
            bias_name = k.split("lora_")[0] + "bias"
            if bias_name in state_dict:
                to_return[bias_name] = state_dict[bias_name]
```

Adapted layers wrap the original module as `base_layer`, so the bias lives at `...<module>.base_layer.bias`, **not** `...<module>.bias`. For a LoRA key like `base_model.model.lin0.lora_A.default.weight`, `k.split("lora_")[0]` is `base_model.model.lin0.`, so the code looks up `base_model.model.lin0.bias` — a key that never exists. The `if bias_name in state_dict` guard is therefore always `False`, and the trained bias is **silently dropped** from the saved state dict, defeating the whole purpose of `bias="lora_only"`.

The BOFT branch has the identical mistake (`k.split("boft_")[0] + "bias"`).

## Evidence (same-file convention proves intent)

The base params are addressed via `base_layer` everywhere else in this file:
- `embedding_key = f"{name}.base_layer.weight"`
- `has_valid_embedding_base_layer` / `get_embedding_layer_name` rely on `layer.base_layer`

So the correct bias key is `...base_layer.bias`.

## Reproduction

A tiny model with biased `nn.Linear` layers wrapped by LoRA, saved with `bias="lora_only"`:

| | saved bias keys | save/load round-trip |
|---|---|---|
| before | `[]` (bias lost) ❌ | output diverges (diff ≈ 10.6) |
| after | `[...base_layer.bias]` ✅ | exact match (diff 0.0) |

Same result for BOFT `bias="boft_only"`.

## Fix

```python
bias_name = k.split("lora_")[0] + "base_layer.bias"   # and "boft_" -> base_layer.bias
```
