### PR TITLE
FIX TST Use distributed_config kwarg for TP tests with transformers >= 5.13

### DIFF
--- a/src/peft/import_utils.py
+++ b/src/peft/import_utils.py
@@ -29,6 +29,12 @@ is_transformers_ge_v5_4_0 = packaging.version.parse(transformers.__version__) >=
 
 is_transformers_ge_v5_6_0 = packaging.version.parse(transformers.__version__) >= packaging.version.parse("5.6.0.dev0")
 
+# transformers 5.13.0 introduced the `distributed_config` kwarg for `from_pretrained`,
+# replacing the `tp_plan` and `tp_size` kwargs (removed in 5.15.0).
+is_transformers_ge_v5_13_0 = packaging.version.parse(transformers.__version__) >= packaging.version.parse(
+    "5.13.0.dev0"
+)
+
 is_transformers_le_4_53 = packaging.version.parse(transformers.__version__) < packaging.version.parse("4.54.0.dev0")
 
 

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -6631,9 +6631,8 @@ TP_PLAN = {
 def _get_tp_kwargs(tp_plan=None, tp_size=WORLD_SIZE):
     """Build kwargs for from_pretrained to enable tensor parallelism.
 
-    transformers >= 5.13.0 uses the ``distributed_config`` kwarg (a ``DistributedConfig`` instance). Older versions use
-    the ``tp_plan`` and ``tp_size`` kwargs directly. The ``tp_plan``/``tp_size`` kwargs were removed in transformers
-    5.15.0.
+    transformers >= 5.13.0 uses the `distributed_config` kwarg (a `DistributedConfig` instance). Older versions use the
+    `tp_plan` and `tp_size` kwargs directly. The `tp_plan`/`tp_size` kwargs were removed in transformers 5.15.0.
     """
     if is_transformers_ge_v5_13_0:
         from transformers.distributed import DistributedConfig

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -95,6 +95,7 @@ from peft.import_utils import (
     is_diffusers_available,
     is_te_available,
     is_transformers_ge_v5,
+    is_transformers_ge_v5_13_0,
     is_xpu_available,
 )
 from peft.tuners import boft
@@ -6627,6 +6628,20 @@ TP_PLAN = {
 }
 
 
+def _get_tp_kwargs(tp_plan=None, tp_size=WORLD_SIZE):
+    """Build kwargs for from_pretrained to enable tensor parallelism.
+
+    transformers >= 5.13.0 uses the ``distributed_config`` kwarg (a ``DistributedConfig`` instance). Older versions use
+    the ``tp_plan`` and ``tp_size`` kwargs directly. The ``tp_plan``/``tp_size`` kwargs were removed in transformers
+    5.15.0.
+    """
+    if is_transformers_ge_v5_13_0:
+        from transformers.distributed import DistributedConfig
+
+        return {"distributed_config": DistributedConfig(tp_plan=tp_plan, tp_size=tp_size)}
+    return {"tp_plan": tp_plan, "tp_size": tp_size}
+
+
 def _find_free_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("", 0))
@@ -6661,7 +6676,7 @@ def _test_lora_weight_synchronization(rank, world_size, port):
     """
     Test that non-sharded LoRA weights are identical across ranks after training step.
     """
-    model = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, tp_plan=TP_PLAN)
+    model = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, **_get_tp_kwargs(tp_plan=TP_PLAN))
     lora_config = LoraConfig(r=4, target_modules=TARGET_MODULES, init_lora_weights=True)
     model = get_peft_model(model, lora_config)
 
@@ -6726,7 +6741,7 @@ def _test_load_from_checkpoint(rank, world_size, port, tmp_dir):
     torch.cuda.set_device(rank)
     device = torch.device("cuda", rank)
 
-    tp_base = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, tp_plan=TP_PLAN)
+    tp_base = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, **_get_tp_kwargs(tp_plan=TP_PLAN))
     tp_base.to(device)
     tp_model = PeftModel.from_pretrained(tp_base, tmp_dir)
 
@@ -6786,7 +6801,7 @@ def _test_save_unsharded_weights(rank, world_size, port, tmp_dir_reference, tmp_
     torch.cuda.set_device(rank)
     device = torch.device("cuda", rank)
 
-    tp_base = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, tp_plan=TP_PLAN)
+    tp_base = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, **_get_tp_kwargs(tp_plan=TP_PLAN))
     tp_base.to(device)
     tp_model = PeftModel.from_pretrained(tp_base, tmp_dir_reference)
     tp_model.save_pretrained(tmp_dir_tp)
@@ -6810,7 +6825,7 @@ def _test_multiple_adapters(rank, world_size, port):
     """Two LoRA adapters coexist on a TP model and can be switched between."""
     torch.cuda.set_device(rank)
     device = torch.device("cuda", rank)
-    model = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, tp_plan=TP_PLAN)
+    model = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, **_get_tp_kwargs(tp_plan=TP_PLAN))
     model.to(device)
 
     for adapter_name in ["adapter_a", "adapter_b"]:
@@ -6847,7 +6862,7 @@ def _test_load_adapter_forward(rank, world_size, port, tmp_dir_reference):
 
     dist.monitored_barrier(timeout=TIMEOUT_BARRIER, wait_all_ranks=True)
 
-    model = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, tp_plan=TP_PLAN)
+    model = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, **_get_tp_kwargs(tp_plan=TP_PLAN))
     model.load_adapter(tmp_dir_reference)
     model.to(device)
 
