### PR TITLE
CI Enable test coverage only on one of the runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,7 +136,11 @@ jobs:
           TRANSFORMERS_IS_CI: 1
           CI: 1
         run: |
-          make test
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" && "${{ matrix.python-version }}" == "3.13" ]]; then
+            make test
+          else
+            PYTEST_ADDOPTS="--no-cov" make test
+          fi
           # clean up all pytest temporary directories that are kept due to retention since space
           # is a scarce resource on the runners and tasks like model cache creation (further below)
           # fail if there's not enough space available.


### PR DESCRIPTION
Disable coverage on the test matrix except for one run (Ubuntu + Python 3.13). The hypothesis was that coverage slows down testing, which I explored in #3467.

In recent CI runs, I consistently saw test times of ~25 min for Ubuntu and ~33 min for Windows. Judging from the times shown below, removing coverage indeed helps a lot with testing times. In particular, note that for Ubuntu + Python 3.13, where coverage is enabled, we see 29 min vs 20, 18, 18 min for Ubuntu without coverage enabled. All Windows runs also finished in < 27 min.