### PR TITLE
fix: avoid modules_to_save key collisions with adapter prefixes

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -384,6 +384,11 @@ def get_peft_model_state_dict(
             module_state_dict = {
                 k.removeprefix(f"{name}."): v for k, v in state_dict.items() if k.startswith(f"{name}.")
             }
+            # Drop keys that were selected only because the module name contains a
+            # tuner prefix (e.g. "lora_head.weight" matched by prefix "lora_"). The
+            # wrapper then re-inserts the correct modules_to_save keys (#3433).
+            for stale_key in [k for k in to_return if k.startswith(f"{name}.")]:
+                del to_return[stale_key]
             to_return.update(
                 {f"{name}.{k}": v for k, v in module.adapter_state_dict(adapter_name, module_state_dict).items()}
             )
@@ -463,7 +468,12 @@ def get_peft_model_state_dict(
             if not embedding_is_targeted or has_valid_embedding_base_layer(layer):
                 embedding_module_name = get_embedding_layer_name(model, layer, embedding_is_targeted)
                 if embedding_module_name:
-                    to_return.update({k: v for k, v in state_dict.items() if embedding_module_name in k})
+                    # Anchor on the module path boundary so a sibling such as
+                    # `embed_tokens_extra` is not selected by a substring match
+                    # against `embed_tokens` (#3433 / embedding-key boundary).
+                    to_return.update(
+                        {k: v for k, v in state_dict.items() if k.startswith(f"{embedding_module_name}.")}
+                    )
     elif save_embedding_layers:
         warnings.warn("Could not identify embedding layer(s) because the model is not a 🤗 transformers model.")
 
@@ -543,6 +553,13 @@ def _insert_adapter_name_into_state_dict(
             _, _, suffix = key.rpartition(parameter_prefix)
             if "." in suffix:
                 suffix_to_replace = ".".join(suffix.split(".")[1:])
+                # Adapter parameters are leaf attributes (e.g. "lora_A.weight"). A longer
+                # suffix means the prefix matched a module name that happens to contain
+                # the adapter prefix (e.g. "lora_head.weight" with prefix "lora_"), not
+                # a real adapter parameter — leave those keys untouched (#3433).
+                if "." in suffix_to_replace:
+                    peft_model_state_dict[key] = val
+                    continue
                 # only replace the substring if the key ends on the substring to avoid accidental replacement inside of
                 # the key if a module happens to have a name that contains the substring
                 key = re.sub(re.escape(suffix_to_replace) + r"$", f"{adapter_name}.{suffix_to_replace}", key)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -26,7 +26,7 @@ from transformers import (
     LlavaForConditionalGeneration,
 )
 
-from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model
+from peft import LoraConfig, PeftModel, VeraConfig, get_peft_model, get_peft_model_state_dict, set_peft_model_state_dict
 from peft.import_utils import is_transformers_ge_v5_1_0, is_transformers_ge_v5_6_0
 from peft.utils.other import (
     ModulesToSaveWrapper,
@@ -425,6 +425,62 @@ class TestModulesToSaveNameSubstringBug:
             param_merged = sd_merged[key]
             param_unmerged = sd_unmerged[key]
             assert torch.allclose(param_merged, param_unmerged)
+
+
+class TestModulesToSaveNameContainsPrefixBug:
+    """modules_to_save modules whose names contain a tuner prefix (e.g. ``lora_``)
+    were misclassified by unanchored substring matching during save/load (#3433).
+    """
+
+    def get_model(self):
+        class ModelWithLoraNamedModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.body = nn.Linear(2, 2, bias=False)
+                # Ordinary module whose name contains the LoRA parameter prefix.
+                self.lora_head = nn.Linear(2, 2, bias=False)
+
+            def forward(self, x):
+                return self.lora_head(self.body(x))
+
+        torch.manual_seed(0)
+        return ModelWithLoraNamedModule()
+
+    def test_save_load_round_trip_restores_weight(self):
+        config = LoraConfig(target_modules=["body"], modules_to_save=["lora_head"])
+        source = get_peft_model(self.get_model(), config)
+        with torch.no_grad():
+            source.base_model.model.lora_head.modules_to_save["default"].weight.fill_(7.0)
+
+        state_dict = get_peft_model_state_dict(source)
+        assert {k for k in state_dict if "lora_head" in k} == {"base_model.model.lora_head.weight"}
+
+        target = get_peft_model(self.get_model(), copy.deepcopy(config))
+        result = set_peft_model_state_dict(target, state_dict)
+
+        assert not [k for k in result.unexpected_keys if "lora_head" in k]
+        loaded_weight = target.base_model.model.lora_head.modules_to_save["default"].weight
+        assert torch.allclose(loaded_weight, torch.full_like(loaded_weight, 7.0))
+
+    def test_save_embedding_layers_does_not_include_similarly_named_module(self):
+        class ModelWithEmbedding(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.body = nn.Linear(2, 2)
+                self.embed_tokens = nn.Embedding(4, 2)
+                self.embed_tokens_extra = nn.Embedding(4, 2)
+
+            def get_input_embeddings(self):
+                return self.embed_tokens
+
+            def get_output_embeddings(self):
+                return None
+
+        model = get_peft_model(ModelWithEmbedding(), LoraConfig(target_modules=["body"]))
+        state_dict = get_peft_model_state_dict(model, save_embedding_layers=True)
+
+        assert "base_model.model.embed_tokens.weight" in state_dict
+        assert not any("embed_tokens_extra" in k for k in state_dict)
 
 
 class TestTargetingAuxiliaryTrainingWrapper:


### PR DESCRIPTION
## Summary

Fixes #3433.

A `modules_to_save` module whose name contains a tuner prefix (e.g. `lora_head` under LoRA) is silently not restored on load. Root cause: unanchored substring matching (`parameter_prefix in key`) in:

1. **`_insert_adapter_name_into_state_dict` (load)** — treats `lora_head.weight` as if it were a LoRA leaf (`lora_A.weight`) and rewrites it incorrectly
2. **`get_peft_model_state_dict` (save)** — prefix match over-selects the module, then the wrapper path must re-insert the correct keys; also embedding saves used the same unanchored match against siblings like `embed_tokens_extra`

## Fix

- On load: if the remainder after the prefix still contains `.`, leave the key untouched (adapter params are leaves)
- On save: drop stale prefix-matched keys for `AuxiliaryTrainingWrapper` modules before re-inserting the correct `modules_to_save` keys
- On embedding save: anchor with `k.startswith(f"{embedding_module_name}.")`

## Tests

```text
python -m pytest tests/test_other.py -k ModulesToSaveNameContainsPrefixBug -q
# 2 passed
```

Covers the issue repro (`lora_head` round-trip) and the embedding sibling boundary case.

## Note

A previous community PR (#3451) explored the same fix but was closed for process/coordination reasons while the issue remains open. Happy to adjust if maintainers prefer a different approach.