### PR TITLE
Fix insecure deserialization in LoRA-GA/CorDA cache loading

### DIFF
--- a/src/peft/tuners/lora/corda.py
+++ b/src/peft/tuners/lora/corda.py
@@ -28,6 +28,7 @@ from transformers.pytorch_utils import Conv1D
 from peft.tuners.lora.config import LoraConfig
 from peft.tuners.lora.model import LoraModel
 from peft.utils.other import get_pattern_key
+from peft.utils.save_and_load import torch_load
 
 
 @dataclass
@@ -99,7 +100,7 @@ def preprocess_corda(
 
     # If cache exists, skip building
     if cache_file is not None and os.path.exists(cache_file) and os.path.getsize(cache_file) > 0:
-        cache = torch.load(cache_file, map_location=get_model_device(model))
+        cache = torch_load(cache_file, map_location=get_model_device(model))
         for name, module in target_modules(model, lora_config):
             module.eigens = CordaEigens(
                 S_WC=cache[f"{name}.eigens.S_WC"],
@@ -160,7 +161,7 @@ def calib_cov_distribution(
     covariance_file: Optional[str],
 ):
     if covariance_file is not None and os.path.exists(covariance_file) and os.path.getsize(covariance_file) > 0:
-        all_covariance_matrix = torch.load(covariance_file, map_location=get_model_device(model))
+        all_covariance_matrix = torch_load(covariance_file, map_location=get_model_device(model))
         for name, module in target_modules(model, config):
             module.covariance_matrix = all_covariance_matrix[name]
         return

--- a/src/peft/tuners/lora/loraga.py
+++ b/src/peft/tuners/lora/loraga.py
@@ -25,6 +25,7 @@ from transformers.pytorch_utils import Conv1D
 
 from peft.tuners.lora.config import LoraConfig
 from peft.tuners.lora.model import LoraModel
+from peft.utils.save_and_load import torch_load
 
 
 def get_target_modules(model: nn.Module, config: LoraConfig):
@@ -98,7 +99,7 @@ def preprocess_loraga(
 
     # If cache exists, load from cache
     if cache_file is not None and os.path.exists(cache_file) and os.path.getsize(cache_file) > 0:
-        cache = torch.load(cache_file, map_location=get_model_device(model))
+        cache = torch_load(cache_file, map_location=get_model_device(model))
         for name, module in get_target_modules(model, lora_config):
             module._peft_loraga_grad = cache[f"{name}._peft_loraga_grad"]
     else:


### PR DESCRIPTION
## What does this PR do?

`preprocess_loraga` (`loraga.py`) and `preprocess_corda` / `calib_cov_distribution` (`corda.py`) load cached gradient/eigen/covariance tensors from disk via a raw `torch.load(cache_file, map_location=...)` call, without `weights_only`.

This bypasses the `torch_load` helper in `peft/utils/save_and_load.py` that #1993 introduced specifically so adapter-state loading defaults to `weights_only=True` everywhere in this codebase, instead of relying on `torch.load`'s own (version-dependent) default. `loraga.py` was added afterwards (#2926) and `corda.py` predates/postdates that sweep as well, and neither uses the helper.

Both LoRA-GA and CorDA are designed so this cache can be computed once and reused (`LoraConfig(...).corda_config.cache_file`/`covariance_file`, and the equivalent LoRA-GA argument) -- i.e. it's a file that plausibly gets shared/reused the same way checkpoints are, so it should get the same treatment as every other adapter-state load in this repo.

## Fix

Use the existing `torch_load` helper (default `weights_only=True`) at the three call sites instead of raw `torch.load`, mirroring #1993. Purely mechanical, no behavior change for legitimate cache files (they're plain tensor dicts, fully compatible with restricted unpickling).

## Before submitting
- [x] Did you make sure to update the documentation with your changes? N/A, no public API/behavior change.
- [x] Did you write any new necessary tests? N/A, matches the existing (untested) pattern used by `torch_load` elsewhere in the file; happy to add a regression test if maintainers want one.
