### PR TITLE
Fix IA3 Conv3d layer error message to reference Conv3d

### DIFF
--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -333,4 +333,4 @@ class Conv3d(_ConvNd):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not self._kernel_dim == 5:
-            raise ValueError(f"Conv2d layer kernel must have 5 dimensions, not {self._kernel_dim}")
+            raise ValueError(f"Conv3d layer kernel must have 5 dimensions, not {self._kernel_dim}")


### PR DESCRIPTION
## Summary

The IA3 `Conv3d` layer's dimension check is correct (it requires 5 kernel dimensions), but its error message labels the layer as **"Conv2d"** — copied from the sibling `Conv2d`, whose message correctly says "Conv2d ... 4 dimensions":

```python
class Conv2d(_ConvNd):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        if not self._kernel_dim == 4:
            raise ValueError(f"Conv2d layer kernel must have 4 dimensions, not {self._kernel_dim}")


class Conv3d(_ConvNd):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        if not self._kernel_dim == 5:
            raise ValueError(f"Conv2d layer kernel must have 5 dimensions, not {self._kernel_dim}")  # <-- says Conv2d
```

A user passing a mis-shaped 3D conv kernel gets a misleading diagnostic naming the wrong layer type.

## Fix

```diff
-            raise ValueError(f"Conv2d layer kernel must have 5 dimensions, not {self._kernel_dim}")
+            raise ValueError(f"Conv3d layer kernel must have 5 dimensions, not {self._kernel_dim}")
```

One-character-class-name change; no logic change.
