### PR TITLE
Fix PeftMixedModel.disable_adapter to restore prior adapter state

### DIFF
--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -194,11 +194,17 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
         """
         Disables the adapter module.
         """
+        from peft.tuners.tuners_utils import BaseTunerLayer
+
+        was_enabled = any(
+            not module.disable_adapters for module in self.modules() if isinstance(module, BaseTunerLayer)
+        )
         try:
             self.base_model.disable_adapter_layers()
             yield
         finally:
-            self.base_model.enable_adapter_layers()
+            if was_enabled:
+                self.base_model.enable_adapter_layers()
 
     def add_adapter(
         self,

--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -588,6 +588,36 @@ class TestMixedAdapterTypes(unittest.TestCase):
         assert torch.isfinite(output_unloaded).all()
         assert torch.allclose(output_base, output_unloaded, atol=atol, rtol=rtol)
 
+    def test_disable_adapter_restores_state(self):
+        # Regression test for #3507: PeftMixedModel.disable_adapter() must restore the
+        # adapter-enabled state that existed on entry, instead of unconditionally
+        # re-enabling. Covers (a) nested contexts and (b) an already-disabled model.
+        atol = 1e-5
+        rtol = 1e-5
+        input = torch.arange(90).reshape(9, 10).to(self.torch_device)
+
+        config = LoraConfig(r=4, lora_alpha=4, target_modules=["lin0", "lin1"], init_lora_weights=False)
+        peft_model = self._get_model(SimpleNet, config, "adapter0", seed=0)
+
+        output_adapter = peft_model(input)
+
+        with peft_model.disable_adapter():
+            output_base = peft_model(input)
+            with peft_model.disable_adapter():
+                pass
+            output_after_inner = peft_model(input)
+
+        assert not torch.allclose(output_adapter, output_base, atol=atol, rtol=rtol)
+        assert torch.allclose(output_after_inner, output_base, atol=atol, rtol=rtol)
+        assert not torch.allclose(output_after_inner, output_adapter, atol=atol, rtol=rtol)
+
+        peft_model.base_model.disable_adapter_layers()
+        before = {m.disable_adapters for m in peft_model.modules() if hasattr(m, "disable_adapters")}
+        with peft_model.disable_adapter():
+            pass
+        after = {m.disable_adapters for m in peft_model.modules() if hasattr(m, "disable_adapters")}
+        assert before == after == {True}
+
     def test_delete_adapter(self):
         atol = 1e-5
         rtol = 1e-5


### PR DESCRIPTION
Closes #3507.

## Problem
`PeftMixedModel.disable_adapter()` unconditionally called `enable_adapter_layers()` in its `finally`, so it *always* enabled adapters on exit, even if they were disabled on entry. Two symptoms:
- **Nested contexts:** an inner `disable_adapter()` re-enabled adapters while an outer context was still active.
- **Already-disabled models:** a model disabled before entering came out enabled.

Regular `PeftModel.disable_adapter()` doesn't have this problem because it snapshots state and only restores on exit.

## Fix
`PeftModel` uses `get_model_status()` to snapshot state, but that method raises `TypeError` for `PeftMixedModel` (it's explicitly unsupported). So this snapshots the enabled state directly from the `BaseTunerLayer.disable_adapters` flags on entry and only re-enables on exit if adapters were enabled to begin with.

## Tests
Added `test_disable_adapter_restores_state` covering both the nested and already-disabled cases. Full `tests/test_mixed.py` passes locally (macOS/MPS).

Note: `test_deeply_nested` fails on my machine, but I confirmed it fails identically on a clean `main` (stashing this change), it's a pre-existing MPS float-precision issue in the merge-comparison path, unrelated to this fix and is already skipped on Linux CI.