### PR TITLE
fix(lora): handle eva/corda init configs independently of loftq

### DIFF
--- a/src/peft/tuners/lora/config.py
+++ b/src/peft/tuners/lora/config.py
@@ -961,13 +961,15 @@ class LoraConfig(PeftConfig):
             self.loftq_config = {}
             warnings.warn("`loftq_config` specified but will be ignored when `init_lora_weights` is not 'loftq'.")
 
-        elif self.init_lora_weights == "eva" and self.eva_config is None:
+        # handle init_lora_weights and eva_config
+        if self.init_lora_weights == "eva" and self.eva_config is None:
             warnings.warn("`init_lora_weights` is 'eva' but `eva_config` is not specified. Using default EVA config.")
             self.eva_config = EvaConfig()
         elif self.init_lora_weights != "eva" and self.eva_config is not None:
             warnings.warn("`eva_config` specified but will be ignored when `init_lora_weights` is not 'eva'.")
 
-        elif self.init_lora_weights == "corda" and self.corda_config is None:
+        # handle init_lora_weights and corda_config
+        if self.init_lora_weights == "corda" and self.corda_config is None:
             warnings.warn(
                 "`init_lora_weights` is 'corda' but `corda_config` is not specified. Using default CorDA config."
             )

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -3817,6 +3817,45 @@ class TestEvaInitialization:
         ):
             LoraConfig(init_lora_weights=True, eva_config=EvaConfig())
 
+    def test_lora_config_corda_default_created_when_unrelated_config_passed(self):
+        """
+        Tests that a default CorDA config is still created when `init_lora_weights='corda'` even if an unrelated
+        sub-config (here `eva_config`) is also passed.
+
+        The `init_lora_weights` handling for loftq/eva/corda used to be a single ``if``/``elif`` chain, so passing an
+        `eva_config` while requesting corda would trigger the "eva_config ignored" branch and skip the corda default
+        creation, leaving `corda_config` as `None` (which later crashes CorDA initialization).
+        """
+        with pytest.warns(
+            UserWarning, match="`eva_config` specified but will be ignored when `init_lora_weights` is not 'eva'."
+        ):
+            config = LoraConfig(init_lora_weights="corda", eva_config=EvaConfig())
+        assert config.corda_config is not None
+
+    def test_lora_config_eva_default_created_when_unrelated_config_passed(self):
+        """
+        Tests that a default EVA config is still created when `init_lora_weights='eva'` even if an unrelated
+        `loftq_config` is also passed (which used to short-circuit the shared ``if``/``elif`` chain and leave
+        `eva_config` as `None`).
+        """
+        with pytest.warns(
+            UserWarning, match="`loftq_config` specified but will be ignored when `init_lora_weights` is not 'loftq'."
+        ):
+            config = LoraConfig(init_lora_weights="eva", loftq_config={"loftq_bits": 4})
+        assert config.eva_config is not None
+
+    def test_lora_config_warns_for_both_ignored_configs(self):
+        """
+        Tests that both the eva and corda "specified but will be ignored" warnings are emitted when both sub-configs
+        are passed but neither initialization method is selected. The former ``if``/``elif`` chain only emitted the
+        first matching warning.
+        """
+        with pytest.warns(UserWarning) as record:
+            LoraConfig(init_lora_weights=True, eva_config=EvaConfig(), corda_config=CordaConfig())
+        messages = [str(w.message) for w in record]
+        assert any("`eva_config` specified but will be ignored" in m for m in messages)
+        assert any("`corda_config` specified but will be ignored" in m for m in messages)
+
 
 class TestLilyInitialization:
     """Tests for Lily adapter initialization and parameter sharing.


### PR DESCRIPTION
## What / Why

In `LoraConfig.__post_init__`, the handling of `init_lora_weights` for `loftq`, `eva` and `corda` is collapsed into a single `if`/`elif` cascade:

```python
if self.init_lora_weights == "loftq":
    ...
elif self.loftq_config:
    ...
elif self.init_lora_weights == "eva" and self.eva_config is None:
    ...
elif self.init_lora_weights != "eva" and self.eva_config is not None:
    ...
elif self.init_lora_weights == "corda" and self.corda_config is None:
    ...
elif self.init_lora_weights != "corda" and self.corda_config is not None:
    ...
```

These are independent concerns, but chaining them means only the first matching branch runs. When a sub-config for one method is passed while another method is selected, the default-config creation for the selected method is skipped:

- `LoraConfig(init_lora_weights="corda", eva_config=EvaConfig())` matches the `eva_config ... will be ignored` branch and never reaches the corda branch, so `corda_config` stays `None`. CorDA init later dereferences `lora_config.corda_config.cache_file` etc. and crashes.
- `LoraConfig(init_lora_weights="eva", loftq_config=...)` matches the `loftq_config ... will be ignored` branch, so the default `eva_config` is never created.
- Passing both `eva_config` and `corda_config` (with neither method selected) only emits the first "will be ignored" warning; the corda one is swallowed.

Normal single-config usage is unaffected, because the mismatched-config branches are only entered when the other method's config is actually set.

## Fix

Split the eva and corda handling into their own `if` blocks so each runs regardless of the loftq branch and of each other. The loftq `if`/`elif` pair is unchanged.

## Tests

Added regression tests in `tests/test_initialization.py`:
- `test_lora_config_corda_default_created_when_unrelated_config_passed`
- `test_lora_config_eva_default_created_when_unrelated_config_passed`
- `test_lora_config_warns_for_both_ignored_configs`

All three fail on `main` and pass with this change. `tests/test_config.py` (1193 passed) and the eva/corda/loftq tests in `tests/test_initialization.py` (34 passed) remain green.