### PR TITLE
FIX Zero density produces NaN in DARE adapter merging

### DIFF
--- a/src/peft/utils/merge_utils.py
+++ b/src/peft/utils/merge_utils.py
@@ -67,7 +67,8 @@ def random_pruning(tensor: torch.Tensor, density: float, rescale: bool) -> torch
     """
     mask = torch.bernoulli(torch.full_like(input=tensor, fill_value=density))
     pruned_tensor = tensor * mask
-    if rescale:
+    if rescale and density > 0:
+        # at density == 0 the tensor is already all zeros and dividing by it would produce NaNs
         pruned_tensor = pruned_tensor / density
     return pruned_tensor
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -4164,6 +4164,60 @@ class TestPeftCustomModel(PeftCommonTester):
         output = model(dummy_input)
         assert output is not None
 
+    @pytest.mark.parametrize("combination_type", ["ties", "dare_ties", "dare_linear", "magnitude_prune"])
+    def test_add_weighted_adapter_zero_density_prunes_everything(self, combination_type):
+        # density=0 means that all values are pruned, so the merged adapter should be all zeros. The dare
+        # combination types returned NaNs instead, as they rescale the pruned tensor by 1 / density.
+        torch.manual_seed(42)
+        model = MLP()
+        config = LoraConfig(target_modules=["lin0"], init_lora_weights=False)
+
+        model = get_peft_model(model, config, adapter_name="adapter1")
+        model.add_adapter("adapter2", config)
+
+        model.add_weighted_adapter(
+            adapters=["adapter1", "adapter2"],
+            weights=[1.0, 1.0],
+            adapter_name="merged",
+            combination_type=combination_type,
+            density=0.0,
+        )
+
+        delta_weight = model.base_model.model.lin0.get_delta_weight("merged")
+        assert torch.isfinite(delta_weight).all()
+        assert torch.allclose(delta_weight, torch.zeros_like(delta_weight))
+
+    def test_add_weighted_adapter_dare_linear_rescales_by_density(self):
+        # dare_linear prunes at random and rescales the values that survive by 1 / density to preserve the
+        # expected value. The second adapter is zeroed out so that every surviving value stems from the first
+        # adapter, which makes the rescaling factor observable.
+        torch.manual_seed(42)
+        model = MLP()
+        # lora_alpha == r, so that the scaling of the source adapters is 1.0
+        config = LoraConfig(r=8, lora_alpha=8, target_modules=["lin0"], init_lora_weights=False)
+        density = 0.5
+
+        model = get_peft_model(model, config, adapter_name="adapter1")
+        model.add_adapter("adapter2", config)
+
+        lora_layer = model.base_model.model.lin0
+        lora_layer.lora_A["adapter2"].weight.data.zero_()
+        lora_layer.lora_B["adapter2"].weight.data.zero_()
+        lora_A_before = lora_layer.lora_A["adapter1"].weight.data.clone()
+
+        model.add_weighted_adapter(
+            adapters=["adapter1", "adapter2"],
+            weights=[1.0, 1.0],
+            adapter_name="merged",
+            combination_type="dare_linear",
+            density=density,
+        )
+
+        merged_lora_A = lora_layer.lora_A["merged"].weight.data
+        survived = merged_lora_A != 0
+        assert survived.any()
+        assert torch.allclose(merged_lora_A[survived], lora_A_before[survived] / density)
+
     def test_multiple_adapters_no_needless_copy_modules_to_save(self):
         # See 2206
         # The problem was that we keep a "global" modules_to_save on the model which contains all possible


### PR DESCRIPTION
### Problem

`add_weighted_adapter` documents `density` as "Value between 0 and 1. 0 means all values are pruned and 1 means no values are pruned", so `density=0` is a documented input. With `combination_type="dare_linear"` or `"dare_ties"` the merged adapter comes out all NaN, and nothing raises on the way there. `ties` and `magnitude_prune` return the all-zero delta the docstring describes, which is what makes it easy to miss.

Merging two LoRA adapters on `main` (5f55a63) and looking at `get_delta_weight` of the merged adapter:

```
density=0.0:  {'ties': 'all-zero', 'dare_ties': 'NaN', 'dare_linear': 'NaN', 'magnitude_prune': 'all-zero'}
density=0.25: {'ties': 'finite-nonzero', 'dare_ties': 'finite-nonzero', 'dare_linear': 'finite-nonzero', 'magnitude_prune': 'finite-nonzero'}
```

### Root cause

`random_pruning` rescales the surviving values to preserve the expected value of the tensor, `src/peft/utils/merge_utils.py:68-72`:

```python
mask = torch.bernoulli(torch.full_like(input=tensor, fill_value=density))
pruned_tensor = tensor * mask
if rescale:
    pruned_tensor = pruned_tensor / density
```

At `density=0` the mask is all zeros, so the rescale is `0 / 0` and the NaNs flow into the merged `lora_A` and `lora_B`. Only the two DARE methods get there, because they are the only callers passing `rescale=True` (`merge_utils.py:232` and `merge_utils.py:261`); the other two prune by magnitude and never divide. `prune()` warns at `density >= 1` and raises below 0, so `density=0` is the endpoint that falls between the two guards.

### Fix

Skip the rescale at `density=0`. Everything has been pruned, so there is no expected value left to preserve and `pruned_tensor` is already the all-zero tensor that `density=0` is documented to produce. Densities in `(0, 1]` are unchanged. Keeping `density=0` working rather than raising also leaves `ties` and `magnitude_prune` alone, which accept it today.

### Verification

Two tests in `tests/test_custom_models.py`, after `test_add_weighted_adapter_negative_weight_with_different_scaling`, both going through `add_weighted_adapter`. The second pins that at `density=0.5` the surviving values are scaled by `1 / density`, so the NaN cannot be made to go away by dropping the division.

With `merge_utils.py` reverted to main and the tests kept:

```
$ pytest tests/test_custom_models.py -k "zero_density or rescales_by_density"
FAILED tests/test_custom_models.py::TestPeftCustomModel::test_add_weighted_adapter_zero_density_prunes_everything[dare_ties]
FAILED tests/test_custom_models.py::TestPeftCustomModel::test_add_weighted_adapter_zero_density_prunes_everything[dare_linear]
2 failed, 3 passed, 17142 deselected
```

With the fix applied:

```
$ pytest tests/test_custom_models.py -k "zero_density or rescales_by_density"
5 passed, 17142 deselected in 12.63s

$ pytest tests/test_custom_models.py -k "add_weighted_adapter or weighted"
15 passed, 17132 deselected in 5.05s

$ pytest tests/test_decoder_models.py -k "weighted_combination"
20 passed, 202 skipped, 7632 deselected in 31.88s
```

Python 3.12, torch 2.13.0, transformers 5.14.1, CPU. `make style` and `make quality` are clean.

### Coordination

This picks up #3486 by @ErenAta16, who found the bug, diagnosed it and wrote the same one-line change. It was reviewed there, https://github.com/huggingface/peft/pull/3486#pullrequestreview-4827678812, and then closed by its author without follow-up. The diagnosis and the `merge_utils.py` change are theirs, not mine; I reproduced both and redid the tests per the review comments: no separate test file, placed next to the existing `add_weighted_adapter` tests, driven through `add_weighted_adapter`, and cut down to the two cases asked for.

@ErenAta16, I went ahead because this had been sitting for over a week after the review. Happy to close this in favour of yours if you would rather pick it back up.

No other open PR or issue covers this.

AI assistance was used for this change, including the code, the tests and this description.
