### PR TITLE
MetaMathQA: consistent tokenizer padding behavior

### DIFF
--- a/method_comparison/MetaMathQA/run.py
+++ b/method_comparison/MetaMathQA/run.py
@@ -83,7 +83,10 @@ def get_generation_config(*, seq_len, generate_kwargs) -> GenerationConfig:
 
 def evaluate(model, tokenizer, ds, batch_size, generate_kwargs, use_tqdm: bool = False) -> tuple[list[str], list[str]]:
     generate_kwargs = generate_kwargs.copy()
-    generate_kwargs["pad_token_id"] = tokenizer.eos_token_id
+
+    if "pad_token_id" not in generate_kwargs:
+        generate_kwargs["pad_token_id"] = tokenizer.pad_token_id
+
     with torch.inference_mode():
         predictions = []
         responses = []
@@ -371,7 +374,7 @@ def train(
             tokenizer=tokenizer,
             ds=ds_test,
             batch_size=batch_size_eval,
-            generate_kwargs={**generation_kwargs, "pad_token_id": tokenizer.eos_token_id},
+            generate_kwargs={**generation_kwargs},
             use_tqdm=len(ds_test) > 100,
         )
         accuracy = get_accuracy(predictions=predictions, responses=responses)

--- a/method_comparison/MetaMathQA/utils.py
+++ b/method_comparison/MetaMathQA/utils.py
@@ -204,8 +204,14 @@ def init_accelerator() -> int:
 def get_tokenizer(*, model_id: str, max_seq_length: int):
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     tokenizer.model_max_length = max_seq_length
-    if not tokenizer.pad_token:
-        tokenizer.pad_token = tokenizer.eos_token
+
+    # Override tokenizer settings to match our code.
+    # We assume that inputs are padded on the right side and we also assume
+    # the padding token to be the EOS token. We'll use this in the label
+    # creation so that we always have an EOS token at the end. See train().
+    tokenizer.padding_side = "right"
+    tokenizer.pad_token = tokenizer.eos_token
+
     return tokenizer
 
 


### PR DESCRIPTION
Using models like `unsloth/llama-3.2-3B` currently breaks the training code (50% less task accuracy) as it introduces left padding mode and a different padding token.

Since the training code expects right padding and padding_token = eos_token we make sure that the tokenizer is configured as such. Technically we could make the code agnostic to these settings but there is no benefit that I can see.

This was discovered when working on #3524.