### PR TITLE
CHORE Dockerfile installs mslk differently

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -67,7 +67,6 @@ RUN conda run -n peft pip install -U --no-cache-dir \
         "soundfile>=0.12.1" \
         scipy \
         torchao \
-        mslk-cuda \
         "fbgemm-gpu-genai>=1.2.0" \
         git+https://github.com/huggingface/transformers \
         git+https://github.com/huggingface/accelerate \
@@ -77,7 +76,8 @@ RUN conda run -n peft pip install -U --no-cache-dir \
         # Add HQQ for quantization testing
         hqq \
         deepspeed \
-        "kernels<0.16"
+        "kernels<0.16" \
+        && conda run -n peft pip install -U --no-cache-dir mslk --index-url https://download.pytorch.org/whl/cu132
 
 RUN conda run -n peft pip freeze | grep transformers
 


### PR DESCRIPTION
Our nightly GPU tests currently run into [this error](https://github.com/huggingface/peft/actions/runs/31987901646/job/95265962436#step:8:174):

> OSError: Could not load this library: /opt/conda/envs/peft/lib/python3.11/site-packages/mslk/mslk.so

Now installing the mslk package differently, following the [instructions here](https://github.com/meta-pytorch/MSLK#installation).

