### PR TITLE
Keep dtype and device when loading an adapter with low_cpu_mem_usage

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -544,7 +544,29 @@ def set_peft_model_state_dict(
         model, peft_model_state_dict, ignore_mismatched_sizes=ignore_mismatched_sizes
     )
     if low_cpu_mem_usage:
+        # assign=True swaps the checkpoint tensor object into the module, so anything it
+        # loads takes the checkpoint's dtype and device instead of the model's. That is
+        # what makes the fast path fast for freshly injected adapter weights, which live
+        # on meta until they are replaced. It is wrong for every other key the checkpoint
+        # can carry: modules_to_save weights, and the base weights that
+        # save_embedding_layers writes in when the adapter targets an embedding. Those
+        # already exist as real tensors on the model, so record what they were and put it
+        # back for exactly the entries that changed.
+        expected_dtype_device = {}
+        for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
+            if name in peft_model_state_dict and tensor.device.type != "meta":
+                expected_dtype_device[name] = (tensor.dtype, tensor.device)
+
         load_result = model.load_state_dict(peft_model_state_dict, strict=False, assign=True)
+
+        for name, tensor in list(model.named_parameters()) + list(model.named_buffers()):
+            expected = expected_dtype_device.get(name)
+            if expected is None:
+                continue
+            dtype, device = expected
+            if tensor.dtype != dtype or tensor.device != device:
+                tensor.data = tensor.data.to(device=device, dtype=dtype)
+
         # ensure that the correct device is set
         for module in model.modules():
             if hasattr(module, "_move_adapter_to_device_of_base_layer"):

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -14,7 +14,6 @@
 import copy
 import platform
 import re
-import tempfile
 
 import pytest
 import torch
@@ -363,10 +362,49 @@ class TestInjectAdapterFromStateDict:
             # all PEFT parameters should be on meta device
             assert {p.device.type for p in get_peft_model_state_dict(model).values()} == {"meta"}
 
-    def _tiny_causal_lm(self, dtype):
-        # Built in process rather than pulled from the hub because the modules_to_save case
-        # needs an untied lm_head: with tie_word_embeddings=True, PEFT writes no
-        # modules_to_save entry into the checkpoint at all and the case is unreachable.
+    _DTYPE_PAIRS = ((torch.float32, torch.bfloat16), (torch.bfloat16, torch.float32))
+
+    @pytest.mark.parametrize("save_dtype, load_dtype", _DTYPE_PAIRS)
+    def test_load_low_cpu_mem_usage_keeps_modules_to_save_dtype(self, save_dtype, load_dtype, tmp_path):
+        # `assign=True` swaps the checkpoint tensor object into the module, so the loaded
+        # weight takes the checkpoint's dtype rather than the model's. That is what makes
+        # the fast path fast for freshly injected adapter weights, which sit on meta until
+        # they are replaced, but modules_to_save weights already exist as real tensors on
+        # the model. Loading an adapter saved in one dtype into a base model in another
+        # left them at the checkpoint dtype, and the first forward raised
+        # "mat1 and mat2 must have the same dtype".
+        config = LoraConfig(r=4, target_modules=["linear"], modules_to_save=["lm_head"])
+        inputs = torch.randint(0, 9, (2, 4))
+        tmp_dir = tmp_path / f"{save_dtype}_{load_dtype}"
+
+        model = get_peft_model(DummyModel().to(save_dtype), config)
+        model.save_pretrained(tmp_dir)
+        del model
+
+        loaded = PeftModel.from_pretrained(
+            DummyModel().to(load_dtype), tmp_dir, low_cpu_mem_usage=True, torch_device="cpu"
+        )
+        dtypes = {p.dtype for name, p in loaded.named_parameters() if "modules_to_save" in name}
+        assert dtypes == {load_dtype}
+
+        # and it runs, which is what the dtype mismatch used to break
+        loaded.eval()
+        with torch.no_grad():
+            loaded(inputs)
+
+    @pytest.mark.parametrize("save_dtype, load_dtype", _DTYPE_PAIRS)
+    def test_load_low_cpu_mem_usage_keeps_base_embedding_dtype(self, save_dtype, load_dtype, tmp_path):
+        # Same statement, different class of key. When the adapter targets an embedding,
+        # save_embedding_layers writes the BASE embedding weight into the checkpoint, so
+        # `assign=True` replaced the base model's own embedding with the checkpoint tensor.
+        # In the checkpoint-lower-precision direction there is no error at all, and the
+        # whole embedding table quietly changes dtype.
+        #
+        # This one cannot use DummyModel: save_embedding_layers auto-detection bails out on
+        # a plain nn.Module ("Could not identify embedding layer(s) because the model is not
+        # a transformers model"), so no base embedding reaches the checkpoint and the test
+        # would assert nothing. It is built in process rather than pulled from the hub so the
+        # test needs no network.
         config = LlamaConfig(
             vocab_size=64,
             hidden_size=16,
@@ -375,60 +413,26 @@ class TestInjectAdapterFromStateDict:
             num_attention_heads=4,
             num_key_value_heads=4,
             max_position_embeddings=64,
-            tie_word_embeddings=False,
         )
