### PR TITLE
FIX BOFT and HRA crash on grouped Conv2d layers

### DIFF
--- a/src/peft/tuners/boft/layer.py
+++ b/src/peft/tuners/boft/layer.py
@@ -716,6 +716,13 @@ class Conv2d(nn.Module, BOFTLayer):
 
         # layer information from the base layer
         base_layer = self.get_base_layer()
+        if base_layer.groups > 1:
+            # The rotation below is built over the full in_channels * kernel_size**2, but a grouped conv's
+            # weight only holds in_channels // groups there, so forward and merge both crash on shape mismatch.
+            raise NotImplementedError(
+                f"BOFT does not support {type(base_layer).__name__} layers with groups > 1 "
+                f"(got groups={base_layer.groups})."
+            )
         conv_filter_dim = self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0]
 
         # Initialize the BOFT parameters.

--- a/src/peft/tuners/hra/layer.py
+++ b/src/peft/tuners/hra/layer.py
@@ -80,6 +80,13 @@ class HRALayer(BaseTunerLayer):
         if isinstance(base_layer, nn.Linear):
             self.hra_u[adapter_name] = nn.Parameter(torch.empty(self.in_features, r), requires_grad=True)
         elif isinstance(base_layer, nn.Conv2d):
+            if base_layer.groups > 1:
+                # hra_u is sized for the full in_channels * kernel_size**2, but a grouped conv's weight only
+                # holds in_channels // groups there, so forward and merge both crash on shape mismatch.
+                raise NotImplementedError(
+                    f"HRA does not support {type(base_layer).__name__} layers with groups > 1 "
+                    f"(got groups={base_layer.groups})."
+                )
             self.hra_u[adapter_name] = nn.Parameter(
                 torch.empty(self.in_features * base_layer.kernel_size[0] * base_layer.kernel_size[0], r),
                 requires_grad=True,

--- a/tests/test_boft.py
+++ b/tests/test_boft.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 from safetensors.torch import load_file
+from torch import nn
 from transformers import AutoModelForCausalLM
 
 from peft import BOFTConfig, PeftModel, get_peft_model
@@ -82,3 +84,20 @@ class TestBoft:
 
         atol, rtol = 1e-5, 1e-8
         assert torch.allclose(output_peft, output_old, atol=atol, rtol=rtol)
+
+    def test_boft_conv2d_groups_greater_than_one_raises(self):
+        # BOFT's rotation is built over the full in_channels * kernel_size**2, which does not match a grouped
+        # conv's weight shape (in_channels // groups). Constructing the adapter must fail immediately and
+        # clearly instead of crashing with a shape mismatch on the first forward call.
+        class ModelConvGroups(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(8, 8, kernel_size=3, groups=2)
+
+            def forward(self, X):
+                return self.conv(X)
+
+        model = ModelConvGroups().eval()
+        config = BOFTConfig(target_modules=["conv"], boft_block_size=4)
+        with pytest.raises(NotImplementedError, match="BOFT does not support .* layers with groups > 1"):
+            get_peft_model(model, config)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -39,6 +39,7 @@ from peft import (
     FrodConfig,
     GraloraConfig,
     HiraConfig,
+    HRAConfig,
     IA3Config,
     KasaConfig,
     LilyConfig,
@@ -2989,6 +2990,28 @@ class TestHiraInitialization:
         base_model = self.get_model_conv_groups(conv_cls, groups=2)
         config = HiraConfig(target_modules=["conv"], r=4)
         with pytest.raises(NotImplementedError, match="HiRA does not support .* layers with groups > 1"):
+            get_peft_model(base_model, config)
+
+
+class TestHraInitialization:
+    """Test class to check the initialization of HRA adapters."""
+
+    torch_device = infer_device()
+
+    def test_error_raised_for_conv2d_groups_greater_than_one(self):
+        # HRA does not support grouped convolutions, so constructing an adapter for a Conv2d layer with
+        # `groups > 1` must fail immediately and clearly.
+        class ModelConvGroups(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = nn.Conv2d(4, 8, kernel_size=3, groups=2)
+
+            def forward(self, X):
+                return self.conv(X)
+
+        base_model = ModelConvGroups().eval().to(self.torch_device)
+        config = HRAConfig(target_modules=["conv"], r=4)
+        with pytest.raises(NotImplementedError, match="HRA does not support .* layers with groups > 1"):
             get_peft_model(base_model, config)
 
 


### PR DESCRIPTION
Both BOFT and HRA build their transform over the full in_channels * kernel_size**2, but a grouped conv's weight only holds in_channels // groups in that dimension. The mismatch was never checked at adapter construction, so a grouped Conv2d target crashed with a cryptic shape error on the very first forward pass (both merged and unmerged), not just on merge.

Raise NotImplementedError at construction time instead, matching the guard style already used by LoRA and HiRA for the same grouped-conv limitation.