### PR TITLE
FIX `modules_to_save` buffer handling in `convert_to_lora`

### DIFF
--- a/src/peft/tuners/lora/conversion.py
+++ b/src/peft/tuners/lora/conversion.py
@@ -345,17 +345,25 @@ def convert_to_lora(
     ##################
 
     if (peft_config is not None) and getattr(peft_config, "modules_to_save", None):
-        # logic to take care of modules_to_save; might not cover all edge cases, like sharded model
+        # Match the normal PEFT serialization contract, which includes persistent buffers in addition to parameters.
         lora_config.modules_to_save = copy.copy(peft_config.modules_to_save)
 
+        model_state_dict = model.state_dict()  # this gets the full state dict, including buffers, not only params
         for module_name, module in model.named_modules():
             if isinstance(module, ModulesToSaveWrapper):
-                for param_name, param in module.modules_to_save.named_parameters():
-                    # it is expected that '.modules_to_save.' is not part of the key
-                    prefix, _, _ = module_name.partition(".modules_to_save.")
-                    # remove the adapter name
-                    _, _, suffix = param_name.rpartition(".")
-                    state_dict[f"{prefix}.{suffix}"] = param.data
+                # extract only the keys that belong to this wrapper, and remove the prefix
+                module_state_dict = {
+                    key.removeprefix(f"{module_name}."): value
+                    for key, value in model_state_dict.items()
+                    if key.startswith(f"{module_name}.")
+                }
+                # update the state dict with the adapter's state dict, which includes both parameters and buffers
+                state_dict.update(
+                    {
+                        f"{module_name}.{key}": value
+                        for key, value in module.adapter_state_dict(adapter_name, module_state_dict).items()
+                    }
+                )
 
     return lora_config, state_dict
 

--- a/tests/test_lora_conversion.py
+++ b/tests/test_lora_conversion.py
@@ -492,6 +492,56 @@ class TestLoraConversion:
         # here we expect an actual loss of 0, since only the modules_to_save affect the result, and those are identical
         assert mse_converted == 0.0
 
+    def test_convert_model_with_modules_to_save_buffers(self):
+        # ModulesToSaveWrapper can wrap modules with persistent buffers (e.g. BatchNorm)
+        # The converted state dict must include those buffers, not only parameters
+        class ModelWithBatchNorm(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(4, 4)
+                self.head = nn.BatchNorm1d(4)
+
+            def forward(self, x):
+                return self.head(self.linear(x))
+
+        torch.manual_seed(0)
+        base_model = ModelWithBatchNorm().eval()
+        lokr_model = get_peft_model(
+            copy.deepcopy(base_model),
+            LoKrConfig(target_modules=["linear"], modules_to_save=["head"]),
+        ).eval()
+
+        # modify the saved BatchNorm buffers so we can verify they are preserved
+        source_head = lokr_model.base_model.model.head.modules_to_save.default
+        source_head.running_mean.copy_(torch.tensor([1.0, -2.0, 3.0, -4.0]))
+        source_head.running_var.copy_(torch.tensor([0.25, 0.5, 2.0, 4.0]))
+        source_head.num_batches_tracked.fill_(17)
+
+        lora_config, state_dict = convert_to_lora(lokr_model, rank=4)
+
+        # buffers must be present in the converted checkpoint
+        expected_buffer_keys = {
+            "base_model.model.head.running_mean",
+            "base_model.model.head.running_var",
+            "base_model.model.head.num_batches_tracked",
+        }
+        assert expected_buffer_keys <= state_dict.keys()
+
+        # loading into a fresh LoRA model should not miss any saved-module keys
+        lora_model = get_peft_model(copy.deepcopy(base_model), lora_config).eval()
+        load_result = set_peft_model_state_dict(lora_model, state_dict)
+        assert not [key for key in load_result.missing_keys if ".modules_to_save." in key]
+
+        # the loaded buffers must match the source buffers exactly
+        target_head = lora_model.base_model.model.head.modules_to_save.default
+        assert torch.equal(target_head.running_mean, source_head.running_mean)
+        assert torch.equal(target_head.running_var, source_head.running_var)
+        assert torch.equal(target_head.num_batches_tracked, source_head.num_batches_tracked)
+
+        # inference outputs must match since only the saved module changed
+        inputs = torch.tensor([[1.0, 2.0, 3.0, 4.0], [-1.0, 0.0, 2.0, 1.0]])
+        assert torch.allclose(lora_model(inputs), lokr_model(inputs))
+
     @pytest.mark.parametrize("bias", ["c3a_only", "all"])
     def test_convert_model_with_trainable_bias_raises(self, bias):
         # If the original adapter includes trainable bias terms, we raise. LoKr doesn't support this, so taking C3A


### PR DESCRIPTION
## Description

`convert_to_lora` currently saves `modules_to_save` weights by iterating over `module.modules_to_save.named_parameters()`. This drops persistent buffers such as `BatchNorm1d`'s `running_mean`, `running_var`, and `num_batches_tracked`

Because PEFT's loader expects those buffer keys (via `ModulesToSaveWrapper.adapter_state_dict_load_map`), the converted checkpoint fails to reload with:

```text
KeyError: 'base_model.model.head.running_mean'
```

This PR reuses the existing `adapter_state_dict` to serialize the wrapped module, which includes both parameters and buffers.

### Changes

- conversion.py: use `module.adapter_state_dict(...)` instead of hand-rolling parameter extraction.
- test_lora_conversion.py: add a regression test with a `BatchNorm1d` module in `modules_to_save`.

### Tests

```text
pytest tests/test_lora_conversion.py
# 32 passed 
```