### PR TITLE
FIX inject_adapter raises when a non-first adapter matches nothing

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -276,5 +276,7 @@
       title: Converting non-LoRA adapters to LoRA
     - local: package_reference/warnings
       title: Warnings emitted by PEFT
+    - local: package_reference/errors
+      title: Errors raised by PEFT
     title: Utilities
   title: API reference

--- a/docs/source/package_reference/errors.md
+++ b/docs/source/package_reference/errors.md
@@ -1,0 +1,5 @@
+# Errors
+
+[[autodoc]] utils.error.PeftError
+
+[[autodoc]] utils.error.NoMatchingPeftModuleError

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -159,7 +159,7 @@ from .tuners.cartridge.utils import (
 )
 from .utils import (
     TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING,
-    NoMatchingPeftModule,
+    NoMatchingPeftModuleError,
     PeftError,
     PeftType,
     PeftWarning,
@@ -246,7 +246,7 @@ __all__ = [
     "MontecloraConfig",
     "MultitaskPromptTuningConfig",
     "MultitaskPromptTuningInit",
-    "NoMatchingPeftModule",
+    "NoMatchingPeftModuleError",
     "OFTConfig",
     "OFTModel",
     "OSFConfig",

--- a/src/peft/__init__.py
+++ b/src/peft/__init__.py
@@ -159,6 +159,8 @@ from .tuners.cartridge.utils import (
 )
 from .utils import (
     TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING,
+    NoMatchingPeftModule,
+    PeftError,
     PeftType,
     PeftWarning,
     TaskType,
@@ -244,6 +246,7 @@ __all__ = [
     "MontecloraConfig",
     "MultitaskPromptTuningConfig",
     "MultitaskPromptTuningInit",
+    "NoMatchingPeftModule",
     "OFTConfig",
     "OFTModel",
     "OSFConfig",
@@ -251,6 +254,7 @@ __all__ = [
     "PeanutConfig",
     "PeanutModel",
     "PeftConfig",
+    "PeftError",
     "PeftMixedModel",
     "PeftModel",
     "PeftModelForCausalLM",

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -46,6 +46,7 @@ from peft.utils.constants import (
 from peft.utils.integrations import init_empty_weights
 from peft.utils.other import (
     AuxiliaryTrainingWrapper,
+    _get_input_embeddings_name,
     _get_module_names_tied_with_embedding,
     _set_adapter,
     _set_layer_requires_grad,
@@ -808,6 +809,10 @@ class BaseTuner(nn.Module, ABC):
         unmatched_modules = []
         targeted_modules_from_peft_config: list[str] = []  # only relevant if state_dict is passed
         targets_to_tie: list[str] = []
+        # targeted_module_names and targeted_parameter_names accumulate across all adapters injected into this
+        # tuner, so record their current lengths to detect whether *this* adapter matched anything below.
+        num_targeted_modules_before = len(self.targeted_module_names)
+        num_targeted_parameters_before = len(self.targeted_parameter_names)
         # Note: If possible, all checks should be performed *at the start of this method*.
         # This way, we can raise early if something goes wrong, without leaving the model
         # in a bad (half-initialized) state.
@@ -886,13 +891,9 @@ class BaseTuner(nn.Module, ABC):
                 continue
 
             # It is possible that we're adding an additional adapter, so if we encounter a key that clearly belongs to a
-            # previous adapter we can skip here since we don't want to interfere with adapter internals.
-            for adapter_key in existing_adapter_prefixes:
-                if key.startswith(adapter_key):
-                    excluded_modules.append(key)
-                    break
-
-            if excluded_modules and excluded_modules[-1] == key:
+            # previous adapter we can skip here since we don't want to interfere with adapter internals. These are
+            # adapter internals rather than user-excluded modules, so they are not added to excluded_modules.
+            if any(key.startswith(adapter_key) for adapter_key in existing_adapter_prefixes):
                 continue
 
             if state_dict is None:
@@ -988,7 +989,38 @@ class BaseTuner(nn.Module, ABC):
             if warning_msg:
                 warnings.warn(warning_msg, RuntimeWarning)
 
-        if not self.targeted_module_names and not self.targeted_parameter_names and not uses_dummy_target_modules:
+        matched_modules = len(self.targeted_module_names) > num_targeted_modules_before
+        matched_parameters = len(self.targeted_parameter_names) > num_targeted_parameters_before
+        # An adapter can also be valid through modules_to_save / trainable_token_indices, which are wrapped
+        # later in _set_trainable. Treat this adapter as non-empty if one of those auxiliary targets matches a
+        # module -- with the same suffix rule _set_trainable uses -- that is not itself a target module. A module
+        # targeted by both a tuner and an auxiliary wrapper is a misconfiguration that must still raise (see
+        # TestTargetingAuxiliaryTrainingWrapper in test_other).
+        auxiliary_names = list(getattr(peft_config, "modules_to_save", None) or [])
+        trainable_token_indices = getattr(peft_config, "trainable_token_indices", None)
+        if isinstance(trainable_token_indices, dict):
+            auxiliary_names += list(trainable_token_indices)
+        elif trainable_token_indices:
+            input_embeddings_name = _get_input_embeddings_name(model, "embed_tokens")
+            if input_embeddings_name is not None:
+                auxiliary_names.append(input_embeddings_name)
+        target_modules = peft_config.target_modules
+
+        def _is_target_module(key: str) -> bool:
+            if isinstance(target_modules, str):
+                return match_target_against_key(target_modules, key) is not None
+            if not target_modules:
+                return False
+            return key in target_modules or any(key.endswith(f".{name}") for name in target_modules)
+
+        # Only relevant for a non-first adapter (an earlier adapter already targeted something): a *first* adapter
+        # whose target_modules match nothing is a misconfiguration that must still raise even if modules_to_save
+        # matches, which keeps first-adapter behavior unchanged from before this fix.
+        has_earlier_target = num_targeted_modules_before > 0 or num_targeted_parameters_before > 0
+        matched_auxiliary = has_earlier_target and any(
+            any(key.endswith(name) for name in auxiliary_names) and not _is_target_module(key) for key in key_list
+        )
+        if not matched_modules and not matched_parameters and not uses_dummy_target_modules and not matched_auxiliary:
             if excluded_modules and not unmatched_modules:
                 # All targeted modules were excluded
                 raise ValueError(

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -43,10 +43,10 @@ from peft.utils.constants import (
     MIN_TARGET_MODULES_FOR_OPTIMIZATION,
     SEQ_CLS_HEAD_NAMES,
 )
+from peft.utils.error import NoMatchingPeftModule
 from peft.utils.integrations import init_empty_weights
 from peft.utils.other import (
     AuxiliaryTrainingWrapper,
-    _get_input_embeddings_name,
     _get_module_names_tied_with_embedding,
     _set_adapter,
     _set_layer_requires_grad,
@@ -232,6 +232,18 @@ def _get_in_out_features(module: nn.Module) -> tuple[int, int] | tuple[None, Non
             in_features, out_features = None, None
         warnings.warn(f"Unsupported layer type '{type(module)}' encountered, proceed at your own risk.", UserWarning)
     return in_features, out_features
+
+
+def _extend_unique(existing: list[str], new_names: list[str]) -> None:
+    """Append the entries of new_names that are missing from existing, preserving order.
+
+    The membership check uses a set, as repeated `in` checks on a list could become expensive for large models.
+    """
+    seen = set(existing)
+    for name in new_names:
+        if name not in seen:
+            existing.append(name)
+            seen.add(name)
 
 
 class BaseTuner(nn.Module, ABC):
@@ -809,10 +821,10 @@ class BaseTuner(nn.Module, ABC):
         unmatched_modules = []
         targeted_modules_from_peft_config: list[str] = []  # only relevant if state_dict is passed
         targets_to_tie: list[str] = []
-        # targeted_module_names and targeted_parameter_names accumulate across all adapters injected into this
-        # tuner, so record their current lengths to detect whether *this* adapter matched anything below.
-        num_targeted_modules_before = len(self.targeted_module_names)
-        num_targeted_parameters_before = len(self.targeted_parameter_names)
+        # Modules/parameters targeted by *this* adapter are collected locally and only merged into
+        # self.targeted_module_names / self.targeted_parameter_names (deduplicated) after the checks below passed.
+        targeted_module_names: list[str] = []
+        targeted_parameter_names: list[str] = []
         # Note: If possible, all checks should be performed *at the start of this method*.
         # This way, we can raise early if something goes wrong, without leaving the model
         # in a bad (half-initialized) state.
@@ -911,7 +923,7 @@ class BaseTuner(nn.Module, ABC):
                 elif not result:
                     unmatched_modules.append(key)
                 else:
-                    self.targeted_module_names.append(key)
+                    targeted_module_names.append(key)
                     parent, target, target_name = _get_submodules(model, key)
                     self._check_target_module_compatiblity(peft_config, model, target_name)
                     ctx = init_empty_weights if low_cpu_mem_usage else nullcontext
@@ -933,7 +945,7 @@ class BaseTuner(nn.Module, ABC):
                     if self._check_tied_module_exists(peft_config, key):
                         targets_to_tie.append(key)
                         continue
-                    self.targeted_module_names.append(key)
+                    targeted_module_names.append(key)
                     parent, target, target_name = _get_submodules(model, key)
                     self._check_target_module_compatiblity(peft_config, model, target_name)
                     ctx = init_empty_weights if low_cpu_mem_usage else nullcontext
@@ -949,13 +961,17 @@ class BaseTuner(nn.Module, ABC):
         if getattr(peft_config, "target_parameters", []):
             # Note: We don't need to check for no state_dict being passed, since we already checked this earlier.
             self._inject_parameters(
-                peft_config=peft_config, model=model, adapter_name=adapter_name, low_cpu_mem_usage=low_cpu_mem_usage
+                peft_config=peft_config,
+                model=model,
+                adapter_name=adapter_name,
+                low_cpu_mem_usage=low_cpu_mem_usage,
+                targeted_parameter_names=targeted_parameter_names,
             )
 
         # Here we inject tied adapters for all the layers which were tied
         # Only applicable if `ensure_weight_tying = True` for LoraConfig
         for key in targets_to_tie:
-            self.targeted_module_names.append(key)
+            targeted_module_names.append(key)
             parent, target, target_name = _get_submodules(model, key)
             self._check_target_module_compatiblity(peft_config, model, target_name)
             ctx = init_empty_weights if low_cpu_mem_usage else nullcontext
@@ -970,7 +986,7 @@ class BaseTuner(nn.Module, ABC):
             # in case that the state_dict was used as source of truth and it resulted in different outcomes than what
             # would have been matched with the PEFT config, warn the user about that.
             targeted_set_from_peft_config = set(targeted_modules_from_peft_config)
-            targeted_set_from_state_dict = set(self.targeted_module_names)
+            targeted_set_from_state_dict = set(targeted_module_names)
             diff_peft_config = targeted_set_from_peft_config - targeted_set_from_state_dict
             diff_state_dict = targeted_set_from_state_dict - targeted_set_from_peft_config
             warning_msg = ""
@@ -989,46 +1005,15 @@ class BaseTuner(nn.Module, ABC):
             if warning_msg:
                 warnings.warn(warning_msg, RuntimeWarning)
 
-        matched_modules = len(self.targeted_module_names) > num_targeted_modules_before
-        matched_parameters = len(self.targeted_parameter_names) > num_targeted_parameters_before
-        # An adapter can also be valid through modules_to_save / trainable_token_indices, which are wrapped
-        # later in _set_trainable. Treat this adapter as non-empty if one of those auxiliary targets matches a
-        # module -- with the same suffix rule _set_trainable uses -- that is not itself a target module. A module
-        # targeted by both a tuner and an auxiliary wrapper is a misconfiguration that must still raise (see
-        # TestTargetingAuxiliaryTrainingWrapper in test_other).
-        auxiliary_names = list(getattr(peft_config, "modules_to_save", None) or [])
-        trainable_token_indices = getattr(peft_config, "trainable_token_indices", None)
-        if isinstance(trainable_token_indices, dict):
-            auxiliary_names += list(trainable_token_indices)
-        elif trainable_token_indices:
-            input_embeddings_name = _get_input_embeddings_name(model, "embed_tokens")
-            if input_embeddings_name is not None:
-                auxiliary_names.append(input_embeddings_name)
-        target_modules = peft_config.target_modules
-
-        def _is_target_module(key: str) -> bool:
-            if isinstance(target_modules, str):
-                return match_target_against_key(target_modules, key) is not None
-            if not target_modules:
-                return False
-            return key in target_modules or any(key.endswith(f".{name}") for name in target_modules)
-
-        # Only relevant for a non-first adapter (an earlier adapter already targeted something): a *first* adapter
-        # whose target_modules match nothing is a misconfiguration that must still raise even if modules_to_save
-        # matches, which keeps first-adapter behavior unchanged from before this fix.
-        has_earlier_target = num_targeted_modules_before > 0 or num_targeted_parameters_before > 0
-        matched_auxiliary = has_earlier_target and any(
-            any(key.endswith(name) for name in auxiliary_names) and not _is_target_module(key) for key in key_list
-        )
-        if not matched_modules and not matched_parameters and not uses_dummy_target_modules and not matched_auxiliary:
+        if not targeted_module_names and not targeted_parameter_names and not uses_dummy_target_modules:
             if excluded_modules and not unmatched_modules:
                 # All targeted modules were excluded
-                raise ValueError(
+                raise NoMatchingPeftModule(
                     "All modules were excluded. This is likely unintended. "
                     "Check your `target_modules`, `exclude_modules` and `modules_to_save` configuration."
                 )
             elif not excluded_modules and unmatched_modules and not peft_config.target_modules:
-                raise ValueError(
+                raise NoMatchingPeftModule(
                     "No `target_modules` passed but also no `target_parameters` found. Please check the values for "
                     "these arguments."
                 )
@@ -1042,7 +1027,7 @@ class BaseTuner(nn.Module, ABC):
                     error_msg += f" Note: You specified 'layers_to_transform': {peft_config.layers_to_transform}."
                 if getattr(peft_config, "layers_pattern", None) is not None:
                     error_msg += f" You also specified 'layers_pattern': {peft_config.layers_pattern}."
-                raise ValueError(error_msg)
+                raise NoMatchingPeftModule(error_msg)
             else:
                 # Some modules did not match and some matched but were excluded
                 error_msg = (
@@ -1055,7 +1040,7 @@ class BaseTuner(nn.Module, ABC):
                     error_msg += f" Note: You specified 'layers_to_transform': {peft_config.layers_to_transform}."
                 if getattr(peft_config, "layers_pattern", None) is not None:
                     error_msg += f" You also specified 'layers_pattern': {peft_config.layers_pattern}."
-                raise ValueError(error_msg)
+                raise NoMatchingPeftModule(error_msg)
 
         elif hasattr(peft_config, "exclude_modules") and peft_config.exclude_modules and not excluded_modules:
             # exclude_modules was passed but was not used
@@ -1069,15 +1054,20 @@ class BaseTuner(nn.Module, ABC):
             # error. However, let's warn the user if it seems like
             # - they wanted to match a module but there was no match
             # - they wanted to match a parameter but there was no match
-            if peft_config.target_modules and not self.targeted_module_names:
+            if peft_config.target_modules and not targeted_module_names:
                 warnings.warn(
                     f"target_modules={peft_config.target_modules} were set but no module was matched.", RuntimeWarning
                 )
-            elif getattr(peft_config, "target_parameters", []) and not self.targeted_parameter_names:
+            elif getattr(peft_config, "target_parameters", []) and not targeted_parameter_names:
                 warnings.warn(
                     f"target_parameters={peft_config.target_parameters} were set but no parameter was matched.",
                     RuntimeWarning,
                 )
+
+        # Now that the checks passed, merge this adapter's matches into the tuner-level bookkeeping. Duplicates
+        # are skipped so that names stay unique when several adapters target the same modules.
+        _extend_unique(self.targeted_module_names, targeted_module_names)
+        _extend_unique(self.targeted_parameter_names, targeted_parameter_names)
 
         ################
         # HOUSEKEEPING #
@@ -1103,7 +1093,12 @@ class BaseTuner(nn.Module, ABC):
         )
 
     def _inject_parameters(
-        self, peft_config: PeftConfig, model: nn.Module, adapter_name: str, low_cpu_mem_usage: bool
+        self,
+        peft_config: PeftConfig,
+        model: nn.Module,
+        adapter_name: str,
+        low_cpu_mem_usage: bool,
+        targeted_parameter_names: list[str],
     ) -> None:
         """Inject layers based on peft_config.target_modules"""
 
@@ -1187,7 +1182,7 @@ class BaseTuner(nn.Module, ABC):
                     if getattr(module, param_name, None) is None:
                         continue
                     create_and_replace_param(module_name, key, param_name)
-                    self.targeted_parameter_names.append(key)
+                    targeted_parameter_names.append(key)
             else:
                 # Standard case: the parameter is not already parametrized. Note, however, that the model could already
                 # be nested with lora.ParamWrapper, as this is how we allow targeting multiple Parameters on the same
@@ -1200,7 +1195,7 @@ class BaseTuner(nn.Module, ABC):
                         # Note: We use the unwrapped_module_name to check if the key matches, but we use the module_name for
                         # replacement, since we want to replace the wrapped module.
                         create_and_replace_param(module_name, key, param_name)
-                        self.targeted_parameter_names.append(key)
+                        targeted_parameter_names.append(key)
 
     def _replace_module(self, parent, child_name, new_module, child) -> None:
         """

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -235,7 +235,8 @@ def _get_in_out_features(module: nn.Module) -> tuple[int, int] | tuple[None, Non
 
 
 def _extend_unique(existing: list[str], new_names: list[str]) -> None:
-    """Append the entries of new_names that are missing from existing, preserving order.
+    """
+    Append the entries of new_names that are missing from existing, preserving order.
 
     The membership check uses a set, as repeated `in` checks on a list could become expensive for large models.
     """

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -43,7 +43,7 @@ from peft.utils.constants import (
     MIN_TARGET_MODULES_FOR_OPTIMIZATION,
     SEQ_CLS_HEAD_NAMES,
 )
-from peft.utils.error import NoMatchingPeftModule
+from peft.utils.error import NoMatchingPeftModuleError
 from peft.utils.integrations import init_empty_weights
 from peft.utils.other import (
     AuxiliaryTrainingWrapper,
@@ -960,12 +960,8 @@ class BaseTuner(nn.Module, ABC):
 
         if getattr(peft_config, "target_parameters", []):
             # Note: We don't need to check for no state_dict being passed, since we already checked this earlier.
-            self._inject_parameters(
-                peft_config=peft_config,
-                model=model,
-                adapter_name=adapter_name,
-                low_cpu_mem_usage=low_cpu_mem_usage,
-                targeted_parameter_names=targeted_parameter_names,
+            targeted_parameter_names = self._inject_parameters(
+                peft_config=peft_config, model=model, adapter_name=adapter_name, low_cpu_mem_usage=low_cpu_mem_usage
             )
 
         # Here we inject tied adapters for all the layers which were tied
@@ -1008,12 +1004,12 @@ class BaseTuner(nn.Module, ABC):
         if not targeted_module_names and not targeted_parameter_names and not uses_dummy_target_modules:
             if excluded_modules and not unmatched_modules:
                 # All targeted modules were excluded
-                raise NoMatchingPeftModule(
+                raise NoMatchingPeftModuleError(
                     "All modules were excluded. This is likely unintended. "
                     "Check your `target_modules`, `exclude_modules` and `modules_to_save` configuration."
                 )
             elif not excluded_modules and unmatched_modules and not peft_config.target_modules:
-                raise NoMatchingPeftModule(
+                raise NoMatchingPeftModuleError(
                     "No `target_modules` passed but also no `target_parameters` found. Please check the values for "
                     "these arguments."
                 )
@@ -1027,7 +1023,7 @@ class BaseTuner(nn.Module, ABC):
                     error_msg += f" Note: You specified 'layers_to_transform': {peft_config.layers_to_transform}."
                 if getattr(peft_config, "layers_pattern", None) is not None:
                     error_msg += f" You also specified 'layers_pattern': {peft_config.layers_pattern}."
-                raise NoMatchingPeftModule(error_msg)
+                raise NoMatchingPeftModuleError(error_msg)
             else:
                 # Some modules did not match and some matched but were excluded
                 error_msg = (
@@ -1040,7 +1036,7 @@ class BaseTuner(nn.Module, ABC):
                     error_msg += f" Note: You specified 'layers_to_transform': {peft_config.layers_to_transform}."
                 if getattr(peft_config, "layers_pattern", None) is not None:
                     error_msg += f" You also specified 'layers_pattern': {peft_config.layers_pattern}."
-                raise NoMatchingPeftModule(error_msg)
+                raise NoMatchingPeftModuleError(error_msg)
 
         elif hasattr(peft_config, "exclude_modules") and peft_config.exclude_modules and not excluded_modules:
             # exclude_modules was passed but was not used
@@ -1093,14 +1089,10 @@ class BaseTuner(nn.Module, ABC):
         )
 
     def _inject_parameters(
-        self,
-        peft_config: PeftConfig,
-        model: nn.Module,
-        adapter_name: str,
-        low_cpu_mem_usage: bool,
-        targeted_parameter_names: list[str],
-    ) -> None:
+        self, peft_config: PeftConfig, model: nn.Module, adapter_name: str, low_cpu_mem_usage: bool
+    ) -> list[str]:
         """Inject layers based on peft_config.target_modules"""
+        targeted_parameter_names: list[str] = []
 
         def strip_base_layer_from_name(module_name):
             # It is possible that the layer is already a PEFT layer and needs updating with a new adapter. In this case,
@@ -1196,6 +1188,8 @@ class BaseTuner(nn.Module, ABC):
                         # replacement, since we want to replace the wrapped module.
                         create_and_replace_param(module_name, key, param_name)
                         targeted_parameter_names.append(key)
+
+        return targeted_parameter_names
 
     def _replace_module(self, parent, child_name, new_module, child) -> None:
         """

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .constants import ALLOWED_COMPUTE_DTYPES, UPCAST_DTYPES
-from .error import NoMatchingPeftModule, PeftError
+from .error import NoMatchingPeftModuleError, PeftError
 from .integrations import map_cache_to_layer_device_map
 from .loftq_utils import replace_lora_weights_loftq
 from .other import (
@@ -132,7 +132,7 @@ __all__ = [
     "WEIGHTS_NAME",
     "AuxiliaryTrainingWrapper",
     "ModulesToSaveWrapper",
-    "NoMatchingPeftModule",
+    "NoMatchingPeftModuleError",
     "PeftError",
     "PeftType",
     "PeftWarning",

--- a/src/peft/utils/__init__.py
+++ b/src/peft/utils/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .constants import ALLOWED_COMPUTE_DTYPES, UPCAST_DTYPES
+from .error import NoMatchingPeftModule, PeftError
 from .integrations import map_cache_to_layer_device_map
 from .loftq_utils import replace_lora_weights_loftq
 from .other import (
@@ -131,6 +132,8 @@ __all__ = [
     "WEIGHTS_NAME",
     "AuxiliaryTrainingWrapper",
     "ModulesToSaveWrapper",
+    "NoMatchingPeftModule",
+    "PeftError",
     "PeftType",
     "PeftWarning",
     "TaskType",

--- a/src/peft/utils/error.py
+++ b/src/peft/utils/error.py
@@ -17,7 +17,7 @@ class PeftError(Exception):
     """Base PEFT error"""
 
 
-class NoMatchingPeftModule(PeftError, ValueError):
+class NoMatchingPeftModuleError(PeftError, ValueError):
     """The adapter being injected matched no module or parameter of the base model.
 
     Raised e.g. when the `target_modules` of the PEFT config matched nothing, which most often points at a

--- a/src/peft/utils/error.py
+++ b/src/peft/utils/error.py
@@ -1,0 +1,27 @@
+# Copyright 2026-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class PeftError(Exception):
+    """Base PEFT error"""
+
+
+class NoMatchingPeftModule(PeftError, ValueError):
+    """The adapter being injected matched no module or parameter of the base model.
+
+    Raised e.g. when the `target_modules` of the PEFT config matched nothing, which most often points at a
+    misconfiguration. It subclasses `ValueError` for backwards compatibility with code that intercepted the generic
+    error raised previously. Code that adds such an adapter intentionally can catch this error (or `PeftError`) and
+    proceed.
+    """

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -1376,7 +1376,7 @@ MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES = [
         "lora+trainable_tokens",
         LoraConfig,
         {"target_modules": ["lin0"], "init_lora_weights": False, "trainable_token_indices": {"emb": [0, 1, 2]}},
-        {"target_modules": ["lin1"], "init_lora_weights": False, "trainable_token_indices": {"emb": [3, 4, 5, 6]}},
+        {"target_modules": ["conv1d"], "init_lora_weights": False, "trainable_token_indices": {"emb": [3, 4, 5, 6]}},
     ),
     (
         "LoRA targeting nn.Parameter Same",
@@ -3455,7 +3455,7 @@ class TestPeftCustomModel(PeftCommonTester):
             target_modules=["layers.0.lin0"], modules_to_save=["layers.0.lin1", "layers.1.lin1"], **extra_kwargs
         )
         config1 = config_cls(
-            target_modules=["0layers..lin0"], modules_to_save=["layers.2.lin1", "layers.1.lin1"], **extra_kwargs
+            target_modules=["layers.0.lin0"], modules_to_save=["layers.2.lin1", "layers.1.lin1"], **extra_kwargs
         )
         model = get_peft_model(model, config0, adapter_name="default")
         # adding the adapter is fine

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -36,7 +36,7 @@ from peft import (
     IA3Config,
     LoHaConfig,
     LoraConfig,
-    NoMatchingPeftModule,
+    NoMatchingPeftModuleError,
     PeftError,
     PeftModel,
     PromptTuningConfig,
@@ -629,30 +629,29 @@ class TestExcludedModuleNames:
         # See https://github.com/huggingface/peft/issues/3533.
         model = MLP()
         model = get_peft_model(model, LoraConfig(target_modules=["lin0"]))
-        with pytest.raises(NoMatchingPeftModule, match="Target modules .* not found in the base model"):
+        with pytest.raises(NoMatchingPeftModuleError, match="Target modules .* not found in the base model"):
             model.add_adapter("other", LoraConfig(target_modules=["non_existent_module"]))
 
     def test_second_adapter_only_modules_to_save_raises(self):
         # A second adapter is held to the same standard as a first one: if its target_modules match nothing, it
-        # raises even when modules_to_save matches. The error subclasses PeftError (and ValueError), so callers
-        # who add such an adapter intentionally can catch it and proceed.
+        # raises even when modules_to_save matches.
         # See https://github.com/huggingface/peft/issues/3533.
         model = MLP()
         model = get_peft_model(model, LoraConfig(target_modules=["lin0"]))
-        with pytest.raises(NoMatchingPeftModule, match="No modules were targeted for adaptation"):
+        with pytest.raises(NoMatchingPeftModuleError, match="No modules were targeted for adaptation"):
             model.add_adapter("other", LoraConfig(target_modules=["non_existent_module"], modules_to_save=["lin1"]))
 
     def test_no_matching_peft_module_error_hierarchy(self):
-        # NoMatchingPeftModule stays a ValueError for backwards compatibility and a PeftError for interception
-        assert issubclass(NoMatchingPeftModule, ValueError)
-        assert issubclass(NoMatchingPeftModule, PeftError)
+        # NoMatchingPeftModuleError stays a ValueError for backwards compatibility and a PeftError for interception
+        assert issubclass(NoMatchingPeftModuleError, ValueError)
+        assert issubclass(NoMatchingPeftModuleError, PeftError)
 
     def test_targeted_module_names_unique_across_adapters(self):
         # targeted_module_names records each module once, even when several adapters target the same module
         model = MLP()
-        model = get_peft_model(model, LoraConfig(target_modules=["lin0"]))
+        model = get_peft_model(model, LoraConfig(target_modules=["lin1"]))
         model.add_adapter("other", LoraConfig(target_modules=["lin0", "lin1"]))
-        assert model.base_model.targeted_module_names == ["lin0", "lin1"]
+        assert model.base_model.targeted_module_names == ["lin1", "lin0"]
 
     def test_some_modules_excluded_some_unmatched(self):
         model = MLP()

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -620,6 +620,25 @@ class TestExcludedModuleNames:
         with pytest.raises(ValueError, match="Target modules .* not found in the base model"):
             get_peft_model(model, LoraConfig(target_modules=["non_existent_module"]))
 
+    def test_no_modules_matched_second_adapter(self):
+        # A second adapter whose target_modules match nothing must raise just like the first adapter does
+        # (test_no_modules_matched). The no-match check used to read targeted_module_names, which accumulates
+        # across adapters, so once the first adapter matched a module the second was silently accepted.
+        # See https://github.com/huggingface/peft/issues/3533.
+        model = MLP()
+        model = get_peft_model(model, LoraConfig(target_modules=["lin0"]))
+        with pytest.raises(ValueError, match="Target modules .* not found in the base model"):
+            model.add_adapter("other", LoraConfig(target_modules=["non_existent_module"]))
+
+    def test_second_adapter_only_modules_to_save_is_accepted(self):
+        # A second adapter whose target_modules match nothing is still valid if it contributes through
+        # modules_to_save (a module that is not itself a target), and must not raise.
+        # See https://github.com/huggingface/peft/issues/3533.
+        model = MLP()
+        model = get_peft_model(model, LoraConfig(target_modules=["lin0"]))
+        model.add_adapter("other", LoraConfig(target_modules=["non_existent_module"], modules_to_save=["lin1"]))
+        assert "other" in model.base_model.model.lin1.modules_to_save
+
     def test_some_modules_excluded_some_unmatched(self):
         model = MLP()
         with pytest.raises(ValueError, match="No modules were targeted for adaptation"):

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -36,6 +36,8 @@ from peft import (
     IA3Config,
     LoHaConfig,
     LoraConfig,
+    NoMatchingPeftModule,
+    PeftError,
     PeftModel,
     PromptTuningConfig,
     VeraConfig,
@@ -627,17 +629,30 @@ class TestExcludedModuleNames:
         # See https://github.com/huggingface/peft/issues/3533.
         model = MLP()
         model = get_peft_model(model, LoraConfig(target_modules=["lin0"]))
-        with pytest.raises(ValueError, match="Target modules .* not found in the base model"):
+        with pytest.raises(NoMatchingPeftModule, match="Target modules .* not found in the base model"):
             model.add_adapter("other", LoraConfig(target_modules=["non_existent_module"]))
 
-    def test_second_adapter_only_modules_to_save_is_accepted(self):
-        # A second adapter whose target_modules match nothing is still valid if it contributes through
-        # modules_to_save (a module that is not itself a target), and must not raise.
+    def test_second_adapter_only_modules_to_save_raises(self):
+        # A second adapter is held to the same standard as a first one: if its target_modules match nothing, it
+        # raises even when modules_to_save matches. The error subclasses PeftError (and ValueError), so callers
+        # who add such an adapter intentionally can catch it and proceed.
         # See https://github.com/huggingface/peft/issues/3533.
         model = MLP()
         model = get_peft_model(model, LoraConfig(target_modules=["lin0"]))
-        model.add_adapter("other", LoraConfig(target_modules=["non_existent_module"], modules_to_save=["lin1"]))
-        assert "other" in model.base_model.model.lin1.modules_to_save
+        with pytest.raises(NoMatchingPeftModule, match="No modules were targeted for adaptation"):
+            model.add_adapter("other", LoraConfig(target_modules=["non_existent_module"], modules_to_save=["lin1"]))
+
+    def test_no_matching_peft_module_error_hierarchy(self):
+        # NoMatchingPeftModule stays a ValueError for backwards compatibility and a PeftError for interception
+        assert issubclass(NoMatchingPeftModule, ValueError)
+        assert issubclass(NoMatchingPeftModule, PeftError)
+
+    def test_targeted_module_names_unique_across_adapters(self):
+        # targeted_module_names records each module once, even when several adapters target the same module
+        model = MLP()
+        model = get_peft_model(model, LoraConfig(target_modules=["lin0"]))
+        model.add_adapter("other", LoraConfig(target_modules=["lin0", "lin1"]))
+        assert model.base_model.targeted_module_names == ["lin0", "lin1"]
 
     def test_some_modules_excluded_some_unmatched(self):
         model = MLP()


### PR DESCRIPTION
Fixes #3533.

`BaseTuner.inject_adapter` decides whether an adapter matched nothing by checking `self.targeted_module_names` / `self.targeted_parameter_names`. These lists accumulate across every adapter injected into the tuner and are never reset per call, so once the first adapter matched a module the "no modules were targeted" check could never fire again: a second (or later) adapter whose `target_modules` matched nothing was silently accepted as a no-op instead of raising, unlike the first adapter. It affects all methods (the check is in the shared base tuner).

```python
import torch.nn as nn
from peft import get_peft_model, LoraConfig

class MLP(nn.Module):
    def __init__(self):
        super().__init__()
        self.lin0 = nn.Linear(8, 8)
    def forward(self, x):
        return self.lin0(x)

model = get_peft_model(MLP(), LoraConfig(target_modules=["lin0"]))          # ok
model.add_adapter("other", LoraConfig(target_modules=["does_not_exist"]))   # no error, adapts nothing
```

Changes:
- Collect this adapter's matches in local lists inside `inject_adapter` and run the no-match check against those, so it reflects what *this* adapter matched rather than the cumulative total. The locals are merged into `self.targeted_module_names` / `self.targeted_parameter_names` once the checks pass, skipping duplicates so a module targeted by several adapters is recorded once.
- `_inject_parameters` returns the parameter names it matched instead of appending to the tuner attribute.
- Skip a previous adapter's internal modules without recording them as excluded modules. They are adapter internals rather than user-excluded modules, and counting them suppressed the "exclude_modules was passed but no modules were excluded" warning.
- A non-first adapter is held to the same standard as the first: if its `target_modules` match nothing it raises, even when `modules_to_save` or `trainable_token_indices` match. This reverses the first revision of this PR, which exempted that case.
- The no-match errors raise `NoMatchingPeftModuleError`, a new public exception subclassing both `PeftError` and `ValueError`. `ValueError` keeps existing `except` clauses working; `PeftError` lets code that adds such an adapter deliberately catch it.

### Two existing tests were relying on the bug

Both target modules their model does not have, and passed only because a non-first adapter matching nothing was accepted. With the fix they raise, which broke 36 tests across every tuner.

- `test_multiple_active_adapters_with_overlapping_modules_to_save_raises` passed `target_modules=["0layers..lin0"]`, a transposition of the `"layers.0.lin0"` its two sibling tests use. Its own comment says it is the previous test but with overlapping `modules_to_save`, so the target was meant to be identical.
- The `"LoRA + trainable tokens Different"` case in `MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES` targeted `lin1` on `ModelEmbConv1D`, which has `emb`, `conv1d`, `relu`, `flat`, `lin0` and `sm`. The second adapter contributed no LoRA at all, so the case never tested two adapters on different modules as its name says. Changed to `conv1d`.

### Tests

New in `tests/test_tuners_utils.py::TestExcludedModuleNames`: `test_no_modules_matched_second_adapter` (fails on `main`, passes with the fix), `test_second_adapter_only_modules_to_save_raises`, `test_no_matching_peft_module_error_hierarchy`, `test_targeted_module_names_unique_across_adapters`.

- `tests/test_tuners_utils.py` — 223 passed, 16 skipped.
- `tests/test_other.py`, `tests/test_trainable_tokens.py`, `tests/test_vera.py`, `tests/test_vblora.py` — 131 passed.
- `tests/test_custom_models.py` in full — 356 failures on this branch and 356 on the merge base `5f55a63`, identical sets. All are `AdamssConfig` and unrelated to this PR.
- `make quality` clean, including `check_doc_coverage` at 127/127 after adding a docs page for the two new exceptions.

AI assistance was used for this change. I reviewed every line and ran the tests listed above.
