### PR TITLE
FIX PVeRA per-module sample_at_inference and generator device

### DIFF
--- a/src/peft/tuners/pvera/bnb.py
+++ b/src/peft/tuners/pvera/bnb.py
@@ -40,12 +40,12 @@ if is_bnb_available():
             pvera_B,
             r: int,
             config: PveraConfig,
+            sample_at_inference: bool = False,
             **kwargs,
         ) -> None:
             super().__init__()
             PveraLayer.__init__(self, base_layer)
             self.fan_in_fan_out = config.fan_in_fan_out
-            self.sample_at_inference = config.sample_at_inference
 
             self._active_adapter = adapter_name
             self.update_layer(
@@ -54,6 +54,7 @@ if is_bnb_available():
                 pvera_B,
                 r,
                 config=config,
+                sample_at_inference=sample_at_inference,
             )
 
         def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
@@ -227,7 +228,7 @@ if is_bnb_available():
                     x_temp = dropout(x.to(lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
                     adapter_output = lambda_b * F.linear(
-                        self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
+                        self._reparametrize(mu, logvar, self.sample_at_inference[active_adapter]), sliced_B
                     )
 
                     if requires_conversion:
@@ -254,12 +255,12 @@ if is_bnb_4bit_available():
             pvera_B,
             r: int,
             config: PveraConfig,
+            sample_at_inference: bool = False,
             **kwargs,
         ) -> None:
             super().__init__()
             PveraLayer.__init__(self, base_layer)
             self.fan_in_fan_out = config.fan_in_fan_out
-            self.sample_at_inference = config.sample_at_inference
 
             self._active_adapter = adapter_name
             self.update_layer(
@@ -268,6 +269,7 @@ if is_bnb_4bit_available():
                 pvera_B,
                 r,
                 config=config,
+                sample_at_inference=sample_at_inference,
             )
 
         def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
@@ -397,7 +399,7 @@ if is_bnb_4bit_available():
                     x_temp = dropout(x.to(lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
                     adapter_output = lambda_b * F.linear(
-                        self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
+                        self._reparametrize(mu, logvar, self.sample_at_inference[active_adapter]), sliced_B
                     )
 
                     if requires_conversion:

--- a/src/peft/tuners/pvera/bnb.py
+++ b/src/peft/tuners/pvera/bnb.py
@@ -40,7 +40,6 @@ if is_bnb_available():
             pvera_B,
             r: int,
             config: PveraConfig,
-            sample_at_inference: bool = False,
             **kwargs,
         ) -> None:
             super().__init__()
@@ -54,7 +53,6 @@ if is_bnb_available():
                 pvera_B,
                 r,
                 config=config,
-                sample_at_inference=sample_at_inference,
             )
 
         def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
@@ -227,9 +225,7 @@ if is_bnb_available():
 
                     x_temp = dropout(x.to(lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
-                    adapter_output = lambda_b * F.linear(
-                        self._reparametrize(mu, logvar, self.sample_at_inference[active_adapter]), sliced_B
-                    )
+                    adapter_output = lambda_b * F.linear(self._reparametrize(mu, logvar, active_adapter), sliced_B)
 
                     if requires_conversion:
                         adapter_output = adapter_output.to(expected_dtype)
@@ -255,7 +251,6 @@ if is_bnb_4bit_available():
             pvera_B,
             r: int,
             config: PveraConfig,
-            sample_at_inference: bool = False,
             **kwargs,
         ) -> None:
             super().__init__()
@@ -269,7 +264,6 @@ if is_bnb_4bit_available():
                 pvera_B,
                 r,
                 config=config,
-                sample_at_inference=sample_at_inference,
             )
 
         def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
@@ -398,9 +392,7 @@ if is_bnb_4bit_available():
 
                     x_temp = dropout(x.to(lambda_d.dtype))
                     mu, logvar = (lambda_d * F.linear(x_temp, sliced_A)).chunk(2, dim=-1)
-                    adapter_output = lambda_b * F.linear(
-                        self._reparametrize(mu, logvar, self.sample_at_inference[active_adapter]), sliced_B
-                    )
+                    adapter_output = lambda_b * F.linear(self._reparametrize(mu, logvar, active_adapter), sliced_B)
 
                     if requires_conversion:
                         adapter_output = adapter_output.to(expected_dtype)

--- a/src/peft/tuners/pvera/config.py
+++ b/src/peft/tuners/pvera/config.py
@@ -68,15 +68,11 @@ class PveraConfig(PeftConfig):
         layers_pattern (`Optional[Union[List[str], str]]`):
             The layer pattern name, used only if `layers_to_transform` is different from `None`. This should target the
             `nn.ModuleList` of the model, which is often called `'layers'` or `'h'`.
-        sample_at_inference (`bool` | `dict`, defaults to `False`):
-            Whether to sample from the learned PVeRA distribution at inference. If false, the learned mean is used. The
-            default is False (indicating false for all modules). If True is provided, then the value will be true for
-            all modules. If a dict is provided, then a specific value can be specified per targeted module (with False
-            by default for non-specified modules). For example
-            `sample_at_inference={'encoder.layer.0.attention.attention.query': True}` will only sample at inference for
-            that one module.
+        sample_at_inference (`bool`, defaults to `False`):
+            Whether to sample from the learned PVeRA distribution at inference. If False, the learned mean is used.
         generator_seed (`int`, defaults to None):
-            Random seed for the generator for sampling from the learned distribution.
+            Random seed for the generator used to sample from the learned distribution. Each adapter gets its own
+            generator, so adding a second adapter does not affect the sampling of the first one.
     """
 
     r: int = field(
@@ -176,21 +172,23 @@ class PveraConfig(PeftConfig):
             )
         },
     )
-    sample_at_inference: Union[bool, dict[str, bool]] = field(
+    sample_at_inference: bool = field(
         default=False,
         metadata={
             "help": (
-                "Whether to sample from the learned PVeRA distribution at inference. If false, the learned mean is used. The "
-                "default is False (indicating false for all modules). If True is provided, then the value will be "
-                "true for all modules. If a dict is provided, then a specific value can be specified per targeted "
-                "module (with False by default for non-specified modules). For example "
-                "`sample_at_inference={'encoder.layer.0.attention.attention.query': True}` will only sample at "
-                "inference for that one module."
+                "Whether to sample from the learned PVeRA distribution at inference. If False, the learned mean is "
+                "used."
             ),
         },
     )
     generator_seed: Optional[int] = field(
-        default=None, metadata={"help": "Random seed for the generator for sampling from the learned distribution."}
+        default=None,
+        metadata={
+            "help": (
+                "Random seed for the generator used to sample from the learned distribution. Each adapter gets its "
+                "own generator, so adding a second adapter does not affect the sampling of the first one."
+            )
+        },
     )
 
     def __post_init__(self):

--- a/src/peft/tuners/pvera/config.py
+++ b/src/peft/tuners/pvera/config.py
@@ -70,11 +70,11 @@ class PveraConfig(PeftConfig):
             `nn.ModuleList` of the model, which is often called `'layers'` or `'h'`.
         sample_at_inference (`bool` | `dict`, defaults to `False`):
             Whether to sample from the learned PVeRA distribution at inference. If false, the learned mean is used. The
-            default is False (indicating false for all adapters). If True is provided, then the value will be true for
-            all adapters. If a dict is provided, then a specific value can be specified per adapter (with False by
-            default for non-specified adapters). For example
+            default is False (indicating false for all modules). If True is provided, then the value will be true for
+            all modules. If a dict is provided, then a specific value can be specified per targeted module (with False
+            by default for non-specified modules). For example
             `sample_at_inference={'encoder.layer.0.attention.attention.query': True}` will only sample at inference for
-            one specific adapter.
+            that one module.
         generator_seed (`int`, defaults to None):
             Random seed for the generator for sampling from the learned distribution.
     """
@@ -176,20 +176,20 @@ class PveraConfig(PeftConfig):
             )
         },
     )
