### PR TITLE
Method comparison: Fix adaption prompt experiment

### DIFF
--- a/method_comparison/MetaMathQA/experiments/adaptionprompt/llama-3.2-3B-lr_5e-3/training_params.json
+++ b/method_comparison/MetaMathQA/experiments/adaptionprompt/llama-3.2-3B-lr_5e-3/training_params.json
@@ -1,23 +1,5 @@
 {
-    "model_id": "meta-llama/Llama-3.2-3B",
-    "dtype": "bfloat16",
-    "max_seq_length": 512,
-    "batch_size": 4,
-    "batch_size_eval": 64,
-    "max_steps": 3000,
-    "eval_steps": 500,
-    "compile": false,
-    "use_gc": true,
-    "use_amp": false,
-    "grad_norm_clip": 1.0,
-    "optimizer_type": "AdamW",
     "optimizer_kwargs": {
-        "lr": 0.005,
-        "weight_decay": 0.1
-    },
-    "lr_scheduler": "cosine",
-    "generation_kwargs": {
-        "max_new_tokens": 256
-    },
-    "query_template": "Question: {query} Think step by step.\nAnswer:"
+        "lr": 0.005
     }
+}


### PR DESCRIPTION
In #3301, a new experiment for adaption prompt was added. There, a bunch of training parameters were added to the
training_params.json. Most of these additions have no effect, as they use the defaults, but some, like reducing the max sequence length, lead to the results being impossible to compare with the other PEFT methods (lower sequence length reduces memory usage and accuracy). We want to compare the PEFT methods on equal footing, so these changed parameters are removed.