### PR TITLE
CHORE Upgrade ruff to 0.16.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.16.2
     hooks:
       - id: ruff
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ target-version = ['py310']
 [tool.ruff]
 target-version = "py310"
 line-length = 119
-extend-exclude = ["*.ipynb"]
-required-version = "~=0.15.12"
+extend-exclude = ["*.ipynb", "docs/**/*.md", "examples/**/*.md"]
+required-version = "~=0.16.2"
 
 [tool.ruff.lint]
 preview = true

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras["quality"] = [
     "black",  # doc-builder has an implicit dependency on Black, see huggingface/doc-builder#434
     "hf-doc-builder",
     # when upgrading this, also upgrade required version in pyproject.toml and pre-commit-config.yaml
-    "ruff~=0.15.12",
+    "ruff~=0.16.2",
     "griffe",  # for ./scripts/check_doc_coverage.py
 ]
 extras["docs_specific"] = [

--- a/src/peft/tuners/lora/arrow.py
+++ b/src/peft/tuners/lora/arrow.py
@@ -364,8 +364,10 @@ def ensure_adapters_target_linear_layers_only(model, adapter_names: list[str]):
 
     if offenders:
         lines = [
-            "LoRA adapters must only target Linear-like layers "
-            "(nn.Linear, nn.Conv1d, HF Conv1D, or bitsandbytes.nn.Linear4bit). Found:"
+            (
+                "LoRA adapters must only target Linear-like layers "
+                "(nn.Linear, nn.Conv1d, HF Conv1D, or bitsandbytes.nn.Linear4bit). Found:"
+            )
         ]
         for name, full_name, tname in offenders:
             lines.append(f"  - adapter '{name}' on module '{full_name}' of type {tname}")

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1941,8 +1941,10 @@ class TestAdamssInitialization:
             ),
             (
                 {"init_warmup": 10, "final_warmup": 10},
-                "`init_warmup` must be smaller than `final_warmup` when `use_asa=True` so that ASA has a "
-                "non-empty pruning ramp, got init_warmup=10 and final_warmup=10.",
+                (
+                    "`init_warmup` must be smaller than `final_warmup` when `use_asa=True` so that ASA has a "
+                    "non-empty pruning ramp, got init_warmup=10 and final_warmup=10."
+                ),
             ),
             (
                 {"asa_target_subspaces": 0},


### PR DESCRIPTION
## Description

This PR upgrades ruff from 0.15.12 to 0.16.2. The only changes needed are:

- no implicit string concatenation (whatever, fair)
- exclude markdown files

## Additional context

When I first read:

> Ruff now enables 413 rules by default, up from 59 in previous versions.

I was expecting a bunch of changes all throughout the code base. Fortunately, this was not the case, in fact only one additional rule was affecting our code.

There were, however, a bunch of changes to the code blocks in markdown files in our documentation and examples. I found these changes to vary from "nice to have" to "actively hurting readability". Therefore, I decided to exclude those markdown files.

An example of a change that I found detrimental is:

```diff
-    num_samples=8,         # number of Monte Carlo samples per forward pass
-    sample_scaler=1e-4,    # magnitude of the variational perturbation
-    kl_loss_weight=1e-5,   # weight of the KL term added to the training loss
+    num_samples=8,  # number of Monte Carlo samples per forward pass
+    sample_scaler=1e-4,  # magnitude of the variational perturbation
+    kl_loss_weight=1e-5,  # weight of the KL term added to the training loss
```

Other changes were things like adding two empty lines after imports, which makes a short five-line code block unnecessarily big.

Yes, we could add explicit exceptions for each unwanted change, but this just adds diff noise for no tangible benefit. Therefore, my vote is to fully exclude markdown files from formatting (note: there is no ruff option specific to code blocks in markup files, the only way is to completely exclude those).