### PR TITLE
TST Add regression tests for PEFT checkpoint loading

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -633,15 +633,15 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         def is_shared_parameter(k):
             # TinyLoRA: layer-level tinylora_v is a reference to model-level, exclude from warning
             if "vblora_vector_bank" in k or "prompt_encoder" in k or ".tinylora_v." in k:
-                return False
+                return True
 
-            return not (
+            return (
                 config.peft_type == PeftType.UNILORA
                 and ".unilora_theta_d." in k
                 and not k.startswith("base_model.unilora_theta_d.")
             )
 
-        missing_keys = [k for k in load_result.missing_keys if is_shared_parameter(k)]
+        missing_keys = [k for k in load_result.missing_keys if not is_shared_parameter(k)]
         if missing_keys:
             # Let's warn here since (in contrast to load_adapter) we don't return the load result, so it could be quite
             # difficult for users to even notice that something might have gone wrong here. As we filter out non PEFT

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -630,7 +630,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         # 1. Remove VB-LoRA vector bank, since it's a shared parameter set via the VBLoRAModel
         # 2. Remove the prompt encoder, as it does not need to be part of the checkpoint
         # 3. Remove TinyLoRA layer-level tinylora_v references (they share with model-level tinylora_v)
-        def is_expected_missing_key(k):
+        def is_shared_parameter(k):
             # TinyLoRA: layer-level tinylora_v is a reference to model-level, exclude from warning
             if "vblora_vector_bank" in k or "prompt_encoder" in k or ".tinylora_v." in k:
                 return False
@@ -641,7 +641,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 and not k.startswith("base_model.unilora_theta_d.")
             )
 
-        missing_keys = [k for k in load_result.missing_keys if is_expected_missing_key(k)]
+        missing_keys = [k for k in load_result.missing_keys if is_shared_parameter(k)]
         if missing_keys:
             # Let's warn here since (in contrast to load_adapter) we don't return the load result, so it could be quite
             # difficult for users to even notice that something might have gone wrong here. As we filter out non PEFT

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -634,16 +634,11 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             # TinyLoRA: layer-level tinylora_v is a reference to model-level, exclude from warning
             if "vblora_vector_bank" in k or "prompt_encoder" in k or ".tinylora_v." in k:
                 return False
-            if (
+
+            return not (
                 config.peft_type == PeftType.UNILORA
                 and ".unilora_theta_d." in k
                 and not k.startswith("base_model.unilora_theta_d.")
-            ):
-                return False
-            return not (
-                config.peft_type == PeftType.UNILORA
-                and not getattr(config, "save_indices", False)
-                and (".unilora_indices_" in k or ".unilora_scales_" in k)
             )
 
         missing_keys = [k for k in load_result.missing_keys if is_expected_missing_key(k)]
@@ -1509,12 +1504,6 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     tuner == PeftType.UNILORA
                     and ".unilora_theta_d." in key
                     and not key.startswith("base_model.unilora_theta_d.")
-                ):
-                    continue
-                if (
-                    tuner == PeftType.UNILORA
-                    and not getattr(self.peft_config[adapter_name], "save_indices", False)
-                    and (".unilora_indices_" in key or ".unilora_scales_" in key)
                 ):
                     continue
                 adapter_missing_keys.append(key)

--- a/src/peft/tuners/tinylora/layer.py
+++ b/src/peft/tuners/tinylora/layer.py
@@ -152,6 +152,10 @@ class TinyLoraLayer(BaseTunerLayer):
         inference_mode = config.inference_mode
         fan_in_fan_out = config.fan_in_fan_out
 
+        # The projection tensors P are only part of the checkpoint if save_projection is set, otherwise they are
+        # regenerated from the projection seed when loading.
+        self.tinylora_P.persistent = config.save_projection
+
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
         if u <= 0:

--- a/src/peft/tuners/unilora/layer.py
+++ b/src/peft/tuners/unilora/layer.py
@@ -23,6 +23,8 @@ from peft.tuners._buffer_dict import BufferDict
 from peft.tuners.tuners_utils import BaseTunerLayer, _get_in_out_features, check_adapters_to_merge
 from peft.utils.other import transpose
 
+from .config import UniLoraConfig
+
 
 class UniLoraLayer(BaseTunerLayer):
     other_param_names = (
@@ -67,23 +69,30 @@ class UniLoraLayer(BaseTunerLayer):
         self,
         adapter_name: str,
         unilora_theta_d,
-        r: int,
-        theta_d_length: int,
-        unilora_dropout: float = 0.0,
+        config: UniLoraConfig,
     ):
+        r = config.r
         if r <= 0:
             raise ValueError(f"`r` {r} should be a positive integer value")
 
         self.r[adapter_name] = r
 
-        if unilora_dropout > 0.0:
-            unilora_dropout_layer = nn.Dropout(p=unilora_dropout)
+        # The indices and scales are only part of the checkpoint if save_indices is set, otherwise they are regenerated
+        # when loading. Align the persistence of the buffers accordingly, so that the state_dict only contains entries
+        # that are actually meant to be saved and restored.
+        self.unilora_indices_A.persistent = config.save_indices
+        self.unilora_indices_B.persistent = config.save_indices
+        self.unilora_scales_A.persistent = config.save_indices
+        self.unilora_scales_B.persistent = config.save_indices
+
+        if config.unilora_dropout > 0.0:
+            unilora_dropout_layer = nn.Dropout(p=config.unilora_dropout)
         else:
             unilora_dropout_layer = nn.Identity()
         self.unilora_dropout.update(nn.ModuleDict({adapter_name: unilora_dropout_layer}))
 
         self.unilora_theta_d = unilora_theta_d
-        self.reset_unilora_parameters(adapter_name, theta_d_length)
+        self.reset_unilora_parameters(adapter_name, config.theta_d_length)
         self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters)
 
@@ -143,9 +152,7 @@ class Linear(nn.Linear, UniLoraLayer):
         base_layer,
         unilora_theta_d,
         adapter_name: str,
-        r: int,
-        theta_d_length: int,
-        unilora_dropout: float = 0.0,
+        config: UniLoraConfig,
         fan_in_fan_out: bool = False,
         is_target_conv_1d_layer: bool = False,
         **kwargs,
@@ -154,13 +161,7 @@ class Linear(nn.Linear, UniLoraLayer):
         UniLoraLayer.__init__(self, base_layer, **kwargs)
         self.fan_in_fan_out = fan_in_fan_out
         self._active_adapter = adapter_name
-        self.update_layer(
-            adapter_name,
-            unilora_theta_d,
-            r,
-            theta_d_length,
-            unilora_dropout,
-        )
+        self.update_layer(adapter_name, unilora_theta_d, config)
         self.is_target_conv_1d_layer = is_target_conv_1d_layer
 
     def supports_lora_conversion(self, adapter_name: str = "default") -> bool:

--- a/src/peft/tuners/unilora/model.py
+++ b/src/peft/tuners/unilora/model.py
@@ -188,9 +188,7 @@ class UniLoraModel(BaseTuner):
             target.update_layer(
                 adapter_name=adapter_name,
                 unilora_theta_d=self.unilora_theta_d,
-                r=unilora_config.r,
-                theta_d_length=unilora_config.theta_d_length,
-                unilora_dropout=unilora_config.unilora_dropout,
+                config=unilora_config,
             )
         else:
             new_module = self._create_new_module(
@@ -235,8 +233,6 @@ class UniLoraModel(BaseTuner):
             base_layer=target,
             unilora_theta_d=unilora_theta_d,
             adapter_name=adapter_name,
-            r=unilora_config.r,
-            theta_d_length=unilora_config.theta_d_length,
-            unilora_dropout=unilora_config.unilora_dropout,
+            config=unilora_config,
             **kwargs,
         )

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -843,6 +843,17 @@ def set_peft_model_state_dict(
                     " PRNG initialisation to restore these projections using `config.projection_prng_key`, which may"
                     " not be accurate on all system configurations."
                 )