@@ -6894,7 +6909,7 @@ def _test_load_adapter_save(rank, world_size, port, tmp_dir_reference, tmp_dir_t
     torch.cuda.set_device(rank)
     device = torch.device("cuda", rank)
 
-    tp_base = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, tp_plan=TP_PLAN)
+    tp_base = AutoModelForCausalLM.from_pretrained(TINY_MODEL_ID, **_get_tp_kwargs(tp_plan=TP_PLAN))
     tp_base.load_adapter(tmp_dir_reference)
     tp_base.to(device)
 

--- a/tests/training/lora_tp.py
+++ b/tests/training/lora_tp.py
@@ -30,7 +30,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, set_seed
 from transformers.testing_utils import ColoredFormatter, Colors
 
 from peft import LoraConfig, get_peft_model
-from peft.import_utils import is_transformers_ge_v5_4_0
+from peft.import_utils import is_transformers_ge_v5_4_0, is_transformers_ge_v5_13_0
 
 
 TINY_MODEL_ID = "peft-internal-testing/zephyr-smol_llama-100m-sft-full"
@@ -50,6 +50,19 @@ BATCH_SIZE = 4
 LEARNING_RATE = 1e-3
 LOSS_REDUCTION_THRESHOLD = 0.9
 GRAD_NORM_REDUCTION_THRESHOLD = 0.9
+
+
+def _get_tp_kwargs(tp_plan, tp_size=2):
+    """Build kwargs for from_pretrained to enable tensor parallelism.
+
+    transformers >= 5.13.0 uses the ``distributed_config`` kwarg. Older versions use ``tp_plan`` and ``tp_size`` kwargs
+    directly (removed in 5.15.0).
+    """
+    if is_transformers_ge_v5_13_0:
+        from transformers.distributed import DistributedConfig
+
+        return {"distributed_config": DistributedConfig(tp_plan=tp_plan, tp_size=tp_size)}
+    return {"tp_plan": tp_plan, "tp_size": tp_size}
 
 
 def init_test_logger(rank):
@@ -88,7 +101,9 @@ def main(model_id: str, target_modules: list[str]):
     set_seed(42)
 
     tokenizer = AutoTokenizer.from_pretrained(model_id)
-    model = AutoModelForCausalLM.from_pretrained(model_id, tp_plan=TP_PLAN)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id, **_get_tp_kwargs(tp_plan=TP_PLAN, tp_size=dist.get_world_size())
+    )
     config = model.config
 
     torch.cuda.set_device(rank)

--- a/tests/training/lora_tp.py
+++ b/tests/training/lora_tp.py
@@ -55,7 +55,7 @@ GRAD_NORM_REDUCTION_THRESHOLD = 0.9
 def _get_tp_kwargs(tp_plan, tp_size=2):
     """Build kwargs for from_pretrained to enable tensor parallelism.
 
-    transformers >= 5.13.0 uses the ``distributed_config`` kwarg. Older versions use ``tp_plan`` and ``tp_size`` kwargs
+    transformers >= 5.13.0 uses the `distributed_config` kwarg. Older versions use `tp_plan` and `tp_size` kwargs
     directly (removed in 5.15.0).
     """
     if is_transformers_ge_v5_13_0:


### PR DESCRIPTION
## Problem

Transformers PR [#47352](https://github.com/huggingface/transformers/pull/47352) (merged July 21) removed the `tp_plan` and `tp_size` kwargs from `from_pretrained`, replacing them with the `distributed_config` kwarg (a `DistributedConfig` instance). This causes 6 LoRA tensor parallel tests to fail in the multi-GPU nightly CI:

```
TypeError: LlamaForCausalLM.__init__() got an unexpected keyword argument 'tp_plan'
```

The failing tests are in `tests/test_gpu_examples.py` (`TestLoraTensorParallel`) and `tests/training/lora_tp.py`.

## Fix

- Added `is_transformers_ge_v5_13_0` version guard to `src/peft/import_utils.py`
- Added a `_get_tp_kwargs` helper in both test files that returns the correct kwargs based on the transformers version:
  - **transformers >= 5.13.0**: `{"distributed_config": DistributedConfig(tp_plan=..., tp_size=...)}`
  - **older versions**: `{"tp_plan": ..., "tp_size": ...}` (the old API, for backwards compatibility)
- Replaced all 6 `from_pretrained(..., tp_plan=TP_PLAN)` calls in `test_gpu_examples.py` and the 1 call in `lora_tp.py` with `from_pretrained(..., **_get_tp_kwargs(tp_plan=TP_PLAN))`

## Scope

PEFT source code is **not affected** — it reads `tp_plan` from model attributes (`_hf_tp_plan`, `_tp_size`), not from `from_pretrained` kwargs. Only the test code needed updating.

## Testing

- `make style` passes (ruff check + format)
- Syntax verified via `ast.parse` on both files
- Could not run the GPU tests locally (no GPU available). The TP tests require multi-GPU and `torchrun`. These should be verified on the CI.
- With transformers 5.12.1 (locally), the version guard correctly evaluates to `False`, so the old `tp_plan`/`tp_size` path is used

## Context

This was identified while investigating the multi-GPU nightly CI failures (run [30418326234](https://github.com/huggingface/peft/actions/runs/30418326234)). The `tp_plan` kwarg was available from transformers 5.4.0. The `distributed_config` kwarg was introduced in transformers 5.13.0 (PR [#46980](https://github.com/huggingface/transformers/pull/46980)). The `tp_plan`/`tp_size` kwargs were removed in transformers 5.15.0 (PR [#47352](https://github.com/huggingface/transformers/pull/47352)).

AI assistance was used in the preparation of this PR.