### PR TITLE
FIX Preserve rslora scaling in add_weighted_adapter

### DIFF
--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -731,6 +731,11 @@ class LoraModel(BaseTuner):
             target_modules=new_target_modules,
             alpha_pattern={},
             rank_pattern={},
+            # The combined weights already have each source adapter's scaling baked in, so the
+            # merged adapter must apply a scaling of exactly 1 (== lora_alpha / r). use_rslora is
+            # copied from adapters[0]; if left True the scaling becomes lora_alpha / sqrt(r) ==
+            # sqrt(new_rank), which re-scales the merged delta incorrectly. Force it off here.
+            use_rslora=False,
         )
         self.inject_adapter(self.model, adapter_name)
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -4011,6 +4011,45 @@ class TestPeftCustomModel(PeftCommonTester):
                 dw_negative = module.get_delta_weight("merged_negative")
                 assert torch.allclose(dw_adapter1, -dw_negative, atol=1e-6)
 
+    def test_add_weighted_adapter_preserves_rslora_scaling(self):
+        # The merged adapter bakes each source adapter's scaling into its weights and is created
+        # with lora_alpha == r, so its own scaling must be exactly 1. If use_rslora leaks into the
+        # merged config, the scaling becomes lora_alpha / sqrt(r) == sqrt(new_rank), inflating the
+        # merged delta. Regression test for that.
+
+        # Single-adapter merge (coerced to "linear"): the identity merge must reproduce the source.
+        torch.manual_seed(42)
+        model = MLP()
+        config = LoraConfig(target_modules=["lin0"], r=8, lora_alpha=8, use_rslora=True, init_lora_weights=False)
+        model = get_peft_model(model, config, adapter_name="adapter1")
+        model.add_weighted_adapter(adapters=["adapter1"], weights=[1.0], adapter_name="merged")
+        assert model.peft_config["merged"].use_rslora is False
+        for module in model.modules():
+            if isinstance(module, lora.LoraLayer) and "merged" in module.scaling:
+                assert module.scaling["merged"] == 1.0
+                dw_source = module.get_delta_weight("adapter1")
+                dw_merged = module.get_delta_weight("merged")
+                assert torch.allclose(dw_source, dw_merged, atol=1e-5)
+
+        # Two-adapter merges genuinely exercise the cat / svd rank paths; the merged adapter's
+        # scaling must still be exactly 1 (i.e. use_rslora must not leak into the merged config).
+        for combination_type in ["cat", "svd"]:
+            torch.manual_seed(42)
+            model = MLP()
+            config = LoraConfig(target_modules=["lin0"], r=8, lora_alpha=8, use_rslora=True, init_lora_weights=False)
+            model = get_peft_model(model, config, adapter_name="a1")
+            model.add_adapter("a2", config)
+            merged_name = f"merged_{combination_type}"
+            model.add_weighted_adapter(
+                adapters=["a1", "a2"], weights=[1.0, 1.0], adapter_name=merged_name, combination_type=combination_type
+            )
+            assert model.peft_config[merged_name].use_rslora is False
+            for module in model.modules():
+                if isinstance(module, lora.LoraLayer) and merged_name in module.scaling:
+                    assert module.scaling[merged_name] == 1.0, (
+                        f"combination_type={combination_type}: merged adapter scaling != 1"
+                    )
+
     def test_add_weighted_adapter_subtraction_with_negative_weights(self):
         # Test that merging two identical adapters with weights [1.0, -1.0] results in approximately zero weights
         model = MLP()


### PR DESCRIPTION
## What does this PR do?

`add_weighted_adapter` builds the merged adapter by baking each source adapter's scaling into the combined `lora_A`/`lora_B` weights, and creates the merged config with `r == lora_alpha == new_rank` so the merged adapter's scaling is exactly `1` (`lora_alpha / r`). All three reconstruction paths (`linear`/`cat`/`svd`) rely on that.

But the merged config is built with `dataclasses.replace(self.peft_config[adapters[0]], ...)`, which copies `use_rslora` from the first source adapter and never resets it. When `use_rslora=True`, the merged adapter's scaling becomes `lora_alpha / sqrt(r) == sqrt(new_rank)` instead of `1`, so the merged delta is silently inflated by a factor of `sqrt(new_rank)`.

### Symptom

Merging rslora adapters produces wrong weights. The clearest case: an identity merge — a single adapter with weight `1.0` — should reproduce that adapter exactly. It does for standard LoRA but not for rslora:

```python
import torch, torch.nn as nn
from peft import LoraConfig, get_peft_model

class M(nn.Module):
    def __init__(self): super().__init__(); self.lin = nn.Linear(8, 8, bias=False)
    def forward(self, x): return self.lin(x)

x = torch.randn(3, 8)
for rslora in (False, True):
    base = M()
    cfg = LoraConfig(r=4, lora_alpha=4, target_modules=["lin"], use_rslora=rslora, init_lora_weights=False)
    pm = get_peft_model(base, cfg, adapter_name="a").eval()
    with torch.no_grad(): out_a = pm(x)
    pm.add_weighted_adapter(["a"], [1.0], "combo")
    pm.set_adapter("combo"); pm.eval()
    with torch.no_grad(): out_combo = pm(x)
    print(f"use_rslora={rslora}: max|out_a - out_combo| = {(out_a - out_combo).abs().max():.4e}")

# use_rslora=False: 0.0000e+00   (correct)
# use_rslora=True : ~1.8e+00     (wrong: merged delta scaled by sqrt(new_rank))
```

### Fix

Force `use_rslora=False` on the merged config so its scaling stays `1`, matching the assumption every combination type already makes. The non-rslora path is unaffected (`adapters[0].use_rslora` is already `False`). No interaction with `use_dora` (which does not change the scaling factor).

### Tests

Added `test_add_weighted_adapter_preserves_rslora_scaling`:
- single-adapter identity merge (coerced to `linear`) reproduces the source adapter's delta exactly, and the merged config has `use_rslora is False` with layer scaling `1.0`;
- two-adapter `cat` and `svd` merges (which genuinely exercise those rank paths) assert the merged adapter's scaling is `1.0`.

Red before the fix, green after. `ruff check` + `ruff format --check` clean; existing `add_weighted_adapter` tests still pass.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/peft/blob/main/PEFT%20Docs/...)?
- [x] Did you write any new necessary tests?

## Who can review?

@BenjaminBossan
