### PR TITLE
FIX DoRA unmerge on fan_in_fan_out layers

### DIFF
--- a/src/peft/tuners/lora/variants.py
+++ b/src/peft/tuners/lora/variants.py
@@ -212,7 +212,8 @@ class DoraLinearVariant(LoraVariant):
         delta_weight = module.get_delta_weight(active_adapter)
         weight_norm = module._cache_pop(f"{active_adapter}-weight_norm")
         dora_factor = module.lora_magnitude_vector[active_adapter].weight / weight_norm
-        new_weight = orig_weight.data / dora_factor.view(-1, 1) - delta_weight
+        dora_factor = transpose(dora_factor.view(-1, 1), module.fan_in_fan_out)
+        new_weight = orig_weight.data / dora_factor - delta_weight
         new_weight = new_weight.to(orig_dtype)
         return new_weight
 

--- a/tests/test_lora_variants.py
+++ b/tests/test_lora_variants.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 from torch import nn
 from transformers import AutoModelForCausalLM
+from transformers.pytorch_utils import Conv1D
 
 from peft import KasaConfig, LoraConfig, TaskType, get_peft_model
 from peft.tuners.lora.layer import Conv1d as LoraConv1d
@@ -72,6 +73,16 @@ class CustomModel(nn.Module):
         output = self.relu(self.linear1(torch.concat([x1_flat, x2_flat], dim=1)))
         output = self.linear2(output)
         return output
+
+
+# A single transformers Conv1D layer, i.e. a fan_in_fan_out linear layer as used by GPT-2.
+class ModelWithConv1D(nn.Module):
+    def __init__(self, out_features, in_features):
+        super().__init__()
+        self.c = Conv1D(out_features, in_features)
+
+    def forward(self, x):
+        return self.c(x)
 
 
 # Used for testing alora_offsets for aLoRA
@@ -186,6 +197,29 @@ class TestLoraVariants:
 
         for layer in layer_names:
             assert getattr(peft_model.base_model.model, layer).lora_magnitude_vector["default"].weight.grad is not None
+
+    @pytest.mark.parametrize("out_features, in_features", [(6, 6), (8, 4)])
+    def test_dora_unmerge_inverts_merge_for_fan_in_fan_out_layer(self, out_features, in_features):
+        # Regression test for DoraLinearVariant.unmerge on a fan_in_fan_out layer such as a transformers
+        # Conv1D. merge applies the fan_in_fan_out transpose to the DoRA magnitude factor, so unmerge has
+        # to apply it too; otherwise it divides along the wrong axis, which crashes on a non-square weight
+        # and silently corrupts a square one. The discrepancy only surfaces once the magnitude has moved
+        # away from its initial value, so it is perturbed here to emulate a trained adapter.
+        torch.manual_seed(0)
+        model = ModelWithConv1D(out_features, in_features)
+        peft_model = get_peft_model(model, LoraConfig(target_modules=["c"], use_dora=True, fan_in_fan_out=True))
+
+        magnitude = peft_model.base_model.model.c.lora_magnitude_vector["default"].weight
+        with torch.no_grad():
+            magnitude.add_(0.5)
+
+        base_layer = peft_model.base_model.model.c.base_layer
+        original_weight = base_layer.weight.detach().clone()
+
+        peft_model.merge_adapter()
+        peft_model.unmerge_adapter()
+
+        assert torch.allclose(base_layer.weight, original_weight, atol=1e-4, rtol=1e-4)
 
     def test_kasa_params_have_gradients(self):
         """Ensure that the lora_diag parameter added by the KaSA variant participates in the output computation."""

--- a/tests/test_lora_variants.py
+++ b/tests/test_lora_variants.py
@@ -75,14 +75,13 @@ class CustomModel(nn.Module):
         return output
 
 
-# A single transformers Conv1D layer, i.e. a fan_in_fan_out linear layer as used by GPT-2.
+# A single transformers Conv1D layer, i.e. a fan_in_fan_out linear layer as used by GPT-2. Tests must use
+# out_features > 1: with a single output feature the DoRA magnitude factor is a scalar, the fan_in_fan_out
+# transpose is a no-op, and the unmerge test would pass trivially even without the fix.
 class ModelWithConv1D(nn.Module):
     def __init__(self, out_features, in_features):
         super().__init__()
         self.c = Conv1D(out_features, in_features)
-
-    def forward(self, x):
-        return self.c(x)
 
 
 # Used for testing alora_offsets for aLoRA


### PR DESCRIPTION
Fixes #3531.

`DoraLinearVariant.unmerge` was missing the `fan_in_fan_out` transpose that `DoraLinearVariant.merge` applies to the DoRA magnitude factor. On a `fan_in_fan_out=True` layer (transformers `Conv1D`), unmerge divided along the wrong axis: a shape-mismatch crash on a non-square weight such as GPT-2 `c_attn`, and silent corruption of the base weight on a square one such as `c_proj`. This makes `unmerge_adapter()` and `disable_adapter()` on a merged DoRA model unsafe for the GPT-2 family. The sibling `Embedding` and `ConvNd` variants are already symmetric; only the Linear variant's unmerge was affected, and plain `nn.Linear` and `merge_and_unload()` were never affected.

The fix mirrors merge: transpose the magnitude factor by `fan_in_fan_out` before dividing, so unmerge is the exact inverse of merge.

Why it wasn't caught: the existing transformers-`Conv1D` DoRA coverage uses `Conv1D(1, ...)` (out_features = 1), where the transpose is a no-op, and merge/unmerge is only exercised at initialization, where the DoRA magnitude equals the cached weight norm so the factor is 1 regardless of the transpose. The new test uses out_features > 1 (square and non-square) and perturbs the magnitude to emulate a trained adapter.

Tests run:
- `pytest tests/test_lora_variants.py -k dora_unmerge_inverts` — new test; fails on `main`, passes with the fix.
- `pytest tests/test_lora_variants.py` — 26 passed.
- `pytest tests/test_custom_models.py -k "dora and (merge or unmerge or disable)"` — 118 passed, 27 skipped.
- `ruff check` and `ruff format --check` — clean (ruff 0.15.12).

AI assistance was used for this change. I reviewed every line and ran the tests listed above.
