### PR TITLE
FIX Reject duplicate adapter names

### DIFF
--- a/src/peft/mixed_model.py
+++ b/src/peft/mixed_model.py
@@ -234,6 +234,9 @@ class PeftMixedModel(PushToHubMixin, torch.nn.Module):
                 only affect select PEFT tuners. If set to `False`, the dtypes will stay the same as those of the
                 corresponding layer.
         """
+        if adapter_name in self.peft_config:
+            raise ValueError(f"Adapter with name '{adapter_name}' already exists.")
+
         _check_config_compatible(peft_config)
 
         try:

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1096,6 +1096,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 only affect select PEFT tuners. If set to `False`, the dtypes will stay the same as those of the
                 corresponding layer.
         """
+        if adapter_name in self.peft_config:
+            raise ValueError(f"Adapter with name '{adapter_name}' already exists.")
+
         prefix = PEFT_TYPE_TO_PREFIX_MAPPING.get(peft_config.peft_type)
         if prefix and adapter_name in prefix:
             warnings.warn(

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -153,7 +153,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
 
         self._is_prompt_learning = peft_config.is_prompt_learning
         if self._is_prompt_learning:
-            self._peft_config = {adapter_name: peft_config}
+            self._peft_config = {}
             self.base_model = model
             self.add_adapter(adapter_name, peft_config, low_cpu_mem_usage=low_cpu_mem_usage)
         else:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -3284,6 +3284,26 @@ class TestPeftCustomModel(PeftCommonTester):
         # model.active_adapter would not work, thus we have to check the base_model directly
         assert model.base_model.active_adapter == ["default", "other"]
 
+    @pytest.mark.parametrize("mixed", [False, True])
+    def test_add_adapter_rejects_duplicate_name_without_mutation(self, mixed):
+        # A duplicate name must fail before replacing the existing config or reinitializing its weights.
+        # LoRA is sufficient here because all PEFT methods go through the same add_adapter code path.
+        config = LoraConfig(target_modules=["lin0"], r=2, init_lora_weights=False)
+        model = get_peft_model(MLP(), config, adapter_name="existing", mixed=mixed)
+
+        config_before = model.peft_config["existing"]
+        state_dict_before = copy.deepcopy(model.state_dict())
+        replacement_config = LoraConfig(target_modules=["lin0"], r=4, init_lora_weights=False)
+
+        with pytest.raises(ValueError, match="Adapter with name 'existing' already exists"):
+            model.add_adapter("existing", replacement_config)
+
+        assert model.peft_config["existing"] is config_before
+        state_dict_after = model.state_dict()
+        assert state_dict_after.keys() == state_dict_before.keys()
+        for key, value in state_dict_before.items():
+            assert torch.equal(state_dict_after[key], value)
+
     @pytest.mark.parametrize("config_cls", ALL_PEFT_CONFIG_CLASSES)
     def test_set_adapter_non_overlapping_modules(self, config_cls):
         # Ensure that when setting multiple adapters, the active adapters are correctly being set, even if

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -1676,9 +1676,8 @@ class PeftCommonTester:
                 for adapter_name in new_adapters:
                     if "single" in adapter_name:
                         new_delta_weight = target.get_delta_weight(adapter_name)
+                        # A negative merge weight must also negate the resulting delta weight.
                         weighted_original_delta_weights = target.get_delta_weight(adapter_list[0]) * weight_list[0]
-                        sign = 1 if weight_list[0] > 0 else -1
-                        weighted_original_delta_weights = sign * weighted_original_delta_weights
                         assert torch.allclose(new_delta_weight, weighted_original_delta_weights, atol=1e-4, rtol=1e-4)
                     elif "svd" in adapter_name:
                         assert target.r[adapter_name] == 20
@@ -1747,15 +1746,22 @@ class PeftCommonTester:
             return pytest.skip(f"Test not applicable for {config}")
 
         with hub_online_once(model_id):
-            model = self.transformers_class.from_pretrained(model_id)
-            model = get_peft_model(model, config, adapter_list[0])
+
+            def create_model():
+                # Positive and negative scenarios reuse adapter names, so they need isolated registries.
+                model = self.transformers_class.from_pretrained(model_id)
+                return get_peft_model(model, copy.deepcopy(config), adapter_list[0])
 
             if isinstance(config, LoraConfig):
-                self._test_weighted_combination_of_adapters_lora(model, config, adapter_list, weight_list)
-                self._test_weighted_combination_of_adapters_lora(model, config, adapter_list, negative_weight_list)
+                self._test_weighted_combination_of_adapters_lora(create_model(), config, adapter_list, weight_list)
+                self._test_weighted_combination_of_adapters_lora(
+                    create_model(), config, adapter_list, negative_weight_list
+                )
             elif isinstance(config, IA3Config):
-                self._test_weighted_combination_of_adapters_ia3(model, config, adapter_list, weight_list)
-                self._test_weighted_combination_of_adapters_ia3(model, config, adapter_list, negative_weight_list)
+                self._test_weighted_combination_of_adapters_ia3(create_model(), config, adapter_list, weight_list)
+                self._test_weighted_combination_of_adapters_ia3(
+                    create_model(), config, adapter_list, negative_weight_list
+                )
             else:
                 pytest.skip(f"Test not applicable for {config}")
 


### PR DESCRIPTION
## What does this PR do?

Reject duplicate adapter names in `PeftModel.add_adapter` and `PeftMixedModel.add_adapter` before any model state is mutated.

The public API documents `adapter_name` as unique, but previously passing an existing name silently replaced its configuration and reinjected the adapter. This reinitialized the adapter layers and could destroy trained weights. If reinjection then failed, the rollback path could also delete the original configuration.

The new validation makes this operation atomic: duplicate names raise a clear `ValueError`, while the existing configuration and all model weights remain unchanged. Existing `load_adapter` behavior is unaffected because it only calls `add_adapter` when the requested name is not already present. Prompt-learning initialization now starts with an empty adapter registry and registers its initial adapter through the same `add_adapter` path, so the duplicate-name check does not reject normal model construction.

## Coordination

This minor bug fix was submitted directly under the contribution guide exception for simple fixes. The implementation approach has since been reviewed by a maintainer: [maintainer review](https://github.com/huggingface/peft/pull/3559#pullrequestreview-4981588365).

## Assistance disclosure

AI assistance was used to inspect the shared code path and help prepare the regression test. I personally reviewed every changed line, reproduced the failure, and ran all tests listed below.

## Tests

- `python -m pytest tests/test_custom_models.py::TestPeftCustomModel::test_add_adapter_rejects_duplicate_name_without_mutation tests/test_feature_extraction_models.py::TestPeftFeatureExtractionModel::test_adapter_name tests/test_lora_conversion.py::TestLoraConversion::test_prompt_learning_model_raises --no-cov -q` (127 passed)
- `python -m pytest tests/test_custom_models.py::TestPeftCustomModel::test_add_adapter_rejects_duplicate_name_without_mutation tests/test_other.py tests/test_mixed.py tests/test_frod.py tests/test_config.py -k "not deeply_nested" --no-cov -q` (1317 passed, 12 skipped, 1 deselected)
- `make quality`