### PR TITLE
PERF Speed up adapter injection by avoiding repeated adapter-prefix scans

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -869,13 +869,12 @@ class BaseTuner(nn.Module, ABC):
         ###############################
 
         # Skip existing tuner internals, but keep the tuner layer itself eligible for adding the new adapter
-        existing_adapter_children = {
-            id(child)
-            for _, module in named_modules
-            if isinstance(module, BaseTunerLayer)
-            for child in module.modules()
-            if child is not module
-        }
+        existing_adapter_children = set()
+        for _, module in named_modules:
+            if isinstance(module, BaseTunerLayer):
+                for child in module.modules():
+                    if child is not module:
+                        existing_adapter_children.add(id(child))
 
         # TODO: check if this the most robust way
         module_names: set[str] = set()

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -868,10 +868,14 @@ class BaseTuner(nn.Module, ABC):
         # MATCHING & CREATING MODULES #
         ###############################
 
-        existing_adapter_prefixes = []
-        for key, module in named_modules:
-            if isinstance(module, BaseTunerLayer):
-                existing_adapter_prefixes.append(key + ".")
+        # Skip existing tuner internals, but keep the tuner layer itself eligible for adding the new adapter
+        existing_adapter_children = {
+            id(child)
+            for _, module in named_modules
+            if isinstance(module, BaseTunerLayer)
+            for child in module.modules()
+            if child is not module
+        }
 
         # TODO: check if this the most robust way
         module_names: set[str] = set()
@@ -887,12 +891,8 @@ class BaseTuner(nn.Module, ABC):
 
             # It is possible that we're adding an additional adapter, so if we encounter a key that clearly belongs to a
             # previous adapter we can skip here since we don't want to interfere with adapter internals.
-            for adapter_key in existing_adapter_prefixes:
-                if key.startswith(adapter_key):
-                    excluded_modules.append(key)
-                    break
-
-            if excluded_modules and excluded_modules[-1] == key:
+            if id(module) in existing_adapter_children:
+                excluded_modules.append(key)
                 continue
 
             if state_dict is None:


### PR DESCRIPTION
### What does this PR do?

When adding a new adapter to a model that already contains adapters, `BaseTuner.inject_adapter` needs to skip the internals of existing tuner layers.

The previous implementation checked every module name against every existing adapter prefix using repeated `startswith` calls. This becomes increasingly expensive as model depth and the number of adapter modules grow.

This PR replaces those string-prefix scans with identity-based membership:

- Collect the identities of descendants inside existing `BaseTunerLayer` instances
- Skip those descendants during injection
- Keep the `BaseTunerLayer` itself eligible so the new adapter can be added to it

The behavior is unchanged, but the filtering step scales much better with model depth.

### Benchmark

https://gist.github.com/eSVeeF/2379ebb60841544520d2d0d7bb3b4554

The benchmark uses a synthetic CPU-only transformer-like model with one PyTorch thread. It compares the old prefix-scan implementation with the new identity-based implementation.

Results across three runs:

| Model depth | Modules | Filtering speedup |
| ---: | ---: | ---: |
| 32 | 802 | 3.8x-4.3x |
| 64 | 1,602 | 7.5x-7.7x |
| 128 | 3,202 | 9.7x-14.7x |
| 256 | 6,402 | 25.0x-33.7x |

As an additional context (rather than a direct before/after comparison), the end-to-end measurement includes model construction and first-adapter injection:

| Model depth | Current second-adapter injection |
| ---: | ---: |
| 32 | 54-62 ms |
| 64 | 115-126 ms |
| 128 | 342-381 ms |
| 256 | 612-699 ms |

### Validation

Ran:

```bash
pytest -q --no-cov tests/test_tuners_utils.py
```

Result:

```text
219 passed, 16 skipped
```

Also ran the focused low-level API tests:

```bash
pytest -q --no-cov tests/test_low_level_api.py
```

Result:

```text
1 failed, 50 passed, 1 xfailed
```

The failure is unrelated to this change. The test
`test_inject_from_state_dict_model_with_weight_conversion` expects the loaded `CLIPTextModel` to expose `model.encoder`, but the installed Transformers version exposes the encoder under `model.text_model`. The failure occurs in the test's sanity-check assertion before it validates the adapter injection result.