-        torch.manual_seed(0)
-        return AutoModelForCausalLM.from_config(config).to(dtype)
 
-    def test_load_low_cpu_mem_usage_keeps_modules_to_save_dtype(self):
-        # `assign=True` swaps the checkpoint tensor object into the module, so the loaded
-        # weight takes the checkpoint's dtype rather than the model's. That is what makes
-        # the fast path fast for freshly injected adapter weights, which sit on meta until
-        # they are replaced, but modules_to_save weights already exist as real tensors on
-        # the model. Loading an adapter saved in one dtype into a base model in another
-        # left them at the checkpoint dtype, and the first forward raised
-        # "expected m1 and m2 to have the same dtype".
-        config = LoraConfig(r=4, target_modules=["q_proj"], modules_to_save=["lm_head"])
-        inputs = torch.randint(0, 60, (2, 8))
+        def build(dtype):
+            torch.manual_seed(0)
+            return AutoModelForCausalLM.from_config(config).to(dtype)
 
-        for save_dtype, load_dtype in ((torch.float32, torch.bfloat16), (torch.bfloat16, torch.float32)):
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                model = get_peft_model(self._tiny_causal_lm(save_dtype), config)
-                model.save_pretrained(tmp_dir)
-                del model
+        lora_config = LoraConfig(r=4, target_modules=["embed_tokens"])
+        tmp_dir = tmp_path / f"{save_dtype}_{load_dtype}"
 
-                loaded = PeftModel.from_pretrained(
-                    self._tiny_causal_lm(load_dtype), tmp_dir, low_cpu_mem_usage=True, torch_device="cpu"
-                )
-                dtypes = {p.dtype for name, p in loaded.named_parameters() if "modules_to_save" in name}
-                assert dtypes == {load_dtype}, (save_dtype, load_dtype, dtypes)
+        model = get_peft_model(build(save_dtype), lora_config)
+        model.save_pretrained(tmp_dir)
+        del model
 
