### PR TITLE
FIX Save trained base_layer.bias for LoraConfig(bias="lora_only") and…

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -91,6 +91,13 @@ def _filter_state_dict_for_adapter_name(
     }
 
 
+def _find_bias_key(state_dict: dict[str, torch.Tensor], prefix: str) -> Optional[str]:
+    for bias_name in (prefix + "base_layer.bias", prefix + "bias"):
+        if bias_name in state_dict:
+            return bias_name
+    return None
+
+
 def get_peft_model_state_dict(
     model,
     state_dict=None,
@@ -178,8 +185,8 @@ def get_peft_model_state_dict(
             for k in state_dict:
                 if "lora_" in k:
                     to_return[k] = state_dict[k]
-                    bias_name = k.split("lora_")[0] + "bias"
-                    if bias_name in state_dict:
+                    bias_name = _find_bias_key(state_dict, k.split("lora_")[0])
+                    if bias_name is not None:
                         to_return[bias_name] = state_dict[bias_name]
         else:
             raise NotImplementedError
@@ -215,8 +222,8 @@ def get_peft_model_state_dict(
             for k in state_dict:
                 if "boft_" in k:
                     to_return[k] = state_dict[k]
-                    bias_name = k.split("boft_")[0] + "bias"
-                    if bias_name in state_dict:
+                    bias_name = _find_bias_key(state_dict, k.split("boft_")[0])
+                    if bias_name is not None:
                         to_return[bias_name] = state_dict[bias_name]
         else:
             raise NotImplementedError

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1509,6 +1509,34 @@ class TestLoraInitialization:
                 # only layers targeted with target_modules
                 assert param.requires_grad is ("linear" in name) or ("conv2d" in name)
 
+    def test_lora_with_bias_lora_only_save_load_roundtrip(self, tmp_path, data):
+        # bias="lora_only" trains base_layer.bias, but get_peft_model_state_dict/save_pretrained
+        # used to drop it, so a reloaded adapter did not reproduce the trained output. See #3306.
+        torch.manual_seed(0)
+        model = self.get_model()
+        config = LoraConfig(target_modules=["linear", "conv2d"], bias="lora_only")
+        model = get_peft_model(model, config)
+
+        with torch.no_grad():
+            for param in model.parameters():
+                if param.requires_grad:
+                    param.add_(torch.randn_like(param) * 0.1)
+
+        with torch.no_grad():
+            expected = model(data)
+
+        model.save_pretrained(tmp_path)
+        state_dict = load_file(tmp_path / "adapter_model.safetensors")
+        assert any(key.endswith("base_layer.bias") for key in state_dict)
+
+        torch.manual_seed(0)
+        reloaded = PeftModel.from_pretrained(self.get_model(), tmp_path)
+        with torch.no_grad():
+            actual = reloaded(data)
+
+        for exp, act in zip(expected, actual):
+            assert torch.allclose(exp, act)
+
     def test_lora_with_bias_extra_params(self):
         # lora with lora_bias=True
         model = self.get_model()


### PR DESCRIPTION
Fixes #3306

get_peft_model_state_dict reconstructed the bias key as <prefix>bias, but
a targeted layer's bias actually lives at <prefix>base_layer.bias, so it
was silently dropped from the saved adapter and never restored on load.

Look up the base_layer path first, falling back to the old plain bias key.
Fixed both LoRA/AdaLoRA and BOFT, since they share the identical bug
pattern in the same function. Added a save/load roundtrip regression test.
