### PR TITLE
DOC Fix duplicate tuner navigation entries

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -220,24 +220,10 @@
       title: PSOFT
     - local: package_reference/pvera
       title: PVeRA
-    - local: package_reference/fourierft
-      title: FourierFT
     - local: package_reference/frod
       title: FRoD
     - local: package_reference/glora
       title: GLoRA
-    - local: package_reference/gralora
-      title: GraLoRA
-    - local: package_reference/vblora
-      title: VB-LoRA
-    - local: package_reference/hira
-      title: HiRA
-    - local: package_reference/hra
-      title: HRA
-    - local: package_reference/deft
-      title: DEFT
-    - local: package_reference/cpt
-      title: CPT
     - local: package_reference/trainable_tokens
       title: Trainable Tokens
     - local: package_reference/randlora
@@ -250,8 +236,6 @@
       title: TinyLoRA
     - local: package_reference/unilora
       title: UniLoRA
-    - local: package_reference/trainable_tokens
-      title: Trainable Tokens
     - local: package_reference/vblora
       title: VB-LoRA
     - local: package_reference/vera

--- a/docs/source/package_reference/glora.md
+++ b/docs/source/package_reference/glora.md
@@ -103,6 +103,6 @@ model.merge_and_unload()
 - GLoRA supports all standard PEFT adapter management features (add, delete, switch, merge, etc).
 
 ## See Also
-- [Adapter conceptual guide](../conceptual_guides/adapter.md)
+- [Adapter methods overview](../methods/overview#adapter-methods)
 - [LoRA reference](./lora.md)
 - [Paper: https://huggingface.co/papers/2306.07967](https://huggingface.co/papers/2306.07967)


### PR DESCRIPTION
The API reference sidebar currently lists eight tuner pages twice within the same section. This removes the later duplicate entries while keeping every unique tuner page in place.

The GLoRA page also links to a conceptual-guide source file that no longer exists. Its See Also link now points to the adapter methods overview, which is the current conceptual entry point.

Validation:
- parsed `docs/source/_toctree.yml` as YAML
- checked every sibling `sections` list for duplicate `local` entries
- checked local Markdown link targets under `docs/source`
- ran `git diff --check`

This only changes documentation navigation and links.