### PR TITLE
Fix DeepSpeed guide example script path

### DIFF
--- a/docs/source/accelerate/deepspeed.md
+++ b/docs/source/accelerate/deepspeed.md
@@ -399,7 +399,7 @@ That is all! The rest of the script handles the training loop, evaluation, and e
 Run the following command to launch the training script. Earlier, you saved the configuration file to `ds_zero3_cpu.yaml`, so you'll need to pass the path to the launcher with the `--config_file` argument like this:
 
 ```bash
-accelerate launch --config_file ds_zero3_cpu.yaml examples/peft_lora_seq2seq_accelerate_ds_zero3_offload.py
+accelerate launch --config_file ds_zero3_cpu.yaml examples/conditional_generation/peft_lora_seq2seq_accelerate_ds_zero3_offload.py
 ```
 
 You'll see some output logs that track memory usage during training, and once it's completed, the script returns the accuracy and compares the predictions to the labels:


### PR DESCRIPTION
# What does this PR do?

The DeepSpeed guide's **Train** command (`docs/source/accelerate/deepspeed.md`) runs:

```
accelerate launch --config_file ds_zero3_cpu.yaml examples/peft_lora_seq2seq_accelerate_ds_zero3_offload.py
```

but that script lives under `examples/conditional_generation/` — there is no `examples/peft_lora_seq2seq_accelerate_ds_zero3_offload.py`, so the command fails with `No such file or directory`. The **same guide** already links to the correct `examples/conditional_generation/peft_lora_seq2seq_accelerate_ds_zero3_offload.py` path in three other places (the training-script link and the walkthrough), confirming the intended path. This aligns the runnable command to it.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).