### PR TITLE
Check merged adapters when merging trainable tokens one at a time

### DIFF
--- a/src/peft/tuners/trainable_tokens/layer.py
+++ b/src/peft/tuners/trainable_tokens/layer.py
@@ -162,13 +162,15 @@ class TrainableTokensLayer(nn.Module, BaseTunerLayer):
         This is currently not supported and can lead to undefined behavior of the model if no specific merging between
         the overlapping indices' values is applied.
         """
-        if len(adapter_names) <= 1:
+        # We take already merged adapters into account as well since they can be overridden by new adapters as well.
+        # Merged ones come first so that the adapter reported in the error is the one being added.
+        adapters_to_check = list(dict.fromkeys(self.merged_adapters + list(adapter_names)))
+        if len(adapters_to_check) <= 1:
             return
 
         indices = set()
 
-        # we take already merged adapters into account as well since they can be overridden by new adapters as well.
-        for adapter_name in set(adapter_names + self.merged_adapters):
+        for adapter_name in adapters_to_check:
             index_set = set(self.token_indices[adapter_name])
             if len(indices.intersection(index_set)):
                 raise ValueError(

--- a/src/peft/tuners/trainable_tokens/layer.py
+++ b/src/peft/tuners/trainable_tokens/layer.py
@@ -157,14 +157,15 @@ class TrainableTokensLayer(nn.Module, BaseTunerLayer):
 
         self._move_adapter_to_device_of_base_layer(adapter_name)
 
-    def _check_overlapping_tokens(self, adapter_names):
+    def _check_overlapping_tokens(self, adapter_names: list[str]):
         """Raises an error if the token indices of the given adapter names are overlapping.
         This is currently not supported and can lead to undefined behavior of the model if no specific merging between
         the overlapping indices' values is applied.
         """
         # We take already merged adapters into account as well since they can be overridden by new adapters as well.
-        # Merged ones come first so that the adapter reported in the error is the one being added.
-        adapters_to_check = list(dict.fromkeys(self.merged_adapters + list(adapter_names)))
+        # Merged ones come first so that the adapter reported in the error is the one being added. Duplicates are
+        # dropped so that a name repeated within one call is not reported as overlapping with itself.
+        adapters_to_check = list(dict.fromkeys(self.merged_adapters + adapter_names))
         if len(adapters_to_check) <= 1:
             return
 

--- a/tests/test_trainable_tokens.py
+++ b/tests/test_trainable_tokens.py
@@ -469,9 +469,9 @@ class TestTrainableTokens:
         model = get_peft_model(model, peft_config_1, adapter_name="adapter_1")
         model.add_adapter("adapter_2", peft_config_2)
 
-        model.base_model.merge_adapter(adapter_names=["adapter_1"])
+        model.merge_adapter(adapter_names=["adapter_1"])
         with pytest.raises(ValueError) as e:
-            model.base_model.merge_adapter(adapter_names=["adapter_2"])
+            model.merge_adapter(adapter_names=["adapter_2"])
         assert "adapter_2" in str(e.value)
         assert "are already defined and would result in undefined merging behavior" in str(e.value)
 
@@ -492,8 +492,8 @@ class TestTrainableTokens:
         model = get_peft_model(model, peft_config_1, adapter_name="adapter_1")
         model.add_adapter("adapter_2", peft_config_2)
 
-        model.base_model.merge_adapter(adapter_names=["adapter_1"])
-        model.base_model.merge_adapter(adapter_names=["adapter_2"])
+        model.merge_adapter(adapter_names=["adapter_1"])
+        model.merge_adapter(adapter_names=["adapter_2"])
 
         for module in model.modules():
             if isinstance(module, TrainableTokensLayer):

--- a/tests/test_trainable_tokens.py
+++ b/tests/test_trainable_tokens.py
@@ -450,6 +450,58 @@ class TestTrainableTokens:
     @pytest.mark.parametrize(
         "peft_config_factory",
         [
+            lambda token_indices: LoraConfig(
+                target_modules="all-linear",
+                trainable_token_indices={"embed_tokens": token_indices},
+            ),
+        ],
+    )
+    def test_multiple_adapters_overlapping_token_indices_merging_sequentially(self, model, peft_config_factory):
+        # merging one adapter at a time must reject the same overlap that a single combined call rejects, since the
+        # second merge would otherwise overwrite the first adapter's values for the shared indices with no way to
+        # restore them on unmerge
+        token_indices_1 = [0, 1, 2]
+        token_indices_2 = [2, 3, 4]
+
+        peft_config_1 = peft_config_factory(token_indices_1)
+        peft_config_2 = peft_config_factory(token_indices_2)
+
+        model = get_peft_model(model, peft_config_1, adapter_name="adapter_1")
+        model.add_adapter("adapter_2", peft_config_2)
+
+        model.base_model.merge_adapter(adapter_names=["adapter_1"])
+        with pytest.raises(ValueError) as e:
+            model.base_model.merge_adapter(adapter_names=["adapter_2"])
+        assert "adapter_2" in str(e.value)
+        assert "are already defined and would result in undefined merging behavior" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "peft_config_factory",
+        [
+            lambda token_indices: LoraConfig(
+                target_modules="all-linear",
+                trainable_token_indices={"embed_tokens": token_indices},
+            ),
+        ],
+    )
+    def test_multiple_adapters_disjunct_token_indices_merging_sequentially(self, model, peft_config_factory):
+        # control for the test above: disjunct indices must still merge one at a time
+        peft_config_1 = peft_config_factory([0, 1, 2])
+        peft_config_2 = peft_config_factory([3, 4, 5])
+
+        model = get_peft_model(model, peft_config_1, adapter_name="adapter_1")
+        model.add_adapter("adapter_2", peft_config_2)
+
+        model.base_model.merge_adapter(adapter_names=["adapter_1"])
+        model.base_model.merge_adapter(adapter_names=["adapter_2"])
+
+        for module in model.modules():
+            if isinstance(module, TrainableTokensLayer):
+                assert module.merged_adapters == ["adapter_1", "adapter_2"]
+
+    @pytest.mark.parametrize(
+        "peft_config_factory",
+        [
             lambda targets, token_indices: LoraConfig(
                 target_modules=targets,
                 trainable_token_indices={"embed_tokens": token_indices},


### PR DESCRIPTION
## What does this PR do?

Fixes #3510.

`TrainableTokensLayer._check_overlapping_tokens` returned before it looked at `self.merged_adapters`:

```python
if len(adapter_names) <= 1:
    return
...
# we take already merged adapters into account as well since they can be overridden by new adapters as well.
for adapter_name in set(adapter_names + self.merged_adapters):
```

The comment says already-merged adapters are taken into account, but the early return fires first whenever a single name is passed, so merging one adapter at a time skipped the check entirely. `merge(["a", "b"])` correctly raised on overlapping token indices while `merge(["a"])` followed by `merge(["b"])` accepted them, and the second `index_copy` then overwrote the first adapter's values for the shared indices with no way to restore them on unmerge.

The guard now counts the adapters that will actually be compared, so it only skips when there is nothing to compare against.

Two incidental improvements from the same change: iteration order is now deterministic (it was over a `set`), and merged adapters are visited first, so the adapter named in the error is the one being added rather than one that was already merged successfully.

## Coordination

- Issue discussion: #3510
- Maintainer approval: https://github.com/huggingface/peft/issues/3510#issuecomment-5189799249

## Tests

Added to `tests/test_trainable_tokens.py`, mirroring the existing `test_multiple_adapters_overlapping_token_indices_merging`:

- `test_multiple_adapters_overlapping_token_indices_merging_sequentially` — overlapping indices merged one at a time must raise, and the error must name the adapter being added. Fails on `main`, passes here.
- `test_multiple_adapters_disjunct_token_indices_merging_sequentially` — control: disjunct indices still merge one at a time and both end up in `merged_adapters`. Passes both before and after.

Commands run:

- `PYTHONPATH=src pytest tests/test_trainable_tokens.py --no-cov`: 60 passed
- `PYTHONPATH=src pytest tests/ -k trainable_token --no-cov`: 176 passed, 14 skipped
- `ruff check` and `ruff format --check` on the two changed files

Note on the forward path: `_check_overlapping_tokens` is also called from `forward`, but only in the branch guarded by `elif self.merged` / `else`, where `merged_adapters` is empty by construction, so that call site is unaffected.

## AI assistance

AI assistance was used to investigate the issue, prepare the patch, and run the validation above. I reviewed the final diff and the test results and can explain the change end to end.