+
+            if "base_model.vera_A" in peft_model_state_dict:
+                # The projections are shared between the layers and stored on the model itself, so their keys don't
+                # contain the parameter prefix and were thus not remapped by _insert_adapter_name_into_state_dict.
+                # Without inserting the adapter name here, they would not be restored by load_state_dict below.
+                peft_model_state_dict[f"base_model.vera_A.{adapter_name}"] = peft_model_state_dict.pop(
+                    "base_model.vera_A"
+                )
+                peft_model_state_dict[f"base_model.vera_B.{adapter_name}"] = peft_model_state_dict.pop(
+                    "base_model.vera_B"
+                )
         elif config.peft_type == PeftType.TINYLORA:
             has_projection = any(".tinylora_P." in k for k in peft_model_state_dict)
             if config.save_projection and not has_projection:
@@ -878,6 +889,17 @@ def set_peft_model_state_dict(
                     "Specified to not load pvera_A and pvera_B from state dictionary. This means we will be relying on"
                     " PRNG initialisation to restore these projections using `config.projection_prng_key`, which may"
                     " not be accurate on all system configurations."
+                )
+
+            if "base_model.pvera_A" in peft_model_state_dict:
+                # The projections are shared between the layers and stored on the model itself, so their keys don't
+                # contain the parameter prefix and were thus not remapped by _insert_adapter_name_into_state_dict.
+                # Without inserting the adapter name here, they would not be restored by load_state_dict below.
+                peft_model_state_dict[f"base_model.pvera_A.{adapter_name}"] = peft_model_state_dict.pop(
+                    "base_model.pvera_A"
+                )
+                peft_model_state_dict[f"base_model.pvera_B.{adapter_name}"] = peft_model_state_dict.pop(
+                    "base_model.pvera_B"
                 )
         elif config.peft_type == PeftType.FROD:
             has_projection = any(

--- a/tests/regression/test_state_dict.py
+++ b/tests/regression/test_state_dict.py
@@ -110,6 +110,7 @@ from peft import (
     WaveFTConfig,
     get_peft_model,
 )
+from peft.tuners.tuners_utils import BaseTunerLayer
 
 
 def strtobool(val):
@@ -400,8 +401,16 @@ def build_base_model(model_cls_name, model_id):
     return model
 
 
+def _deterministic_fill(tensor, name):
+    # Even if the RNG is not stable between torch releases, this is fine, as we only test that the weights can be loaded
+    # correctly, it doesn't really matter under which RNG they were created.
+    generator = torch.Generator().manual_seed(zlib.crc32(name.encode("utf-8")))
+    values = torch.rand(tensor.shape, generator=generator, dtype=torch.float32) * 0.2 - 0.1
+    tensor.copy_(values.to(dtype=tensor.dtype))
+
+
 def fill_trainable_params(model):
-    """Overwrite all trainable parameters with deterministic values (simulates training).
+    """Overwrite all trainable parameters and persistent adapter buffers with deterministic values.
 
     The values are derived from the parameter name, so that they depend neither on the order of iteration nor on the
     global RNG state. Why this approach:
@@ -420,14 +429,36 @@ def fill_trainable_params(model):
     """
     with torch.no_grad():
         for name, param in model.named_parameters():
-            if not param.requires_grad:
-                continue
+            if param.requires_grad:
+                _deterministic_fill(param, name)
 
-            # Even if RNG is not stable between torch releases, this is fine, as we only test that the weights can be
-            # loaded correctly, it doesn't really matter under which RNG they were created.
-            generator = torch.Generator().manual_seed(zlib.crc32(name.encode("utf-8")))
-            values = torch.rand(param.shape, generator=generator, dtype=torch.float32) * 0.2 - 0.1
-            param.copy_(values.to(dtype=param.dtype))
+        # Additionally fill the adapter buffers declared in other_param_names, e.g. the shared projections of VeRA.
+        # They are not trained, but if they are part of the checkpoint, their restoration needs to be verified as well:
+        # they are typically generated from a fixed random seed, so on the same machine, a failure to restore them would
+        # otherwise be masked by the identical re-generated values. Only persistent buffers are filled, as
+        # non-persistent ones (e.g. projections with save_projection=False) are meant to be re-generated instead of
+        # restored, and only float buffers, as integer buffers like indices cannot hold arbitrary values. Note that a
+        # buffer shared between layers (like the VeRA projections, which each layer holds a reference to) is yielded
+        # only once by named_buffers, which de-duplicates by storage, so it is filled exactly once, under a
+        # deterministic name.
+        buffer_prefixes = set()
+        for module_name, module in model.named_modules():
+            if not isinstance(module, BaseTunerLayer):
+                continue
+            for attr_name in module.other_param_names:
+                buffer_prefixes.add(f"{module_name}.{attr_name}" if module_name else attr_name)
+
+        # note: torch's state_dict is used to determine persistence, not get_peft_model_state_dict, so this check does
+        # not depend on the very code that this test is supposed to verify
+        state_dict_keys = set(model.state_dict().keys())
+        for name, buffer in model.named_buffers():
+            if not buffer.dtype.is_floating_point:
+                continue
+            if name not in state_dict_keys:  # non-persistent
+                continue
+            if not any((name == prefix) or name.startswith(prefix + ".") for prefix in buffer_prefixes):
+                continue
+            _deterministic_fill(buffer, name)
 
 
 def get_output(model, inputs):

--- a/tests/regression/test_state_dict.py
+++ b/tests/regression/test_state_dict.py
@@ -53,6 +53,7 @@ import tempfile
 import zlib
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 import pytest
 import torch
@@ -194,11 +195,11 @@ class Case:
     config_kwargs: dict
     model_id: str = MODEL_OPT
     model_cls: str = "AutoModelForCausalLM"
-    inputs: dict = field(default_factory=lambda: INPUTS_DECODER)
+    inputs: dict = field(default_factory=lambda: dict(INPUTS_DECODER))
     atol: float = 1e-6
     rtol: float = 1e-6
     # special creation flows that go beyond get_peft_model + save_pretrained
-    variant: str | None = None  # None | "multi_adapter" | "pissa_conversion"
+    variant: None | Literal["multi_adapter", "pissa_conversion"] = None
     notes: str = ""
 
 
@@ -451,10 +452,15 @@ def create_artifact(case, case_dir, tmp_path):
         save_kwargs["path_initial_model_for_weight_conversion"] = init_dir
     elif case.variant == "multi_adapter":
         # A second adapter is present in the model but not saved; its weights must not leak into the checkpoint.
-        model.add_adapter("other", case.config_cls(**case.config_kwargs))
-        save_kwargs["selected_adapters"] = ["default"]
+        model.add_adapter("default2", case.config_cls(**case.config_kwargs))
+        model.base_model.set_adapter(["default", "default2"])  # make both trainable so that their weights are altered
+        save_kwargs["selected_adapters"] = ["default"]  # we're only interested in saving and loading 'default'
 
     fill_trainable_params(model)
+
+    if case.variant == "multi_adapter":
+        model.base_model.set_adapter(["default"])  # for generating outputs, switch back to 'default'
+
     logits = get_output(model, case.inputs)
 
     assert torch.isfinite(logits).all(), "the model output must be finite"

--- a/tests/regression/test_state_dict.py
+++ b/tests/regression/test_state_dict.py
@@ -35,9 +35,10 @@
 #
 # `HF_TOKEN=<token> REGRESSION_CREATION_MODE=True pytest tests/regression/test_state_dict.py --regression`
 #
-# This will fail if the git worktree is dirty, to ensure that possibly buggy states are not "blessed" as the
-# reference; override with REGRESSION_FORCE_MODE=True if you know what you're doing. The commit that created the
-# artifacts is recorded in their manifest.json.
+# This will fail if the git worktree is dirty, to ensure that possibly buggy states are not "blessed" as the reference;
+# override with REGRESSION_FORCE_MODE=True if you know what you're doing. The commit that created the artifacts is
+# recorded in their manifest.json. Tip: A fake HF_TOKEN can be used to test the creation mode without actually uploading
+# anything.
 #
 # The token requires write access to the repo below. With `-k`, only the selected cases are created and uploaded,
 # leaving the other artifacts on the Hub untouched. This is also the way to go when a change to PEFT intentionally
@@ -209,8 +210,6 @@ class Case:
     model_id: str = MODEL_OPT
     model_cls: str = "AutoModelForCausalLM"
     inputs: dict = field(default_factory=lambda: dict(INPUTS_DECODER))
-    atol: float = 1e-6
-    rtol: float = 1e-6
     # special creation flows that go beyond get_peft_model + save_pretrained
     variant: None | Literal["multi_adapter", "pissa_conversion"] = None
     notes: str = ""
@@ -307,8 +306,6 @@ CASES = [
         "lora_pissa_conversion",
         LoraConfig,
         {"task_type": "CAUSAL_LM", "r": 8, "init_lora_weights": "pissa", "target_modules": ["q_proj", "v_proj"]},
-        atol=1e-5,
-        rtol=1e-4,
         variant="pissa_conversion",
         notes="saved via path_initial_model_for_weight_conversion, loadable as a plain LoRA on the unmutated base",
     ),
@@ -382,8 +379,6 @@ CASES = [
         "vblora_topk",
         VBLoRAConfig,
         {"task_type": "CAUSAL_LM", "vector_length": 1, "num_vectors": 2, "save_only_topk_weights": True},
-        atol=1e-5,
-        rtol=1e-4,
         notes="topk saving is intentionally lossy, the logits are reconstructed from topk weights when loading",
     ),
     Case(
@@ -481,10 +476,13 @@ def fill_trainable_params(model):
         state_dict_keys = set(model.state_dict().keys())
         for name, buffer in model.named_buffers():
             if not buffer.dtype.is_floating_point:
+                # don't randomize tensors containing indices etc., as they cannot be safely randomized
                 continue
             if name not in state_dict_keys:  # non-persistent
                 continue
             if not any((name == prefix) or name.startswith(prefix + ".") for prefix in buffer_prefixes):
+                # only include buffers listed in `other_param_names` as we assume those contain all relevant buffers; we
+                # test elsewhere that `other_param_names` is complete
                 continue
             _deterministic_fill(buffer, name)
 
@@ -549,8 +547,6 @@ def create_artifact(case, case_dir, tmp_path):
         "base_model_id": case.model_id,
         "model_cls": case.model_cls,
         "inputs": case.inputs,
-        "atol": case.atol,
-        "rtol": case.rtol,
         "state_dict_keys": sorted(state_dict.keys()),
         "notes": case.notes,
     }
@@ -583,8 +579,8 @@ class TestCreateArtifacts:
             model = load_model_from_artifact(case_dir, manifest)
             expected = safe_load_file(case_dir / MODEL_OUTPUT_FILENAME)["logits"]
             logits = get_output(model, case.inputs)
-            # defensively use small tolerances for non-deterministic outputs
-            torch.testing.assert_close(logits, expected, atol=case.atol, rtol=case.rtol)
+            # defensively use small tolerances in case non-deterministic functions are used by the model
+            torch.testing.assert_close(logits, expected)
         except Exception:
             # don't leave partial artifacts behind, they would be uploaded at the end of the session
             shutil.rmtree(case_dir, ignore_errors=True)
@@ -606,7 +602,7 @@ class TestStateDictRegression:
         model = load_model_from_artifact(case_dir, manifest)
         logits = get_output(model, manifest["inputs"])
         expected = safe_load_file(case_dir / MODEL_OUTPUT_FILENAME)["logits"]
-        torch.testing.assert_close(logits, expected, atol=manifest["atol"], rtol=manifest["rtol"])
+        torch.testing.assert_close(logits, expected)
 
     @pytest.mark.parametrize("case", CASES, ids=CASE_IDS)
     def test_load_with_different_adapter_name(self, case):
@@ -616,7 +612,7 @@ class TestStateDictRegression:
         model = load_model_from_artifact(case_dir, manifest, adapter_name="other")
         logits = get_output(model, manifest["inputs"])
         expected = safe_load_file(case_dir / MODEL_OUTPUT_FILENAME)["logits"]
-        torch.testing.assert_close(logits, expected, atol=manifest["atol"], rtol=manifest["rtol"])
+        torch.testing.assert_close(logits, expected)
 
     @pytest.mark.parametrize("case", CASES, ids=CASE_IDS)
     def test_save_load_roundtrip(self, case, tmp_path):
@@ -634,7 +630,5 @@ class TestStateDictRegression:
             torch.testing.assert_close(
                 new_state_dict[key],
                 old_state_dict[key],
-                atol=manifest["atol"],
-                rtol=manifest["rtol"],
                 msg=lambda m, key=key: f"Mismatch in key {key}:\n{m}",
             )

--- a/tests/regression/test_state_dict.py
+++ b/tests/regression/test_state_dict.py
@@ -348,7 +348,7 @@ CASES = [
     ),
     Case("prefix_tuning", PrefixTuningConfig, {"task_type": "CAUSAL_LM", "num_virtual_tokens": 10}),
     Case(
-        "prefix_tuning",
+        "prefix_tuning_gemma4",
         PrefixTuningConfig,
         {"task_type": "CAUSAL_LM", "num_virtual_tokens": 10},
         model_id=MODEL_GEMMA4,

--- a/tests/regression/test_state_dict.py
+++ b/tests/regression/test_state_dict.py
@@ -132,7 +132,8 @@ REGRESSION_DIR = tempfile.mkdtemp(prefix="peft_state_dict_regression_")
 
 
 def check_clean_git_status(force):
-    """Ensure that the worktree is not dirty, so that possibly buggy code states are not "blessed" as the reference.
+    """Ensure that the worktree is not dirty and that we're on main, so that possibly buggy code states are not
+    "blessed" as the reference.
 
     In contrast to test_regression.py, there is no check for a tagged release, as the artifacts are typically created
     from a clean main commit right before a refactoring, not from a release. The manifest records the exact commit.
@@ -145,6 +146,13 @@ def check_clean_git_status(force):
         else:
             raise RuntimeError("Git worktree is dirty") from exc
 
+    branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True).strip()
+    if branch != "main":
+        if force:
+            print(f"Overriding despite being on branch '{branch}' instead of main", file=sys.stderr)
+        else:
+            raise RuntimeError(f"Not on main branch (currently on '{branch}')")
+
 
 def get_git_commit():
     try:
@@ -154,7 +162,7 @@ def get_git_commit():
 
 
 MANIFEST_NAME = "manifest.json"
-OUTPUT_NAME = "output.safetensors"
+MODEL_OUTPUT_FILENAME = "output.safetensors"
 ADAPTER_WEIGHTS_NAME = "adapter_model.safetensors"
 
 MODEL_OPT = "peft-internal-testing/tiny-random-OPTForCausalLM"
@@ -325,7 +333,7 @@ CASES = [
     Case("psoft", PsoftConfig, {"task_type": "CAUSAL_LM", "r": 4, "psoft_alpha": 4}),
     Case("pvera", PveraConfig, {"task_type": "CAUSAL_LM", "r": 8}),
     Case("randlora", RandLoraConfig, {"target_modules": ["q_proj", "v_proj"], "r": 4}),
-    Case("road", RoadConfig, {"task_type": "CAUSAL_LM", "variant": "road_1", "group_size": 2}),
+    Case("road", RoadConfig, {"task_type": "CAUSAL_LM", "group_size": 2}),
     Case("shira", ShiraConfig, {"task_type": "CAUSAL_LM", "r": 1, "init_weights": False}),
     Case("tinylora", TinyLoraConfig, {"task_type": "CAUSAL_LM"}),
     Case(
@@ -489,7 +497,7 @@ def create_artifact(case, case_dir, tmp_path):
     }
     with open(case_dir / MANIFEST_NAME, "w") as f:
         json.dump(manifest, f, indent=2)
-    safe_save_file({"logits": logits}, case_dir / OUTPUT_NAME)
+    safe_save_file({"logits": logits}, case_dir / MODEL_OUTPUT_FILENAME)
     return manifest
 
 
@@ -514,8 +522,9 @@ class TestCreateArtifacts:
 
             # sanity check: the artifact must be restorable by the version that created it
             model = load_model_from_artifact(case_dir, manifest)
-            expected = safe_load_file(case_dir / OUTPUT_NAME)["logits"]
+            expected = safe_load_file(case_dir / MODEL_OUTPUT_FILENAME)["logits"]
             logits = get_output(model, case.inputs)
+            # defensively use small tolerances for non-deterministic outputs
             torch.testing.assert_close(logits, expected, atol=case.atol, rtol=case.rtol)
         except Exception:
             # don't leave partial artifacts behind, they would be uploaded at the end of the session
@@ -537,7 +546,7 @@ class TestStateDictRegression:
         manifest = self.load_manifest(case_dir)
         model = load_model_from_artifact(case_dir, manifest)
         logits = get_output(model, manifest["inputs"])
-        expected = safe_load_file(case_dir / OUTPUT_NAME)["logits"]
+        expected = safe_load_file(case_dir / MODEL_OUTPUT_FILENAME)["logits"]
         torch.testing.assert_close(logits, expected, atol=manifest["atol"], rtol=manifest["rtol"])
 
     @pytest.mark.parametrize("case", CASES, ids=CASE_IDS)
@@ -547,7 +556,7 @@ class TestStateDictRegression:
         manifest = self.load_manifest(case_dir)
         model = load_model_from_artifact(case_dir, manifest, adapter_name="other")
         logits = get_output(model, manifest["inputs"])
-        expected = safe_load_file(case_dir / OUTPUT_NAME)["logits"]
+        expected = safe_load_file(case_dir / MODEL_OUTPUT_FILENAME)["logits"]
         torch.testing.assert_close(logits, expected, atol=manifest["atol"], rtol=manifest["rtol"])
 
     @pytest.mark.parametrize("case", CASES, ids=CASE_IDS)

--- a/tests/regression/test_state_dict.py
+++ b/tests/regression/test_state_dict.py
@@ -169,6 +169,10 @@ ADAPTER_WEIGHTS_NAME = "adapter_model.safetensors"
 MODEL_OPT = "peft-internal-testing/tiny-random-OPTForCausalLM"
 MODEL_LLAMA = "trl-internal-testing/tiny-random-LlamaForCausalLM"
 MODEL_T5 = "peft-internal-testing/tiny-random-T5ForConditionalGeneration-calibrated"
+# decoder model with a more exotic architecture than opt
+MODEL_GEMMA4 = "peft-internal-testing/tiny-random-gemma4-E2B"
+# model for targeting MoE parameters
+MODEL_GPTOSS = "trl-internal-testing/tiny-GptOssForCausalLM"
 
 MODEL_CLASSES = {
     "AutoModelForCausalLM": AutoModelForCausalLM,
@@ -265,7 +269,25 @@ CASES = [
     ),
     Case("loha", LoHaConfig, {"target_modules": ["q_proj", "v_proj"]}),
     Case("lokr", LoKrConfig, {"target_modules": ["q_proj", "v_proj"]}),
-    Case("lora", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "lora_alpha": 32}),
+    Case("lora", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "lora_alpha": 16}),
+    Case("lora_rslora", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "use_rslora": True}),
+    Case(
+        "lora_rank_alpha_pattern",
+        LoraConfig,
+        {
+            "task_type": "CAUSAL_LM",
+            "r": 8,
+            "rank_pattern": {"layers.1.self_attn.k_proj": 16, "layers.2.self_attn.k_proj": 32},
+            "alpha_pattern": {"layers.2.self_attn.k_proj": 4, "layers.3.self_attn.k_proj": 16},
+        },
+    ),
+    Case("lora_gemma4", LoraConfig, {"task_type": "CAUSAL_LM"}, model_id=MODEL_GEMMA4),
+    Case(
+        "lora_gptoss",
+        LoraConfig,
+        {"task_type": "CAUSAL_LM", "target_parameters": ["mlp.experts.down_proj", "mlp.experts.gate_up_proj"]},
+        model_id=MODEL_GPTOSS,
+    ),
     Case("lora_alora", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "alora_invocation_tokens": [1]}),
     Case("lora_bias_all", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "bias": "all"}),
     Case("lora_dora", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "use_dora": True}),
@@ -325,6 +347,12 @@ CASES = [
         inputs={**INPUTS_SEQ2SEQ, "task_ids": [0, 1]},
     ),
     Case("prefix_tuning", PrefixTuningConfig, {"task_type": "CAUSAL_LM", "num_virtual_tokens": 10}),
+    Case(
+        "prefix_tuning",
+        PrefixTuningConfig,
+        {"task_type": "CAUSAL_LM", "num_virtual_tokens": 10},
+        model_id=MODEL_GEMMA4,
+    ),
     Case(
         "prompt_encoder",
         PromptEncoderConfig,

--- a/tests/regression/test_state_dict.py
+++ b/tests/regression/test_state_dict.py
@@ -1,0 +1,566 @@
+# Copyright 2026-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# State dict regression testing: check that adapter checkpoints can be saved and restored consistently across PEFT
+# versions. In contrast to test_regression.py, which checks numerical outputs of specific methods, this suite covers
+# (almost) all PEFT methods and focuses on the serialization contract: the set of keys in the saved state dict,
+# restoration of the model from the checkpoint, independence of the adapter name, and roundtrip stability of
+# save -> load -> save.
+#
+# Run this only if there is a change affecting the saving and loading logic that could invalidate existing
+# checkpoints. There is no need to run it on a regular basis. Remember to add new PEFT methods to the test cases if they
+# should be covered.
+#
+# To verify the current code against the stored artifacts, run:
+#
+# `pytest tests/regression/test_state_dict.py --regression`
+#
+# The artifacts are downloaded from the Hub on a per-test-case basis, so `-k` can be used to only download and check a
+# subset, e.g. `-k lora`. The artifact of each case is a `save_pretrained` output plus a manifest with the expected
+# state dict keys and metadata, and the model output on a fixed input.
+#
+# To create and upload new regression artifacts (this will overwrite the existing ones, so only do this when the
+# current state dict format is considered correct), run:
+#
+# `HF_TOKEN=<token> REGRESSION_CREATION_MODE=True pytest tests/regression/test_state_dict.py --regression`
+#
+# This will fail if the git worktree is dirty, to ensure that possibly buggy states are not "blessed" as the
+# reference; override with REGRESSION_FORCE_MODE=True if you know what you're doing. The commit that created the
+# artifacts is recorded in their manifest.json.
+#
+# The token requires write access to the repo below. With `-k`, only the selected cases are created and uploaded,
+# leaving the other artifacts on the Hub untouched. This is also the way to go when a change to PEFT intentionally
+# alters the saved state dict of a method (e.g. a bug fix that removes keys that were never needed): once the new
+# format is considered correct, re-create the artifacts of the affected cases.
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zlib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import torch
+import transformers
+from huggingface_hub import snapshot_download, upload_folder
+from safetensors.torch import load_file as safe_load_file
+from safetensors.torch import save_file as safe_save_file
+from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM
+
+import peft
+from peft import (
+    AdaLoraConfig,
+    AdamssConfig,
+    AdaptionPromptConfig,
+    BeftConfig,
+    BOFTConfig,
+    C3AConfig,
+    CartridgeConfig,
+    CPTConfig,
+    DeftConfig,
+    DeloraConfig,
+    FourierFTConfig,
+    FrodConfig,
+    GloraConfig,
+    GraloraConfig,
+    HiraConfig,
+    HRAConfig,
+    IA3Config,
+    LilyConfig,
+    LNTuningConfig,
+    LoHaConfig,
+    LoKrConfig,
+    LoraConfig,
+    MissConfig,
+    MultitaskPromptTuningConfig,
+    OFTConfig,
+    OSFConfig,
+    PeanutConfig,
+    PeftModel,
+    PolyConfig,
+    PrefixTuningConfig,
+    PromptEncoderConfig,
+    PromptTuningConfig,
+    PsoftConfig,
+    PveraConfig,
+    RandLoraConfig,
+    RoadConfig,
+    ShiraConfig,
+    TinyLoraConfig,
+    TrainableTokensConfig,
+    UniLoraConfig,
+    VBLoRAConfig,
+    VeraConfig,
+    WaveFTConfig,
+    get_peft_model,
+)
+
+
+def strtobool(val):
+    """Copied from distutils.util"""
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
+
+
+# the repo has to be created manually once, it is not automatically created
+HF_REPO = "peft-internal-testing/regression-tests-state-dict"
+HF_TOKEN = os.environ.get("HF_TOKEN")
+CREATION_MODE = strtobool(os.environ.get("REGRESSION_CREATION_MODE", "0"))
+FORCE_MODE = strtobool(os.environ.get("REGRESSION_FORCE_MODE", "0"))
+REGRESSION_DIR = tempfile.mkdtemp(prefix="peft_state_dict_regression_")
+
+
+def check_clean_git_status(force):
+    """Ensure that the worktree is not dirty, so that possibly buggy code states are not "blessed" as the reference.
+
+    In contrast to test_regression.py, there is no check for a tagged release, as the artifacts are typically created
+    from a clean main commit right before a refactoring, not from a release. The manifest records the exact commit.
+    """
+    try:
+        subprocess.check_output(["git", "diff", "--quiet", "HEAD"])
+    except subprocess.CalledProcessError as exc:
+        if force:
+            print("Overriding despite dirty git worktree", file=sys.stderr)
+        else:
+            raise RuntimeError("Git worktree is dirty") from exc
+
+
+def get_git_commit():
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+MANIFEST_NAME = "manifest.json"
+OUTPUT_NAME = "output.safetensors"
+ADAPTER_WEIGHTS_NAME = "adapter_model.safetensors"
+
+MODEL_OPT = "peft-internal-testing/tiny-random-OPTForCausalLM"
+MODEL_LLAMA = "trl-internal-testing/tiny-random-LlamaForCausalLM"
+MODEL_T5 = "peft-internal-testing/tiny-random-T5ForConditionalGeneration-calibrated"
+
+MODEL_CLASSES = {
+    "AutoModelForCausalLM": AutoModelForCausalLM,
+    "AutoModelForSeq2SeqLM": AutoModelForSeq2SeqLM,
+}
+
+INPUTS_DECODER = {"input_ids": [[1, 2, 3], [6, 5, 4]], "attention_mask": [[1, 1, 1], [1, 1, 1]]}
+INPUTS_SEQ2SEQ = {**INPUTS_DECODER, "decoder_input_ids": [[0, 1, 2], [2, 0, 1]]}
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_teardown():
+    if FORCE_MODE and not CREATION_MODE:
+        raise RuntimeError("REGRESSION_FORCE_MODE can only be used together with REGRESSION_CREATION_MODE")
+
+    if CREATION_MODE:
+        check_clean_git_status(FORCE_MODE)
+        if HF_TOKEN is None:
+            raise RuntimeError("HF_TOKEN environment variable must be set in creation mode")
+
+    yield
+
+    # optionally upload the created regression artifacts at the end of the test session, then delete the local copies
+    if CREATION_MODE and os.listdir(REGRESSION_DIR):
+        upload_folder(repo_id=HF_REPO, folder_path=REGRESSION_DIR, token=HF_TOKEN)
+    shutil.rmtree(REGRESSION_DIR)
+
+
+@dataclass
+class Case:
+    name: str
+    config_cls: type
+    config_kwargs: dict
+    model_id: str = MODEL_OPT
+    model_cls: str = "AutoModelForCausalLM"
+    inputs: dict = field(default_factory=lambda: INPUTS_DECODER)
+    atol: float = 1e-6
+    rtol: float = 1e-6
+    # special creation flows that go beyond get_peft_model + save_pretrained
+    variant: str | None = None  # None | "multi_adapter" | "pissa_conversion"
+    notes: str = ""
+
+
+CASES = [
+    Case("adalora", AdaLoraConfig, {"task_type": "CAUSAL_LM", "total_step": 1}),
+    Case(
+        "adamss",
+        AdamssConfig,
+        {"target_modules": ["q_proj", "v_proj"], "r": 8, "num_subspaces": 4, "subspace_rank": 1, "use_asa": False},
+    ),
+    Case(
+        "adaption_prompt",
+        AdaptionPromptConfig,
+        {"task_type": "CAUSAL_LM", "adapter_layers": 1, "adapter_len": 4},
+        model_id=MODEL_LLAMA,
+    ),
+    Case("beft", BeftConfig, {"task_type": "CAUSAL_LM"}),
+    Case("boft", BOFTConfig, {"task_type": "CAUSAL_LM"}),
+    Case("c3a", C3AConfig, {"task_type": "CAUSAL_LM", "block_size": 1}),
+    Case("cartridge", CartridgeConfig, {"task_type": "CAUSAL_LM", "num_virtual_tokens": 4, "num_frozen_tokens": 1}),
+    Case(
+        "cpt",
+        CPTConfig,
+        {
+            "task_type": "CAUSAL_LM",
+            "cpt_token_ids": [0, 1, 2, 3, 4, 5, 6, 7],
+            "cpt_mask": [1, 1, 1, 1, 1, 1, 1, 1],
+            "cpt_tokens_type_mask": [1, 2, 2, 2, 3, 3, 4, 4],
+        },
+    ),
+    Case("deft", DeftConfig, {"task_type": "CAUSAL_LM"}),
+    Case("delora", DeloraConfig, {"task_type": "CAUSAL_LM", "r": 2}),
+    Case("fourierft", FourierFTConfig, {"task_type": "CAUSAL_LM", "n_frequency": 10}),
+    Case("frod", FrodConfig, {"task_type": "CAUSAL_LM", "sparse_rate": 0.01}),
+    Case("glora", GloraConfig, {"task_type": "CAUSAL_LM", "init_weights": True}),
+    Case(
+        "gralora",
+        GraloraConfig,
+        {"task_type": "CAUSAL_LM", "r": 8, "alpha": 16, "gralora_k": 2, "hybrid_r": 0},
+    ),
+    Case(
+        "gralora_hybrid",
+        GraloraConfig,
+        {"task_type": "CAUSAL_LM", "r": 16, "alpha": 32, "gralora_k": 4, "hybrid_r": 4},
+    ),
+    Case("hira", HiraConfig, {"task_type": "CAUSAL_LM"}),
+    Case("hra", HRAConfig, {"task_type": "CAUSAL_LM"}),
+    Case("ia3", IA3Config, {"task_type": "CAUSAL_LM"}),
+    Case("lily", LilyConfig, {"target_modules": ["q_proj", "v_proj"], "r": 8, "stride_A": 1, "num_B": 2}),
+    Case(
+        "ln_tuning",
+        LNTuningConfig,
+        {"task_type": "CAUSAL_LM", "target_modules": ["self_attn_layer_norm", "final_layer_norm"]},
+    ),
+    Case("loha", LoHaConfig, {"target_modules": ["q_proj", "v_proj"]}),
+    Case("lokr", LoKrConfig, {"target_modules": ["q_proj", "v_proj"]}),
+    Case("lora", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "lora_alpha": 32}),
+    Case("lora_alora", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "alora_invocation_tokens": [1]}),
+    Case("lora_bias_all", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "bias": "all"}),
+    Case("lora_dora", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8, "use_dora": True}),
+    Case(
+        "lora_modules_to_save",
+        LoraConfig,
+        {"task_type": "CAUSAL_LM", "r": 8, "modules_to_save": ["final_layer_norm"]},
+    ),
+    Case(
+        "lora_modules_to_save_tied",
+        LoraConfig,
+        {"task_type": "CAUSAL_LM", "r": 8, "modules_to_save": ["lm_head"]},
+        notes="lm_head is tied to embed_tokens in OPT, exercises the tied-weights handling of ModulesToSaveWrapper",
+    ),
+    Case("lora_multi_adapter", LoraConfig, {"task_type": "CAUSAL_LM", "r": 8}, variant="multi_adapter"),
+    Case(
+        "lora_pissa_conversion",
+        LoraConfig,
+        {"task_type": "CAUSAL_LM", "r": 8, "init_lora_weights": "pissa", "target_modules": ["q_proj", "v_proj"]},
+        atol=1e-5,
+        rtol=1e-4,
+        variant="pissa_conversion",
+        notes="saved via path_initial_model_for_weight_conversion, loadable as a plain LoRA on the unmutated base",
+    ),
+    Case(
+        "lora_target_embedding",
+        LoraConfig,
+        {"task_type": "CAUSAL_LM", "r": 8, "target_modules": ["embed_tokens"]},
+        notes="triggers the save_embedding_layers='auto' path, the base embedding weight is part of the checkpoint",
+    ),
+    Case(
+        "lora_trainable_tokens",
+        LoraConfig,
+        {"task_type": "CAUSAL_LM", "r": 8, "trainable_token_indices": [0, 1, 3]},
+    ),
+    Case("miss", MissConfig, {"task_type": "CAUSAL_LM", "r": 2}),
+    Case(
+        "multitask_prompt_tuning",
+        MultitaskPromptTuningConfig,
+        {"task_type": "CAUSAL_LM", "num_virtual_tokens": 10, "num_tasks": 2},
+        model_id=MODEL_LLAMA,
+        inputs={**INPUTS_DECODER, "task_ids": [0, 1]},
+    ),
+    Case("oft", OFTConfig, {"task_type": "CAUSAL_LM"}),
+    Case("osf", OSFConfig, {"task_type": "CAUSAL_LM"}),
+    Case(
+        "peanut",
+        PeanutConfig,
+        {"target_modules": ["q_proj", "v_proj"], "r": 4, "depth": 1, "act_fn": "relu", "init_weights": True},
+    ),
+    Case(
+        "poly",
+        PolyConfig,
+        {"task_type": "SEQ_2_SEQ_LM", "r": 2, "n_tasks": 2, "n_skills": 2, "n_splits": 1},
+        model_id=MODEL_T5,
+        model_cls="AutoModelForSeq2SeqLM",
+        inputs={**INPUTS_SEQ2SEQ, "task_ids": [0, 1]},
+    ),
+    Case("prefix_tuning", PrefixTuningConfig, {"task_type": "CAUSAL_LM", "num_virtual_tokens": 10}),
+    Case(
+        "prompt_encoder",
+        PromptEncoderConfig,
+        {"task_type": "CAUSAL_LM", "num_virtual_tokens": 10, "encoder_hidden_size": 32},
+    ),
+    Case("prompt_tuning", PromptTuningConfig, {"task_type": "CAUSAL_LM", "num_virtual_tokens": 10}),
+    Case("psoft", PsoftConfig, {"task_type": "CAUSAL_LM", "r": 4, "psoft_alpha": 4}),
+    Case("pvera", PveraConfig, {"task_type": "CAUSAL_LM", "r": 8}),
+    Case("randlora", RandLoraConfig, {"target_modules": ["q_proj", "v_proj"], "r": 4}),
+    Case("road", RoadConfig, {"task_type": "CAUSAL_LM", "variant": "road_1", "group_size": 2}),
+    Case("shira", ShiraConfig, {"task_type": "CAUSAL_LM", "r": 1, "init_weights": False}),
+    Case("tinylora", TinyLoraConfig, {"task_type": "CAUSAL_LM"}),
+    Case(
+        "tinylora_no_projection",
+        TinyLoraConfig,
+        {"task_type": "CAUSAL_LM", "save_projection": False},
+        notes="projection is regenerated from the projection seed on load, only exact on the same system configuration",
+    ),
+    Case("trainable_tokens", TrainableTokensConfig, {"task_type": "CAUSAL_LM", "token_indices": [0, 1, 3]}),
+    Case("unilora", UniLoraConfig, {"task_type": "CAUSAL_LM", "theta_d_length": 257}),
+    Case(
+        "vblora",
+        VBLoRAConfig,
+        {"task_type": "CAUSAL_LM", "vector_length": 1, "num_vectors": 2},
+    ),
+    Case(
+        "vblora_topk",
+        VBLoRAConfig,
+        {"task_type": "CAUSAL_LM", "vector_length": 1, "num_vectors": 2, "save_only_topk_weights": True},
+        atol=1e-5,
+        rtol=1e-4,
+        notes="topk saving is intentionally lossy, the logits are reconstructed from topk weights when loading",
+    ),
+    Case(
+        "vera",
+        VeraConfig,
+        {"task_type": "CAUSAL_LM", "r": 8, "projection_prng_key": 0xFF, "d_initial": 0.1, "save_projection": True},
+    ),
+    Case(
+        "vera_no_projection",
+        VeraConfig,
+        {"task_type": "CAUSAL_LM", "r": 8, "projection_prng_key": 0xFF, "d_initial": 0.1, "save_projection": False},
+        notes="projection is regenerated from the PRNG key on load, only exact on the same system configuration",
+    ),
+    Case("waveft", WaveFTConfig, {"task_type": "CAUSAL_LM", "n_frequency": 8}),
+    # Not covered:
+    # - X-LoRA: its config references the sub-adapters by filesystem path, which makes the artifacts non-portable.
+    # - LoftQ/EVA/LoRA-GA and other init methods that require calibration data or quantized weights.
+    # - bias="lora_only"/"boft_only": these used to silently drop the trained biases (see PR #3457), so no valid
+    #   artifact can be created before the fix; add cases once that is resolved.
+]
+
+CASE_IDS = [case.name for case in CASES]
+
+
+def download_artifact(case_name):
+    """Download the artifact of a single test case from the Hub, so that with -k, only the needed artifacts are
+    loaded."""
+    snapshot_path = snapshot_download(repo_id=HF_REPO, allow_patterns=[f"{case_name}/*"])
+    case_dir = Path(snapshot_path) / case_name
+    if not (case_dir / MANIFEST_NAME).exists():
+        pytest.fail(
+            f"No regression artifact found for case '{case_name}' in {HF_REPO}. Create it first by running with "
+            "REGRESSION_CREATION_MODE=1."
+        )
+    return case_dir
+
+
+def build_base_model(model_cls_name, model_id):
+    torch.manual_seed(0)
+    model_cls = MODEL_CLASSES[model_cls_name]
+    model = model_cls.from_pretrained(model_id)
+    model.eval()
+    return model
+
+
+def fill_trainable_params(model):
+    """Overwrite all trainable parameters with deterministic values (simulates training).
+
+    The values are derived from the parameter name, so that they depend neither on the order of iteration nor on the
+    global RNG state. Why this approach:
+
+    - Initializing the adapter as a non-identity transform (à la set_init_weights_false): a dropped or unrestored
+      checkpoint entry is only observable if the corresponding tensor differs from the value it has after a fresh load.
+      This must also hold for tensors whose initial value would be identical after loading, e.g. the biases trained
+      with bias="lora_only" or the module copies of modules_to_save, hence all trainable parameters need to be
+      "trained". For the same reason, using a different RNG seed for creation vs. loading would not be reliable, as not
+      all initial values are drawn from the RNG.
+    - Filling all parameters with the same magic value: the tensors need to differ from each other, otherwise a tensor
+      that is stored under the key of another, same-shaped tensor goes unnoticed (e.g. the keys of two layers being
+      swapped, or the weights of a filtered-out adapter leaking into the saved one). Likewise, the elements within each
+      tensor need to differ, otherwise layout mistakes (transposing, slicing, scattering) go unnoticed, as a constant
+      tensor is invariant under these operations.
+    """
+    with torch.no_grad():
+        for name, param in model.named_parameters():
+            if not param.requires_grad:
+                continue
+
+            # Even if RNG is not stable between torch releases, this is fine, as we only test that the weights can be
+            # loaded correctly, it doesn't really matter under which RNG they were created.
+            generator = torch.Generator().manual_seed(zlib.crc32(name.encode("utf-8")))
+            values = torch.rand(param.shape, generator=generator, dtype=torch.float32) * 0.2 - 0.1
+            param.copy_(values.to(dtype=param.dtype))
+
+
+def get_output(model, inputs):
+    model.eval()
+    inputs = {key: torch.tensor(val, dtype=torch.long) for key, val in inputs.items()}
+    with torch.no_grad():
+        output = model(**inputs)
+    return output.logits.detach().to(torch.float32).cpu()
+
+
+def create_artifact(case, case_dir, tmp_path):
+    torch.manual_seed(0)
+    base_model = build_base_model(case.model_cls, case.model_id)
+    # record the base model output before creating the PEFT model, as some methods mutate the base weights
+    base_inputs = {k: v for k, v in case.inputs.items() if k != "task_ids"}  # the base model accepts no task_ids
+    base_logits = get_output(base_model, base_inputs)
+
+    torch.manual_seed(0)
+    config = case.config_cls(**case.config_kwargs)
+    model = get_peft_model(base_model, config)
+
+    save_kwargs = {}
+    if case.variant == "pissa_conversion":
+        # The PiSSA -> LoRA conversion requires the initial adapter as saved directly after initialization, before any
+        # training. Its config needs init_lora_weights=True, otherwise loading it would mutate the base weights again.
+        init_dir = os.path.join(tmp_path, "pissa_init")
+        model.peft_config["default"].init_lora_weights = True
+        model.save_pretrained(init_dir)
+        model.peft_config["default"].init_lora_weights = case.config_kwargs["init_lora_weights"]
+        save_kwargs["path_initial_model_for_weight_conversion"] = init_dir
+    elif case.variant == "multi_adapter":
+        # A second adapter is present in the model but not saved; its weights must not leak into the checkpoint.
+        model.add_adapter("other", case.config_cls(**case.config_kwargs))
+        save_kwargs["selected_adapters"] = ["default"]
+
+    fill_trainable_params(model)
+    logits = get_output(model, case.inputs)
+
+    assert torch.isfinite(logits).all(), "the model output must be finite"
+    # sanity check that the simulated training changed the model output, otherwise broken serialization would go
+    # unnoticed, as the recorded output could be reproduced without restoring the adapter; a shape mismatch (prompt
+    # learning methods insert virtual tokens) always implies a changed output
+    if logits.shape == base_logits.shape:
+        assert not torch.allclose(logits, base_logits), "the adapter must change the output of the base model"
+
+    model.save_pretrained(str(case_dir), **save_kwargs)
+
+    state_dict = safe_load_file(case_dir / ADAPTER_WEIGHTS_NAME)
+    manifest = {
+        "case_name": case.name,
+        "peft_version": peft.__version__,
+        "git_commit": get_git_commit(),
+        "torch_version": torch.__version__,
+        "transformers_version": transformers.__version__,
+        "base_model_id": case.model_id,
+        "model_cls": case.model_cls,
+        "inputs": case.inputs,
+        "atol": case.atol,
+        "rtol": case.rtol,
+        "state_dict_keys": sorted(state_dict.keys()),
+        "notes": case.notes,
+    }
+    with open(case_dir / MANIFEST_NAME, "w") as f:
+        json.dump(manifest, f, indent=2)
+    safe_save_file({"logits": logits}, case_dir / OUTPUT_NAME)
+    return manifest
+
+
+def load_model_from_artifact(case_dir, manifest, adapter_name="default"):
+    base_model = build_base_model(manifest["model_cls"], manifest["base_model_id"])
+    torch.manual_seed(0)
+    model = PeftModel.from_pretrained(base_model, str(case_dir), adapter_name=adapter_name)
+    model.eval()
+    return model
+
+
+@pytest.mark.regression
+class TestCreateArtifacts:
+    @pytest.mark.skipif(not CREATION_MODE, reason="Set REGRESSION_CREATION_MODE=1 to create regression artifacts")
+    @pytest.mark.parametrize("case", CASES, ids=CASE_IDS)
+    def test_create_artifact(self, case, tmp_path):
+        case_dir = Path(REGRESSION_DIR) / case.name
+        case_dir.mkdir(parents=True)
+
+        try:
+            manifest = create_artifact(case, case_dir, tmp_path)
+
+            # sanity check: the artifact must be restorable by the version that created it
+            model = load_model_from_artifact(case_dir, manifest)
+            expected = safe_load_file(case_dir / OUTPUT_NAME)["logits"]
+            logits = get_output(model, case.inputs)
+            torch.testing.assert_close(logits, expected, atol=case.atol, rtol=case.rtol)
+        except Exception:
+            # don't leave partial artifacts behind, they would be uploaded at the end of the session
+            shutil.rmtree(case_dir, ignore_errors=True)
+            raise
+
+
+@pytest.mark.regression
+@pytest.mark.skipif(CREATION_MODE, reason="Skipping tests in CREATION_MODE")
+class TestStateDictRegression:
+    def load_manifest(self, case_dir):
+        with open(case_dir / MANIFEST_NAME) as f:
+            return json.load(f)
+
+    @pytest.mark.parametrize("case", CASES, ids=CASE_IDS)
+    def test_load_and_forward(self, case):
+        # the checkpoint must load into the current version and produce the recorded output
+        case_dir = download_artifact(case.name)
+        manifest = self.load_manifest(case_dir)
+        model = load_model_from_artifact(case_dir, manifest)
+        logits = get_output(model, manifest["inputs"])
+        expected = safe_load_file(case_dir / OUTPUT_NAME)["logits"]
+        torch.testing.assert_close(logits, expected, atol=manifest["atol"], rtol=manifest["rtol"])
+
+    @pytest.mark.parametrize("case", CASES, ids=CASE_IDS)
+    def test_load_with_different_adapter_name(self, case):
+        # the checkpoint format is independent of the adapter name, so loading under any name must work
+        case_dir = download_artifact(case.name)
+        manifest = self.load_manifest(case_dir)
+        model = load_model_from_artifact(case_dir, manifest, adapter_name="other")
+        logits = get_output(model, manifest["inputs"])
+        expected = safe_load_file(case_dir / OUTPUT_NAME)["logits"]
+        torch.testing.assert_close(logits, expected, atol=manifest["atol"], rtol=manifest["rtol"])
+
+    @pytest.mark.parametrize("case", CASES, ids=CASE_IDS)
+    def test_save_load_roundtrip(self, case, tmp_path):
+        # saving the loaded model must reproduce the checkpoint: same keys and same tensor values
+        case_dir = download_artifact(case.name)
+        manifest = self.load_manifest(case_dir)
+        model = load_model_from_artifact(case_dir, manifest)
+        model.save_pretrained(str(tmp_path))
+
+        old_state_dict = safe_load_file(case_dir / ADAPTER_WEIGHTS_NAME)
+        new_state_dict = safe_load_file(tmp_path / ADAPTER_WEIGHTS_NAME)
+        assert set(new_state_dict.keys()) == set(manifest["state_dict_keys"])
+
+        for key in sorted(new_state_dict.keys()):
+            torch.testing.assert_close(
+                new_state_dict[key],
+                old_state_dict[key],
+                atol=manifest["atol"],
+                rtol=manifest["rtol"],
+                msg=lambda m, key=key: f"Mismatch in key {key}:\n{m}",
+            )

--- a/tests/test_pvera.py
+++ b/tests/test_pvera.py
@@ -106,6 +106,36 @@ class TestPVeRA:
         with pytest.raises(ValueError, match=msg):
             peft_model.add_adapter("other", config2)
 
+    def test_save_projection_true_restores_saved_projections(self, mlp, tmp_path):
+        # With save_projection=True, the projections stored in the checkpoint must actually be restored when loading,
+        # instead of relying on the PRNG re-generated ones. To make a failure observable, the projections are modified
+        # before saving, as on the same system, the re-generated projections would be identical to the saved ones.
+        torch.manual_seed(1)
+        config = PveraConfig(target_modules=["lin1", "lin2"], init_weights=False, save_projection=True)
+        peft_model = get_peft_model(mlp, config)
+        # eval mode, since in training mode, the forward pass samples from a distribution whose variance depends on
+        # the (here: perturbed) projections, which is neither deterministic nor numerically stable
+        peft_model.eval()
+        with torch.no_grad():
+            peft_model.base_model.pvera_A["default"] += 1.0
+            peft_model.base_model.pvera_B["default"] += 1.0
+        input = torch.randn(5, 10)
+        output = peft_model(input)
+
+        peft_model.save_pretrained(tmp_path)
+
+        torch.manual_seed(0)
+        peft_model_loaded = PeftModel.from_pretrained(MLP(), tmp_path)
+        peft_model_loaded.eval()
+        torch.testing.assert_close(
+            peft_model_loaded.base_model.pvera_A["default"], peft_model.base_model.pvera_A["default"]
+        )
+        torch.testing.assert_close(
+            peft_model_loaded.base_model.pvera_B["default"], peft_model.base_model.pvera_B["default"]
+        )
+        output_loaded = peft_model_loaded(input)
+        torch.testing.assert_close(output_loaded, output)
+
     def test_multiple_adapters_save_load_save_projection_false(self, mlp, tmp_path):
         # check saving and loading works with multiple adapters without saved projection weights
         torch.manual_seed(1)

--- a/tests/test_unilora.py
+++ b/tests/test_unilora.py
@@ -56,8 +56,10 @@ def _make_unilora_config(**kwargs):
 
 
 def _get_unilora_index_state(model):
+    # note: the indices are non-persistent buffers unless save_indices is set, so they need to be collected from the
+    # modules instead of from the state_dict
     return {
-        name: tensor.detach().cpu().clone() for name, tensor in model.state_dict().items() if "unilora_indices" in name
+        name: buffer.detach().cpu().clone() for name, buffer in model.named_buffers() if "unilora_indices" in name
     }
 
 

--- a/tests/test_unilora.py
+++ b/tests/test_unilora.py
@@ -58,9 +58,7 @@ def _make_unilora_config(**kwargs):
 def _get_unilora_index_state(model):
     # note: the indices are non-persistent buffers unless save_indices is set, so they need to be collected from the
     # modules instead of from the state_dict
-    return {
-        name: buffer.detach().cpu().clone() for name, buffer in model.named_buffers() if "unilora_indices" in name
-    }
+    return {name: buffer.detach().cpu().clone() for name, buffer in model.named_buffers() if "unilora_indices" in name}
 
 
 class TestUniLora:

--- a/tests/test_vera.py
+++ b/tests/test_vera.py
@@ -106,6 +106,32 @@ class TestVera:
         with pytest.raises(ValueError, match=msg):
             peft_model.add_adapter("other", config2)
 
+    def test_save_projection_true_restores_saved_projections(self, mlp, tmp_path):
+        # With save_projection=True, the projections stored in the checkpoint must actually be restored when loading,
+        # instead of relying on the PRNG re-generated ones. To make a failure observable, the projections are modified
+        # before saving, as on the same system, the re-generated projections would be identical to the saved ones.
+        torch.manual_seed(1)
+        config = VeraConfig(target_modules=["lin1", "lin2"], init_weights=False, save_projection=True)
+        peft_model = get_peft_model(mlp, config)
+        with torch.no_grad():
+            peft_model.base_model.vera_A["default"] += 1.0
+            peft_model.base_model.vera_B["default"] += 1.0
+        input = torch.randn(5, 10)
+        output = peft_model(input)
+
+        peft_model.save_pretrained(tmp_path)
+
+        torch.manual_seed(0)
+        peft_model_loaded = PeftModel.from_pretrained(MLP(), tmp_path)
+        torch.testing.assert_close(
+            peft_model_loaded.base_model.vera_A["default"], peft_model.base_model.vera_A["default"]
+        )
+        torch.testing.assert_close(
+            peft_model_loaded.base_model.vera_B["default"], peft_model.base_model.vera_B["default"]
+        )
+        output_loaded = peft_model_loaded(input)
+        torch.testing.assert_close(output_loaded, output)
+
     def test_multiple_adapters_save_load_save_projection_false(self, mlp, tmp_path):
         # check saving and loading works with multiple adapters without saved projection weights
         torch.manual_seed(1)


### PR DESCRIPTION
## Description

This PR adds regression tests that load the PEFT checkpoint of all implemented PEFT methods and the model output from HF Hub and check that the loaded model:

1. produces the same output
2. produces the expected state dict

This new test is structurally similar to the existing `test_regression.py`. That test differs, however, because it doesn't check the state dict directly and only checks a few specific PEFT methods. Moreover, this new test modifies all trainable parameters, which covers more ground than just passing init_weights=False (e.g. it covers making biases trainable).

Regression artifacts have been created based on v0.20.0 at:

https://huggingface.co/peft-internal-testing/regression-tests-state-dict

## Context

The point of adding this new regression test is not to run it regularly on CI. Instead, I need it because I plan to work on a big refactor of the state dict handling in PEFT and I was lacking confidence that this wouldn't break existing checkpoints, which we need to avoid at all cost.

Once this PR is merged, I would proceed with creating the refactoring PR and check its validity with the new regression test.

In the future, each time we plan a refactor of the state dict handling, we can use the new regression test to ensure that nothing breaks. We might need to extend the test cases to include new PEFT methods though. As the need to run this test only comes up rarely, I decided not to make it a contribution requirement to update the test cases when a new PEFT method is being added.

**Update**

The original idea for this PR was to only provide the tests and to create the regression artifacts based on those. However, there were multiple bugs with shared buffers (UniLoRA, TinyLoRA, VeRA, PVeRA), which would result in incorrect state dicts being created as reference. Therefore, we need to fix those issues now, even if they would already be fixed by the refactor.