### PR TITLE
Fix per-layer prefix KV sizing

### DIFF
--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1207,7 +1207,7 @@ def _prepare_prompt_learning_config(peft_config, model_config):
             for layer_cfg in per_layer.values():
                 layer_head_dim = layer_cfg.get("head_dim", base_head_dim)
                 layer_num_kv = layer_cfg.get("num_key_value_heads", base_num_kv_heads)
-                if layer_head_dim > head_dim:
+                if layer_head_dim * layer_num_kv > head_dim * num_key_value_heads:
                     head_dim = layer_head_dim
                     num_key_value_heads = layer_num_kv
         elif model_config.get("head_dim", None) is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,6 +68,7 @@ from peft import (
     WaveFTConfig,
     XLoraConfig,
 )
+from peft.utils.other import _prepare_prompt_learning_config
 
 
 class TestingCommitHashError(Exception):
@@ -124,6 +125,24 @@ ALL_CONFIG_CLASSES = (
 
 
 class TestPeftConfig:
+    def test_prepare_prompt_learning_config_uses_largest_per_layer_kv_footprint(self):
+        config = PrefixTuningConfig(task_type=TaskType.CAUSAL_LM, num_virtual_tokens=4)
+        model_config = {
+            "num_hidden_layers": 2,
+            "hidden_size": 1024,
+            "num_attention_heads": 8,
+            "num_key_value_heads": 4,
+            "head_dim": 128,
+            "per_layer_config": {
+                1: {"head_dim": 128, "num_key_value_heads": 8},
+            },
+        }
+
+        _prepare_prompt_learning_config(config, model_config)
+
+        assert config.num_attention_heads == 8
+        assert config.token_dim == 1024
+
     @pytest.mark.parametrize("config_class, mandatory_kwargs", ALL_CONFIG_CLASSES)
     def test_methods(self, config_class, mandatory_kwargs):
         r"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,6 +126,7 @@ ALL_CONFIG_CLASSES = (
 
 class TestPeftConfig:
     def test_prepare_prompt_learning_config_uses_largest_per_layer_kv_footprint(self):
+        # Regression test for https://github.com/huggingface/peft/issues/3478
         config = PrefixTuningConfig(task_type=TaskType.CAUSAL_LM, num_virtual_tokens=4)
         model_config = {
             "num_hidden_layers": 2,


### PR DESCRIPTION
Fixes #3478

`_prepare_prompt_learning_config` currently chooses the largest per-layer override by `head_dim` alone. That under-provisions prefix embeddings when an override has the same head dimension but more key-value heads.

This compares the full KV footprint (`head_dim * num_key_value_heads`) and adds a pure configuration regression test.

Tests:
- `PYTHONPATH=src pytest tests/test_config.py -q --no-cov` (1194 passed, 12 skipped)
- `ruff check src/peft/utils/other.py tests/test_config.py`
- `ruff format --check src/peft/utils/other.py tests/test_config.py`