### PR TITLE
STY Remove unused local variables in src/peft

### DIFF
--- a/src/peft/mapping_func.py
+++ b/src/peft/mapping_func.py
@@ -136,7 +136,6 @@ def get_peft_model(
             False if you intend on training the model, unless the adapter weights will be replaced by different weights
             before training starts.
     """
-    model_config = BaseTuner.get_model_config(model)
     old_name = peft_config.base_model_name_or_path
     new_name = model.__dict__.get("name_or_path", None)
     peft_config.base_model_name_or_path = new_name

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -2567,7 +2567,6 @@ class PeftModelForSeq2SeqLM(PeftModel):
             model_kwargs["task_ids"] = task_ids
         elif peft_config.peft_type in (PeftType.PREFIX_TUNING, PeftType.CARTRIDGE):
             past_key_values = model_kwargs.get("past_key_values", None)
-            cache_position = model_kwargs.get("cache_position", [None])
             # check prefill stage
             is_prefill_stage = kwargs.get("is_first_iteration")
             if is_prefill_stage is None:  # transformers < v5

--- a/src/peft/tuners/adamss/layer.py
+++ b/src/peft/tuners/adamss/layer.py
@@ -201,9 +201,6 @@ class AdamssLayer(BaseTunerLayer):
         # Store projection matrix in BufferDict (frozen, device-aware)
         self.adamss_newB[adapter_name] = VVT[0, 0, :, :].detach().to(dtype)
 
-        # Use user-specified subspace_rank
-        rank_per_subspace = subspace_rank
-
         # Initialize trainable subspace parameters
         # Collect parameters in lists, then create ParameterList for proper state_dict keys
         A_params = []

--- a/src/peft/tuners/hira/layer.py
+++ b/src/peft/tuners/hira/layer.py
@@ -486,13 +486,9 @@ class _ConvNd(nn.Module, HiraLayer):
             hira_dropout_layer = nn.Identity()
 
         self.hira_dropout[adapter_name] = hira_dropout_layer
-        conv_cls = type(base)
         in_channels = base.in_channels
         out_channels = base.out_channels
         kernel_size = base.kernel_size
-        stride = base.stride
-        padding = base.padding
-        dilation = getattr(base, "dilation", (1,) * (base.weight.dim() - 2))
         # Spatial dims for B: 1 in each spatial dimension
         spatial_ones = (1,) * (base.weight.dim() - 2)
 

--- a/src/peft/tuners/lora/conversion.py
+++ b/src/peft/tuners/lora/conversion.py
@@ -60,7 +60,6 @@ def _convert_miss_module_to_lora(
     miss_block = module.miss_block[adapter_name]
     in_features = module.in_features
     out_features = module.out_features
-    r_miss = module.miss_r[adapter_name]
     orig_dtype = miss_block.dtype
     device = miss_block.device
 

--- a/src/peft/tuners/miss/layer.py
+++ b/src/peft/tuners/miss/layer.py
@@ -179,7 +179,6 @@ class MissLinear(nn.Module, MissLayer):
 
         for active_adapter in adapter_names:
             if active_adapter in self.miss_block.keys():
-                base_layer = self.get_base_layer()
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
@@ -216,7 +215,6 @@ class MissLinear(nn.Module, MissLayer):
 
         while len(self.merged_adapters) > 0:
             active_adapter = self.merged_adapters.pop()
-            base_layer = self.get_base_layer()
             if active_adapter in self.miss_block.keys():
                 weight = self.get_base_weight()
                 orig_dtype = weight.dtype

--- a/src/peft/tuners/oft/layer.py
+++ b/src/peft/tuners/oft/layer.py
@@ -111,8 +111,6 @@ class OFTRotationModule(nn.Module):
         return matrix
 
     def _pytorch_skew_symmetric_inv(self, matrix, block_size):
-        batch_size = matrix.shape[0]
-
         # Extract the upper triangular elements
         vec = matrix[:, self.rows, self.cols]
         return vec

--- a/src/peft/tuners/pvera/model.py
+++ b/src/peft/tuners/pvera/model.py
@@ -198,7 +198,7 @@ class PveraModel(BaseTuner):
         if is_bnb_4bit_available():
             from .bnb import Linear4bit
 
-        bias = kwargs.pop("bias", False)
+        _ = kwargs.pop("bias", False)
         loaded_in_8bit = kwargs.get("loaded_in_8bit", False)
         loaded_in_4bit = kwargs.get("loaded_in_4bit", False)
 

--- a/src/peft/tuners/shira/layer.py
+++ b/src/peft/tuners/shira/layer.py
@@ -176,7 +176,6 @@ class Linear(nn.Module, ShiraLayer):
 
         for active_adapter in adapter_names:
             if active_adapter in self.shira_weight.keys():
-                base_layer = self.get_base_layer()
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.

--- a/src/peft/utils/integrations.py
+++ b/src/peft/utils/integrations.py
@@ -101,8 +101,6 @@ def dequantize_bnb_weight(weight: torch.nn.Parameter, state: Optional[Any] = Non
     """Helper function to dequantize 4bit or 8bit bnb weights."""
     import bitsandbytes as bnb
 
-    device = weight.device
-
     cls_name = weight.__class__.__name__
     if cls_name == "Params4bit":
         dequantized = bnb.functional.dequantize_4bit(weight.data, weight.quant_state)

--- a/src/peft/utils/loftq_utils.py
+++ b/src/peft/utils/loftq_utils.py
@@ -179,7 +179,7 @@ class _SafetensorLoader:
         with safe_open(file_path, framework="pt", device="cpu") as f:
             try:
                 tensor = f.get_tensor(name)
-            except SafetensorError as exc:
+            except SafetensorError:
                 # no matching key found, we probably need to remove the base model prefix
                 if self.base_model_prefix:
                     # remove 1 extra character for "."


### PR DESCRIPTION
## Summary
- Removes assigned-but-never-used locals in `src/peft` that ruff F841 currently ignores (`mapping_func`, `peft_model`, AdaMSS, HiRA, MiSS, OFT, SHiRA, LoRA conversion, PVeRA bias pop, loftq, bnb dequant).
- Keeps `kwargs.pop("bias", False)` for PVeRA as `_ = ...` so bias is still stripped and not forwarded into `Linear`.
- Does **not** drop `"F841"` from the ruff ignore list: `tests/` still has 29 unused locals, and two `src/peft` hits remain on purpose (`pvera` `module_sample_at_inference` is a real bug filed separately; `oft/hqq.py` is deleted by another PR).

Requested by a maintainer on https://github.com/huggingface/peft/issues/3562 as a separate PR from the GraLoRA docstring fix.

## Test plan
- [x] `ruff check --isolated --select F841 src/peft` — only the two intentionally skipped hits remain
- [x] `pytest -o addopts= tests/test_pvera.py tests/test_shira.py tests/test_adamss_asa.py tests/test_mapping.py -q` — 33 passed
- [ ] `pytest tests/test_initialization.py tests/test_lora_conversion.py` (not collected here: `datasets` missing)

AI assistance was used to find and apply this fix. I have reviewed the changed lines.