-                # and it runs, which is what the dtype mismatch used to break
-                loaded.eval()
-                with torch.no_grad():
-                    loaded(inputs)
-
-    def test_load_low_cpu_mem_usage_keeps_base_embedding_dtype(self):
-        # Same statement, different class of key. When the adapter targets an embedding,
-        # save_embedding_layers writes the BASE embedding weight into the checkpoint, so
-        # `assign=True` replaced the base model's own embedding with the checkpoint tensor.
-        # In the checkpoint-lower-precision direction there is no error at all, and the
-        # whole embedding table quietly changes dtype.
-        config = LoraConfig(r=4, target_modules=["embed_tokens"])
-
-        for save_dtype, load_dtype in ((torch.float32, torch.bfloat16), (torch.bfloat16, torch.float32)):
-            with tempfile.TemporaryDirectory() as tmp_dir:
-                model = get_peft_model(self._tiny_causal_lm(save_dtype), config)
-                model.save_pretrained(tmp_dir)
-                del model
-
-                loaded = PeftModel.from_pretrained(
-                    self._tiny_causal_lm(load_dtype), tmp_dir, low_cpu_mem_usage=True, torch_device="cpu"
-                )
-                dtypes = {
-                    p.dtype for name, p in loaded.named_parameters() if name.endswith("embed_tokens.base_layer.weight")
-                }
-                assert dtypes == {load_dtype}, (save_dtype, load_dtype, dtypes)
+        loaded = PeftModel.from_pretrained(
+            build(load_dtype), tmp_dir, low_cpu_mem_usage=True, torch_device="cpu"
+        )
+        dtypes = {
+            p.dtype for name, p in loaded.named_parameters() if name.endswith("embed_tokens.base_layer.weight")
+        }
+        assert dtypes == {load_dtype}
 
     def test_inject_from_state_dict_missing_keys_warning(self):
         # check that if the PEFT config specifies **more** target modules than the state_dict, we get a warning for that

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -14,6 +14,7 @@
 import copy
 import platform
 import re
+import tempfile
 
 import pytest
 import torch
