### PR TITLE
MetaMathQA: Add bank-1024 VBLoRA configuration

### DIFF
--- a/method_comparison/MetaMathQA/experiments/vblora/llama-3.2-3B-bank1024-lr5e4/adapter_config.json
+++ b/method_comparison/MetaMathQA/experiments/vblora/llama-3.2-3B-bank1024-lr5e4/adapter_config.json
@@ -1,0 +1,26 @@
+{
+  "auto_mapping": null,
+  "base_model_name_or_path": null,
+  "bias": "none",
+  "exclude_modules": null,
+  "fan_in_fan_out": false,
+  "inference_mode": false,
+  "init_logits_std": 0.1,
+  "init_vector_bank_bound": 0.02,
+  "layers_pattern": null,
+  "layers_to_transform": null,
+  "modules_to_save": null,
+  "num_vectors": 1024,
+  "peft_type": "VBLORA",
+  "r": 4,
+  "revision": null,
+  "save_only_topk_weights": false,
+  "target_modules": [
+    "v_proj",
+    "q_proj"
+  ],
+  "task_type": null,
+  "topk": 2,
+  "vblora_dropout": 0.0,
+  "vector_length": 256
+}

--- a/method_comparison/MetaMathQA/experiments/vblora/llama-3.2-3B-bank1024-lr5e4/training_params.json
+++ b/method_comparison/MetaMathQA/experiments/vblora/llama-3.2-3B-bank1024-lr5e4/training_params.json
@@ -1,0 +1,6 @@
+{
+  "optimizer_kwargs": {
+    "lr": 0.0005,
+    "weight_decay": 0.1
+  }
+}


### PR DESCRIPTION
## Summary

Adds one VBLoRA MetaMathQA experiment for Llama 3.2 3B using:

- `num_vectors=1024`
- `vector_length=256`
- `r=4`
- `topk=2`
- learning rate `5e-4`
- weight decay `0.1`

This is a configuration-only addition following the experiments discussed in [Discussion #3521](https://github.com/huggingface/peft/discussions/3521#discussioncomment-18001803).

## Experiment design

I first reproduced the existing 256-vector baseline after applying the tokenizer padding behavior from #3526. I then performed a bounded follow-up search, changing one factor at a time before testing their combination:

| Run | `num_vectors` | LR | Step 5000 loss | GSM8K test accuracy | Forgetting |
|---|---:|---:|---:|---:|---:|
| Reproduced baseline | 256 | 1e-4 | 0.716351 | 33.2828% | 0.0465 |
| C2 | 512 | 3e-4 | 0.671287 | 36.8461% | 0.0643 |
| C3 | 1024 | 3e-4 | 0.658788 | 39.7271% | 0.0555 |
| C4 | 512 | 5e-4 | 0.661107 | 38.9689% | 0.0654 |
| C5 | 1024 | 5e-4 | 0.648648 | 41.2434% | 0.0591 |

These were single seed-0 local runs. Both single-factor changes improved over C2, and their combination in C5 performed best. The search was stopped at this predefined boundary rather than continuing to tune against the test benchmark.

## Trade-offs

Compared with the reproduced 256-vector baseline, C5 improved GSM8K test accuracy by approximately 7.96 percentage points. The 1024-vector configuration has approximately 4x the trainable adapter parameters and checkpoint size:

| Run | Trainable parameters | Checkpoint size |
|---|---:|---:|
| Reproduced baseline | 1,212,416 | 4,864,912 bytes |
| C5 | 4,849,664 | 19,414,168 bytes |

This is therefore an accuracy/adapter-size trade-off rather than a Pareto improvement.

The measured training peak memory did not increase substantially. The benchmark records `accelerator_memory_max` as peak reserved accelerator memory after subtracting the initial allocation:

| Run | `num_vectors` | LR | Max reserved memory |
|---|---:|---:|---:|
| B0 | 256 | 1e-4 | 12.6426 GiB |
| C1 | 512 | 1e-4 | 12.5332 GiB |
| C2 | 512 | 3e-4 | 12.6621 GiB |
| C3 | 1024 | 3e-4 | 12.5703 GiB |
| C4 | 512 | 5e-4 | 12.6621 GiB |
| C5 | 1024 | 5e-4 | 12.6973 GiB |

C5 used 56 MiB more peak reserved memory than B0, an increase of approximately 0.43%. The small differences between runs are likely within CUDA allocator variation. This is consistent with the VBLoRA vector bank being shared.

## Local environment

The supporting runs used:

- NVIDIA RTX 5080 16 GB under WSL2
- gradient checkpointing
- the `unsloth/Llama-3.2-3B` snapshot whose weights were confirmed in Discussion #3521 to match the Meta model
- locally cached MetaMathQA, GSM8K, and FineWiki datasets
- PEFT commit `6b2eda7` with the MetaMathQA tokenizer padding behavior from #3526 applied

The submitted configuration retains the benchmark's default Meta model ID and does not include local paths, gradient-checkpointing overrides, result files, or runner changes.

## Validation

- loaded the configuration with `PeftConfig.from_pretrained`
- verified the resolved default model ID, 5,000 steps, seed 0, and disabled gradient checkpointing
- verified `lr=5e-4` and `weight_decay=0.1`
- verified discovery through `make list`
- validated both JSON files
- ran `git diff --check`
- confirmed that the diff contains only the two files in the new experiment directory

Related to #2310.

## AI assistance

AI assistance was used for repository navigation, experiment orchestration, result summarization, and draft preparation. I reviewed the experiment design, configurations, reported metrics, and final diff.
