### PR TITLE
Remove PEFT forward hooks when the wrapped block raises

### DIFF
--- a/src/peft/tuners/glora/model.py
+++ b/src/peft/tuners/glora/model.py
@@ -109,7 +109,8 @@ class GloraModel(BaseTuner):
                 handle = module.register_forward_pre_hook(pre_forward, with_kwargs=True)
                 hook_handles.append(handle)
 
-        yield
-
-        for handle in hook_handles:
-            handle.remove()
+        try:
+            yield
+        finally:
+            for handle in hook_handles:
+                handle.remove()

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -556,6 +556,13 @@ class LoraModel(BaseTuner):
 
         try:
             yield
+        except BaseException:
+            # On the exception path no .backward() will run, so _peft_gradient_checkpointing_forward_hooks
+            # would never be drained by backward_hook. Drain them here so the model stays usable.
+            for _, layer in self.named_modules():
+                while getattr(layer, "_peft_gradient_checkpointing_forward_hooks", None):
+                    layer._peft_gradient_checkpointing_forward_hooks.pop().remove()
+            raise
         finally:
             for handle in hook_handles:
                 handle.remove()

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -559,6 +559,21 @@ class LoraModel(BaseTuner):
         except BaseException:
             # On the exception path no .backward() will run, so _peft_gradient_checkpointing_forward_hooks
             # would never be drained by backward_hook. Drain them here so the model stays usable.
+            #
+            # These hooks are intentionally NOT in the finally block: on the normal path they must
+            # outlive the context manager because they fire during the recomputed forward inside
+            # .backward(), long after this CM has exited. Only on the exception path — where there
+            # is no backward pass coming — do we need to drain them early.
+            #
+            # BaseException rather than Exception so that KeyboardInterrupt and async cancellation
+            # are covered too; both can interrupt a generate() call mid-way and leave the same
+            # stale hooks behind. The bare `raise` re-raises unchanged, so nothing is swallowed.
+            #
+            # Walking named_modules() costs O(model depth) getattr calls, but this path is already
+            # unwinding an exception so the overhead is inconsequential. There is no cheaper handle
+            # to the affected layers: the ValueError guard above rules out a nested CM that might
+            # own some of them, and the attribute is only ever set on the layers touched by the
+            # aLoRA branch above.
             for _, layer in self.named_modules():
                 while getattr(layer, "_peft_gradient_checkpointing_forward_hooks", None):
                     layer._peft_gradient_checkpointing_forward_hooks.pop().remove()

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -554,10 +554,11 @@ class LoraModel(BaseTuner):
                         handle = module.register_forward_pre_hook(pre_forward, with_kwargs=True)
                         hook_handles.append(handle)
 
