### PR TITLE
TESTING Run CI to collect test durations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.13"]
         os: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,10 @@ jobs:
       matrix:
         python-version: ["3.13"]
         os: ["ubuntu-latest", "windows-latest"]
+      include:
+        - os: ubuntu-latest
+          python-version: "3.13"
+          coverage: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -135,8 +139,23 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           TRANSFORMERS_IS_CI: 1
           CI: 1
+        if: matrix.coverage != true
         run: |
           make test
+          # clean up all pytest temporary directories that are kept due to retention since space
+          # is a scarce resource on the runners and tasks like model cache creation (further below)
+          # fail if there's not enough space available.
+          (rm -r "/tmp/pytest-of-$(id -u -n)" || true)
+      - name: Test with pytest coverage
+        if: matrix.coverage == true
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          TRANSFORMERS_IS_CI: 1
+          CI: 1
+        if: matrix.coverage != true
+        run: |
+          make test_with_coverage
           # clean up all pytest temporary directories that are kept due to retention since space
           # is a scarce resource on the runners and tasks like model cache creation (further below)
           # fail if there's not enough space available.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,10 +48,10 @@ jobs:
       matrix:
         python-version: ["3.13"]
         os: ["ubuntu-latest", "windows-latest"]
-      include:
-        - os: ubuntu-latest
-          python-version: "3.13"
-          coverage: true
+        include:
+          - os: ubuntu-latest
+            python-version: "3.13"
+            coverage: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -147,13 +147,12 @@ jobs:
           # fail if there's not enough space available.
           (rm -r "/tmp/pytest-of-$(id -u -n)" || true)
       - name: Test with pytest coverage
-        if: matrix.coverage == true
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           TRANSFORMERS_IS_CI: 1
           CI: 1
-        if: matrix.coverage != true
+        if: matrix.coverage == true
         run: |
           make test_with_coverage
           # clean up all pytest temporary directories that are kept due to retention since space

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ style:
 	doc-builder style src/peft tests docs/source --max_len 119
 
 test:
-	OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 python -m pytest -n 3 tests/ $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
+	python -m pytest -n 3 tests/ $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
+
+test_with_coverage:
+	python -m pytest -n 3 --cov=src/peft --cov-report=term-missing tests/ $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
 
 tests_examples_multi_gpu:
 	python -m pytest -m multi_gpu_tests tests/test_gpu_examples.py $(if $(IS_GITHUB_CI),--report-log "multi_gpu_examples.log",)

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ style:
 	doc-builder style src/peft tests docs/source --max_len 119
 
 test:
-	python -m pytest -n 3 tests/ $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
+	OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 python -m pytest -n 3 tests/ $(if $(IS_GITHUB_CI),--report-log "ci_tests.log",)
 
 tests_examples_multi_gpu:
 	python -m pytest -m multi_gpu_tests tests/test_gpu_examples.py $(if $(IS_GITHUB_CI),--report-log "multi_gpu_examples.log",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ doctest_optionflags = [
     "NUMBER",
 ]
 
-addopts = ["--cov=src/peft", "--cov-report=term-missing", "--durations=10"]
+addopts = ["--cov=src/peft", "--cov-report=term-missing", "--durations=200"]
 
 markers = [
     "single_gpu_tests: tests that run on a single GPU",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ doctest_optionflags = [
     "NUMBER",
 ]
 
-addopts = ["--cov=src/peft", "--cov-report=term-missing", "--durations=200"]
+addopts = ["--durations=200"]
 
 markers = [
     "single_gpu_tests: tests that run on a single GPU",


### PR DESCRIPTION
**DON'T MERGE**

Test 1: control

Only run with Python 3.13

- windows: 31 min
- ubuntu: 25 min

Same times as normal CI, as expected.

Test 2: force 1 thread

Add `OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1`

- windows: 33 min
- ubuntu: 24 min

Test 3: Run coverage only on Ubuntu + Python 3.13, use sysmon:

- windows: 22 min
- ubuntu: 30 min