### PR TITLE
Fix sequential merge invariants for FRoD, HiRA, and PEANuT

### DIFF
--- a/src/peft/tuners/frod/layer.py
+++ b/src/peft/tuners/frod/layer.py
@@ -190,10 +190,9 @@ class Linear(nn.Linear, FrodLayer):
 
         base_layer = self.get_base_layer()
         adapter_deltas = []
-        reference_weight = self._get_base_weight_before_merge()
         for active_adapter in adapter_names:
             if active_adapter in self.frod_lambda_l.keys():
-                adapter_deltas.append((active_adapter, self.get_delta_weight(active_adapter, reference_weight)))
+                adapter_deltas.append((active_adapter, self.get_delta_weight(active_adapter)))
 
         for active_adapter, delta_weight in adapter_deltas:
             delta_weight = delta_weight.to(device=base_layer.weight.device, dtype=base_layer.weight.dtype)
@@ -229,14 +228,12 @@ class Linear(nn.Linear, FrodLayer):
         self._base_weight_before_merge = None
         self.merged_adapters.clear()
 
-    def get_delta_weight(self, adapter, reference_weight: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def get_delta_weight(self, adapter) -> torch.Tensor:
         self._move_base_weight_to_device_of_adapter(adapter)
         weight = self.get_base_layer().weight
         device = weight.device
         dtype = weight.dtype
-        if reference_weight is None:
-            reference_weight = weight
-        reference_weight = reference_weight.to(device=device, dtype=dtype)
+        reference_weight = self._get_base_weight_before_merge()
         base_weight = transpose(reference_weight, self.fan_in_fan_out)
         U, V, S_sparse, lambda_l = self._get_frod_tensors(adapter, device=device, dtype=dtype)
         S = S_sparse.to_dense()

--- a/src/peft/tuners/frod/layer.py
+++ b/src/peft/tuners/frod/layer.py
@@ -57,7 +57,7 @@ class FrodLayer(BaseTunerLayer):
 
         self._disable_adapters = False
         self.merged_adapters = []
-        self._frod_merged_delta = {}
+        self._base_weight_before_merge: Optional[torch.Tensor] = None
 
         self.in_features, self.out_features = _get_in_out_features(self.get_base_layer())
         self.kwargs = kwargs
@@ -150,6 +150,12 @@ class FrodLayer(BaseTunerLayer):
             with torch.no_grad():
                 nn.init.zeros_(self.frod_lambda_s_values[adapter_name])
 
+    def _get_base_weight_before_merge(self) -> torch.Tensor:
+        base_weight = self.get_base_layer().weight
+        if self._base_weight_before_merge is None:
+            self._base_weight_before_merge = base_weight.data.detach().clone().cpu()
+        return self._base_weight_before_merge.to(device=base_weight.device, dtype=base_weight.dtype)
+
 
 class Linear(nn.Linear, FrodLayer):
     def __init__(
@@ -184,10 +190,10 @@ class Linear(nn.Linear, FrodLayer):
 
         base_layer = self.get_base_layer()
         adapter_deltas = []
-        # FRoD deltas are computed against the current base weight, so compute all deltas before mutating it.
+        reference_weight = self._get_base_weight_before_merge()
         for active_adapter in adapter_names:
             if active_adapter in self.frod_lambda_l.keys():
-                adapter_deltas.append((active_adapter, self.get_delta_weight(active_adapter)))
+                adapter_deltas.append((active_adapter, self.get_delta_weight(active_adapter, reference_weight)))
 
         for active_adapter, delta_weight in adapter_deltas:
             delta_weight = delta_weight.to(device=base_layer.weight.device, dtype=base_layer.weight.dtype)
@@ -201,7 +207,6 @@ class Linear(nn.Linear, FrodLayer):
                 base_layer.weight.data = orig_weights
             else:
                 base_layer.weight.data += delta_weight
-            self._frod_merged_delta[active_adapter] = delta_weight
             self.merged_adapters.append(active_adapter)
 
     def unload_and_optionally_merge_module(
@@ -219,22 +224,20 @@ class Linear(nn.Linear, FrodLayer):
             warnings.warn("Already unmerged. Nothing to do.")
             return
 
-        while len(self.merged_adapters) > 0:
-            active_adapter = self.merged_adapters.pop()
-            if active_adapter in self.frod_lambda_l.keys():
-                delta_weight = self._frod_merged_delta.pop(active_adapter, None)
-                if delta_weight is None:
-                    delta_weight = self.get_delta_weight(active_adapter)
-                base_weight = self.get_base_layer().weight
-                delta_weight = delta_weight.to(device=base_weight.device, dtype=base_weight.dtype)
-                base_weight.data -= delta_weight
+        base_weight = self.get_base_layer().weight
+        base_weight.data.copy_(self._base_weight_before_merge.to(device=base_weight.device, dtype=base_weight.dtype))
+        self._base_weight_before_merge = None
+        self.merged_adapters.clear()
 
-    def get_delta_weight(self, adapter) -> torch.Tensor:
+    def get_delta_weight(self, adapter, reference_weight: Optional[torch.Tensor] = None) -> torch.Tensor:
         self._move_base_weight_to_device_of_adapter(adapter)
         weight = self.get_base_layer().weight
         device = weight.device
         dtype = weight.dtype
-        base_weight = transpose(weight, self.fan_in_fan_out)
+        if reference_weight is None:
+            reference_weight = weight
+        reference_weight = reference_weight.to(device=device, dtype=dtype)
+        base_weight = transpose(reference_weight, self.fan_in_fan_out)
         U, V, S_sparse, lambda_l = self._get_frod_tensors(adapter, device=device, dtype=dtype)
         S = S_sparse.to_dense()
         L = torch.diag_embed(lambda_l)

--- a/src/peft/tuners/hira/bnb.py
+++ b/src/peft/tuners/hira/bnb.py
@@ -66,6 +66,7 @@ if is_bnb_available():
                 # no adapter to merge
                 return
 
+            # Each adapter is requantized separately, so batch and sequential merges can produce different results.
             for active_adapter in adapter_names:
                 if active_adapter not in self.hira_A.keys():
                     continue
@@ -290,6 +291,7 @@ if is_bnb_4bit_available():
                 # no adapter to merge
                 return
 
+            # Each adapter is requantized separately, so batch and sequential merges can produce different results.
             for active_adapter in adapter_names:
                 if active_adapter not in self.hira_A.keys():
                     continue

--- a/src/peft/tuners/hira/layer.py
+++ b/src/peft/tuners/hira/layer.py
@@ -46,7 +46,7 @@ class HiraLayer(BaseTunerLayer):
         # Mark the weight as unmerged
         self._disable_adapters = False
         self.merged_adapters = []
-        self._caches: dict[str, Any] = {}
+        self._base_weight_before_merge: Optional[torch.Tensor] = None
         self.ephemeral_gpu_offload: bool = ephemeral_gpu_offload
         # flag to enable/disable casting of input to weight dtype during forward call
         self.cast_input_dtype_enabled: bool = True
@@ -76,24 +76,25 @@ class HiraLayer(BaseTunerLayer):
         self.in_features = in_features
         self.out_features = out_features
 
-    def _merge_adapter_weights(
-        self, safe_merge: bool, adapter_names: Optional[list[str]], available_adapters: nn.ParameterDict
-    ) -> None:
+    def _get_base_weight_before_merge(self) -> torch.Tensor:
+        weight = self.get_base_layer().weight
+        if self._base_weight_before_merge is None:
+            self._base_weight_before_merge = weight.data.detach().clone().cpu()
+        return self._base_weight_before_merge.to(device=weight.device, dtype=weight.dtype)
+
+    def _merge(self, safe_merge: bool, adapter_names: Optional[list[str]], available_adapters: set[str]) -> None:
         adapter_names = check_adapters_to_merge(self, adapter_names)
         adapter_names = [name for name in adapter_names if name in available_adapters]
         if not adapter_names:
             return
 
         weight = self.get_base_layer().weight
-        if not self.merged_adapters:
-            self._caches["base_weight_before_merge"] = weight.data.detach().clone().cpu()
+        base_weight = self._get_base_weight_before_merge()
+        new_delta = torch.zeros_like(weight.data)
+        for active_adapter in adapter_names:
+            new_delta += self.get_delta_weight(active_adapter).to(weight.dtype)
 
-        merged_delta = torch.zeros_like(weight.data)
-        for active_adapter in [*self.merged_adapters, *adapter_names]:
-            merged_delta += self.get_delta_weight(active_adapter).to(weight.dtype)
-
-        base_weight = self._caches["base_weight_before_merge"].to(device=weight.device, dtype=weight.dtype)
-        merged_weight = base_weight * (1 + merged_delta)
+        merged_weight = weight.data + base_weight * new_delta
         if safe_merge and not torch.isfinite(merged_weight).all():
             raise ValueError(
                 f"NaNs detected in the merged weights. The adapter {','.join(adapter_names)} seems to be broken"
@@ -102,14 +103,15 @@ class HiraLayer(BaseTunerLayer):
         weight.data.copy_(merged_weight)
         self.merged_adapters.extend(adapter_names)
 
-    def _unmerge_adapter_weights(self) -> None:
+    def _unmerge(self) -> None:
         if not self.merged:
             warnings.warn("Already unmerged. Nothing to do.")
             return
 
         weight = self.get_base_layer().weight
-        base_weight = self._caches.pop("base_weight_before_merge")
+        base_weight = self._base_weight_before_merge
         weight.data.copy_(base_weight.to(device=weight.device, dtype=weight.dtype))
+        self._base_weight_before_merge = None
         self.merged_adapters.clear()
 
     def update_layer(
@@ -196,13 +198,17 @@ class Linear(nn.Module, HiraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        self._merge_adapter_weights(safe_merge, adapter_names, self.hira_A)
+        self._merge(
+            safe_merge=safe_merge,
+            adapter_names=adapter_names,
+            available_adapters=set(self.hira_A),
+        )
 
     def unmerge(self) -> None:
         """
         This method unmerges all merged adapter layers from the base weights.
         """
-        self._unmerge_adapter_weights()
+        self._unmerge()
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
         """
@@ -337,13 +343,17 @@ class Embedding(nn.Module, HiraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        self._merge_adapter_weights(safe_merge, adapter_names, self.hira_embedding_A)
+        self._merge(
+            safe_merge=safe_merge,
+            adapter_names=adapter_names,
+            available_adapters=set(self.hira_embedding_A),
+        )
 
     def unmerge(self) -> None:
         """
         This method unmerges all merged adapter layers from the base weights.
         """
-        self._unmerge_adapter_weights()
+        self._unmerge()
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
         """
@@ -517,13 +527,17 @@ class _ConvNd(nn.Module, HiraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        self._merge_adapter_weights(safe_merge, adapter_names, self.hira_A)
+        self._merge(
+            safe_merge=safe_merge,
+            adapter_names=adapter_names,
+            available_adapters=set(self.hira_A),
+        )
 
     def unmerge(self) -> None:
         """
         This method unmerges all merged adapter layers from the base weights.
         """
-        self._unmerge_adapter_weights()
+        self._unmerge()
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
         """

--- a/src/peft/tuners/hira/layer.py
+++ b/src/peft/tuners/hira/layer.py
@@ -76,6 +76,42 @@ class HiraLayer(BaseTunerLayer):
         self.in_features = in_features
         self.out_features = out_features
 
+    def _merge_adapter_weights(
+        self, safe_merge: bool, adapter_names: Optional[list[str]], available_adapters: nn.ParameterDict
+    ) -> None:
+        adapter_names = check_adapters_to_merge(self, adapter_names)
+        adapter_names = [name for name in adapter_names if name in available_adapters]
+        if not adapter_names:
+            return
+
+        weight = self.get_base_layer().weight
+        if not self.merged_adapters:
+            self._caches["base_weight_before_merge"] = weight.data.detach().clone().cpu()
+
+        merged_delta = torch.zeros_like(weight.data)
+        for active_adapter in [*self.merged_adapters, *adapter_names]:
+            merged_delta += self.get_delta_weight(active_adapter).to(weight.dtype)
+
+        base_weight = self._caches["base_weight_before_merge"].to(device=weight.device, dtype=weight.dtype)
+        merged_weight = base_weight * (1 + merged_delta)
+        if safe_merge and not torch.isfinite(merged_weight).all():
+            raise ValueError(
+                f"NaNs detected in the merged weights. The adapter {','.join(adapter_names)} seems to be broken"
+            )
+
+        weight.data.copy_(merged_weight)
+        self.merged_adapters.extend(adapter_names)
+
+    def _unmerge_adapter_weights(self) -> None:
+        if not self.merged:
+            warnings.warn("Already unmerged. Nothing to do.")
+            return
+
+        weight = self.get_base_layer().weight
+        base_weight = self._caches.pop("base_weight_before_merge")
+        weight.data.copy_(base_weight.to(device=weight.device, dtype=weight.dtype))
+        self.merged_adapters.clear()
+
     def update_layer(
         self,
         adapter_name,
@@ -160,57 +196,13 @@ class Linear(nn.Module, HiraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        adapter_names = check_adapters_to_merge(self, adapter_names)
-        if not adapter_names:
-            # no adapter to merge
-            return
-
-        base_layer = self.get_base_layer()
-        orig_dtype = base_layer.weight.data.dtype
-
-        merged_delta = torch.zeros_like(base_layer.weight.data, dtype=orig_dtype)
-        for active_adapter in adapter_names:
-            if active_adapter in self.hira_A.keys():
-                merged_delta = merged_delta + self.get_delta_weight(active_adapter).to(orig_dtype)
-                self.merged_adapters.append(active_adapter)
-
-        if safe_merge:
-            orig_weight = base_layer.weight.data.clone()
-            merged_weight = orig_weight * (1 + merged_delta)
-
-            if not torch.isfinite(merged_weight).all():
-                raise ValueError(
-                    f"NaNs detected in the merged weights. The adapter {','.join(adapter_names)} seems to be broken"
-                )
-
-            base_layer.weight.data = merged_weight
-        else:
-            base_layer.weight.data *= 1 + merged_delta
+        self._merge_adapter_weights(safe_merge, adapter_names, self.hira_A)
 
     def unmerge(self) -> None:
         """
         This method unmerges all merged adapter layers from the base weights.
         """
-        if not self.merged:
-            warnings.warn("Already unmerged. Nothing to do.")
-            return
-        weight = self.get_base_layer().weight
-        orig_dtype = weight.dtype
-        merged_delta = torch.zeros_like(weight.data, dtype=torch.float32)
-
-        for active_adapter in self.merged_adapters:
-            if active_adapter in self.hira_A.keys():
-                merged_delta = merged_delta + self.get_delta_weight(active_adapter).to(torch.float32)
-
-        # avoid NaN error, cast to fp32
-        w32 = weight.data.to(torch.float32)
-        den32 = 1 + merged_delta
-        tiny = torch.finfo(den32.dtype).tiny  # ~1e-45 for float32
-        den32 = torch.where(den32 == 0, tiny, den32)
-        w32 = w32 / den32
-        weight.data.copy_(w32.to(orig_dtype))
-
-        self.merged_adapters.clear()
+        self._unmerge_adapter_weights()
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
         """
@@ -345,54 +337,13 @@ class Embedding(nn.Module, HiraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        adapter_names = check_adapters_to_merge(self, adapter_names)
-        if not adapter_names:
-            # no adapter to merge
-            return
-
-        base_layer = self.get_base_layer()
-        orig_dtype = base_layer.weight.dtype
-        merged_delta = torch.zeros_like(base_layer.weight.data, dtype=orig_dtype)
-
-        for active_adapter in adapter_names:
-            if active_adapter in self.hira_embedding_A.keys():
-                merged_delta = merged_delta + self.get_delta_weight(active_adapter).to(orig_dtype)
-                self.merged_adapters.append(active_adapter)
-
-        if safe_merge:
-            orig_weight = base_layer.weight.data.clone()
-            merged_weight = orig_weight * (1 + merged_delta)
-            if not torch.isfinite(merged_weight).all():
-                raise ValueError(
-                    f"NaNs detected in the merged weights. The adapter {','.join(adapter_names)} seems to be broken"
-                )
-            base_layer.weight.data = merged_weight
-        else:
-            base_layer.weight.data *= 1 + merged_delta
+        self._merge_adapter_weights(safe_merge, adapter_names, self.hira_embedding_A)
 
     def unmerge(self) -> None:
         """
         This method unmerges all merged adapter layers from the base weights.
         """
-        if not self.merged:
-            warnings.warn("Already unmerged. Nothing to do.")
-            return
-        weight = self.get_base_layer().weight
-        orig_dtype = weight.dtype
-        merged_delta = torch.zeros_like(weight.data, dtype=torch.float32)
-
-        for active_adapter in self.merged_adapters:
-            if active_adapter in self.hira_embedding_A.keys():
-                merged_delta = merged_delta + self.get_delta_weight(active_adapter).to(torch.float32)
-
-        w32 = weight.data.to(torch.float32)
-        den32 = 1 + merged_delta
-        tiny = torch.finfo(den32.dtype).tiny  # ~1e-45 for float32
-        den32 = torch.where(den32 == 0, tiny, den32)
-        w32 = w32 / den32
-        weight.data.copy_(w32.to(orig_dtype))
-
-        self.merged_adapters.clear()
+        self._unmerge_adapter_weights()
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
         """
@@ -566,58 +517,13 @@ class _ConvNd(nn.Module, HiraLayer):
                 The list of adapter names that should be merged. If None, all active adapters will be merged. Defaults
                 to `None`.
         """
-        adapter_names = check_adapters_to_merge(self, adapter_names)
-        if not adapter_names:
-            # no adapter to merge
-            return
-
-        base_layer = self.get_base_layer()
-        orig_dtype = base_layer.weight.dtype
-
-        merged_delta = torch.zeros_like(base_layer.weight.data, dtype=orig_dtype)
-
-        for active_adapter in adapter_names:
-            if active_adapter in self.hira_A.keys():
-                merged_delta = merged_delta + self.get_delta_weight(active_adapter).to(orig_dtype)
-                self.merged_adapters.append(active_adapter)
-
-        if safe_merge:
-            orig_weight = base_layer.weight.data.clone()
-            merged_weight = orig_weight * (1 + merged_delta)
-
-            if not torch.isfinite(merged_weight).all():
-                raise ValueError(
-                    f"NaNs detected in the merged weights. The adapter {','.join(adapter_names)} seems to be broken"
-                )
-
-            base_layer.weight.data = merged_weight
-
-        else:
-            base_layer.weight.data *= 1 + merged_delta.to(orig_dtype)
+        self._merge_adapter_weights(safe_merge, adapter_names, self.hira_A)
 
     def unmerge(self) -> None:
         """
         This method unmerges all merged adapter layers from the base weights.
         """
-        if not self.merged:
-            warnings.warn("Already unmerged. Nothing to do.")
-            return
-        weight = self.get_base_layer().weight
-        orig_dtype = weight.dtype
-        merged_delta = torch.zeros_like(weight.data, dtype=torch.float32)
-
-        for active_adapter in self.merged_adapters:
-            if active_adapter in self.hira_A.keys():
-                merged_delta = merged_delta + self.get_delta_weight(active_adapter).to(torch.float32)
-
-        w32 = weight.data.to(torch.float32)
-        den32 = 1 + merged_delta
-        tiny = torch.finfo(den32.dtype).tiny  # ~1e-45 for float32
-        den32 = torch.where(den32 == 0, tiny, den32)
-        w32 = w32 / den32
-        weight.data.copy_(w32.to(orig_dtype))
-
-        self.merged_adapters.clear()
+        self._unmerge_adapter_weights()
 
     def get_delta_weight(self, adapter) -> torch.Tensor:
         """

--- a/src/peft/tuners/peanut/layer.py
+++ b/src/peft/tuners/peanut/layer.py
@@ -46,7 +46,7 @@ class PeanutLayer(BaseTunerLayer):
 
         self._disable_adapters = False
         self.merged_adapters = []
-        self._cached_delta_weights = {}
+        self._base_weight_before_merge: Optional[torch.Tensor] = None
 
         base_layer = self.get_base_layer()
 
@@ -107,6 +107,12 @@ class PeanutLayer(BaseTunerLayer):
         else:
             nn.init.kaiming_uniform_(self.peanut_B[adapter_name].weight, a=math.sqrt(5))
 
+    def _get_base_weight_before_merge(self) -> torch.Tensor:
+        base_weight = self.get_base_layer().weight
+        if self._base_weight_before_merge is None:
+            self._base_weight_before_merge = base_weight.data.detach().clone().cpu()
+        return self._base_weight_before_merge.to(device=base_weight.device, dtype=base_weight.dtype)
+
 
 class Linear(nn.Module, PeanutLayer):
     # PEANuT implemented in a dense layer
@@ -164,7 +170,7 @@ class Linear(nn.Module, PeanutLayer):
             return
 
         base_layer = self.get_base_layer()
-        merge_base_weight = base_layer.weight.data.detach().clone()
+        merge_base_weight = self._get_base_weight_before_merge()
 
         for active_adapter in adapter_names:
             if active_adapter not in self.peanut_A:
@@ -187,11 +193,6 @@ class Linear(nn.Module, PeanutLayer):
                 else:
                     base_layer.weight.data.add_(delta_weight)
 
-            if delta_weight.device.type != "cpu":
-                cached_delta_weight = delta_weight.detach().to("cpu")
-            else:
-                cached_delta_weight = delta_weight.detach()
-            self._cached_delta_weights[active_adapter] = cached_delta_weight
             self.merged_adapters.append(active_adapter)
 
     def unmerge(self) -> None:
@@ -200,18 +201,11 @@ class Linear(nn.Module, PeanutLayer):
             return
 
         base_layer = self.get_base_layer()
-        while len(self.merged_adapters) > 0:
-            active_adapter = self.merged_adapters.pop()
-            if active_adapter not in self.peanut_A:
-                continue
-
-            delta_weight = self._cached_delta_weights.pop(active_adapter, None)
-            if delta_weight is None:
-                raise ValueError(f"Cached delta weight for adapter '{active_adapter}' is missing; cannot unmerge.")
-
-            base_layer.weight.data.sub_(
-                delta_weight.to(dtype=base_layer.weight.dtype, device=base_layer.weight.device)
-            )
+        base_layer.weight.data.copy_(
+            self._base_weight_before_merge.to(device=base_layer.weight.device, dtype=base_layer.weight.dtype)
+        )
+        self._base_weight_before_merge = None
+        self.merged_adapters.clear()
 
     def forward(self, x: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
         if self.disable_adapters:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1828,6 +1828,16 @@ MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES = [
     ),
 ]
 
+SEQUENTIAL_MERGE_TEST_CASES = []
+for test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2 in MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES:
+    if not test_name.endswith(" Same"):
+        continue
+    # QR is used above to amplify DEFT adapter outputs for a different assertion; use its default variant here.
+    if tuner_method == "deft":
+        config_kwargs_1 = {**config_kwargs_1, "decomposition_method": "relu"}
+        config_kwargs_2 = {**config_kwargs_2, "decomposition_method": "relu"}
+    SEQUENTIAL_MERGE_TEST_CASES.append((test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2))
+
 
 def _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs):
     if (config_cls == LoraConfig) and config_kwargs.get("target_parameters"):
@@ -4714,6 +4724,60 @@ class TestMultipleActiveAdapters:
             disabled_adapter_output = peft_model(**X)
 
         assert torch.allclose(disabled_adapter_output, base_output, atol=1e-4)
+
+    @pytest.mark.parametrize(
+        "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", SEQUENTIAL_MERGE_TEST_CASES
+    )
+    def test_sequential_merge_matches_batch_merge(
+        self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2
+    ):
+        _skip_if_merging_not_supported(test_name, config_cls, config_kwargs_1)
+        _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs_2)
+
+        torch.manual_seed(0)
+        model = self.resolve_model_cls(tuner_method).to(self.torch_device).eval()
+        config_1 = config_cls(**config_kwargs_1)
+        config_2 = config_cls(**config_kwargs_2)
+        model = get_peft_model(model, config_1, adapter_name="adapter_1").eval()
+        model.add_adapter("adapter_2", config_2)
+        sequential_model = copy.deepcopy(model)
+        X = self.prepare_inputs_for_testing()
+
+        model.merge_adapter(["adapter_1", "adapter_2"])
+        batch_output = model(**X)
+
+        sequential_model.merge_adapter(["adapter_1"])
+        sequential_model.merge_adapter(["adapter_2"])
+        sequential_output = sequential_model(**X)
+
+        assert torch.allclose(sequential_output, batch_output, atol=1e-3, rtol=1e-3)
+
+    @pytest.mark.parametrize(
+        "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", SEQUENTIAL_MERGE_TEST_CASES
+    )
+    def test_unmerge_after_sequential_merge_restores_base(
+        self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2
+    ):
+        _skip_if_merging_not_supported(test_name, config_cls, config_kwargs_1)
+        _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs_2)
+
+        torch.manual_seed(0)
+        model = self.resolve_model_cls(tuner_method).to(self.torch_device).eval()
+        X = self.prepare_inputs_for_testing()
+        base_output = model(**X)
+        config_1 = config_cls(**config_kwargs_1)
+        config_2 = config_cls(**config_kwargs_2)
+        model = get_peft_model(model, config_1, adapter_name="adapter_1").eval()
+        model.add_adapter("adapter_2", config_2)
+
+        model.merge_adapter(["adapter_1"])
+        model.merge_adapter(["adapter_2"])
+        model.unmerge_adapter()
+
+        with model.disable_adapter():
+            unmerged_output = model(**X)
+
+        assert torch.allclose(unmerged_output, base_output, atol=1e-3, rtol=1e-3)
 
     @pytest.mark.parametrize(
         "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1828,16 +1828,6 @@ MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES = [
     ),
 ]
 
-SEQUENTIAL_MERGE_TEST_CASES = []
-for test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2 in MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES:
-    if not test_name.endswith(" Same"):
-        continue
-    # QR is used above to amplify DEFT adapter outputs for a different assertion; use its default variant here.
-    if tuner_method == "deft":
-        config_kwargs_1 = {**config_kwargs_1, "decomposition_method": "relu"}
-        config_kwargs_2 = {**config_kwargs_2, "decomposition_method": "relu"}
-    SEQUENTIAL_MERGE_TEST_CASES.append((test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2))
-
 
 def _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs):
     if (config_cls == LoraConfig) and config_kwargs.get("target_parameters"):
@@ -4726,60 +4716,6 @@ class TestMultipleActiveAdapters:
         assert torch.allclose(disabled_adapter_output, base_output, atol=1e-4)
 
     @pytest.mark.parametrize(
-        "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", SEQUENTIAL_MERGE_TEST_CASES
-    )
-    def test_sequential_merge_matches_batch_merge(
-        self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2
-    ):
-        _skip_if_merging_not_supported(test_name, config_cls, config_kwargs_1)
-        _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs_2)
-
-        torch.manual_seed(0)
-        model = self.resolve_model_cls(tuner_method).to(self.torch_device).eval()
-        config_1 = config_cls(**config_kwargs_1)
-        config_2 = config_cls(**config_kwargs_2)
-        model = get_peft_model(model, config_1, adapter_name="adapter_1").eval()
-        model.add_adapter("adapter_2", config_2)
-        sequential_model = copy.deepcopy(model)
-        X = self.prepare_inputs_for_testing()
-
-        model.merge_adapter(["adapter_1", "adapter_2"])
-        batch_output = model(**X)
-
-        sequential_model.merge_adapter(["adapter_1"])
-        sequential_model.merge_adapter(["adapter_2"])
-        sequential_output = sequential_model(**X)
-
-        assert torch.allclose(sequential_output, batch_output, atol=1e-3, rtol=1e-3)
-
-    @pytest.mark.parametrize(
-        "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", SEQUENTIAL_MERGE_TEST_CASES
-    )
-    def test_unmerge_after_sequential_merge_restores_base(
-        self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2
-    ):
-        _skip_if_merging_not_supported(test_name, config_cls, config_kwargs_1)
-        _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs_2)
-
-        torch.manual_seed(0)
-        model = self.resolve_model_cls(tuner_method).to(self.torch_device).eval()
-        X = self.prepare_inputs_for_testing()
-        base_output = model(**X)
-        config_1 = config_cls(**config_kwargs_1)
-        config_2 = config_cls(**config_kwargs_2)
-        model = get_peft_model(model, config_1, adapter_name="adapter_1").eval()
-        model.add_adapter("adapter_2", config_2)
-
-        model.merge_adapter(["adapter_1"])
-        model.merge_adapter(["adapter_2"])
-        model.unmerge_adapter()
-
-        with model.disable_adapter():
-            unmerged_output = model(**X)
-
-        assert torch.allclose(unmerged_output, base_output, atol=1e-3, rtol=1e-3)
-
-    @pytest.mark.parametrize(
         "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES
     )
     def test_merge_layers_multi(self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2):
@@ -4859,6 +4795,66 @@ class TestMultipleActiveAdapters:
             outputs_merged_adapter_default = model_merged_adapter_default(**dummy_input)
 
         assert torch.allclose(outputs_merged_adapter_default, outputs_adapter_1, atol=1e-3, rtol=1e-3)
+
+    @pytest.mark.parametrize(
+        "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES
+    )
+    def test_sequential_merge_matches_batch_merge(
+        self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2
+    ):
+        _skip_if_merging_not_supported(test_name, config_cls, config_kwargs_1)
+        _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs_2)
+        if tuner_method == "deft":
+            config_kwargs_1 = {**config_kwargs_1, "decomposition_method": "relu"}
+            config_kwargs_2 = {**config_kwargs_2, "decomposition_method": "relu"}
+
+        torch.manual_seed(0)
+        model = self.resolve_model_cls(tuner_method).to(self.torch_device).eval()
+        config_1 = config_cls(**config_kwargs_1)
+        config_2 = config_cls(**config_kwargs_2)
+        model = get_peft_model(model, config_1, adapter_name="adapter_1").eval()
+        model.add_adapter("adapter_2", config_2)
+        sequential_model = copy.deepcopy(model)
+        X = self.prepare_inputs_for_testing()
+
+        model.merge_adapter(["adapter_1", "adapter_2"])
+        batch_output = model(**X)
+
+        sequential_model.merge_adapter(["adapter_1"])
+        sequential_model.merge_adapter(["adapter_2"])
+        sequential_output = sequential_model(**X)
+
+        assert torch.allclose(sequential_output, batch_output, atol=1e-3, rtol=1e-3)
+
+    @pytest.mark.parametrize(
+        "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES
+    )
+    def test_unmerge_after_sequential_merge_restores_base(
+        self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2
+    ):
+        _skip_if_merging_not_supported(test_name, config_cls, config_kwargs_1)
+        _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs_2)
+        if tuner_method == "deft":
+            config_kwargs_1 = {**config_kwargs_1, "decomposition_method": "relu"}
+            config_kwargs_2 = {**config_kwargs_2, "decomposition_method": "relu"}
+
+        torch.manual_seed(0)
+        model = self.resolve_model_cls(tuner_method).to(self.torch_device).eval()
+        X = self.prepare_inputs_for_testing()
+        base_output = model(**X)
+        config_1 = config_cls(**config_kwargs_1)
+        config_2 = config_cls(**config_kwargs_2)
+        model = get_peft_model(model, config_1, adapter_name="adapter_1").eval()
+        model.add_adapter("adapter_2", config_2)
+
+        model.merge_adapter(["adapter_1"])
+        model.merge_adapter(["adapter_2"])
+        model.unmerge_adapter()
+
+        with model.disable_adapter():
+            unmerged_output = model(**X)
+
+        assert torch.allclose(unmerged_output, base_output, atol=1e-3, rtol=1e-3)
 
 
 class MLP_2x_same_shape(nn.Module):


### PR DESCRIPTION
## Summary

- add a method-level regression matrix comparing batch and sequential merges, including unmerge restoration
- keep FRoD and PEANuT deltas anchored to the weight from before the first merge
- make HiRA apply later adapters incrementally from the same base snapshot and restore it exactly on unmerge

## Discussion

- #3472
- Maintainer approval: https://github.com/huggingface/peft/issues/3472#issuecomment-5089157613

## Tests

- `python -m pytest tests/test_custom_models.py -k "sequential_merge_matches_batch_merge or unmerge_after_sequential_merge_restores_base" -q --no-cov` (116 passed, 12 skipped)
- `python -m pytest tests/test_frod.py tests/test_custom_models.py -k "frod or peanut or hira" -q --no-cov` (1400 passed, 55 skipped)
- `python -m ruff check src tests examples docs scripts docker`
- `python -m ruff format --check src tests examples docs scripts docker`

## AI assistance disclosure

AI assistance was used to help implement and test these changes.