### PR TITLE
[Proposal] FEAT Add per-adapter targeted module inspection

### DIFF
--- a/docs/source/developer_guides/custom_models.md
+++ b/docs/source/developer_guides/custom_models.md
@@ -236,6 +236,17 @@ peft_model.print_trainable_parameters()
 print(peft_model.targeted_module_names)
 ```
 
+When a model contains multiple adapters, use `get_targeted_module_names` to inspect the layers targeted by a specific
+adapter. Unlike `targeted_module_names`, this does not deduplicate layers shared by multiple adapters.
+
+```python
+peft_model = get_peft_model(my_model, LoraConfig(target_modules=["lin0"]))
+peft_model.add_adapter("second", LoraConfig(target_modules=["lin0", "lin1"]))
+
+print(peft_model.get_targeted_module_names("second"))
+# ['lin0', 'lin1']
+```
+
 ## Unsupported module types
 
 Methods like LoRA only work if the target modules are supported by PEFT. For example, it's possible to apply LoRA to `nn.Linear` and `nn.Conv2d` layers, but not, for instance, to `nn.LSTM`. If you find a layer class you want to apply PEFT to is not supported, you can:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -279,6 +279,8 @@ class BaseTuner(nn.Module, ABC):
         targeted_module_names (`list[str]`):
             The list of module names that were actually adapted. Can be useful to inspect if you want to quickly
             double-check that the `config.target_modules` were specified correctly.
+        _targeted_module_names_by_adapter (`dict[str, list[str]]`):
+            The module names that were actually adapted, grouped by adapter name.
         targeted_parameter_names (`list[str]`):
             The list of parameter names that were actually adapted. Can be useful to inspect if you want to quickly
             double-check that the `config.target_parameters` were specified correctly.
@@ -309,6 +311,7 @@ class BaseTuner(nn.Module, ABC):
 
         self.model = model
         self.targeted_module_names: list[str] = []
+        self._targeted_module_names_by_adapter: dict[str, list[str]] = {}
         self.targeted_parameter_names: list[str] = []
 
         # For advanced developers, if you want to attach multiple adapters to your
@@ -574,7 +577,25 @@ class BaseTuner(nn.Module, ABC):
         new_adapter = delete_adapter(
             model=self.model, adapter_name=adapter_name, prefix=self.prefix, layer_cls=self.tuner_layer_cls
         )
+        self._targeted_module_names_by_adapter.pop(adapter_name, None)
         self.active_adapter = new_adapter or []
+
+    def get_targeted_module_names(self, adapter_name: str) -> list[str]:
+        """Get the module names that were adapted for one adapter.
+
+        This is a per-adapter counterpart to `targeted_module_names`, which contains a deduplicated aggregate of all
+        adapted modules.
+
+        Args:
+            adapter_name (`str`): The name of the adapter whose targeted modules should be returned.
+
+        Returns:
+            `list[str]`: The module names that were adapted for `adapter_name`, in injection order.
+
+        """
+        if adapter_name not in self.peft_config:
+            raise ValueError(f"Adapter {adapter_name} does not exist")
+        return self._targeted_module_names_by_adapter.get(adapter_name, []).copy()
 
     def set_requires_grad(self, adapter_names: str | Sequence[str], requires_grad: bool = True) -> None:
         """
@@ -1083,6 +1104,7 @@ class BaseTuner(nn.Module, ABC):
         # Now that the checks passed, merge this adapter's matches into the tuner-level bookkeeping. Duplicates
         # are skipped so that names stay unique when several adapters target the same modules.
         _extend_unique(self.targeted_module_names, targeted_module_names)
+        self._targeted_module_names_by_adapter[adapter_name] = targeted_module_names
         _extend_unique(self.targeted_parameter_names, targeted_parameter_names)
 
         ################

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -655,6 +655,18 @@ class TestExcludedModuleNames:
         model.add_adapter("other", LoraConfig(target_modules=["lin0", "lin1"]))
         assert model.base_model.targeted_module_names == ["lin1", "lin0"]
 
+    def test_targeted_module_names_by_adapter(self):
+        model = get_peft_model(MLP(), LoraConfig(target_modules=["lin0"]))
+        model.add_adapter("other", LoraConfig(target_modules=["lin0", "lin1"]))
+
+        assert model.get_targeted_module_names("default") == ["lin0"]
+        assert model.get_targeted_module_names("other") == ["lin0", "lin1"]
+        assert model.targeted_module_names == ["lin0", "lin1"]
+
+        model.delete_adapter("other")
+        with pytest.raises(ValueError, match="Adapter other does not exist"):
+            model.get_targeted_module_names("other")
+
     def test_some_modules_excluded_some_unmatched(self):
         model = MLP()
         with pytest.raises(ValueError, match="No modules were targeted for adaptation"):


### PR DESCRIPTION
This is a small proposal for adding a way to inspect which modules were targeted by a specific adapter:

```python
model.get_targeted_module_names(adapter_name)
```

The implementation is intentionally small and this PR is mainly here to get feedback on the API and the scope before polishing it further.

## Motivation

PEFT already exposes `targeted_module_names`, which is useful for checking which modules were adapted. The problem is that with multiple adapters, this is an aggregate (and deduplicated) list across all adapters.

For example, if one adapter targets `lin0` and another targets `lin0` and `lin1`, the current API returns:

```python
['lin0', 'lin1']
```

but doesn't tell you which adapter targeted which module.

This proposal adds that missing per-adapter view.

## Example

```python
import torch.nn as nn

from peft import LoraConfig, get_peft_model


class MLP(nn.Module):
    def __init__(self):
        super().__init__()
        self.lin0 = nn.Linear(10, 20)
        self.lin1 = nn.Linear(20, 2)

    def forward(self, inputs):
        return self.lin1(self.lin0(inputs))


model = get_peft_model(MLP(), LoraConfig(target_modules=["lin0"]))
model.add_adapter("other", LoraConfig(target_modules=["lin0", "lin1"]))

print(model.targeted_module_names)
# ['lin0', 'lin1']

print(model.get_targeted_module_names("default"))
# ['lin0']

print(model.get_targeted_module_names("other"))
# ['lin0', 'lin1']
```

The existing `targeted_module_names` behavior stays unchanged, this just adds a way to inspect the targets for one adapter.

## Implementation

The prototype builds on information that `BaseTuner.inject_adapter()` already has while injecting an adapter.

The basic idea is:

* keep the existing aggregate `targeted_module_names` behavior
* store the targeted module names for each adapter
* expose them through `get_targeted_module_names(adapter_name)`
* remove the stored information when the adapter is deleted

The returned list is a copy rather than the internal state.

The prototype currently includes a focused LoRA test covering overlapping targets, the existing aggregate behavior, and cleanup after deletion.

I also added a short note to `developer_guides/custom_models` showing how to use the new API.

## Scope

This draft intentionally keeps the feature narrow. It does not include:

* per-adapter `targeted_parameter_names`
* `PeftMixedModel` support
* prompt-learning-specific support
* a dry-run target matching API
* changes to the existing aggregate `targeted_module_names` API
* broader refactoring of adapter injection/state tracking

## Feedback

A few things I'd especially like feedback on:

1. Should the initial implementation cover all `BaseTuner`-based methods, or would a smaller/documented support boundary be preferable?
2. Does `get_targeted_module_names(adapter_name)` feel like the right public API, or would a mapping-style API make more sense?
3. Should the target information be removed when an adapter is deleted, or would it be useful to keep it around?

Since this is still an early draft, I'm mainly looking for an overall direction before expanding the implementation.
