### PR TITLE
Fix LoRA+ embedding parameter grouping in create_loraplus_optimizer

### DIFF
--- a/src/peft/optimizers/loraplus.py
+++ b/src/peft/optimizers/loraplus.py
@@ -18,8 +18,6 @@ This module contains the implementation of the LoraPlus optimizer.
 
 from __future__ import annotations
 
-from operator import attrgetter
-
 from torch import nn
 from torch.optim import Optimizer
 from transformers.pytorch_utils import ALL_LAYERNORM_LAYERS
@@ -71,7 +69,18 @@ def create_loraplus_optimizer(
         if not param.requires_grad:
             continue
 
-        module = attrgetter(name)(model)
+        parts = name.split(".")
+
+        # LoRA params end with ".default"
+        if "lora_" in name:
+            module_path = parts[:-2]
+        else:
+            module_path = parts[:-1]
+
+        module = model
+        for part in module_path:
+            module = getattr(module, part)
+
         if isinstance(module, Embedding):
             param_groups["embedding"][name] = param
         elif "lora_B" in name or param.ndim == 1:

--- a/tests/test_loraplus.py
+++ b/tests/test_loraplus.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
+from peft import LoraConfig, get_peft_model
 from peft.import_utils import is_bnb_available
 from peft.optimizers import create_loraplus_optimizer
 
@@ -97,3 +98,38 @@ def test_lora_plus_optimizer_sucess():
     loss_value = loss(output, label)
     loss_value.backward()
     optim.step()
+
+
+def test_loraplus_embedding_parameters_are_grouped_correctly():
+    model = get_peft_model(
+        SimpleNet(),
+        LoraConfig(target_modules=["embedding", "lin0"]),
+    )
+
+    optimizer = create_loraplus_optimizer(
+        model=model,
+        optimizer_cls=torch.optim.AdamW,
+        lr=5e-5,
+        loraplus_lr_ratio=1.2,
+        loraplus_lr_embedding=1e-6,
+    )
+
+    id_to_name = {id(p): n for n, p in model.named_parameters()}
+
+    group_a_names = {
+        id_to_name[id(p)]
+        for p in optimizer.param_groups[0]["params"]
+    }
+
+    embedding_names = {
+        id_to_name[id(p)]
+        for p in optimizer.param_groups[1]["params"]
+    }
+
+    assert embedding_names == {
+        "base_model.model.embedding.lora_embedding_A.default",
+        "base_model.model.embedding.lora_embedding_B.default",
+    }
+
+    assert "base_model.model.embedding.lora_embedding_A.default" not in group_a_names
+    assert "base_model.model.embedding.lora_embedding_B.default" not in group_a_names


### PR DESCRIPTION
## Summary

Fixes #3499.

This PR fixes `create_loraplus_optimizer` incorrectly resolving the parameter instead of the parent module when checking for LoRA embedding layers. As a result, embedding LoRA parameters were never assigned to the embedding optimizer group, so `loraplus_lr_embedding` was never applied.

### Changes

- Resolve the parent module before performing the embedding check.
- Correctly assign LoRA embedding parameters to the embedding parameter group.
- Add a CPU regression test covering the issue.

### Testing

```bash
pytest tests/test_loraplus.py -k embedding -v
ruff check src/peft/optimizers/loraplus.py tests/test_loraplus.py