### PR TITLE
FIX Don't apply new adapter's inference_mode to active adapters in inject_adapter

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1053,7 +1053,14 @@ class BaseTuner(nn.Module, ABC):
         # It's important to set the adapter here (again), because otherwise it can happen that if a 2nd adapter is
         # added, and it targets different layer(s) than the first adapter (which is active), then those different
         # layers will be activated, which we don't want.
-        self.set_adapter(self.active_adapters, inference_mode=peft_config.inference_mode)
+        # Note: Don't pass peft_config.inference_mode here, as it belongs to the adapter that is being injected,
+        # whereas set_adapter acts on the currently active adapters, which don't necessarily include the new adapter.
+        # Passing it would apply the new adapter's inference_mode across adapter boundaries (see #3487). Instead,
+        # derive the inference_mode from the configs of the active adapters themselves.
+        inference_mode = all(
+            self.peft_config[active_adapter].inference_mode for active_adapter in self.active_adapters
+        )
+        self.set_adapter(self.active_adapters, inference_mode=inference_mode)
         self._mark_only_adapters_as_trainable(model)
 
         if self.peft_config[adapter_name].inference_mode:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -5178,16 +5178,8 @@ class TestRequiresGrad:
             "base_model.model.lin0.ia3_l.adapter1",
         )
 
-    @pytest.mark.xfail(strict=True)
     def test_requires_grad_adalora_different_targets(self):
         # test two different AdaLora adapters that target different modules
-
-        # Note: This test is expected to fail because first loading one adapter, then the next adapter with
-        # inference_mode=True incorrectly leads to the requires_grad of the first adapter being turned to False. This is
-        # of course not desired but has yet to be fixed. In practice, it's unlikely that a user would pass
-        # inference_mode=True for add_adapter, this flag is mostly being used when calling PeftModel.from_pretrained, so
-        # we accept this issue for now. Note that only for AdaLoRA do we even need to pass inference_mode=True here,
-        # other PEFT methods don't require this.
         config0 = AdaLoraConfig(target_modules=["lin0"], total_step=1)
         peft_model = get_peft_model(MLP(), config0)
 
@@ -5233,16 +5225,8 @@ class TestRequiresGrad:
             "base_model.model.lin1.lora_E.adapter1",
         )
 
-    @pytest.mark.xfail(strict=True)
     def test_requires_grad_adalora_same_targets(self):
         # same as previous test, except that AdaLora adapters target the same layer
-
-        # Note: This test is expected to fail because first loading one adapter, then the next adapter with
-        # inference_mode=True incorrectly leads to the requires_grad of the first adapter being turned to False. This is
-        # of course not desired but has yet to be fixed. In practice, it's unlikely that a user would pass
-        # inference_mode=True for add_adapter, this flag is mostly being used when calling PeftModel.from_pretrained, so
-        # we accept this issue for now. Note that only for AdaLoRA do we even need to pass inference_mode=True here,
-        # other PEFT methods don't require this.
         config0 = AdaLoraConfig(target_modules=["lin0"], total_step=1)
         peft_model = get_peft_model(MLP(), config0)
 
@@ -5288,6 +5272,33 @@ class TestRequiresGrad:
             "base_model.model.lin0.lora_B.adapter1",
             "base_model.model.lin0.lora_E.adapter1",
         )
+
+    def test_requires_grad_inject_adapter_does_not_change_active_adapter(self):
+        # Injecting a new adapter should not apply the new adapter's inference_mode to the already active adapter, see
+        # #3487.
+
+        # add an adapter with inference_mode=True to a model whose active adapter is trainable: the active adapter
+        # should stay trainable
+        config0 = LoraConfig(target_modules=["lin0"])
+        peft_model = get_peft_model(MLP(), config0)
+
+        config1 = LoraConfig(target_modules=["lin0"], inference_mode=True)
+        peft_model.add_adapter("adapter1", config1)
+
+        self.check_requires_grad(
+            peft_model,
+            "base_model.model.lin0.lora_A.default.weight",
+            "base_model.model.lin0.lora_B.default.weight",
+        )
+
+        # add a trainable adapter to a model whose active adapter is frozen: the active adapter should stay frozen
+        config0 = LoraConfig(target_modules=["lin0"], inference_mode=True)
+        peft_model = get_peft_model(MLP(), config0)
+        self.check_requires_grad(peft_model)
+
+        config1 = LoraConfig(target_modules=["lin0"])
+        peft_model.add_adapter("adapter1", config1)
+        self.check_requires_grad(peft_model)
 
     def test_requires_grad_lora_conv2d(self):
         # test two different LoRA adapters that target different modules