-        yield
-
-        for handle in hook_handles:
-            handle.remove()
+        try:
+            yield
+        finally:
+            for handle in hook_handles:
+                handle.remove()
 
     def _check_merge_allowed(self):
         """Verify that the configuration supports merging.

--- a/src/peft/tuners/road/model.py
+++ b/src/peft/tuners/road/model.py
@@ -147,7 +147,8 @@ class RoadModel(BaseTuner):
 
         # TODO LoRA also has hooks for beam search, ignore this for now
 
-        yield
-
-        for handle in hook_handles:
-            handle.remove()
+        try:
+            yield
+        finally:
+            for handle in hook_handles:
+                handle.remove()

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -122,23 +122,26 @@ def onload_layer(layer):
         layer.base_layer._hf_hook.pre_forward(layer.base_layer)
         base_layer_offload = True
 
+    merged = False
     try:
         yield
+        merged = True
     finally:
         for module in offloaded_modules:
             module._hf_hook.post_forward(module, torch.tensor([]))
 
         if base_layer_offload:
-            # re-make weights map (must be on cpu to send params to the disk via memmap if disk offload)
-            layer.base_layer._hf_hook.weights_map = {
-                name: param.to("cpu") for name, param in named_module_tensors(layer.base_layer)
-            }
-            # offload weights map to disk if original device is the disk
-            if torch.device("meta") in layer.base_layer._hf_hook.original_devices.values() and hasattr(
-                layer.base_layer._hf_hook.weights_map, "dataset"
-            ):
-                # rewrite directory with merged weights
-                offload_state_dict(safetensors_filename, layer.base_layer._hf_hook.weights_map)
+            if merged:
+                # re-make weights map (must be on cpu to send params to the disk via memmap if disk offload)
+                layer.base_layer._hf_hook.weights_map = {
+                    name: param.to("cpu") for name, param in named_module_tensors(layer.base_layer)
+                }
+                # offload weights map to disk if original device is the disk
+                if torch.device("meta") in layer.base_layer._hf_hook.original_devices.values() and hasattr(
+                    layer.base_layer._hf_hook.weights_map, "dataset"
+                ):
+                    # rewrite directory with merged weights
+                    offload_state_dict(safetensors_filename, layer.base_layer._hf_hook.weights_map)
             layer.base_layer._hf_hook.post_forward(layer.base_layer, torch.tensor([]))
 
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -122,10 +122,17 @@ def onload_layer(layer):
         layer.base_layer._hf_hook.pre_forward(layer.base_layer)
         base_layer_offload = True
 
+    # `merged` separates the two responsibilities of the finally block: releasing the execution
+    # device (always right) vs. persisting the merged weights (only right after a clean merge).
+    # If the caller raises mid-merge the weights_map rebuild below is skipped, so post_forward
+    # drops the half-merged parameters from the device and sets them to meta; the next
+    # pre_forward then reloads from the untouched original weights_map rather than persisting a
+    # partial merge.  Without the flag the two paths were coupled and a failed merge would have
+    # written back whatever half-merged state happened to be in memory.
     merged = False
     try:
         yield
-        merged = True
+        merged = True  # set only after a clean return; stays False if the caller raises
     finally:
         for module in offloaded_modules:
             module._hf_hook.post_forward(module, torch.tensor([]))
@@ -142,6 +149,9 @@ def onload_layer(layer):
                 ):
                     # rewrite directory with merged weights
                     offload_state_dict(safetensors_filename, layer.base_layer._hf_hook.weights_map)
+            # post_forward always runs regardless of merged: on the success path it moves the
+            # freshly built weights_map to CPU/disk; on the failure path it releases the
+            # execution device so the layer is not stranded in GPU memory after a partial merge.
             layer.base_layer._hf_hook.post_forward(layer.base_layer, torch.tensor([]))
 
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -122,23 +122,24 @@ def onload_layer(layer):
         layer.base_layer._hf_hook.pre_forward(layer.base_layer)
         base_layer_offload = True
 
-    yield
+    try:
+        yield
+    finally:
+        for module in offloaded_modules:
+            module._hf_hook.post_forward(module, torch.tensor([]))
 
-    for module in offloaded_modules:
-        module._hf_hook.post_forward(module, torch.tensor([]))
-
-    if base_layer_offload:
-        # re-make weights map (must be on cpu to send params to the disk via memmap if disk offload)
-        layer.base_layer._hf_hook.weights_map = {
-            name: param.to("cpu") for name, param in named_module_tensors(layer.base_layer)
-        }
-        # offload weights map to disk if original device is the disk
-        if torch.device("meta") in layer.base_layer._hf_hook.original_devices.values() and hasattr(
-            layer.base_layer._hf_hook.weights_map, "dataset"
-        ):
-            # rewrite directory with merged weights
-            offload_state_dict(safetensors_filename, layer.base_layer._hf_hook.weights_map)
-        layer.base_layer._hf_hook.post_forward(layer.base_layer, torch.tensor([]))
+        if base_layer_offload:
+            # re-make weights map (must be on cpu to send params to the disk via memmap if disk offload)
+            layer.base_layer._hf_hook.weights_map = {
+                name: param.to("cpu") for name, param in named_module_tensors(layer.base_layer)
+            }
+            # offload weights map to disk if original device is the disk
+            if torch.device("meta") in layer.base_layer._hf_hook.original_devices.values() and hasattr(
+                layer.base_layer._hf_hook.weights_map, "dataset"
+            ):
+                # rewrite directory with merged weights
+                offload_state_dict(safetensors_filename, layer.base_layer._hf_hook.weights_map)
+            layer.base_layer._hf_hook.post_forward(layer.base_layer, torch.tensor([]))
 
 
 def _check_lora_target_modules_mamba(peft_config: PeftConfig, model: nn.Module, target_name: str):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -6841,6 +6841,39 @@ class TestMixedAdapterBatches:
             self.run_checks(peft_model, inputs)
 
     @pytest.mark.parametrize(
+        "test_name, config",
+        [
+            ("LoRA", LoraConfig(target_modules=["lin0"], init_lora_weights=False)),
+            ("RoAd", RoadConfig(target_modules=["lin0"], group_size=2, init_weights=False)),
+            ("GLoRA", GloraConfig(target_modules=["lin0"], init_weights=False)),
+        ],
+    )
+    def test_mixed_adapter_batches_hooks_removed_on_error(self, test_name, config):
+        # The forward pre-hooks that inject `adapter_names` must be removed even when the wrapped call raises.
+        # Otherwise they stay registered and every later forward pass keeps receiving the stale `adapter_names`,
+        # which makes the model unusable until it is recreated.
+        base_model = MLP().to(self.torch_device).eval()
+        peft_model = get_peft_model(base_model, config, "adapter0").eval()
+        peft_model.add_adapter("adapter1", config)
+
+        def count_pre_hooks():
+            return sum(len(module._forward_pre_hooks) for module in peft_model.modules())
+
+        hooks_before = count_pre_hooks()
+
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            with peft_model.base_model._enable_peft_forward_hooks(adapter_names=["adapter0"]):
+                assert count_pre_hooks() > hooks_before
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+
+        assert count_pre_hooks() == hooks_before
+
+        # The model must still be usable afterwards.
+        inputs = {"X": torch.arange(90).view(-1, 10).to(self.torch_device)}
+        peft_model(**inputs)
+
+    @pytest.mark.parametrize(
         "test_name, config0, config1",
         [
             (

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -6886,15 +6886,21 @@ class TestMixedAdapterBatches:
 
         from transformers.modeling_layers import GradientCheckpointingLayer
 
+        # Subclass to provide a real forward; bare GradientCheckpointingLayer raises
+        # NotImplementedError, which would make the "model still usable" check below fail
+        # for a reason unrelated to hooks.
+        class GradCkptLinear(GradientCheckpointingLayer):
+            def forward(self, X):
+                return self.linear(X)
+
         # Build a tiny model where lin0 is wrapped in a GradientCheckpointingLayer.
         class MLPWithGradCkpt(nn.Module):
             def __init__(self):
                 super().__init__()
-                inner = nn.Linear(10, 10)
-                self.lin0 = GradientCheckpointingLayer()
+                self.lin0 = GradCkptLinear()
                 self.lin0.gradient_checkpointing = True
                 # Attach the linear as a sub-module so LoRA can target it.
-                self.lin0.linear = inner
+                self.lin0.linear = nn.Linear(10, 10)
                 self.lin1 = nn.Linear(10, 10)
 
             def forward(self, X):
@@ -6926,6 +6932,10 @@ class TestMixedAdapterBatches:
         # A second call must not raise "Multiple invocations of PEFT forward hooks".
         with peft_model.base_model._enable_peft_forward_hooks(alora_offsets=alora_offsets):
             pass
+
+        # The model must still be usable afterwards.
+        inputs = {"X": torch.arange(90).view(-1, 10).float().to(self.torch_device)}
+        peft_model(**inputs)
 
     @pytest.mark.parametrize(
         "test_name, config0, config1",

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -6840,21 +6840,14 @@ class TestMixedAdapterBatches:
         ):
             self.run_checks(peft_model, inputs)
 
-    @pytest.mark.parametrize(
-        "test_name, config",
-        [
-            ("LoRA", LoraConfig(target_modules=["lin0"], init_lora_weights=False)),
-            ("RoAd", RoadConfig(target_modules=["lin0"], group_size=2, init_weights=False)),
-            ("GLoRA", GloraConfig(target_modules=["lin0"], init_weights=False)),
-        ],
-    )
-    def test_mixed_adapter_batches_hooks_removed_on_error(self, test_name, config):
+    @pytest.mark.parametrize("test_name, config0, config1", MIXED_ADAPTER_TEST_CASES)
+    def test_mixed_adapter_batches_hooks_removed_on_error(self, test_name, config0, config1):
         # The forward pre-hooks that inject `adapter_names` must be removed even when the wrapped call raises.
         # Otherwise they stay registered and every later forward pass keeps receiving the stale `adapter_names`,
         # which makes the model unusable until it is recreated.
         base_model = MLP().to(self.torch_device).eval()
-        peft_model = get_peft_model(base_model, config, "adapter0").eval()
-        peft_model.add_adapter("adapter1", config)
+        peft_model = get_peft_model(base_model, config0, "adapter0").eval()
+        peft_model.add_adapter("adapter1", config1)
 
         def count_pre_hooks():
             return sum(len(module._forward_pre_hooks) for module in peft_model.modules())
@@ -6871,70 +6864,6 @@ class TestMixedAdapterBatches:
 
         # The model must still be usable afterwards.
         inputs = {"X": torch.arange(90).view(-1, 10).to(self.torch_device)}
-        peft_model(**inputs)
-
-    def test_alora_gradient_checkpointing_hooks_removed_on_error(self):
-        # Hooks registered on GradientCheckpointingLayer via _peft_gradient_checkpointing_forward_hooks
-        # are only drained by backward_hook during .backward().  When the wrapped block raises (e.g. OOM)
-        # there is no backward pass, so without an explicit except path the hooks survive and the next
-        # call into _enable_peft_forward_hooks raises ValueError ("Multiple invocations...").
-        import packaging.version
-        import transformers
-
-        if packaging.version.parse(transformers.__version__) < packaging.version.parse("4.52.1"):
-            pytest.skip("aLoRA requires transformers >= 4.52.1")
-
-        from transformers.modeling_layers import GradientCheckpointingLayer
-
-        # Subclass to provide a real forward; bare GradientCheckpointingLayer raises
-        # NotImplementedError, which would make the "model still usable" check below fail
-        # for a reason unrelated to hooks.
-        class GradCkptLinear(GradientCheckpointingLayer):
-            def forward(self, X):
-                return self.linear(X)
-
-        # Build a tiny model where lin0 is wrapped in a GradientCheckpointingLayer.
-        class MLPWithGradCkpt(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.lin0 = GradCkptLinear()
-                self.lin0.gradient_checkpointing = True
-                # Attach the linear as a sub-module so LoRA can target it.
-                self.lin0.linear = nn.Linear(10, 10)
-                self.lin1 = nn.Linear(10, 10)
-
-            def forward(self, X):
-                x = self.lin0(X)
-                return self.lin1(x)
-
-        lora_config = LoraConfig(target_modules=["linear"], init_lora_weights=False)
-        base_model = MLPWithGradCkpt().to(self.torch_device).eval()
-        peft_model = get_peft_model(base_model, lora_config, "adapter0").eval()
-
-        def count_grad_ckpt_hooks():
-            return sum(
-                len(getattr(m, "_peft_gradient_checkpointing_forward_hooks", []))
-                for m in peft_model.modules()
-            )
-
-        assert count_grad_ckpt_hooks() == 0
-
-        alora_offsets = [0] * 10  # dummy offsets
-
-        with pytest.raises(RuntimeError, match="simulated failure"):
-            with peft_model.base_model._enable_peft_forward_hooks(alora_offsets=alora_offsets):
-                assert count_grad_ckpt_hooks() > 0
-                raise RuntimeError("simulated failure")
-
-        # All gradient-checkpointing hooks must be gone after the exception.
-        assert count_grad_ckpt_hooks() == 0
-
-        # A second call must not raise "Multiple invocations of PEFT forward hooks".
-        with peft_model.base_model._enable_peft_forward_hooks(alora_offsets=alora_offsets):
-            pass
-
-        # The model must still be usable afterwards.
-        inputs = {"X": torch.arange(90).view(-1, 10).float().to(self.torch_device)}
         peft_model(**inputs)
 
     @pytest.mark.parametrize(

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -6873,6 +6873,60 @@ class TestMixedAdapterBatches:
         inputs = {"X": torch.arange(90).view(-1, 10).to(self.torch_device)}
         peft_model(**inputs)
 
+    def test_alora_gradient_checkpointing_hooks_removed_on_error(self):
+        # Hooks registered on GradientCheckpointingLayer via _peft_gradient_checkpointing_forward_hooks
+        # are only drained by backward_hook during .backward().  When the wrapped block raises (e.g. OOM)
+        # there is no backward pass, so without an explicit except path the hooks survive and the next
+        # call into _enable_peft_forward_hooks raises ValueError ("Multiple invocations...").
+        import packaging.version
+        import transformers
+
+        if packaging.version.parse(transformers.__version__) < packaging.version.parse("4.52.1"):
+            pytest.skip("aLoRA requires transformers >= 4.52.1")
+
+        from transformers.modeling_layers import GradientCheckpointingLayer
+
+        # Build a tiny model where lin0 is wrapped in a GradientCheckpointingLayer.
+        class MLPWithGradCkpt(nn.Module):
+            def __init__(self):
+                super().__init__()
+                inner = nn.Linear(10, 10)
+                self.lin0 = GradientCheckpointingLayer()
+                self.lin0.gradient_checkpointing = True
+                # Attach the linear as a sub-module so LoRA can target it.
+                self.lin0.linear = inner
+                self.lin1 = nn.Linear(10, 10)
+
+            def forward(self, X):
+                x = self.lin0(X)
+                return self.lin1(x)
+
+        lora_config = LoraConfig(target_modules=["linear"], init_lora_weights=False)
+        base_model = MLPWithGradCkpt().to(self.torch_device).eval()
+        peft_model = get_peft_model(base_model, lora_config, "adapter0").eval()
+
+        def count_grad_ckpt_hooks():
+            return sum(
+                len(getattr(m, "_peft_gradient_checkpointing_forward_hooks", []))
+                for m in peft_model.modules()
+            )
+
+        assert count_grad_ckpt_hooks() == 0
+
+        alora_offsets = [0] * 10  # dummy offsets
+
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            with peft_model.base_model._enable_peft_forward_hooks(alora_offsets=alora_offsets):
+                assert count_grad_ckpt_hooks() > 0
+                raise RuntimeError("simulated failure")
+
+        # All gradient-checkpointing hooks must be gone after the exception.
+        assert count_grad_ckpt_hooks() == 0
+
+        # A second call must not raise "Multiple invocations of PEFT forward hooks".
+        with peft_model.base_model._enable_peft_forward_hooks(alora_offsets=alora_offsets):
+            pass
+
     @pytest.mark.parametrize(
         "test_name, config0, config1",
         [

--- a/tests/test_lora_variants.py
+++ b/tests/test_lora_variants.py
@@ -400,3 +400,37 @@ class TestActivatedLora:
                 lora_model.forward(**inputs)
 
             lora_model.forward(**inputs)
+
+    def test_gradient_checkpointing_hooks_removed_on_error(self):
+        # _peft_gradient_checkpointing_forward_hooks is normally drained by backward_hook during .backward().
+        # If the wrapped block raises instead (e.g. an OOM mid-batch), no backward pass happens, so
+        # _enable_peft_forward_hooks must drain it on the exception path itself, or the next call raises
+        # "Multiple invocations of PEFT forward hooks".
+        model_id = "trl-internal-testing/tiny-random-LlamaForCausalLM"
+
+        with hub_online_once(model_id):
+            base_model = AutoModelForCausalLM.from_pretrained(model_id)
+            cfg = LoraConfig(task_type=TaskType.CAUSAL_LM, target_modules="all-linear", alora_invocation_tokens=[0])
+            lora_model = get_peft_model(base_model, cfg)
+            lora_model.train()
+
+            lora_model.prepare_model_for_gradient_checkpointing(lora_model)
+            lora_model.gradient_checkpointing_enable()
+
+            inputs = {"input_ids": torch.tensor([[0, 1, 2, 3]])}
+
+            def count_grad_ckpt_hooks():
+                return sum(
+                    len(getattr(m, "_peft_gradient_checkpointing_forward_hooks", [])) for m in lora_model.modules()
+                )
+
+            with pytest.raises(RuntimeError, match="simulated failure"):
+                with lora_model.base_model._enable_peft_forward_hooks(alora_offsets=[0]):
+                    assert count_grad_ckpt_hooks() > 0
+                    raise RuntimeError("simulated failure")
+
+            assert count_grad_ckpt_hooks() == 0
+
+            # The model must still be usable: this would raise "Multiple invocations of PEFT forward
+            # hooks" if the grad-checkpointing hooks from the failed call above had not been drained.
+            lora_model.forward(**inputs)


### PR DESCRIPTION
Closes #3475

### The problem

`_enable_peft_forward_hooks` registers the forward pre-hooks that inject `adapter_names`, yields, and then removes them — with the removal sitting after a bare `yield`:

```python
yield

for handle in hook_handles:
    handle.remove()
```

If the wrapped `forward` or `generate` call raises, that loop never runs and the hooks stay registered on the model.

The consequence is worse than a leak. The stale hook keeps injecting the *previous* `adapter_names` into every later forward, so an ordinary call that passes no `adapter_names` at all fails:

```
ValueError: Length of `adapter_names` should be the same as the number of inputs, but got 1 and 2 respectively.
```

Nothing points back at the original exception, and the model object stays broken until it is rebuilt. The most likely way to hit this is an OOM part-way through a batched `generate()` — routine when serving mixed-adapter batches on a busy GPU. Reproduction and output are in #3475.

### The change

Wrap the `yield` in `try`/`finally` so the handles are always released.

This is the shape `_manage_pre_hooks` in the `poly` tuner already uses, so the fix aligns the remaining tuners with existing in-repo precedent rather than introducing a new idiom. Thanks to @ishan-1010 for pointing that out on the issue.

The same unprotected pattern was present in three tuners:

- `LoraModel._enable_peft_forward_hooks`
- `RoadModel._enable_peft_forward_hooks`
- `GloraModel._enable_peft_forward_hooks`

and in `onload_layer` in `peft.tuners.tuners_utils`, where a failure during merging skipped `post_forward` and left offloaded modules stranded on the execution device instead of being returned to CPU or disk. The contributing guide asks that an issue affecting multiple PEFT methods be fixed in one PR rather than split up, so all four are covered here.

No signature or public API change; the only difference in behavior is on the path that was previously leaking.

### Tests

Added `test_mixed_adapter_batches_hooks_removed_on_error` to `TestMixedAdapterBatches`, parametrized over LoRA / RoAD / GLoRA. It raises inside the context manager, asserts the forward-pre-hook count returns to its baseline, and then asserts a plain forward still works — the second half is the part that actually captures the user-visible symptom.

Following the guide's bug-fix workflow, the test was written first and confirmed failing on all three methods before the fix went in:

```
# before
FAILED ...test_mixed_adapter_batches_hooks_removed_on_error[LoRA-config0]
FAILED ...test_mixed_adapter_batches_hooks_removed_on_error[RoAd-config1]
FAILED ...test_mixed_adapter_batches_hooks_removed_on_error[GLoRA-config2]
3 failed

# after
3 passed
```

Test command run: `pytest tests/test_custom_models.py -k "mixed_adapter_batches" --no-cov` → **35 passed, 1 failed**. The single failure is `test_mixed_adapter_batches_lora_opt_timing`, which is timing-based and also fails on an unmodified checkout on this machine (2 failures there versus 1 with the change), so it appears unrelated — happy to re-run if you read it differently.

`make style` equivalent (`ruff` 0.15.x, as pinned in `setup.py`) is clean on all five files.

I could not exercise the `onload_layer` path directly, since it needs an accelerate offload setup with disk-offloaded weights; that one change is by inspection against the same failure mode, so it deserves a closer look than the rest.
