### PR TITLE
TST Fix some multi GPU tests

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -67,6 +67,7 @@ RUN conda run -n peft pip install -U --no-cache-dir \
         "soundfile>=0.12.1" \
         scipy \
         torchao \
+        mslk-cuda \
         "fbgemm-gpu-genai>=1.2.0" \
         git+https://github.com/huggingface/transformers \
         git+https://github.com/huggingface/accelerate \

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -1540,7 +1540,7 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
             config = PveraConfig(
                 r=16,
                 target_modules=["q_proj", "v_proj"],
-                vera_dropout=0.05,
+                pvera_dropout=0.05,
                 bias="none",
                 task_type="CAUSAL_LM",
             )
@@ -4283,6 +4283,7 @@ class PeftEetqGPUTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             quantization_config = EetqConfig("int8")
 
+            # TODO: remove try/except once/if EETQ kernel for CUDA 13+
             try:
                 model = AutoModelForCausalLM.from_pretrained(
                     self.causal_lm_model_id, device_map="auto", quantization_config=quantization_config
@@ -4342,11 +4343,15 @@ class PeftEetqGPUTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             quantization_config = EetqConfig("int8")
 
-            model = AutoModelForCausalLM.from_pretrained(
-                self.causal_lm_model_id,
-                device_map=DEVICE_MAP_MAP[self.causal_lm_model_id],
-                quantization_config=quantization_config,
-            )
+            # TODO: remove try/except once/if EETQ kernel for CUDA 13+
+            try:
+                model = AutoModelForCausalLM.from_pretrained(
+                    self.causal_lm_model_id,
+                    device_map=DEVICE_MAP_MAP[self.causal_lm_model_id],
+                    quantization_config=quantization_config,
+                )
+            except FileNotFoundError:
+                pytest.skip("There is no kernel for EETQ on this architecture, skipping this test.")
 
             assert set(model.hf_device_map.values()) == set(range(device_count))
             assert {p.device.index for p in model.parameters()} == set(range(device_count))
@@ -4728,7 +4733,7 @@ class TestPeftTorchao:
         )
 
         msg = re.escape("TorchaoLoraLinear only supports int8 weights for now")
-        with pytest.raises(ValueError, match=msg):
+        with pytest.raises(TypeError, match=msg):
             get_peft_model(model, config)
 
     @pytest.mark.single_gpu_tests

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -5581,11 +5581,11 @@ class TestALoRAInferenceGPU:
             assert cos > 0.9
 
 
-@pytest.mark.multi_gpu_tests
 class TestPrefixTuning:
     device = infer_device()
     causal_lm_model_id = "peft-internal-testing/opt-125m"
 
+    @pytest.mark.multi_gpu_tests
     @require_torch_multi_accelerator
     def test_prefix_tuning_multiple_devices_decoder_model(self):
         # See issue 2134
@@ -5611,6 +5611,7 @@ class TestPrefixTuning:
         model = get_peft_model(model, peft_config)
         model.generate(**inputs)  # does not raise
 
+    @pytest.mark.multi_gpu_tests
     @require_torch_multi_accelerator
     def test_prefix_tuning_multiple_devices_encoder_decoder_model(self):
         # See issue 2134


### PR DESCRIPTION
Failing tests:
https://github.com/huggingface/peft/actions/runs/29713695792/job/88262249657#step:6:1244

Fixes:

- torchao: install mslk-cuda (required by transformers for torchao)
- torchao: used to raise ValueError, now raises TypeError on wrong dtype
- PVeRA: rename wrongly named argument (vera_dropout -> pvera_dropout
- EETQ: skip test with missing kernel for given CUDA version (#3351 was incomplete)
- prefix tuning: one test was accidentally marked as multi GPU but it's single GPU

In confirmed that these tests pass locally.