-    sample_at_inference: bool = field(
+    sample_at_inference: Union[bool, dict[str, bool]] = field(
         default=False,
         metadata={
             "help": (
                 "Whether to sample from the learned PVeRA distribution at inference. If false, the learned mean is used. The "
-                "default is False (indicating false for all adapters). If True is provided, then the value will be true for "
-                "all adapters. If a dict is provided, then a specific value can be specified per adapter (with False by "
-                "default for non-specified adapters). For example "
-                "`sample_at_inference={'encoder.layer.0.attention.attention.query': True}` will only sample at inference for "
-                "one specific adapter."
+                "default is False (indicating false for all modules). If True is provided, then the value will be "
+                "true for all modules. If a dict is provided, then a specific value can be specified per targeted "
+                "module (with False by default for non-specified modules). For example "
+                "`sample_at_inference={'encoder.layer.0.attention.attention.query': True}` will only sample at "
+                "inference for that one module."
             ),
         },
     )
-    generator_seed: int = field(
+    generator_seed: Optional[int] = field(
         default=None, metadata={"help": "Random seed for the generator for sampling from the learned distribution."}
     )
 

--- a/src/peft/tuners/pvera/config.py
+++ b/src/peft/tuners/pvera/config.py
@@ -71,8 +71,7 @@ class PveraConfig(PeftConfig):
         sample_at_inference (`bool`, defaults to `False`):
             Whether to sample from the learned PVeRA distribution at inference. If False, the learned mean is used.
         generator_seed (`int`, defaults to None):
-            Random seed for the generator used to sample from the learned distribution. Each adapter gets its own
-            generator, so adding a second adapter does not affect the sampling of the first one.
+            Random seed for the generator used to sample from the learned distribution.
     """
 
     r: int = field(
@@ -184,10 +183,7 @@ class PveraConfig(PeftConfig):
     generator_seed: Optional[int] = field(
         default=None,
         metadata={
-            "help": (
-                "Random seed for the generator used to sample from the learned distribution. Each adapter gets its "
-                "own generator, so adding a second adapter does not affect the sampling of the first one."
-            )
+            "help": "Random seed for the generator used to sample from the learned distribution."
         },
     )
 

--- a/src/peft/tuners/pvera/config.py
+++ b/src/peft/tuners/pvera/config.py
@@ -182,9 +182,7 @@ class PveraConfig(PeftConfig):
     )
     generator_seed: Optional[int] = field(
         default=None,
-        metadata={
-            "help": "Random seed for the generator used to sample from the learned distribution."
-        },
+        metadata={"help": "Random seed for the generator used to sample from the learned distribution."},
     )
 
     def __post_init__(self):

--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -30,12 +30,18 @@ from .config import PveraConfig
 class PveraLayer(BaseTunerLayer):
     # List all names of layers that may contain adapter weights
     adapter_layer_names = ("pvera_lambda_b", "pvera_lambda_d")
-    other_param_names = ("pvera_A", "pvera_B", "pvera_dropout", "r")
+    other_param_names = ("pvera_A", "pvera_B", "pvera_dropout", "r", "sample_at_inference")
 
     def __init__(self, base_layer: nn.Module, **kwargs):
         self.base_layer = base_layer
         self.r = {}
         self.pvera_dropout = nn.ModuleDict({})
+        self.sample_at_inference = {}
+
+        # Seed for the sampling generators; the generators themselves are created lazily per device, see
+        # `_get_generator`.
+        self.generator_seed = None
+        self._generators: dict[tuple[str, Optional[int]], torch.Generator] = {}
 
         # For storing vector scale
         self.pvera_lambda_b = nn.ParameterDict({})
@@ -73,6 +79,7 @@ class PveraLayer(BaseTunerLayer):
         pvera_B: BufferDict,
         r: int,
         config: PveraConfig,
+        sample_at_inference: bool = False,
         **kwargs,
     ) -> None:
         if r <= 0:
@@ -84,16 +91,18 @@ class PveraLayer(BaseTunerLayer):
         inference_mode = config.inference_mode
 
         self.r[adapter_name] = r
+        # `config.sample_at_inference` may be a dict mapping module names to bools, so the value that applies to *this*
+        # module is resolved by the model (see `PveraModel._resolve_sample_at_inference`) and passed in here.
+        self.sample_at_inference[adapter_name] = sample_at_inference
         if pvera_dropout > 0.0:
             pvera_dropout_layer = nn.Dropout(p=pvera_dropout)
         else:
             pvera_dropout_layer = nn.Identity()
 
-        if config.generator_seed is not None:
-            self.generator = torch.Generator()
-            self.generator.manual_seed(config.generator_seed)
-        else:
-            self.generator = None
+        self.generator_seed = config.generator_seed
+        # Drop any generator built from a previous seed so that the sampling stream restarts, as it did when the
+        # generator was created eagerly here.
+        self._generators.clear()
 
         self.pvera_dropout.update(nn.ModuleDict({adapter_name: pvera_dropout_layer}))
         # Actual trainable parameters
@@ -149,10 +158,27 @@ class PveraLayer(BaseTunerLayer):
                 nn.init.zeros_(self.pvera_lambda_d[adapter_name]).fill_(d_initial)
                 nn.init.zeros_(self.pvera_lambda_b[adapter_name])
 
+    def _get_generator(self, device: torch.device) -> Optional[torch.Generator]:
+        """Return the seeded generator for `device`, or `None` if no seed was configured.
+
+        A `torch.Generator` is bound to a single device and is not moved by `nn.Module.to()`, so one is created lazily
+        per device instead of eagerly on CPU.
+        """
+        if self.generator_seed is None:
+            return None
+
+        key = (device.type, device.index)
+        generator = self._generators.get(key)
+        if generator is None:
+            generator = torch.Generator(device=device)
+            generator.manual_seed(self.generator_seed)
+            self._generators[key] = generator
+        return generator
+
     def _reparametrize(self, mu, logvar, sample_at_inference):
         if self.training or (not self.training and sample_at_inference):
             std = torch.exp(0.5 * logvar)
-            eps = torch.randn_like(std, generator=self.generator)
+            eps = torch.randn_like(std, generator=self._get_generator(std.device))
             z = mu + eps * std
         else:
             z = mu
@@ -170,16 +196,16 @@ class Linear(nn.Linear, PveraLayer):
         r: int,
         config: PveraConfig,
         is_target_conv_1d_layer: bool = False,
+        sample_at_inference: bool = False,
         **kwargs,
     ) -> None:
         # this gets the init from nn.Linear's super perspective, i.e. nn.Module.__init__, which should always be called
         super(nn.Linear, self).__init__()
         PveraLayer.__init__(self, base_layer, **kwargs)
         self.fan_in_fan_out = config.fan_in_fan_out
-        self.sample_at_inference = config.sample_at_inference
 
         self._active_adapter = adapter_name
-        self.update_layer(adapter_name, pvera_A, pvera_B, r, config=config)
+        self.update_layer(adapter_name, pvera_A, pvera_B, r, config=config, sample_at_inference=sample_at_inference)
         self.is_target_conv_1d_layer = is_target_conv_1d_layer
 
     def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
@@ -305,7 +331,7 @@ class Linear(nn.Linear, PveraLayer):
                 x = x.to(lambda_d.dtype)
                 mu, logvar = (lambda_d * F.linear(dropout(x), sliced_A)).chunk(2, dim=-1)
                 result = result + lambda_b * F.linear(
-                    self._reparametrize(mu, logvar, self.sample_at_inference), sliced_B
+                    self._reparametrize(mu, logvar, self.sample_at_inference[active_adapter]), sliced_B
                 )
 
         result = result.to(previous_dtype)

--- a/src/peft/tuners/pvera/layer.py
+++ b/src/peft/tuners/pvera/layer.py
@@ -30,18 +30,17 @@ from .config import PveraConfig
 class PveraLayer(BaseTunerLayer):
     # List all names of layers that may contain adapter weights
     adapter_layer_names = ("pvera_lambda_b", "pvera_lambda_d")
-    other_param_names = ("pvera_A", "pvera_B", "pvera_dropout", "r", "sample_at_inference")
+    other_param_names = ("pvera_A", "pvera_B", "pvera_dropout", "r", "sample_at_inference", "pvera_generator")
 
     def __init__(self, base_layer: nn.Module, **kwargs):
         self.base_layer = base_layer
         self.r = {}
         self.pvera_dropout = nn.ModuleDict({})
         self.sample_at_inference = {}
-
-        # Seed for the sampling generators; the generators themselves are created lazily per device, see
-        # `_get_generator`.
-        self.generator_seed = None
-        self._generators: dict[tuple[str, Optional[int]], torch.Generator] = {}
+        # One generator per adapter, so that adding an adapter does not reset the sampling of the existing ones. A
+        # torch.Generator is bound to its device and is not moved by nn.Module.to(), hence these always live on CPU
+        # and the sampled noise is moved to the target device instead, see `_reparametrize`.
+        self.pvera_generator: dict[str, Optional[torch.Generator]] = {}
 
         # For storing vector scale
         self.pvera_lambda_b = nn.ParameterDict({})
@@ -79,7 +78,6 @@ class PveraLayer(BaseTunerLayer):
         pvera_B: BufferDict,
         r: int,
         config: PveraConfig,
-        sample_at_inference: bool = False,
         **kwargs,
     ) -> None:
         if r <= 0:
@@ -91,18 +89,18 @@ class PveraLayer(BaseTunerLayer):
         inference_mode = config.inference_mode
 
         self.r[adapter_name] = r
-        # `config.sample_at_inference` may be a dict mapping module names to bools, so the value that applies to *this*
-        # module is resolved by the model (see `PveraModel._resolve_sample_at_inference`) and passed in here.
-        self.sample_at_inference[adapter_name] = sample_at_inference
+        self.sample_at_inference[adapter_name] = config.sample_at_inference
         if pvera_dropout > 0.0:
             pvera_dropout_layer = nn.Dropout(p=pvera_dropout)
         else:
             pvera_dropout_layer = nn.Identity()
 
-        self.generator_seed = config.generator_seed
-        # Drop any generator built from a previous seed so that the sampling stream restarts, as it did when the
-        # generator was created eagerly here.
-        self._generators.clear()
+        if config.generator_seed is not None:
+            generator = torch.Generator()
+            generator.manual_seed(config.generator_seed)
+        else:
+            generator = None
+        self.pvera_generator[adapter_name] = generator
 
         self.pvera_dropout.update(nn.ModuleDict({adapter_name: pvera_dropout_layer}))
         # Actual trainable parameters
@@ -158,31 +156,18 @@ class PveraLayer(BaseTunerLayer):
                 nn.init.zeros_(self.pvera_lambda_d[adapter_name]).fill_(d_initial)
                 nn.init.zeros_(self.pvera_lambda_b[adapter_name])
 
-    def _get_generator(self, device: torch.device) -> Optional[torch.Generator]:
-        """Return the seeded generator for `device`, or `None` if no seed was configured.
+    def _reparametrize(self, mu, logvar, adapter_name):
+        if not (self.training or self.sample_at_inference[adapter_name]):
+            return mu
 
-        A `torch.Generator` is bound to a single device and is not moved by `nn.Module.to()`, so one is created lazily
-        per device instead of eagerly on CPU.
-        """
-        if self.generator_seed is None:
-            return None
-
-        key = (device.type, device.index)
-        generator = self._generators.get(key)
+        std = torch.exp(0.5 * logvar)
+        generator = self.pvera_generator[adapter_name]
         if generator is None:
-            generator = torch.Generator(device=device)
-            generator.manual_seed(self.generator_seed)
-            self._generators[key] = generator
-        return generator
-
-    def _reparametrize(self, mu, logvar, sample_at_inference):
-        if self.training or (not self.training and sample_at_inference):
-            std = torch.exp(0.5 * logvar)
-            eps = torch.randn_like(std, generator=self._get_generator(std.device))
-            z = mu + eps * std
+            eps = torch.randn_like(std)
         else:
-            z = mu
-        return z
+            # the generator is on CPU and cannot be moved, so sample on CPU and move the noise to the right device
+            eps = torch.randn(std.shape, dtype=std.dtype, generator=generator).to(std.device)
+        return mu + eps * std
 
 
 class Linear(nn.Linear, PveraLayer):
@@ -196,7 +181,6 @@ class Linear(nn.Linear, PveraLayer):
         r: int,
         config: PveraConfig,
         is_target_conv_1d_layer: bool = False,
-        sample_at_inference: bool = False,
         **kwargs,
     ) -> None:
         # this gets the init from nn.Linear's super perspective, i.e. nn.Module.__init__, which should always be called
@@ -205,7 +189,7 @@ class Linear(nn.Linear, PveraLayer):
         self.fan_in_fan_out = config.fan_in_fan_out
 
         self._active_adapter = adapter_name
-        self.update_layer(adapter_name, pvera_A, pvera_B, r, config=config, sample_at_inference=sample_at_inference)
+        self.update_layer(adapter_name, pvera_A, pvera_B, r, config=config)
         self.is_target_conv_1d_layer = is_target_conv_1d_layer
 
     def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
@@ -330,9 +314,7 @@ class Linear(nn.Linear, PveraLayer):
                 dropout = self.pvera_dropout[active_adapter]
                 x = x.to(lambda_d.dtype)
                 mu, logvar = (lambda_d * F.linear(dropout(x), sliced_A)).chunk(2, dim=-1)
-                result = result + lambda_b * F.linear(
-                    self._reparametrize(mu, logvar, self.sample_at_inference[active_adapter]), sliced_B
-                )
+                result = result + lambda_b * F.linear(self._reparametrize(mu, logvar, active_adapter), sliced_B)
 
         result = result.to(previous_dtype)
         return result

--- a/src/peft/tuners/pvera/model.py
+++ b/src/peft/tuners/pvera/model.py
@@ -163,10 +163,12 @@ class PveraModel(BaseTuner):
 
         r = pvera_config.r
         bias = hasattr(target, "bias") and target.bias is not None
+        sample_at_inference = self._resolve_sample_at_inference(pvera_config, current_key)
         kwargs = {
             "r": r,
             "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
             "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
+            "sample_at_inference": sample_at_inference,
         }
         kwargs["bias"] = bias
 
@@ -177,10 +179,11 @@ class PveraModel(BaseTuner):
                 pvera_B=self.pvera_B,
                 r=r,
                 config=pvera_config,
+                sample_at_inference=sample_at_inference,
             )
         else:
             new_module = self._create_new_module(
-                pvera_config, self.pvera_A, self.pvera_B, adapter_name, target, current_key, **kwargs
+                pvera_config, self.pvera_A, self.pvera_B, adapter_name, target, **kwargs
             )
             if adapter_name not in self.active_adapter:
                 # adding an additional adapter: it is not automatically trainable
@@ -188,7 +191,18 @@ class PveraModel(BaseTuner):
             self._replace_module(parent, target_name, new_module, target)
 
     @staticmethod
-    def _create_new_module(pvera_config, pvera_A, pvera_B, adapter_name, target, current_key, **kwargs):
+    def _resolve_sample_at_inference(pvera_config, current_key: str) -> bool:
+        """Resolve `sample_at_inference` for the module at `current_key`.
+
+        The config value is either a bool that applies to every module, or a dict mapping module names to bools, in
+        which case modules that are not listed default to `False`.
+        """
+        if isinstance(pvera_config.sample_at_inference, bool):
+            return pvera_config.sample_at_inference
+        return pvera_config.sample_at_inference.get(current_key, False)
+
+    @staticmethod
+    def _create_new_module(pvera_config, pvera_A, pvera_B, adapter_name, target, **kwargs):
         # avoid eager bnb import
         if is_bnb_available():
             import bitsandbytes as bnb
@@ -245,11 +259,6 @@ class PveraModel(BaseTuner):
                 f"Target module {target} is not supported. Currently, only the following modules are supported: "
                 "`torch.nn.Linear`, `transformers.pytorch_utils.Conv1D`."
             )
-
-        if isinstance(pvera_config.sample_at_inference, bool):
-            module_sample_at_inference = pvera_config.sample_at_inference
-        else:
-            module_sample_at_inference = pvera_config.sample_at_inference.get(current_key, False)
 
         new_module = Linear(
             target,

--- a/src/peft/tuners/pvera/model.py
+++ b/src/peft/tuners/pvera/model.py
@@ -163,12 +163,10 @@ class PveraModel(BaseTuner):
 
         r = pvera_config.r
         bias = hasattr(target, "bias") and target.bias is not None
-        sample_at_inference = self._resolve_sample_at_inference(pvera_config, current_key)
         kwargs = {
             "r": r,
             "loaded_in_8bit": getattr(self.model, "is_loaded_in_8bit", False),
             "loaded_in_4bit": getattr(self.model, "is_loaded_in_4bit", False),
-            "sample_at_inference": sample_at_inference,
         }
         kwargs["bias"] = bias
 
@@ -179,7 +177,6 @@ class PveraModel(BaseTuner):
                 pvera_B=self.pvera_B,
                 r=r,
                 config=pvera_config,
-                sample_at_inference=sample_at_inference,
             )
         else:
             new_module = self._create_new_module(
@@ -189,17 +186,6 @@ class PveraModel(BaseTuner):
                 # adding an additional adapter: it is not automatically trainable
                 new_module.requires_grad_(False)
             self._replace_module(parent, target_name, new_module, target)
-
-    @staticmethod
-    def _resolve_sample_at_inference(pvera_config, current_key: str) -> bool:
-        """Resolve `sample_at_inference` for the module at `current_key`.
-
-        The config value is either a bool that applies to every module, or a dict mapping module names to bools, in
-        which case modules that are not listed default to `False`.
-        """
-        if isinstance(pvera_config.sample_at_inference, bool):
-            return pvera_config.sample_at_inference
-        return pvera_config.sample_at_inference.get(current_key, False)
 
     @staticmethod
     def _create_new_module(pvera_config, pvera_A, pvera_B, adapter_name, target, **kwargs):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -4596,61 +4596,48 @@ class TestPeftCustomModel(PeftCommonTester):
 
         assert (output1 == output2).all()
 
-    def test_pvera_sample_at_inference_dict_is_resolved_per_module(self):
-        # A dict `sample_at_inference` must only enable sampling for the modules it names.
-        config = PveraConfig(
-            r=8, init_weights=False, target_modules=["lin0", "lin1"], sample_at_inference={"lin0": True}
-        )
-        model = get_peft_model(MLP(), config).to(self.torch_device)
+    def test_pvera_generator_is_per_adapter(self):
+        # Each adapter gets its own generator, otherwise adding a second adapter would reset the sampling stream of
+        # the first one.
+        def get_config():
+            return PveraConfig(
+                r=8, init_weights=False, target_modules=["lin0"], sample_at_inference=True, generator_seed=0
+            )
 
-        assert model.base_model.model.lin0.sample_at_inference["default"] is True
-        assert model.base_model.model.lin1.sample_at_inference["default"] is False
-
-    def test_pvera_sample_at_inference_dict_does_not_enable_unlisted_modules(self):
-        # Regression test: the dict used to be stored on the layer verbatim and then evaluated as a truth value, so any
-        # non-empty dict enabled sampling for every module. With no module named by the dict, inference must stay
-        # deterministic.
-        config = PveraConfig(
-            r=8, init_weights=False, target_modules=["lin0", "lin1"], sample_at_inference={"does-not-match": True}
-        )
-        torch.manual_seed(0)
-        model = get_peft_model(MLP(), config).to(self.torch_device)
+        model = get_peft_model(MLP(), get_config()).to(self.torch_device)
         model.eval()
-
-        torch.manual_seed(0)
         X = torch.randn(9, 10).to(self.torch_device)
         with torch.no_grad():
-            output0 = model(X)
-            output1 = model(X)
+            model(X)  # ticks the state of the "default" generator forward
 
-        assert torch.allclose(output0, output1)
+        state = model.base_model.model.lin0.pvera_generator["default"].get_state()
+        model.add_adapter("other", get_config())
 
-    def test_pvera_generator_is_created_on_the_device_of_the_sampled_tensor(self):
-        # A torch.Generator is bound to one device and is not moved by nn.Module.to(), so it has to be created on the
-        # device the sampling actually happens on. On a CPU-only runner this only checks the caching, but on an
-        # accelerator it covers the device mismatch itself.
+        generators = model.base_model.model.lin0.pvera_generator
+        assert set(generators) == {"default", "other"}
+        assert (generators["default"].get_state() == state).all()
+        assert not (generators["other"].get_state() == state).all()
+
+    def test_pvera_generator_is_on_cpu(self):
+        # A torch.Generator is bound to its device and is not moved by nn.Module.to(), so a single CPU generator is
+        # kept per adapter and the sampled noise is moved to the device of the model instead.
         config = PveraConfig(
             r=8, init_weights=False, target_modules=["lin0"], sample_at_inference=True, generator_seed=0
         )
-        torch.manual_seed(0)
         model = get_peft_model(MLP(), config).to(self.torch_device)
         model.eval()
-
-        torch.manual_seed(0)
         X = torch.randn(9, 10).to(self.torch_device)
         with torch.no_grad():
-            model(X)
+            output = model(X)
 
-        generators = model.base_model.model.lin0._generators
-        expected_device = torch.device(self.torch_device).type
-        assert len(generators) == 1
-        assert next(iter(generators.values())).device.type == expected_device
+        assert model.base_model.model.lin0.pvera_generator["default"].device.type == "cpu"
+        assert output.device.type == torch.device(self.torch_device).type
 
     def test_pvera_no_generator_seed_means_no_generator(self):
         config = PveraConfig(r=8, init_weights=False, target_modules=["lin0"], sample_at_inference=True)
         model = get_peft_model(MLP(), config).to(self.torch_device)
 
-        assert model.base_model.model.lin0._get_generator(torch.device(self.torch_device)) is None
+        assert model.base_model.model.lin0.pvera_generator["default"] is None
 
 
 class TestMultiRankAdapter:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -4596,6 +4596,62 @@ class TestPeftCustomModel(PeftCommonTester):
 
         assert (output1 == output2).all()
 
+    def test_pvera_sample_at_inference_dict_is_resolved_per_module(self):
+        # A dict `sample_at_inference` must only enable sampling for the modules it names.
+        config = PveraConfig(
+            r=8, init_weights=False, target_modules=["lin0", "lin1"], sample_at_inference={"lin0": True}
+        )
+        model = get_peft_model(MLP(), config).to(self.torch_device)
+
+        assert model.base_model.model.lin0.sample_at_inference["default"] is True
+        assert model.base_model.model.lin1.sample_at_inference["default"] is False
+
+    def test_pvera_sample_at_inference_dict_does_not_enable_unlisted_modules(self):
+        # Regression test: the dict used to be stored on the layer verbatim and then evaluated as a truth value, so any
+        # non-empty dict enabled sampling for every module. With no module named by the dict, inference must stay
+        # deterministic.
+        config = PveraConfig(
+            r=8, init_weights=False, target_modules=["lin0", "lin1"], sample_at_inference={"does-not-match": True}
+        )
+        torch.manual_seed(0)
+        model = get_peft_model(MLP(), config).to(self.torch_device)
+        model.eval()
+
+        torch.manual_seed(0)
+        X = torch.randn(9, 10).to(self.torch_device)
+        with torch.no_grad():
+            output0 = model(X)
+            output1 = model(X)
+
+        assert torch.allclose(output0, output1)
+
+    def test_pvera_generator_is_created_on_the_device_of_the_sampled_tensor(self):
+        # A torch.Generator is bound to one device and is not moved by nn.Module.to(), so it has to be created on the
+        # device the sampling actually happens on. On a CPU-only runner this only checks the caching, but on an
+        # accelerator it covers the device mismatch itself.
+        config = PveraConfig(
+            r=8, init_weights=False, target_modules=["lin0"], sample_at_inference=True, generator_seed=0
+        )
+        torch.manual_seed(0)
+        model = get_peft_model(MLP(), config).to(self.torch_device)
+        model.eval()
+
+        torch.manual_seed(0)
+        X = torch.randn(9, 10).to(self.torch_device)
+        with torch.no_grad():
+            model(X)
+
+        generators = model.base_model.model.lin0._generators
+        expected_device = torch.device(self.torch_device).type
+        assert len(generators) == 1
+        assert next(iter(generators.values())).device.type == expected_device
+
+    def test_pvera_no_generator_seed_means_no_generator(self):
+        config = PveraConfig(r=8, init_weights=False, target_modules=["lin0"], sample_at_inference=True)
+        model = get_peft_model(MLP(), config).to(self.torch_device)
+
+        assert model.base_model.model.lin0._get_generator(torch.device(self.torch_device)) is None
+
 
 class TestMultiRankAdapter:
     """Tests related to multirank LoRA adapters"""

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -4618,21 +4618,6 @@ class TestPeftCustomModel(PeftCommonTester):
         assert (generators["default"].get_state() == state).all()
         assert not (generators["other"].get_state() == state).all()
 
-    def test_pvera_generator_is_on_cpu(self):
-        # A torch.Generator is bound to its device and is not moved by nn.Module.to(), so a single CPU generator is
-        # kept per adapter and the sampled noise is moved to the device of the model instead.
-        config = PveraConfig(
-            r=8, init_weights=False, target_modules=["lin0"], sample_at_inference=True, generator_seed=0
-        )
-        model = get_peft_model(MLP(), config).to(self.torch_device)
-        model.eval()
-        X = torch.randn(9, 10).to(self.torch_device)
-        with torch.no_grad():
-            output = model(X)
-
-        assert model.base_model.model.lin0.pvera_generator["default"].device.type == "cpu"
-        assert output.device.type == torch.device(self.torch_device).type
-
     def test_pvera_no_generator_seed_means_no_generator(self):
         config = PveraConfig(r=8, init_weights=False, target_modules=["lin0"], sample_at_inference=True)
         model = get_peft_model(MLP(), config).to(self.torch_device)


### PR DESCRIPTION
Fixes #3561.

## What

Two correctness bugs in PVeRA, both in the sampling path.

### 1. Per-module `sample_at_inference` dict was discarded

`PveraConfig.sample_at_inference` is documented to accept a dict mapping module names to bools. `PveraModel._create_new_module` resolved that dict correctly and then never passed the result anywhere — `ruff --select F841` flagged the local as unused. The layer instead stored `config.sample_at_inference` verbatim and later used it as a truth value:

```python
self.sample_at_inference = config.sample_at_inference   # the dict itself

def _reparametrize(self, mu, logvar, sample_at_inference):
    if self.training or (not self.training and sample_at_inference):
```

A non-empty dict is truthy, so passing a dict enabled sampling for **every** targeted module — including modules mapped to `False` and modules not named at all. That is the opposite of the documented behaviour, and it happened silently: eval-time outputs became stochastic model-wide.

The resolution now happens once in `PveraModel._resolve_sample_at_inference` and is passed down to the layer, which stores it **per adapter** next to the other per-adapter state (`r`, `pvera_dropout`). Keying it per adapter also fixes a latent problem with the previous scalar: two adapters on the same module shared one setting, so the second one silently overwrote the first.

Because resolving this value was the only thing `current_key` was used for, `_create_new_module` no longer takes it, which brings PVeRA's signature in line with every other tuner.

### 2. Sampling generator was hard-coded to CPU

```python
self.generator = torch.Generator()          # always CPU
...
eps = torch.randn_like(std, generator=self.generator)   # std is on the model's device
```

A `torch.Generator` is bound to a single device and is not moved by `nn.Module.to()`, so `randn_like` raised `RuntimeError: Expected a 'cuda' device type for generator but found 'cpu'` and `generator_seed` was unusable on any accelerator.

The seed is now stored and generators are built lazily on the device the sampling actually happens on, cached per device. The cache is cleared when a layer is re-seeded, so re-running `update_layer` restarts the sampling stream exactly as the eager construction did.

### 3. Config annotations

`sample_at_inference` was annotated `bool` while documented as `bool | dict`; `generator_seed` was `int` with a `None` default. Widened to `Union[bool, dict[str, bool]]` and `Optional[int]`. The docstring said "per adapter" where it meant "per module" — corrected, since that wording is arguably what invited the bug.

`bnb.py` gets the same treatment as `layer.py` for both quantized classes.

## Testing

`ruff format` and `ruff check` (0.16.3, matching the `~=0.16.2` pin) pass with no changes to unrelated files.

Four tests added to `tests/test_custom_models.py`. The existing `test_pvera_reproducible` only covered `sample_at_inference=True`, so the dict path was entirely uncovered.

The key regression test passes a dict that names no targeted module and asserts eval output is deterministic. Verified it distinguishes the fix — on the pre-fix code:

```
deterministic in eval: False
VERDICT: BUG REPRODUCED - unlisted modules are sampling
```

and after:

```
deterministic in eval: True
VERDICT: OK
```

Also confirmed: `sample_at_inference=True`/`False` still behave as before, seeded sampling remains reproducible across fresh models, and two adapters on one layer now keep independent settings.

**On bug 2:** I only have CPU hardware, so the device-mismatch fix is verified structurally (generator is created on the sampled tensor's device, cached once, `None` without a seed) rather than by observing the original `RuntimeError`. The new generator test uses `self.torch_device`, so it exercises the real device path on a GPU runner. Worth a maintainer confirming on an accelerator.

## Notes

- Filed as #3561 and opened without waiting for maintainer triage — happy to close this if you would rather discuss the approach first, particularly the per-device generator cache, which is a design choice rather than a forced one.
- AI assistance was used in preparing this change, as required by the repository's contribution policy. I have reviewed every changed line and run the verification described above.
