### PR TITLE
FIX Transformers warnings use return dict, missing inputs_embeds argument, fix causal_mask_creation_function call

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1901,7 +1901,7 @@ class PeftModelForSequenceClassification(PeftModel):
         )
 
         if peft_config.peft_type in (PeftType.PREFIX_TUNING, PeftType.CARTRIDGE):
-            return self._prefix_tuning_forward(input_ids=input_ids, **kwargs)
+            return self._prefix_tuning_forward(input_ids=input_ids, inputs_embeds=inputs_embeds, **kwargs)
         else:
             if kwargs.get("token_type_ids", None) is not None:
                 kwargs["token_type_ids"] = torch.cat(
@@ -2446,6 +2446,7 @@ class PeftModelForSeq2SeqLM(PeftModel):
             kwargs["past_key_values"] = self.get_prompt(batch_size)
             return self.base_model(
                 input_ids=input_ids,
+                inputs_embeds=inputs_embeds,
                 decoder_input_ids=decoder_input_ids,
                 decoder_inputs_embeds=decoder_inputs_embeds,
                 **kwargs,
@@ -2756,7 +2757,7 @@ class PeftModelForTokenClassification(PeftModel):
         )
 
         if peft_config.peft_type in (PeftType.PREFIX_TUNING, PeftType.CARTRIDGE):
-            return self._prefix_tuning_forward(input_ids=input_ids, **kwargs)
+            return self._prefix_tuning_forward(input_ids=input_ids, inputs_embeds=inputs_embeds, **kwargs)
         else:
             if kwargs.get("token_type_ids", None) is not None:
                 kwargs["token_type_ids"] = torch.cat(
@@ -2992,7 +2993,7 @@ class PeftModelForQuestionAnswering(PeftModel):
         )
 
         if peft_config.peft_type in (PeftType.PREFIX_TUNING, PeftType.CARTRIDGE):
-            return self._prefix_tuning_forward(input_ids=input_ids, **kwargs)
+            return self._prefix_tuning_forward(input_ids=input_ids, inputs_embeds=inputs_embeds, **kwargs)
         else:
             if kwargs.get("token_type_ids", None) is not None:
                 kwargs["token_type_ids"] = torch.cat(
@@ -3173,7 +3174,7 @@ class PeftModelForFeatureExtraction(PeftModel):
         if peft_config.peft_type in (PeftType.PREFIX_TUNING, PeftType.CARTRIDGE):
             # overwrite past_kv in kwargs
             kwargs["past_key_values"] = self.get_prompt(batch_size)
-            return self.base_model(input_ids=input_ids, **kwargs)
+            return self.base_model(input_ids=input_ids, inputs_embeds=inputs_embeds, **kwargs)
         else:
             if inputs_embeds is None:
                 inputs_embeds = self.word_embeddings(input_ids)

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -104,6 +104,17 @@ def _get_layer_kv_target_shape(base_config, layer_idx: int) -> tuple[int, int] |
     return num_kv_heads, head_dim
 
 
+def _get_return_dict(config) -> bool:
+    """Default value of `return_dict` from the model config.
+
+    Transformers v5 deprecated the `config.use_return_dict` property in favor of `config.return_dict`, so read the
+    attribute directly. The `torchscript` check replicates the old property's behavior on transformers v4 of never
+    returning dicts in torchscript mode (v5 removed the attribute), see:
+    https://github.com/huggingface/transformers/blob/753d61104116eefc8ffc977327b441ee0c8d599f/src/transformers/configuration_utils.py#L384-L390
+    """
+    return getattr(config, "return_dict", True) and not getattr(config, "torchscript", False)
+
+
 class PeftModel(PushToHubMixin, torch.nn.Module):
     """
     Base model encompassing various Peft methods.
@@ -1855,7 +1866,7 @@ class PeftModelForSequenceClassification(PeftModel):
         task_ids=None,
         **kwargs,
     ):
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        return_dict = return_dict if return_dict is not None else _get_return_dict(self.config)
         peft_config = self.active_peft_config
         if not peft_config.is_prompt_learning:
             with self._enable_peft_forward_hooks(**kwargs):
@@ -2710,7 +2721,7 @@ class PeftModelForTokenClassification(PeftModel):
         **kwargs,
     ):
         peft_config = self.active_peft_config
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        return_dict = return_dict if return_dict is not None else _get_return_dict(self.config)
 
         if not peft_config.is_prompt_learning:
             with self._enable_peft_forward_hooks(**kwargs):
@@ -2943,7 +2954,7 @@ class PeftModelForQuestionAnswering(PeftModel):
         **kwargs,
     ):
         peft_config = self.active_peft_config
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        return_dict = return_dict if return_dict is not None else _get_return_dict(self.config)
 
         if not peft_config.is_prompt_learning:
             if peft_config.peft_type == PeftType.POLY:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -104,7 +104,7 @@ def _get_layer_kv_target_shape(base_config, layer_idx: int) -> tuple[int, int] |
     return num_kv_heads, head_dim
 
 
-def _get_return_dict(config) -> bool:
+def _get_return_dict_transformers_v4(config) -> bool:
     """Default value of `return_dict` from the model config.
 
     Transformers v5 deprecated the `config.use_return_dict` property in favor of `config.return_dict`, so read the
@@ -112,6 +112,7 @@ def _get_return_dict(config) -> bool:
     returning dicts in torchscript mode (v5 removed the attribute), see:
     https://github.com/huggingface/transformers/blob/753d61104116eefc8ffc977327b441ee0c8d599f/src/transformers/configuration_utils.py#L384-L390
     """
+    # TODO: remove this function once Transformers v4 is no longer supported
     return getattr(config, "return_dict", True) and not getattr(config, "torchscript", False)
 
 
@@ -1866,7 +1867,7 @@ class PeftModelForSequenceClassification(PeftModel):
         task_ids=None,
         **kwargs,
     ):
-        return_dict = return_dict if return_dict is not None else _get_return_dict(self.config)
+        return_dict = return_dict if return_dict is not None else _get_return_dict_transformers_v4(self.config)
         peft_config = self.active_peft_config
         if not peft_config.is_prompt_learning:
             with self._enable_peft_forward_hooks(**kwargs):
@@ -2722,7 +2723,7 @@ class PeftModelForTokenClassification(PeftModel):
         **kwargs,
     ):
         peft_config = self.active_peft_config
-        return_dict = return_dict if return_dict is not None else _get_return_dict(self.config)
+        return_dict = return_dict if return_dict is not None else _get_return_dict_transformers_v4(self.config)
 
         if not peft_config.is_prompt_learning:
             with self._enable_peft_forward_hooks(**kwargs):
@@ -2955,7 +2956,7 @@ class PeftModelForQuestionAnswering(PeftModel):
         **kwargs,
     ):
         peft_config = self.active_peft_config
-        return_dict = return_dict if return_dict is not None else _get_return_dict(self.config)
+        return_dict = return_dict if return_dict is not None else _get_return_dict_transformers_v4(self.config)
 
         if not peft_config.is_prompt_learning:
             if peft_config.peft_type == PeftType.POLY:

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -1697,6 +1697,9 @@ def create_attention_mask(
     # the 4D causal mask exists, it should be present in the base model (XXXModel class) or in its decoder.
     base_model = getattr(model, model.base_model_prefix, model)
     decoder = base_model.get_decoder() if hasattr(base_model, "get_decoder") else None
+    # TODO: remove check for _prepare_4d_causal_attention_mask_with_cache_position once Transformers <= v5.2 is
+    # dropped. Note that for <= v5.2, the function may or may not exist, so the fallback in the
+    # `causal_mask_creation_function is None` case is still needed.
     causal_mask_creation_function = getattr(base_model, "_prepare_4d_causal_attention_mask_with_cache_position", None)
     if causal_mask_creation_function is None and decoder is not None:  # it may be in the decoder
         causal_mask_creation_function = getattr(decoder, "_prepare_4d_causal_attention_mask_with_cache_position", None)
@@ -1706,7 +1709,8 @@ def create_attention_mask(
         token_type_ids = getattr(model_input, "token_type_ids", None)
         # Some models may overwrite the general one
         causal_mask_creation_function = getattr(model, "create_masks_for_generate", create_masks_for_generate)
-        # we only need batch size, seq_length and dtype here - we don't care about the values of the embeddings
+        # Transforrmers only uses batch size, seq_length, and dtype of inputs_embeds to create the mask, so it's safe to
+        # create a dummy tensor here.
         dummy_embeds = torch.empty((batch_size, sequence_length), dtype=model.dtype)
         if is_transformers_ge_v5:
             # transformers v5 renamed the input_embeds argument to inputs_embeds and removed cache_position

--- a/src/peft/utils/other.py
+++ b/src/peft/utils/other.py
@@ -36,7 +36,12 @@ from packaging import version
 from safetensors.torch import storage_ptr, storage_size
 from transformers import PreTrainedModel
 
-from ..import_utils import is_gptqmodel_available, is_torch_tpu_available, is_transformers_ge_v5_1_0
+from ..import_utils import (
+    is_gptqmodel_available,
+    is_torch_tpu_available,
+    is_transformers_ge_v5,
+    is_transformers_ge_v5_1_0,
+)
 from .constants import (
     CONFIG_NAME,
     EMBEDDING_LAYER_NAMES,
@@ -1701,16 +1706,28 @@ def create_attention_mask(
         token_type_ids = getattr(model_input, "token_type_ids", None)
         # Some models may overwrite the general one
         causal_mask_creation_function = getattr(model, "create_masks_for_generate", create_masks_for_generate)
-        attention_mask = causal_mask_creation_function(
-            config=model.config,
-            # we only need batch size, seq_length and dtype here - we don't care about the values of the embeddings
-            input_embeds=torch.empty((batch_size, sequence_length), dtype=model.dtype),
-            attention_mask=attention_mask,
-            cache_position=cache_position,
-            past_key_values=past_key_values,
-            token_type_ids=token_type_ids,
-            position_ids=position_ids,
-        )
+        # we only need batch size, seq_length and dtype here - we don't care about the values of the embeddings
+        dummy_embeds = torch.empty((batch_size, sequence_length), dtype=model.dtype)
+        if is_transformers_ge_v5:
+            # transformers v5 renamed the input_embeds argument to inputs_embeds and removed cache_position
+            attention_mask = causal_mask_creation_function(
+                config=model.config,
+                inputs_embeds=dummy_embeds,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                token_type_ids=token_type_ids,
+                position_ids=position_ids,
+            )
+        else:
+            attention_mask = causal_mask_creation_function(
+                config=model.config,
+                input_embeds=dummy_embeds,
+                attention_mask=attention_mask,
+                cache_position=cache_position,
+                past_key_values=past_key_values,
+                token_type_ids=token_type_ids,
+                position_ids=position_ids,
+            )
     else:
         attention_mask = causal_mask_creation_function(
             attention_mask,

--- a/tests/test_decoder_models.py
+++ b/tests/test_decoder_models.py
@@ -24,6 +24,7 @@ from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
     DataCollatorForLanguageModeling,
+    DynamicCache,
     Trainer,
     TrainingArguments,
 )
@@ -933,6 +934,45 @@ class TestDecoderModels(PeftCommonTester):
                 data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False),
             )
             trainer.train()
+
+    def test_prompt_tuning_prepare_inputs_for_generation_4d_attention_mask(self):
+        # Some setups pass a 4d attention mask to prepare_inputs_for_generation. PEFT re-creates the mask to account
+        # for the inserted virtual tokens using create_attention_mask.
+        model_id = "hf-internal-testing/tiny-random-Gemma3ForCausalLM"
+        with hub_online_once(model_id):
+            base = AutoModelForCausalLM.from_pretrained(model_id)
+            num_virtual_tokens = 4
+            model = get_peft_model(
+                base, PromptTuningConfig(num_virtual_tokens=num_virtual_tokens, task_type="CAUSAL_LM")
+            )
+
+            input_ids = torch.tensor([[1, 2, 3]])
+            attention_mask_4d = torch.ones((1, 1, input_ids.shape[1], input_ids.shape[1]))
+            cache_position = torch.arange(input_ids.shape[1])
+
+            def fake_prepare_inputs_for_generation(*args, **kwargs):
+                # generate initializes an empty cache before the first call to prepare_inputs_for_generation
+                return {
+                    "input_ids": input_ids,
+                    "attention_mask": attention_mask_4d,
+                    "cache_position": cache_position.clone(),
+                    "past_key_values": DynamicCache(),
+                }
+
+            model.base_model_prepare_inputs_for_generation = fake_prepare_inputs_for_generation
+            model_kwargs = model.prepare_inputs_for_generation(input_ids)
+
+            total_seq_len = num_virtual_tokens + input_ids.shape[1]
+            assert model_kwargs["input_ids"] is None
+            assert model_kwargs["inputs_embeds"].shape[1] == total_seq_len
+            assert "attention_mask" in model_kwargs
+            # depending on the model and attention implementation, the re-created mask can be a 4d tensor, a dict of
+            # masks, or None (no masking needed)
+            new_mask = model_kwargs["attention_mask"]
+            if isinstance(new_mask, torch.Tensor):
+                assert new_mask.shape[-1] == total_seq_len
+            elif isinstance(new_mask, dict):
+                assert all(mask.shape[-1] == total_seq_len for mask in new_mask.values() if mask is not None)
 
     @pytest.mark.parametrize("model_id", SMALL_GRID_MODELS)
     @pytest.mark.parametrize(

--- a/tests/test_encoder_decoder_models.py
+++ b/tests/test_encoder_decoder_models.py
@@ -56,7 +56,7 @@ from peft import (
 )
 
 from .testing_common import PeftCommonTester
-from .testing_utils import set_init_weights_false
+from .testing_utils import hub_online_once, set_init_weights_false
 
 
 # Note: models from peft-internal-testing are just the safetensors versions of hf-internal-testing
@@ -569,3 +569,32 @@ class TestEncoderDecoderModels(PeftCommonTester):
         with tempfile.TemporaryDirectory() as tmp_dir:
             # This should work fine
             model.save_pretrained(tmp_dir, safe_serialization=True)
+
+    @pytest.mark.parametrize(
+        "config_cls,config_kwargs",
+        [
+            (PrefixTuningConfig, {"task_type": "SEQ_2_SEQ_LM", "num_virtual_tokens": 4}),
+            (PromptEncoderConfig, {"task_type": "SEQ_2_SEQ_LM", "num_virtual_tokens": 4, "encoder_hidden_size": 32}),
+            (PromptTuningConfig, {"task_type": "SEQ_2_SEQ_LM", "num_virtual_tokens": 4}),
+        ],
+    )
+    def test_prompt_learning_forward_with_inputs_embeds(self, config_cls, config_kwargs):
+        # Passing inputs_embeds instead of input_ids should be equivalent.
+        model_id = PEFT_ENCODER_DECODER_MODELS_TO_TEST[0]
+        with hub_online_once(model_id):
+            base_model = AutoModelForSeq2SeqLM.from_pretrained(model_id).to(self.torch_device)
+            model = get_peft_model(base_model, config_cls(base_model_name_or_path=model_id, **config_kwargs))
+            model.eval()
+
+            input_ids = torch.tensor([[1, 1, 1], [1, 2, 1]]).to(self.torch_device)
+            attention_mask = torch.ones_like(input_ids)
+            decoder_input_ids = torch.tensor([[0, 1, 1], [0, 2, 1]]).to(self.torch_device)
+            with torch.no_grad():
+                output_ids = model(
+                    input_ids=input_ids, attention_mask=attention_mask, decoder_input_ids=decoder_input_ids
+                )
+                inputs_embeds = model.get_input_embeddings()(input_ids)
+                output_embeds = model(
+                    inputs_embeds=inputs_embeds, attention_mask=attention_mask, decoder_input_ids=decoder_input_ids
+                )
+            assert torch.allclose(output_ids.logits, output_embeds.logits, atol=1e-5, rtol=1e-5)

--- a/tests/test_feature_extraction_models.py
+++ b/tests/test_feature_extraction_models.py
@@ -328,7 +328,7 @@ ALL_CONFIGS = [
 
 def skip_non_prompt_learning(config_cls):
     if not issubclass(config_cls, PromptLearningConfig):
-        pytest.skip("Skip tests that are not prompt learning or that are prefix tuning")
+        pytest.skip("Skip tests that are not prompt learning")
 
 
 def skip_deberta_lora_tests(config_cls, model_id):

--- a/tests/test_feature_extraction_models.py
+++ b/tests/test_feature_extraction_models.py
@@ -327,7 +327,7 @@ ALL_CONFIGS = [
 
 
 def skip_non_prompt_learning(config_cls):
-    if not issubclass(config_cls, PromptLearningConfig) or (config_cls == PrefixTuningConfig):
+    if not issubclass(config_cls, PromptLearningConfig):
         pytest.skip("Skip tests that are not prompt learning or that are prefix tuning")
 
 

--- a/tests/test_seq_classifier.py
+++ b/tests/test_seq_classifier.py
@@ -228,8 +228,8 @@ ALL_CONFIGS = [
         PsoftConfig,
         {
             "task_type": "SEQ_CLS",
-            "r": 32,
-            "psoft_alpha": 32,
+            "r": 16,  # tiny llama has hidden size 16, so don't choose a greater value
+            "psoft_alpha": 16,
             "target_modules": None,
         },
     ),
@@ -413,3 +413,53 @@ class TestSequenceClassificationModels(PeftCommonTester):
             if classifier is None:
                 raise ValueError(f"Could not determine classifier layer name for {model_id}, please fix the test")
             assert isinstance(classifier, ModulesToSaveWrapper)
+
+    @pytest.mark.parametrize("model_id", PEFT_SEQ_CLS_MODELS_TO_TEST)
+    @pytest.mark.parametrize("config_cls,config_kwargs", ALL_CONFIGS)
+    def test_forward_with_labels(self, model_id, config_cls, config_kwargs):
+        # Check the full forward pass including the loss computation. This is especially relevant for prompt learning
+        # methods, whose sequence classification forward (including the _prefix_tuning_forward fallback for models whose
+        # forward does not accept past_key_values) is implemented in PeftModelForSequenceClassification itself.
+        with hub_online_once(model_id):
+            model = self.transformers_class.from_pretrained(model_id)
+
+            if getattr(model.config, "pad_token_id", None) is None:
+                # needed for a batched forward pass with sequence classification models like Llama
+                model.config.pad_token_id = 0
+
+            config = config_cls(
+                base_model_name_or_path=model_id,
+                **config_kwargs,
+            )
+            model = get_peft_model(model, config).to(self.torch_device)
+            model.eval()
+
+            inputs = self.prepare_inputs_for_testing()
+            num_labels = model.config.num_labels
+            if num_labels == 1:
+                # a single label means that transformers infers regression as the problem type and uses an MSE loss on
+                # float labels; this is the case for the tiny Llama model, whose head has a single output
+                labels = torch.tensor([0.5, -0.5]).to(self.torch_device)
+            else:
+                labels = torch.tensor([0, num_labels - 1]).to(self.torch_device)
+
+            with torch.no_grad():
+                output = model(**inputs, labels=labels)
+
+            assert output.loss is not None
+            assert torch.isfinite(output.loss)
+            assert output.logits.shape == (2, num_labels)
+
+            if num_labels == 1:
+                expected_loss = torch.nn.functional.mse_loss(output.logits.squeeze().float(), labels)
+            else:
+                # int labels and num_labels > 1 result in single label classification, i.e. plain cross entropy
+                expected_loss = torch.nn.functional.cross_entropy(output.logits.float(), labels)
+            # ensure same dtype for allclose call
+            expected_loss = expected_loss.to(dtype=output.loss.dtype)
+
+            if config_cls == AdaLoraConfig:
+                # AdaLora adds an orthogonal regularization term to the loss, so it does not equal the plain task loss
+                assert output.loss > expected_loss
+            else:
+                assert torch.allclose(output.loss, expected_loss, atol=1e-4, rtol=1e-4)

--- a/tests/test_seq_classifier.py
+++ b/tests/test_seq_classifier.py
@@ -463,3 +463,27 @@ class TestSequenceClassificationModels(PeftCommonTester):
                 assert output.loss > expected_loss
             else:
                 assert torch.allclose(output.loss, expected_loss, atol=1e-4, rtol=1e-4)
+
+    @pytest.mark.parametrize(
+        "config_cls,config_kwargs",
+        [
+            (PrefixTuningConfig, {"task_type": "SEQ_CLS", "num_virtual_tokens": 4}),
+            (PromptEncoderConfig, {"task_type": "SEQ_CLS", "num_virtual_tokens": 4, "encoder_hidden_size": 32}),
+            (PromptTuningConfig, {"task_type": "SEQ_CLS", "num_virtual_tokens": 4}),
+        ],
+    )
+    def test_prompt_learning_forward_with_inputs_embeds(self, config_cls, config_kwargs):
+        # Passing inputs_embeds instead of input_ids should be equivalent.
+        model_id = PEFT_SEQ_CLS_MODELS_TO_TEST[0]
+        with hub_online_once(model_id):
+            base_model = AutoModelForSequenceClassification.from_pretrained(model_id).to(self.torch_device)
+            model = get_peft_model(base_model, config_cls(base_model_name_or_path=model_id, **config_kwargs))
+            model.eval()
+
+            input_ids = torch.tensor([[1, 1, 1], [1, 2, 1]]).to(self.torch_device)
+            attention_mask = torch.ones_like(input_ids)
+            with torch.no_grad():
+                output_ids = model(input_ids=input_ids, attention_mask=attention_mask)
+                inputs_embeds = model.get_input_embeddings()(input_ids)
+                output_embeds = model(inputs_embeds=inputs_embeds, attention_mask=attention_mask)
+            assert torch.allclose(output_ids.logits, output_embeds.logits, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
This PR fixes three issues occurring in relation to prompt learning.

1. `use_return_dict` warning

In Transformers v5, `use_return_dict` was deprecated in favor of `return_dict`. In PEFT, we already added code for compatibility, but we still access `use_return_dict` as a fallback, which results in a Transformers deprecation warning.

To avoid this warning, we now replicate the Transformers v4 logic for `use_return_dict` in PEFT, allowing as to avoid accessing the attribute and thus getting the warning.

Normally, Transformers warnings are configured to cause the PEFT tests to fail, so this should have been caught. However, there was simply no test that would cover this case. The test that is added in this PR, `test_forward_with_labels`, is not directly checking this. Instead, it's a test I worked on for different reasons that just happens to trigger this code path. That's why it looks kinda unrelated to the issue. I still chose to add this test instead of a dedicated one , as having a dedicated test would be quite artificial.

We don't have general tests for token classification or question answering tasks, so the fixes there are uncovered, but it's the exact same fix as for sequence classification.

2. Missing `inputs_embeds` argument

There is another error, which is that for prefix tuning (and cartridges) and some task types, the `inputs_embeds` were not being passed. I added the fix and tests for encoder-decoder models and for sequence classification (`test_prompt_learning_forward_with_inputs_embeds`); for feature extraction, this was already covered but it was skipped, so I removed the skip. Again, token classification and question answering has no dedicated tests, so there is no test for that, but the fix is applied there too.

3. `causal_mask_creation_function`

In some situations, we call `causal_mask_creation_function` from Transformers. The call needs to be updated for v5:

- `input_embeds` renamed to `inputs_embeds`
- `cache_position` is no longer an argument

A corresponding test, `test_prompt_tuning_prepare_inputs_for_generation_4d_attention_mask`, is added.