### PR TITLE
Fix Gemma4 prefix tuning with per_layer_config

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -72,13 +72,25 @@ from .utils import (
 def _get_layer_kv_target_shape(base_config, layer_idx: int) -> tuple[int, int] | None:
     """Per-layer (num_kv_heads, head_dim) for prefix-tuning injection, or None for uniform models.
 
-    Models with heterogeneous attention (e.g. Gemma4) expose `global_head_dim` / `num_global_key_value_heads` alongside
-    the sliding-layer `head_dim` / `num_key_value_heads`. The provisioned prefix is sized for the global footprint;
-    this returns the shape each layer actually expects so the caller can slice down or skip layers that don't fit.
+    Models with heterogeneous attention (e.g. Gemma4) expose per-layer config via
+    `config.per_layer_config[layer_idx].head_dim` / `.num_key_value_heads`. Older versions used `global_head_dim` /
+    `num_global_key_value_heads` alongside the sliding-layer `head_dim` / `num_key_value_heads`. The provisioned prefix
+    is sized for the global footprint; this returns the shape each layer actually expects so the caller can slice down
+    or skip layers that don't fit.
     """
     layer_types = getattr(base_config, "layer_types", None)
+    if not layer_types:
+        return None
+
+    # New transformers (>= 5.15) use per_layer_config instead of global_head_dim / num_global_key_value_heads
+    per_layer_config = getattr(base_config, "per_layer_config", None)
+    if per_layer_config is not None:
+        layer_cfg = per_layer_config[layer_idx]
+        return layer_cfg.num_key_value_heads, layer_cfg.head_dim
+
+    # Fallback for older transformers that still use global_head_dim / num_global_key_value_heads
     global_head_dim = getattr(base_config, "global_head_dim", None)
-    if not layer_types or global_head_dim is None:
+    if global_head_dim is None:
         return None
 
     is_sliding = layer_types[layer_idx] == "sliding_attention"

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -82,7 +82,8 @@ def _get_layer_kv_target_shape(base_config, layer_idx: int) -> tuple[int, int] |
     if not layer_types:
         return None
 
-    # New transformers (>= 5.15) use per_layer_config instead of global_head_dim / num_global_key_value_heads
+    # New transformers (>= 5.15) use per_layer_config instead of global_head_dim / num_global_key_value_heads.
+    # per_layer_config can be indexed by layer_idx (what we do here) or by layer_type.
     per_layer_config = getattr(base_config, "per_layer_config", None)
     if per_layer_config is not None:
         layer_cfg = per_layer_config[layer_idx]

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1184,13 +1184,28 @@ def _prepare_prompt_learning_config(peft_config, model_config):
 
     # For grouped-query attention, see #1901.
     if (peft_config.peft_type in {"PREFIX_TUNING", "CARTRIDGE"}) and ("num_key_value_heads" in model_config):
-        # Models with heterogeneous attention (e.g. Gemma4) expose distinct shapes for global vs. sliding layers via
-        # `global_head_dim` / `num_global_key_value_heads`. Provision the prefix for the global-layer footprint; sliding
-        # layers whose KV shape doesn't match are skipped per-layer at injection time. Matches the default in
-        # google-deepmind/gemma#631.
+        # Models with heterogeneous attention (e.g. Gemma4) expose distinct shapes for global vs. sliding layers.
+        # New transformers (>= 5.15) use `per_layer_config` instead of `global_head_dim` / `num_global_key_value_heads`.
+        # Provision the prefix for the largest KV footprint; sliding layers whose KV shape doesn't match are skipped
+        # per-layer at injection time. Matches the default in google-deepmind/gemma#631.
         if model_config.get("global_head_dim") is not None:
             head_dim = model_config["global_head_dim"]
             num_key_value_heads = model_config.get("num_global_key_value_heads") or model_config["num_key_value_heads"]
+        elif model_config.get("per_layer_config") is not None:
+            # New transformers (>= 5.15): per_layer_config stores only the *overrides*; the base head_dim and
+            # num_key_value_heads come from the top-level config. Resolve the effective per-layer values and
+            # provision the prefix for the largest KV footprint (typically the full-attention layers).
+            per_layer = model_config["per_layer_config"]
+            base_head_dim = model_config.get("head_dim", peft_config.token_dim // peft_config.num_attention_heads)
+            base_num_kv_heads = model_config["num_key_value_heads"]
+            head_dim = base_head_dim
+            num_key_value_heads = base_num_kv_heads
+            for layer_cfg in per_layer.values():
+                layer_head_dim = layer_cfg.get("head_dim", base_head_dim)
+                layer_num_kv = layer_cfg.get("num_key_value_heads", base_num_kv_heads)
+                if layer_head_dim > head_dim:
+                    head_dim = layer_head_dim
+                    num_key_value_heads = layer_num_kv
         elif model_config.get("head_dim", None) is not None:
             head_dim = model_config["head_dim"]
             num_key_value_heads = model_config["num_key_value_heads"]

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1192,9 +1192,13 @@ def _prepare_prompt_learning_config(peft_config, model_config):
             head_dim = model_config["global_head_dim"]
             num_key_value_heads = model_config.get("num_global_key_value_heads") or model_config["num_key_value_heads"]
         elif model_config.get("per_layer_config") is not None:
-            # New transformers (>= 5.15): per_layer_config stores only the *overrides*; the base head_dim and
-            # num_key_value_heads come from the top-level config. Resolve the effective per-layer values and
-            # provision the prefix for the largest KV footprint (typically the full-attention layers).
+            # New transformers (>= 5.15): global_head_dim / num_global_key_value_heads were replaced by
+            # per_layer_config. Here model_config is a plain dict (from config.to_dict()), so
+            # per_layer_config contains only the *overrides*; the base head_dim and num_key_value_heads
+            # come from the top-level config. (The per_layer_config property on the config object
+            # returns the full config with overrides applied, but that's not available here.)
+            # Resolve the effective per-layer values and provision the prefix for the largest KV
+            # footprint (typically the full-attention layers).
             per_layer = model_config["per_layer_config"]
             base_head_dim = model_config.get("head_dim", peft_config.token_dim // peft_config.num_attention_heads)
             base_num_kv_heads = model_config["num_key_value_heads"]


### PR DESCRIPTION
## Problem

PEFT CI started failing for prefix tuning tests with Gemma4 after transformers PR [#47384](https://github.com/huggingface/transformers/pull/47384) was merged. The error:

```
RuntimeError: Sizes of tensors must match except in dimension 2. Expected size 32 but got size 64 for tensor number 1 in the list.
```

at `transformers/cache_utils.py:143` in `self.keys = torch.cat([self.keys, key_states], dim=-2)`.

Affected tests:
- `test_prefix_tuning_gemma4_works`
- `test_prefix_tuning_gemma4_warns_if_some_layers_skipped`
- `test_prefix_tuning_gemma4_raises_if_all_layers_skipped`

## Root cause

transformers PR #47384 replaced `global_head_dim` and `num_global_key_value_heads` on `Gemma4TextConfig` with the new `per_layer_config` system — a dict that stores only per-layer *overrides* on top of the base config. PEFT's prefix tuning code referenced the old fields in two places:

1. `_get_layer_kv_target_shape()` in `src/peft/peft_model.py` — checked `global_head_dim` to determine per-layer KV shapes. With the field gone, it returned `None` for all layers, disabling the per-layer shape slicing.

2. `_prepare_prompt_learning_config()` in `src/peft/utils/other.py` — checked `global_head_dim` to provision the prefix size. With the field gone, it fell through to `head_dim` (the *sliding* layer's smaller head_dim), provisioning a prefix too small for full-attention layers.

The combined effect: the prefix was provisioned with the smaller sliding-layer head_dim (32 in the tiny test model), and no per-layer slicing was applied. When a full-attention layer (head_dim=64) tried to write its keys into a cache slot initialized for a sliding layer (head_dim=32), `torch.cat` failed with a shape mismatch.

## Fix

Both functions now check `per_layer_config` first and fall back to the old `global_head_dim` / `num_global_key_value_heads` path for backward compatibility with older transformers versions:

- `_get_layer_kv_target_shape()`: uses `base_config.per_layer_config[layer_idx].head_dim` / `.num_key_value_heads` when available
- `_prepare_prompt_learning_config()`: resolves effective per-layer head_dim and num_key_value_heads from `per_layer_config` overrides, provisioning the prefix for the largest KV footprint (matching previous behavior where `global_head_dim` was the larger dimension)

## Tests

All 7 prefix tuning tests in `tests/test_decoder_models.py` pass:
- 3 Gemma4-specific tests (the ones that were failing)
- 4 other prefix tuning tests (Mistral, Qwen2/Qwen3 GQA, position IDs)

Verified backward compatibility by running the same tests against transformers commit `56af69c` (before PR #47384) — all pass via the old `global_head_dim` fallback path.

## Bisect

The culprit was identified by bisecting transformers commits between the last known good commit and main:

| Commit | PR | Passes? |
|--------|----|---------|
| `56af69c` (before #46572) | — | ✅ |
| `213652a` (#46572) | #46572 | ✅ |
| `7d5bc4f` (#47384) | **#47384** | ❌ first failure |
| `bc14d7e` (main tip) | — | ❌ |

PR #46572 (the initial suspect) is not the cause — it passes. The failure starts at PR #47384.

## AI assistance

This PR was prepared with AI assistance. The investigation, bisection, and fix were performed by an AI agent under the direction of a PEFT maintainer.