### PR TITLE
CHORE Improve type annotations of PeftModel and get_peft_model

### DIFF
--- a/src/peft/mapping_func.py
+++ b/src/peft/mapping_func.py
@@ -15,20 +15,103 @@
 from __future__ import annotations
 
 import warnings
-from typing import Optional
+from typing import TYPE_CHECKING, Literal, Optional, overload
 
-from transformers import PreTrainedModel
+from torch import nn
 
 from .auto import MODEL_TYPE_TO_PEFT_MODEL_MAPPING
-from .config import PeftConfig
+from .config import PeftConfig, PromptLearningConfig
 from .mapping import PEFT_TYPE_TO_CONFIG_MAPPING, PEFT_TYPE_TO_PREFIX_MAPPING
 from .mixed_model import PeftMixedModel
 from .peft_model import PeftModel
 from .tuners.tuners_utils import BaseTuner, BaseTunerLayer
 
 
+if TYPE_CHECKING:
+    from .tuners import LoraConfig, LoraModel
+
+    # A PeftModel forwards missing attributes to the wrapped tuner model via __getattr__, so its interface is
+    # effectively the intersection of both classes. Python's type system cannot express intersections, so we emulate
+    # them for static type checkers with classes that inherit from both, with PeftModel first in the MRO to mirror the
+    # runtime attribute lookup order. These classes only exist for type checkers; at runtime, get_peft_model returns a
+    # plain PeftModel (subclass).
+    class _LoraPeftModel(PeftModel, LoraModel):  # type: ignore[misc]
+        ...
+
+    class _TunerPeftModel(PeftModel, BaseTuner):  # type: ignore[misc]
+        ...
+else:
+    _LoraPeftModel = PeftModel
+    _TunerPeftModel = PeftModel
+
+
+# The overloads only affect static type checking, the returned types are chosen based on what attributes are reachable
+# through __getattr__ forwarding: LoRA has extra methods like add_weighted_adapter, other tuners provide the BaseTuner
+# API (e.g. merge_and_unload), and prompt learning wraps the base model directly, i.e. there is no tuner model whose
+# attributes could be forwarded. Overloads need to be defined before the actual function.
+@overload
 def get_peft_model(
-    model: PreTrainedModel,
+    model: nn.Module,
+    peft_config: PeftConfig,
+    adapter_name: str = ...,
+    *,
+    mixed: Literal[True],
+    autocast_adapter_dtype: bool = ...,
+    revision: Optional[str] = ...,
+    low_cpu_mem_usage: bool = ...,
+) -> PeftMixedModel: ...
+
+
+@overload
+def get_peft_model(
+    model: nn.Module,
+    peft_config: LoraConfig,
+    adapter_name: str = ...,
+    mixed: Literal[False] = ...,
+    autocast_adapter_dtype: bool = ...,
+    revision: Optional[str] = ...,
+    low_cpu_mem_usage: bool = ...,
+) -> _LoraPeftModel: ...
+
+
+@overload
+def get_peft_model(
+    model: nn.Module,
+    peft_config: PromptLearningConfig,
+    adapter_name: str = ...,
+    mixed: Literal[False] = ...,
+    autocast_adapter_dtype: bool = ...,
+    revision: Optional[str] = ...,
+    low_cpu_mem_usage: bool = ...,
+) -> PeftModel: ...
+
+
+@overload
+def get_peft_model(
+    model: nn.Module,
+    peft_config: PeftConfig,
+    adapter_name: str = ...,
+    mixed: Literal[False] = ...,
+    autocast_adapter_dtype: bool = ...,
+    revision: Optional[str] = ...,
+    low_cpu_mem_usage: bool = ...,
+) -> _TunerPeftModel: ...
+
+
+@overload
+def get_peft_model(
+    model: nn.Module,
+    peft_config: PeftConfig,
+    adapter_name: str = ...,
+    mixed: bool = ...,
+    autocast_adapter_dtype: bool = ...,
+    revision: Optional[str] = ...,
+    low_cpu_mem_usage: bool = ...,
+) -> PeftModel | PeftMixedModel: ...
+
+
+def get_peft_model(
+    model: nn.Module,
     peft_config: PeftConfig,
     adapter_name: str = "default",
     mixed: bool = False,
@@ -40,8 +123,9 @@ def get_peft_model(
     Returns a Peft model object from a model and a config, where the model will be modified in-place.
 
     Args:
-        model ([`transformers.PreTrainedModel`]):
-            Model to be wrapped.
+        model ([`torch.nn.Module`]):
+            Model to be wrapped. Typically this is a Transformers model but any `nn.Module` can work, with the caveat
+            that task-specific features (`peft_config.task_type`) require the model to follow Transformers conventions.
         peft_config ([`PeftConfig`]):
             Configuration object containing the parameters of the Peft model.
         adapter_name (`str`, `optional`, defaults to `"default"`):

--- a/src/peft/mapping_func.py
+++ b/src/peft/mapping_func.py
@@ -40,74 +40,66 @@ if TYPE_CHECKING:
 
     class _TunerPeftModel(PeftModel, BaseTuner):  # type: ignore[misc]
         ...
-else:
-    _LoraPeftModel = PeftModel
-    _TunerPeftModel = PeftModel
 
+    # The overloads only affect static type checking, the returned types are chosen based on what attributes are
+    # reachable through __getattr__ forwarding: LoRA has extra methods like add_weighted_adapter, other tuners provide
+    # the BaseTuner API (e.g. merge_and_unload), and prompt learning wraps the base model directly, i.e. there is no
+    # tuner model whose attributes could be forwarded. Overloads need to be defined before the actual function.
+    @overload
+    def get_peft_model(
+        model: nn.Module,
+        peft_config: PeftConfig,
+        adapter_name: str = ...,
+        *,
+        mixed: Literal[True],
+        autocast_adapter_dtype: bool = ...,
+        revision: Optional[str] = ...,
+        low_cpu_mem_usage: bool = ...,
+    ) -> PeftMixedModel: ...
 
-# The overloads only affect static type checking, the returned types are chosen based on what attributes are reachable
-# through __getattr__ forwarding: LoRA has extra methods like add_weighted_adapter, other tuners provide the BaseTuner
-# API (e.g. merge_and_unload), and prompt learning wraps the base model directly, i.e. there is no tuner model whose
-# attributes could be forwarded. Overloads need to be defined before the actual function.
-@overload
-def get_peft_model(
-    model: nn.Module,
-    peft_config: PeftConfig,
-    adapter_name: str = ...,
-    *,
-    mixed: Literal[True],
-    autocast_adapter_dtype: bool = ...,
-    revision: Optional[str] = ...,
-    low_cpu_mem_usage: bool = ...,
-) -> PeftMixedModel: ...
+    @overload
+    def get_peft_model(
+        model: nn.Module,
+        peft_config: LoraConfig,
+        adapter_name: str = ...,
+        mixed: Literal[False] = ...,
+        autocast_adapter_dtype: bool = ...,
+        revision: Optional[str] = ...,
+        low_cpu_mem_usage: bool = ...,
+    ) -> _LoraPeftModel: ...
 
+    @overload
+    def get_peft_model(
+        model: nn.Module,
+        peft_config: PromptLearningConfig,
+        adapter_name: str = ...,
+        mixed: Literal[False] = ...,
+        autocast_adapter_dtype: bool = ...,
+        revision: Optional[str] = ...,
+        low_cpu_mem_usage: bool = ...,
+    ) -> PeftModel: ...
 
-@overload
-def get_peft_model(
-    model: nn.Module,
-    peft_config: LoraConfig,
-    adapter_name: str = ...,
-    mixed: Literal[False] = ...,
-    autocast_adapter_dtype: bool = ...,
-    revision: Optional[str] = ...,
-    low_cpu_mem_usage: bool = ...,
-) -> _LoraPeftModel: ...
+    @overload
+    def get_peft_model(
+        model: nn.Module,
+        peft_config: PeftConfig,
+        adapter_name: str = ...,
+        mixed: Literal[False] = ...,
+        autocast_adapter_dtype: bool = ...,
+        revision: Optional[str] = ...,
+        low_cpu_mem_usage: bool = ...,
+    ) -> _TunerPeftModel: ...
 
-
-@overload
-def get_peft_model(
-    model: nn.Module,
-    peft_config: PromptLearningConfig,
-    adapter_name: str = ...,
-    mixed: Literal[False] = ...,
-    autocast_adapter_dtype: bool = ...,
-    revision: Optional[str] = ...,
-    low_cpu_mem_usage: bool = ...,
-) -> PeftModel: ...
-
-
-@overload
-def get_peft_model(
-    model: nn.Module,
-    peft_config: PeftConfig,
-    adapter_name: str = ...,
-    mixed: Literal[False] = ...,
-    autocast_adapter_dtype: bool = ...,
-    revision: Optional[str] = ...,
-    low_cpu_mem_usage: bool = ...,
-) -> _TunerPeftModel: ...
-
-
-@overload
-def get_peft_model(
-    model: nn.Module,
-    peft_config: PeftConfig,
-    adapter_name: str = ...,
-    mixed: bool = ...,
-    autocast_adapter_dtype: bool = ...,
-    revision: Optional[str] = ...,
-    low_cpu_mem_usage: bool = ...,
-) -> PeftModel | PeftMixedModel: ...
+    @overload
+    def get_peft_model(
+        model: nn.Module,
+        peft_config: PeftConfig,
+        adapter_name: str = ...,
+        mixed: bool = ...,
+        autocast_adapter_dtype: bool = ...,
+        revision: Optional[str] = ...,
+        low_cpu_mem_usage: bool = ...,
+    ) -> PeftModel | PeftMixedModel: ...
 
 
 def get_peft_model(

--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -168,7 +168,7 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
             f"trainable%: {100 * trainable_params / all_param:.4f}"
         )
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> Any:
         """Forward missing attributes to the wrapped module."""
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -109,7 +109,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
     Base model encompassing various Peft methods.
 
     Args:
-        model ([`~transformers.PreTrainedModel`]): The base transformer model used for Peft.
+        model ([`torch.nn.Module`]): The base model to be adapted, typically a Transformers model.
         peft_config ([`PeftConfig`]): The configuration of the Peft model.
         adapter_name (`str`,  *optional*): The name of the adapter, defaults to `"default"`.
         autocast_adapter_dtype (`bool`, *optional*, defaults to `True`):
@@ -138,7 +138,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
     def __init__(
         self,
-        model: PreTrainedModel,
+        model: torch.nn.Module,
         peft_config: PeftConfig,
         adapter_name: str = "default",
         autocast_adapter_dtype: bool = True,
@@ -999,7 +999,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
             f"trainable params: {trainable_params:,d} || all params: {all_param:,d} || trainable%: {100 * trainable_params / all_param:.4f}"
         )
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> Any:
         """Forward missing attributes to the wrapped module."""
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1395,7 +1395,7 @@ class BaseTuner(nn.Module, ABC):
             module.supports_lora_conversion() for module in self.modules() if isinstance(module, BaseTunerLayer)
         )
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> Any:
         """Forward missing attributes to the wrapped module."""
         try:
             return super().__getattr__(name)  # defer to nn.Module's logic


### PR DESCRIPTION
This PR is mainly for developer experience, as some (missing) PEFT type annoations could trip type checkers.

- `__getattr__`: `-> None`

Otherwise, the type checker would incorrectly infer the return type to be `Tensor | Module` and then complain that certain attributes don't exist on those.

- `nn.Module` vs `PreTrainedModel` input

In some places like `get_peft_model`, we wrongly annotated the function to require a `PreTrainedModel` instance. This is incorrect because `nn.Module` works.

- `get_peft_model` overloads

`get_peft_model` has the return type `PeftModel | PeftMixedModel`. One issue is that this is very imprecise, so overloads are added to distinguish the two classes. However, the bigger problem is that the returned `PeftModel` instance also supports methods on the `base_model`. E.g. when the `base_model` is a `LoraModel`, users can call `merge_and_unload`. Currently, however, the type checker would complain that no such method exists. Therefore, the overloads now return 'fake types' with the method of the `base_model` added. This is a bit like fooling the type checker, but AFAIK, the Python type system has no way of properly handling this.