### PR TITLE
Reject deletion of merged adapters

### DIFF
--- a/src/peft/tuners/mixed/model.py
+++ b/src/peft/tuners/mixed/model.py
@@ -22,7 +22,12 @@ from torch import nn
 from tqdm import tqdm
 
 from peft.tuners import adalora, loha, lokr, lora, oft, shira
-from peft.tuners.tuners_utils import BaseTuner, BaseTunerLayer, _delete_auxiliary_adapter
+from peft.tuners.tuners_utils import (
+    BaseTuner,
+    BaseTunerLayer,
+    _check_adapters_not_merged,
+    _delete_auxiliary_adapter,
+)
 from peft.utils import (
     TRANSFORMERS_MODELS_TO_LORA_TARGET_MODULES_MAPPING,
     ModulesToSaveWrapper,
@@ -292,6 +297,8 @@ class MixedModel(BaseTuner):
             raise ValueError(
                 f"Adapter(s) {sorted(mismatched)} not found, available adapters: {sorted(self.peft_config.keys())}"
             )
+
+        _check_adapters_not_merged(self.model, adapter_names)
 
         for adapter_to_delete in adapter_names:
             del self.peft_config[adapter_to_delete]

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -2212,11 +2212,9 @@ def _check_adapters_not_merged(model: nn.Module, adapter_names: str | Sequence[s
         if isinstance(module, BaseTunerLayer)
         for adapter_name in module.merged_adapters
     }
-    for adapter_name in adapter_names:
-        if adapter_name in merged_adapters:
-            raise ValueError(
-                f"Cannot delete adapter '{adapter_name}' while it is merged. Please unmerge the adapter first."
-            )
+    still_merged = sorted(set(adapter_names) & merged_adapters)
+    if still_merged:
+        raise ValueError(f"Cannot delete adapter(s) {still_merged} while they are merged. Please unmerge them first.")
 
 
 def delete_adapter(

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -543,6 +543,7 @@ class BaseTuner(nn.Module, ABC):
         """
         if adapter_name not in list(self.peft_config.keys()):
             raise ValueError(f"Adapter {adapter_name} does not exist")
+        _check_adapters_not_merged(self.model, adapter_name)
         del self.peft_config[adapter_name]
 
         new_adapter = delete_adapter(
@@ -2199,6 +2200,23 @@ def _delete_auxiliary_adapter(model, adapter_name: str, new_active_adapters: Opt
     for module in model.modules():
         if isinstance(module, AuxiliaryTrainingWrapper):
             module.delete_adapter(adapter_name, new_active_adapters=new_active_adapters)
+
+
+def _check_adapters_not_merged(model: nn.Module, adapter_names: str | Sequence[str]) -> None:
+    if isinstance(adapter_names, str):
+        adapter_names = [adapter_names]
+
+    merged_adapters = {
+        adapter_name
+        for module in model.modules()
+        if isinstance(module, BaseTunerLayer)
+        for adapter_name in module.merged_adapters
+    }
+    for adapter_name in adapter_names:
+        if adapter_name in merged_adapters:
+            raise ValueError(
+                f"Cannot delete adapter '{adapter_name}' while it is merged. Please unmerge the adapter first."
+            )
 
 
 def delete_adapter(

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -3580,6 +3580,29 @@ class TestPeftCustomModel(PeftCommonTester):
         _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs)
         self._test_delete_adapter(model_id, config_cls, config_kwargs)
 
+    @pytest.mark.parametrize(
+        ("model_cls", "config_cls", "target_modules"),
+        [
+            pytest.param(MLP, LoraConfig, ["lin0"], id="lora"),
+            pytest.param(MLP_LayerNorm, LNTuningConfig, ["layernorm0"], id="ln-tuning"),
+        ],
+    )
+    def test_delete_merged_adapter_raises_without_mutation(self, model_cls, config_cls, target_modules):
+        model = get_peft_model(model_cls(), config_cls(target_modules=target_modules))
+        adapter_layer = next(module for module in model.modules() if isinstance(module, BaseTunerLayer))
+        model.merge_adapter()
+
+        msg = "Cannot delete adapter 'default' while it is merged. Please unmerge the adapter first."
+        with pytest.raises(ValueError, match=re.escape(msg)):
+            model.delete_adapter("default")
+
+        assert "default" in model.peft_config
+        assert adapter_layer.merged_adapters == ["default"]
+        assert "default" in adapter_layer._all_available_adapter_names()
+
+        model.unmerge_adapter()
+        assert not adapter_layer.merged
+
     @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
     def test_delete_adapter_properly_cleans_up_after_itself(self, test_name, model_id, config_cls, config_kwargs):
         # Generic guard against dangling per-adapter state: after `delete_adapter`, no adapter-specific attributes

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -78,7 +78,11 @@ from peft.tuners.lora.monteclora import MontecloraSampler
 from peft.tuners.tuners_utils import BaseTunerLayer
 from peft.utils import AuxiliaryTrainingWrapper, infer_device
 
-from .testing_common import PeftCommonTester, _skip_if_merging_not_supported
+from .testing_common import (
+    PeftCommonTester,
+    _skip_if_deleting_adapter_not_supported,
+    _skip_if_merging_not_supported,
+)
 from .testing_utils import get_state_dict, require_non_cpu, set_init_weights_false
 
 
@@ -3580,28 +3584,65 @@ class TestPeftCustomModel(PeftCommonTester):
         _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs)
         self._test_delete_adapter(model_id, config_cls, config_kwargs)
 
-    @pytest.mark.parametrize(
-        ("model_cls", "config_cls", "target_modules"),
-        [
-            pytest.param(MLP, LoraConfig, ["lin0"], id="lora"),
-            pytest.param(MLP_LayerNorm, LNTuningConfig, ["layernorm0"], id="ln-tuning"),
-        ],
-    )
-    def test_delete_merged_adapter_raises_without_mutation(self, model_cls, config_cls, target_modules):
-        model = get_peft_model(model_cls(), config_cls(target_modules=target_modules))
-        adapter_layer = next(module for module in model.modules() if isinstance(module, BaseTunerLayer))
+    @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
+    def test_delete_merged_adapter_raises_without_mutation(self, test_name, model_id, config_cls, config_kwargs):
+        _skip_if_deleting_adapter_not_supported(config_cls, config_kwargs)
+        _skip_if_merging_not_supported(model_id, config_cls, config_kwargs)
+
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
+        model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+        model = get_peft_model(model, config_cls(**config_kwargs))
+        tuner_layers = [module for module in model.modules() if isinstance(module, BaseTunerLayer)]
         model.merge_adapter()
 
-        msg = "Cannot delete adapter 'default' while it is merged. Please unmerge the adapter first."
+        merged_before = [layer.merged_adapters[:] for layer in tuner_layers]
+        available_before = [set(layer._all_available_adapter_names()) for layer in tuner_layers]
+
+        msg = "Cannot delete adapter(s) ['default'] while they are merged. Please unmerge them first."
         with pytest.raises(ValueError, match=re.escape(msg)):
             model.delete_adapter("default")
 
+        # the rejected deletion must leave the adapter and the merged state untouched
         assert "default" in model.peft_config
-        assert adapter_layer.merged_adapters == ["default"]
-        assert "default" in adapter_layer._all_available_adapter_names()
+        assert [layer.merged_adapters[:] for layer in tuner_layers] == merged_before
+        assert [set(layer._all_available_adapter_names()) for layer in tuner_layers] == available_before
+
+        # after unmerging, the same deletion goes through
+        model.unmerge_adapter()
+        assert not any(layer.merged for layer in tuner_layers)
+        model.delete_adapter("default")
+        assert "default" not in model.peft_config
+
+    @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
+    def test_delete_merged_adapter_only_rejects_the_merged_one(self, test_name, model_id, config_cls, config_kwargs):
+        # with two adapters and only one of them merged, the merged one cannot be deleted while the other still can
+        _skip_if_deleting_adapter_not_supported(config_cls, config_kwargs)
+        _skip_if_merging_not_supported(model_id, config_cls, config_kwargs)
+        _skip_tests_with_multiple_adapters_with_target_parameters(config_cls, config_kwargs)
+
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
+        config = config_cls(**config_kwargs)
+        model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+        model = get_peft_model(model, config, adapter_name="adapter0")
+        model.add_adapter("adapter1", config)
+        model.set_adapter("adapter1")
+        tuner_layers = [module for module in model.modules() if isinstance(module, BaseTunerLayer)]
+        model.merge_adapter()
+        merged_after_merge = [layer.merged_adapters[:] for layer in tuner_layers]
+
+        msg = "Cannot delete adapter(s) ['adapter1'] while they are merged. Please unmerge them first."
+        with pytest.raises(ValueError, match=re.escape(msg)):
+            model.delete_adapter("adapter1")
+        assert set(model.peft_config) == {"adapter0", "adapter1"}
+
+        # deleting the unmerged adapter is allowed and keeps the merge in place
+        model.delete_adapter("adapter0")
+        assert set(model.peft_config) == {"adapter1"}
+        assert [layer.merged_adapters[:] for layer in tuner_layers] == merged_after_merge
 
         model.unmerge_adapter()
-        assert not adapter_layer.merged
+        model.delete_adapter("adapter1")
+        assert not model.peft_config
 
     @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
     def test_delete_adapter_properly_cleans_up_after_itself(self, test_name, model_id, config_cls, config_kwargs):

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -652,6 +652,29 @@ class TestMixedAdapterTypes(unittest.TestCase):
         output_deleted_01 = peft_model(input)
         assert torch.allclose(output_deleted_01, output_base, atol=atol, rtol=rtol)
 
+    def test_delete_merged_adapter_is_atomic(self):
+        model = SimpleNet().eval().to(self.torch_device)
+        config0 = LoraConfig(target_modules=["lin0"])
+        peft_model = get_peft_model(model, config0, "adapter0", mixed=True)
+        config1 = LoHaConfig(target_modules=["lin1"])
+        peft_model.add_adapter("adapter1", config1)
+        peft_model.base_model.merge_adapter(adapter_names=["adapter1"])
+
+        msg = "Cannot delete adapter 'adapter1' while it is merged. Please unmerge the adapter first."
+        with pytest.raises(ValueError, match=re.escape(msg)):
+            peft_model.delete_adapter(["adapter0", "adapter1"])
+
+        assert set(peft_model.peft_config) == {"adapter0", "adapter1"}
+        available_adapters = set()
+        for module in peft_model.modules():
+            if isinstance(module, BaseTunerLayer):
+                available_adapters.update(module._all_available_adapter_names())
+        assert available_adapters == {"adapter0", "adapter1"}
+
+        peft_model.base_model.unmerge_adapter()
+        peft_model.delete_adapter(["adapter0", "adapter1"])
+        assert not peft_model.peft_config
+
     def test_modules_to_save(self):
         model = SimpleNet().eval().to(self.torch_device)
         config0 = LoraConfig(target_modules=["lin0"], modules_to_save=["lin1"])

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -660,7 +660,7 @@ class TestMixedAdapterTypes(unittest.TestCase):
         peft_model.add_adapter("adapter1", config1)
         peft_model.base_model.merge_adapter(adapter_names=["adapter1"])
 
-        msg = "Cannot delete adapter 'adapter1' while it is merged. Please unmerge the adapter first."
+        msg = "Cannot delete adapter(s) ['adapter1'] while they are merged. Please unmerge them first."
         with pytest.raises(ValueError, match=re.escape(msg)):
             peft_model.delete_adapter(["adapter0", "adapter1"])
 
@@ -671,8 +671,12 @@ class TestMixedAdapterTypes(unittest.TestCase):
                 available_adapters.update(module._all_available_adapter_names())
         assert available_adapters == {"adapter0", "adapter1"}
 
+        # "adapter0" is not merged, so deleting it on its own works while "adapter1" stays merged
+        peft_model.delete_adapter(["adapter0"])
+        assert set(peft_model.peft_config) == {"adapter1"}
+
         peft_model.base_model.unmerge_adapter()
-        peft_model.delete_adapter(["adapter0", "adapter1"])
+        peft_model.delete_adapter(["adapter1"])
         assert not peft_model.peft_config
 
     def test_modules_to_save(self):


### PR DESCRIPTION
## What does this PR do?

Fixes #3498.

Deleting an adapter while it is merged removes the adapter state without first restoring the base weights. That can leave a permanent delta in the base model and make a later unmerge fail because the deleted adapter state is gone.

This rejects deletion of a merged adapter before any configuration or layer state is mutated. The same preflight check is used by regular tuner models and mixed models; mixed multi-adapter deletion validates the full request before deleting any adapter.

The regression coverage includes LoRA, LN Tuning, and an atomic mixed-adapter deletion case.

## Coordination

- Issue discussion: #3498
- Maintainer approval and requested behavior: https://github.com/huggingface/peft/issues/3498#issuecomment-5164371244

## Validation

- Before the fix, the new LoRA and LN Tuning regression cases both failed because no error was raised.
- `python -m pytest tests/test_custom_models.py tests/test_mixed.py -k delete_adapter -q --tb=short` (650 passed, 6 skipped)
- `ruff check src/peft/tuners/tuners_utils.py src/peft/tuners/mixed/model.py tests/test_custom_models.py tests/test_mixed.py`
- `ruff format --check src/peft/tuners/tuners_utils.py src/peft/tuners/mixed/model.py tests/test_custom_models.py tests/test_mixed.py`

## AI assistance

AI assistance was used to inspect the failure, prepare the patch, and run validation. I reviewed the final diff and test results and can explain the change end to end.