### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2210,7 +2210,7 @@ class PeftModelForCausalLM(PeftModel):
                     outputs = self.base_model.generate(*args, **kwargs)
             else:
                 outputs = self.base_model.generate(*args, **kwargs)
-        except:
+        except Exception:
             self.base_model.prepare_inputs_for_generation = self.base_model_prepare_inputs_for_generation
             raise
         else:
@@ -2571,7 +2571,7 @@ class PeftModelForSeq2SeqLM(PeftModel):
                     return self.base_model.generate(**kwargs)
                 else:
                     raise NotImplementedError
-        except:
+        except Exception:
             self.base_model.prepare_inputs_for_generation = self.base_model_prepare_inputs_for_generation
             self.base_model._prepare_encoder_decoder_kwargs_for_generation = (
                 self.base_model_prepare_encoder_decoder_kwargs_for_generation


### PR DESCRIPTION
## Summary
This PR fixes bare except clauses in peft_model.py to follow Python best practices.

## Changes
- \src/peft/peft_model.py:2213\: Replace \except:\ with \except Exception:\
- \src/peft/peft_model.py:2574\: Replace \except:\ with \except Exception:\

## Rationale
Bare except clauses catch all exceptions including SystemExit and KeyboardInterrupt, which can prevent proper program termination and hide serious errors. Using \except Exception:\ is the recommended practice.

## Testing
- Changes maintain the same exception propagation behavior
- Only difference is that system-level exceptions are no longer caught

Note: Local environment limitations, relying on CI/CD automated testing.