### PR TITLE
DOC Fix leftover quotes in GraLoRA target_modules docs

### DIFF
--- a/src/peft/tuners/gralora/config.py
+++ b/src/peft/tuners/gralora/config.py
@@ -33,12 +33,11 @@ class GraloraConfig(PeftConfig):
             Hybrid GraLoRA, a combination of GraLoRA and vanilla LoRA, becomes available when hybrid_r > 0. The
             parameter count of the GraLoRA adapter is r + hybrid_r.
         target_modules (`Union[List[str], str]`):
-            List of module names or regex expression of the module names to replace with GraLoRA. " For example, ['q',
-            'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$'. " This can also be a wildcard 'all-linear'
-            which matches all linear/Conv1D " "(if the model is a PreTrainedModel, the output layer excluded). " If not
-            specified, modules will be chosen according to the model architecture, If the architecture is " not known,
-            an error will be raised -- in this case, you should specify the target modules manually. " To avoid
-            targeting any modules (because you want to apply `target_parameters`), set " `target_modules=[]`.
+            List of module names or regex expression of the module names to replace with GraLoRA. For example, ['q',
+            'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$'. This can also be a wildcard 'all-linear'
+            which matches all linear/Conv1D (if the model is a PreTrainedModel, the output layer excluded). If not
+            specified, modules will be chosen according to the model architecture. If the architecture is not known,
+            an error will be raised -- in this case, you should specify the target modules manually.
         alpha (`int`): GraLoRA alpha.
             GraLoRA alpha is the scaling factor for the GraLoRA adapter. Scale becomes alpha / (r + hybrid_r).
         gralora_dropout (`float`):
@@ -97,14 +96,12 @@ class GraloraConfig(PeftConfig):
         default=None,
         metadata={
             "help": (
-                "List of module names or regex expression of the module names to replace with LoRA. "
+                "List of module names or regex expression of the module names to replace with GraLoRA. "
                 "For example, ['q', 'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$'. "
                 "This can also be a wildcard 'all-linear' which matches all linear/Conv1D "
                 "(if the model is a PreTrainedModel, the output layer excluded). "
-                "If not specified, modules will be chosen according to the model architecture, If the architecture is "
-                "not known, an error will be raised -- in this case, you should specify the target modules manually. "
-                "To avoid targeting any modules (because you want to apply `target_parameters`), set "
-                "`target_modules=[]`."
+                "If not specified, modules will be chosen according to the model architecture. If the architecture is "
+                "not known, an error will be raised -- in this case, you should specify the target modules manually."
             )
         },
     )

--- a/src/peft/tuners/gralora/config.py
+++ b/src/peft/tuners/gralora/config.py
@@ -36,8 +36,8 @@ class GraloraConfig(PeftConfig):
             List of module names or regex expression of the module names to replace with GraLoRA. For example, ['q',
             'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$'. This can also be a wildcard 'all-linear'
             which matches all linear/Conv1D (if the model is a PreTrainedModel, the output layer excluded). If not
-            specified, modules will be chosen according to the model architecture. If the architecture is not known,
-            an error will be raised -- in this case, you should specify the target modules manually.
+            specified, modules will be chosen according to the model architecture. If the architecture is not known, an
+            error will be raised -- in this case, you should specify the target modules manually.
         alpha (`int`): GraLoRA alpha.
             GraLoRA alpha is the scaling factor for the GraLoRA adapter. Scale becomes alpha / (r + hybrid_r).
         gralora_dropout (`float`):


### PR DESCRIPTION
## Summary
- Fixes the `GraloraConfig.target_modules` class docstring leftover string-concatenation quotes, the mid-sentence capital `If`, and drops the `target_parameters` sentence (GraLoRA does not implement it).
- Applies the same content fixes to the field `help` text (including `LoRA` → `GraLoRA`).

Requested by a maintainer on https://github.com/huggingface/peft/issues/3562 as a docs-only PR, separate from the unused-locals cleanup.

## Test plan
- [x] Inspected `GraloraConfig.__doc__` and field help: no leftover concatenation quotes, no `target_parameters`
- [x] Instantiated `GraloraConfig()` successfully
- [ ] `pytest tests/test_config.py` (not run here: `datasets` missing in this env)

AI assistance was used to find and apply this fix. I have reviewed the changed lines.