@@ -26,6 +27,7 @@ from transformers import (
     AutoModelForSequenceClassification,
     CLIPTextModel,
     CLIPTextModelWithProjection,
+    LlamaConfig,
 )
 
 from peft import (
@@ -34,6 +36,7 @@ from peft import (
     IA3Config,
     LoKrConfig,
     LoraConfig,
+    PeftModel,
     PveraConfig,
     RandLoraConfig,
     TinyLoraConfig,
@@ -359,6 +362,73 @@ class TestInjectAdapterFromStateDict:
             model = inject_adapter_in_model(config, model, state_dict=sd_before, low_cpu_mem_usage=True)
             # all PEFT parameters should be on meta device
             assert {p.device.type for p in get_peft_model_state_dict(model).values()} == {"meta"}
+
+    def _tiny_causal_lm(self, dtype):
+        # Built in process rather than pulled from the hub because the modules_to_save case
+        # needs an untied lm_head: with tie_word_embeddings=True, PEFT writes no
+        # modules_to_save entry into the checkpoint at all and the case is unreachable.
+        config = LlamaConfig(
+            vocab_size=64,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=64,
+            tie_word_embeddings=False,
+        )
+        torch.manual_seed(0)
+        return AutoModelForCausalLM.from_config(config).to(dtype)
+
+    def test_load_low_cpu_mem_usage_keeps_modules_to_save_dtype(self):
+        # `assign=True` swaps the checkpoint tensor object into the module, so the loaded
+        # weight takes the checkpoint's dtype rather than the model's. That is what makes
+        # the fast path fast for freshly injected adapter weights, which sit on meta until
+        # they are replaced, but modules_to_save weights already exist as real tensors on
+        # the model. Loading an adapter saved in one dtype into a base model in another
+        # left them at the checkpoint dtype, and the first forward raised
+        # "expected m1 and m2 to have the same dtype".
+        config = LoraConfig(r=4, target_modules=["q_proj"], modules_to_save=["lm_head"])
+        inputs = torch.randint(0, 60, (2, 8))
+
+        for save_dtype, load_dtype in ((torch.float32, torch.bfloat16), (torch.bfloat16, torch.float32)):
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model = get_peft_model(self._tiny_causal_lm(save_dtype), config)
+                model.save_pretrained(tmp_dir)
+                del model
+
+                loaded = PeftModel.from_pretrained(
+                    self._tiny_causal_lm(load_dtype), tmp_dir, low_cpu_mem_usage=True, torch_device="cpu"
+                )
+                dtypes = {p.dtype for name, p in loaded.named_parameters() if "modules_to_save" in name}
+                assert dtypes == {load_dtype}, (save_dtype, load_dtype, dtypes)
+
+                # and it runs, which is what the dtype mismatch used to break
+                loaded.eval()
+                with torch.no_grad():
+                    loaded(inputs)
+
+    def test_load_low_cpu_mem_usage_keeps_base_embedding_dtype(self):
+        # Same statement, different class of key. When the adapter targets an embedding,
+        # save_embedding_layers writes the BASE embedding weight into the checkpoint, so
+        # `assign=True` replaced the base model's own embedding with the checkpoint tensor.
+        # In the checkpoint-lower-precision direction there is no error at all, and the
+        # whole embedding table quietly changes dtype.
+        config = LoraConfig(r=4, target_modules=["embed_tokens"])
+
+        for save_dtype, load_dtype in ((torch.float32, torch.bfloat16), (torch.bfloat16, torch.float32)):
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model = get_peft_model(self._tiny_causal_lm(save_dtype), config)
+                model.save_pretrained(tmp_dir)
+                del model
+
+                loaded = PeftModel.from_pretrained(
+                    self._tiny_causal_lm(load_dtype), tmp_dir, low_cpu_mem_usage=True, torch_device="cpu"
+                )
+                dtypes = {
+                    p.dtype for name, p in loaded.named_parameters() if name.endswith("embed_tokens.base_layer.weight")
+                }
+                assert dtypes == {load_dtype}, (save_dtype, load_dtype, dtypes)
 
     def test_inject_from_state_dict_missing_keys_warning(self):
         # check that if the PEFT config specifies **more** target modules than the state_dict, we get a warning for that


### PR DESCRIPTION
## The bug

`set_peft_model_state_dict` loads with `assign=True` when `low_cpu_mem_usage=True`:

```python
if low_cpu_mem_usage:
    load_result = model.load_state_dict(peft_model_state_dict, strict=False, assign=True)
    # ensure that the correct device is set
    for module in model.modules():
        if hasattr(module, "_move_adapter_to_device_of_base_layer"):
            module._move_adapter_to_device_of_base_layer(adapter_name)
```

`assign=True` swaps the checkpoint tensor object into the module, so whatever it loads takes the checkpoint's dtype and device rather than the model's. That is exactly right for freshly injected adapter weights, which sit on meta until they are replaced, and it is why the fast path is fast. It is wrong for the other keys a PEFT checkpoint can carry, and the loop below it only repairs device, only for modules that expose `_move_adapter_to_device_of_base_layer`.

Two things fall through, both reproduced on CPU against `main`:

**1. `modules_to_save` weights end up at the checkpoint dtype, and the first forward raises.**

```
CONTROL - plain LoRA, no modules_to_save:
  ok   ckpt= float32 model=bfloat16 low_cpu_mem_usage=False | modules_to_save dtype=None | forward=OK
  ok   ckpt= float32 model=bfloat16 low_cpu_mem_usage=True  | modules_to_save dtype=None | forward=OK

SUBJECT - LoRA + modules_to_save=['lm_head']:
  ok   ckpt= float32 model=bfloat16 low_cpu_mem_usage=False | modules_to_save dtype=bfloat16 | forward=OK
  BUG  ckpt= float32 model=bfloat16 low_cpu_mem_usage=True  | modules_to_save dtype=float32  | forward=RAISES RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::BFloat16 != float
  ok   ckpt=bfloat16 model= float32 low_cpu_mem_usage=False | modules_to_save dtype=float32  | forward=OK
  BUG  ckpt=bfloat16 model= float32 low_cpu_mem_usage=True  | modules_to_save dtype=bfloat16 | forward=RAISES RuntimeError: expected m1 and m2 to have the same dtype, but got: float != c10::BFloat16
```

**2. When the adapter targets an embedding, the BASE model's embedding is replaced.** `save_embedding_layers` writes `...embed_tokens.base_layer.weight` into the checkpoint, so `assign=True` swaps out the base weight itself. One direction crashes; the other is silent.

```
CONTROL - adapter does not target the embedding (no base weight in the checkpoint):
  ok   targets=['q_proj']       ckpt= float32 model=bfloat16 lcmu=True  | base weights in ckpt=[] | forward=OK

SUBJECT - adapter targets embed_tokens:
  ok   targets=['embed_tokens'] ckpt= float32 model=bfloat16 lcmu=False | loaded base embed dtype=bfloat16 | forward=OK
  BUG  targets=['embed_tokens'] ckpt= float32 model=bfloat16 lcmu=True  | loaded base embed dtype=float32  | forward=RAISES RuntimeError
  ok   targets=['embed_tokens'] ckpt=bfloat16 model= float32 lcmu=False | loaded base embed dtype=float32  | forward=OK
  BUG  targets=['embed_tokens'] ckpt=bfloat16 model= float32 lcmu=True  | loaded base embed dtype=bfloat16 | forward=OK
```

The last line is the one I would most want caught: no error, and the entire embedding table has silently changed dtype.

Both controls pass in the same run, so this is not the harness. Train in one precision and serve in another is the ordinary case here, not an exotic one, and `low_cpu_mem_usage=True` is the documented speedup for loading large adapters.

## Why this has been hard to pin down

I believe this is the failure behind #2240, which was open from 2024-11 and closed on 2026-07-22 for lack of activity. The blocker there was never the diagnosis, it was that nobody could produce a reproduction: the report was a Flux adapter whose weights were never published, `low_cpu_mem_usage=False` fixed it, and @BenjaminBossan asked several times for something reproducible.

The missing ingredient is that a plain LoRA adapter never trips it. Every key in a plain checkpoint targets a freshly injected adapter weight, which is on meta and *should* take the checkpoint's dtype. You need a checkpoint that also carries a weight the model already owns, which means `modules_to_save`, or an adapter that targets an embedding so `save_embedding_layers` kicks in. That is why the control rows above matter as much as the subject rows.

## The fix

Record the dtype and device of the entries the state dict is about to overwrite, and restore them afterwards for exactly the ones that changed. Anything on meta is skipped, so freshly injected adapter weights keep today's behaviour and today's speed.

The restore only touches keys whose dtype or device actually differ, so the same-precision load, which is the common case, does no extra copying at all. I checked that rather than assuming: a same-dtype round trip still yields bit-identical adapter tensors before and after this change.

## Tests

Two tests added to `tests/test_low_level_api.py`, next to the existing `low_cpu_mem_usage` cases: one for `modules_to_save`, one for the base embedding, each covering both dtype directions and asserting the loaded weight has the *model's* dtype, with the `modules_to_save` one also running a forward pass since that is what the mismatch used to break.

The model is built in process from a `LlamaConfig` rather than pulled from the hub, and that is load-bearing rather than a style choice: the shared test models tie `lm_head`, and with `tie_word_embeddings=True` PEFT writes no `modules_to_save` entry into the checkpoint at all, so the case is unreachable. I found this the slow way, by writing the test against `peft-internal-testing/opt-125m` first and watching it pass on unpatched `main`.

```
before   upstream save_and_load.py + these tests   both FAIL
after    this branch                               both PASS
```

Control, run either side of the change: a same-dtype adapter load still produces bit-identical adapter tensors (4 of 4).

Runner note, since I would rather say it than imply a full-suite run: `tests/test_low_level_api.py` imports `hub_online_once` with a package-relative import that needs the repo layout, and I do not have a checkout here, so I ran the two test bodies extracted verbatim into a standalone script against a `peft @ git+main` install whose `src/peft/utils/save_and_load.py` I diffed against upstream and confirmed byte-identical. `ruff check` and `ruff format --check` with the repo's pinned `ruff==0.15.12` and its own `pyproject.toml` are clean on both changed files, and clean on the unmodified ones too.

## Prior art

#2240 is the closest, and it is closed. @BenjaminBossan said there "we cannot change the argument just like that, as this will lead to failure in loading other models", which I read as the reason not to simply drop `assign=True`; this change keeps `assign=True` and repairs only the entries it should not have taken over. #2334 ("FIX Bug with modules_to_save loading if substring") is a different `modules_to_save` loading bug. No open PR touches `set_peft_model_state_dict`.

Happy to reshape this if you would rather fix it inside `_move_adapter_to_device_of_base_layer` or at the point the checkpoint is assembled.

AI assistance was used for this change.
