### PR TITLE
fix: handle removal of distributed_operation in Transformers TP rework

### DIFF
--- a/src/peft/utils/transformers_weight_conversion.py
+++ b/src/peft/utils/transformers_weight_conversion.py
@@ -199,6 +199,26 @@ class PermuteDims(ConversionOps):
         return f"{self.__class__.__name__}(dims={self.dims})"
 
 
+def _copy_runtime_attributes(src: WeightConverter | WeightRenaming, dst: WeightConverter | WeightRenaming) -> None:
+    """Copy runtime-only attributes from *src* to *dst*.
+
+    ``WeightConverter`` objects created by Transformers carry optional attributes
+    (e.g. ``quantization_operation`` and, on older versions, ``distributed_operation``)
+    that are set after construction during model loading. When PEFT builds new
+    converters from existing ones, those attributes must be propagated so the new
+    converters behave like the originals.
+
+    Because the set of attributes varies across Transformers versions —
+    ``distributed_operation`` was removed in the DTensor-based TP rework
+    (https://github.com/huggingface/transformers/pull/47579) — each attribute is
+    copied with ``getattr``/``setattr`` and silently skipped when it does not exist
+    on the source object.
+    """
+    for attr in ("distributed_operation", "quantization_operation"):
+        if hasattr(src, attr):
+            setattr(dst, attr, getattr(src, attr))
+
+
 def build_peft_weight_mapping(
     weight_conversions: list[WeightConverter | WeightRenaming] | None, adapter_name: str, peft_config=None
 ) -> list[WeightConverter | WeightRenaming]:
@@ -276,8 +296,7 @@ def build_peft_weight_mapping(
                     target_patterns=new_target_patterns,
                     operations=peft_weight_operations,
                 )
-                new_conversion.distributed_operation = orig_conversion.distributed_operation
-                new_conversion.quantization_operation = orig_conversion.quantization_operation
+                _copy_runtime_attributes(orig_conversion, new_conversion)
                 new_weight_conversions.append(new_conversion)
 
         elif len(orig_conversion.target_patterns) == 1 and orig_conversion.target_patterns[0].endswith("down_proj"):
@@ -318,8 +337,7 @@ def build_peft_weight_mapping(
                     target_patterns=new_target_patterns,
                     operations=peft_weight_operations,
                 )
-                new_conversion.distributed_operation = orig_conversion.distributed_operation
-                new_conversion.quantization_operation = orig_conversion.quantization_operation
+                _copy_runtime_attributes(orig_conversion, new_conversion)
                 new_weight_conversions.append(new_conversion)
 
     return new_weight_conversions

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -326,6 +326,37 @@ class TestTransformersV5:
         expected_num_lora_layers = 12  # 2 layers with 6 lora layers each
         assert num_lora_layers == expected_num_lora_layers
 
+    def test_build_peft_weight_mapping_without_distributed_operation(self):
+        # Regression test for compatibility with the DTensor-based TP rework in Transformers
+        # (https://github.com/huggingface/transformers/pull/47579), which removed the
+        # ``distributed_operation`` attribute from ``WeightConverter``. PEFT used to copy
+        # that attribute when building new converters; without the attribute it must not
+        # raise.
+        from transformers.core_model_loading import Concatenate, MergeModulelist, WeightConverter
+
+        from peft.utils.transformers_weight_conversion import build_peft_weight_mapping
+
+        weight_conversions = [
+            WeightConverter(
+                source_patterns=["model.experts.*.w1.weight", "model.experts.*.w3.weight"],
+                target_patterns=["model.experts.gate_up_proj"],
+                operations=[MergeModulelist(dim=0), Concatenate(dim=1)],
+            ),
+            WeightConverter(
+                source_patterns=["model.experts.*.w2.weight"],
+                target_patterns=["model.experts.down_proj"],
+                operations=[MergeModulelist(dim=0)],
+            ),
+        ]
+
+        result = build_peft_weight_mapping(weight_conversions, adapter_name="default")
+        assert len(result) > 0
+        # On older Transformers, distributed_operation is propagated; on newer versions
+        # (post PR #47579) it does not exist and must be silently skipped.
+        for entry in result:
+            if isinstance(entry, WeightConverter):
+                assert hasattr(entry, "quantization_operation")
+
     def test_qwen_v4_lora_weight_conversion_peft_model_from_pretrained(self):
         # Load a PEFT adapter trained with transformers v4 on Qwen3 MoE, which now has converted weights (MoE), using
         # PeftModel.from_pretrained


### PR DESCRIPTION
## Problem

Transformers PR [#47579](https://github.com/huggingface/transformers/pull/47579) reworked tensor parallelism (TP) to use a DTensor-based API, replacing the legacy `distributed_operation` mechanism. This PR removed the `distributed_operation` attribute from `WeightTransform.__slots__` and `__init__` in `core_model_loading.py`.

PEFT's `build_peft_weight_mapping` function in `src/peft/utils/transformers_weight_conversion.py` directly accessed `orig_conversion.distributed_operation` when building new `WeightConverter` objects for MoE LoRA adapter conversion (lines 279 and 321). With the new Transformers code, this attribute no longer exists, causing:

```
AttributeError: 'WeightConverter' object has no attribute 'distributed_operation'
```

This breaks loading LoRA adapters on MoE models (e.g. Mixtral) when using the new Transformers TP code, as exercised by the Transformers test `test_mixtral_lora_conversion`.

## Solution

Introduced a `_copy_runtime_attributes` helper that copies optional runtime attributes (`distributed_operation` and `quantization_operation`) from the original converter to the new PEFT-specific converter using `hasattr`/`setattr`. Attributes that don't exist on the source (like `distributed_operation` on new Transformers) are silently skipped.

This is backward compatible:
- **Older Transformers** (with `distributed_operation`): The attribute is still copied as before.
- **Newer Transformers** (PR #47579, without `distributed_operation`): The attribute is skipped, and only `quantization_operation` is copied.

## Testing

Ran the following tests with both Transformers `main` (v5.16.0.dev0, still has `distributed_operation`) and Transformers PR #47579 branch (v5.15.0.dev0, `distributed_operation` removed):

```
pytest tests/test_integrations.py -k "mixtral" -v
```

All 5 mixtral tests pass on both versions. Also ran the new regression test and the Transformers-side test:

```
pytest tests/test_integrations.py::TestTransformersV5::test_build_peft_weight_mapping_without_distributed_operation
pytest tests/peft_integration/test_peft_integration.py::PeftIntegrationTester::test_mixtral_lora_conversion
```

Both pass on both Transformers versions.

## Regression test

Added `test_build_peft_weight_mapping_without_distributed_operation` to `tests/test_integrations.py` which constructs `WeightConverter` objects (simulating what `get_model_conversion_mapping` returns) and verifies `build_peft_weight_mapping` works regardless of whether `distributed_operation` exists.

## Notes

- AI assistance was used for this PR.
- The fix is minimal and does not change any behavior for existing Transformers versions.