### PR TITLE
TST Add RandLoRA to feature extraction, decoder, encoder-decoder and seq classifier tests

### DIFF
--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -56,6 +56,7 @@ from peft import (
     PromptTuningInit,
     PsoftConfig,
     PveraConfig,
+    RandLoraConfig,
     RoadConfig,
     ShiraConfig,
     TaskType,
@@ -311,6 +312,15 @@ ALL_CONFIGS = [
         {
             "task_type": "CAUSAL_LM",
             "num_virtual_tokens": 10,
+        },
+    ),
+    (
+        RandLoraConfig,
+        {
+            "task_type": "CAUSAL_LM",
+            "target_modules": None,
+            "r": 8,
+            "randlora_alpha": 1,
         },
     ),
     (

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -43,6 +43,7 @@ from peft import (
     PromptTuningConfig,
     PsoftConfig,
     PveraConfig,
+    RandLoraConfig,
     RoadConfig,
     ShiraConfig,
     TaskType,
@@ -231,6 +232,15 @@ ALL_CONFIGS = [
         {
             "num_virtual_tokens": 10,
             "task_type": "SEQ_2_SEQ_LM",
+        },
+    ),
+    (
+        RandLoraConfig,
+        {
+            "task_type": "SEQ_2_SEQ_LM",
+            "target_modules": None,
+            "r": 8,
+            "randlora_alpha": 1,
         },
     ),
     (

--- a/tests/test_feature_extraction_models.py
+++ b/tests/test_feature_extraction_models.py
@@ -40,6 +40,7 @@ from peft import (
     PromptLearningConfig,
     PromptTuningConfig,
     PsoftConfig,
+    RandLoraConfig,
     RoadConfig,
     ShiraConfig,
     TinyLoraConfig,
@@ -231,6 +232,15 @@ ALL_CONFIGS = [
             "depth": 1,
             "act_fn": "relu",
             "scaling": 1.0,
+        },
+    ),
+    (
+        RandLoraConfig,
+        {
+            "task_type": "FEATURE_EXTRACTION",
+            "target_modules": None,
+            "r": 8,
+            "randlora_alpha": 1,
         },
     ),
     (

--- a/tests/test_seq_classifier.py
+++ b/tests/test_seq_classifier.py
@@ -40,6 +40,7 @@ from peft import (
     PromptTuningConfig,
     PromptTuningInit,
     PsoftConfig,
+    RandLoraConfig,
     RoadConfig,
     ShiraConfig,
     TinyLoraConfig,
@@ -240,6 +241,15 @@ ALL_CONFIGS = [
             "act_fn": "relu",
             "task_type": "SEQ_CLS",
             "target_modules": None,
+        },
+    ),
+    (
+        RandLoraConfig,
+        {
+            "task_type": "SEQ_CLS",
+            "target_modules": None,
+            "r": 8,
+            "randlora_alpha": 1,
         },
     ),
     (


### PR DESCRIPTION
Resolves #3508.

Adds `RandLoraConfig` to the parametrized config lists in the four test files named in the issue, following how the recent tuners (deft, gralora) are registered there. Entries use `r=8` and `randlora_alpha=1`, matching the custom-models tests where the default alpha of 640 is lowered to avoid nans at the test learning rates.

Coordination: confirmed with @BenjaminBossan in https://github.com/huggingface/peft/issues/3508#issuecomment-5182962498 before starting ("please go ahead").

Tests run:

```
python -m pytest tests/test_feature_extraction_models.py tests/test_decoder_models.py tests/test_encoder_decoder_models.py tests/test_seq_classifier.py -k "randlora" --no-cov
295 passed, 78 skipped, 12731 deselected
```

One caveat on my environment: I develop on an Apple M1, where five gradient-checkpointing training cases fail with `NotImplementedError: scaled_dot_product_attention for MPS does not support dropout`, raised inside transformers' sdpa integration. That is the MPS backend, not RandLoRA: the already-merged gralora entries fail identically on this machine, and all five pass when the device is forced to cpu (the numbers above are the cpu run).

AI-assisted; I reviewed every line and ran all tests locally.