@@ -6645,9 +6656,9 @@ class TestRequiresGrad:
     @pytest.mark.parametrize("config_cls", [LoraConfig])  # no need to check each method, they all fail
     def test_loading_model_requires_grad_set_correctly_switch_inference_mode(self, config_cls, tmp_path):
         # Same as test_loading_model_requires_grad_set_correctly but this time we first load with is_trainable=False and
-        # then with is_trainable=True. Loading the second adapter should not affect the requires_grad of the first
-        # adapter, but it does. The reason is that is_training/inference_mode is taken from the current PEFT config, but
-        # that config does not necessarily belong to the active adapter, creating a mismatch.
+        # then with is_trainable=True. Loading the second adapter no longer affects the requires_grad of the first
+        # adapter (see #3487), but the second adapter, which is not automatically activated, is loaded frozen despite
+        # is_trainable=True, since requires_grad currently follows the active adapters.
         # When/If this is fixed, the check can be integrated into test_loading_model_requires_grad_set_correctly and
         # this test can be deleted.
         model = DeepMLP(size=256)  # a size that works with all adapters
@@ -6671,14 +6682,10 @@ class TestRequiresGrad:
         # this fails, instead with get ...lora_A.default.weight and ...lora_B.default.weight
         assert params_with_grad == expected
 
-    @pytest.mark.xfail(strict=True)
-    @pytest.mark.parametrize("config_cls", [LoraConfig])  # no need to check each method, they all fail
+    @pytest.mark.parametrize("config_cls", [LoraConfig])  # no need to check each method
     def test_loading_model_requires_grad_load_adapter_then_add_adapter(self, config_cls, tmp_path):
-        # When adding a new adapter with model.add_adapter, through the set_adapter call in update_layer, we activate
-        # the gradients of the first adapter, even if it's not desired. Since there is no is_trainable argument on
-        # add_adapter, there is no way to disable that at the moment.
-        # When/If this is fixed, the check can be integrated into test_loading_model_requires_grad_set_correctly and
-        # this test can be deleted.
+        # Adding a new adapter with model.add_adapter should not activate the gradients of the first, frozen adapter
+        # (see #3487).
         model = DeepMLP(size=256)  # a size that works with all adapters
         extra_kwargs = {}
         config = config_cls(target_modules=["layers.0.lin0"])


### PR DESCRIPTION
Fixes #3487, reported by @DaoyuanLi2816.

`BaseTuner.inject_adapter`'s housekeeping step called `self.set_adapter(self.active_adapters, inference_mode=peft_config.inference_mode)`, where `peft_config` belongs to the adapter being injected but `active_adapters` usually names different adapters. Adding a frozen adapter therefore froze the active trainable one, and adding a trainable adapter un-froze a deliberately frozen one.

The fix derives the `inference_mode` passed to `set_adapter` from the active adapters' own configs instead of the new adapter's config, keeping each adapter's trainability scoped to its own settings. A freeze-all-then-re-enable approach was rejected because tuners like UniLoRA keep trainable params outside `adapter_layer_names` and only handle them in their `set_adapter` override; the committed single-call approach avoids that class of gaps.

Three of the four strict-xfail tests tracking this now pass and were converted to regular tests, plus a new two-adapter differing-inference_mode regression test. The fourth xfail remains: it additionally expects a non-active adapter loaded with `is_trainable=True` to become trainable, a separate semantic that contradicts currently-passing tests. Relevant classes: 343 passed with a failure list byte-identical to the pre-existing (AdaMSS-related, unrelated) baseline. `make style` clean.
