### PR TITLE
Fix nested disable_adapter() context for prompt learning and AdaptionPrompt

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1030,6 +1030,9 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
         ```
         """
         if self.peft_config[self.active_adapter].is_prompt_learning:
+            # Snapshot the state from before this context was entered so that nested contexts don't clobber each
+            # other: only the outermost context that actually disabled the adapters should restore them.
+            was_disabled = getattr(self, "_adapters_disabled", False)
             try:
                 # TODO: consider replacing this patching of methods with a more robust mechanism: setting a flag and
                 # letting the underlying methods deal with it, same as how LoRA does it.
@@ -1040,18 +1043,25 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                 self._adapters_disabled = True
                 yield
             finally:
-                self.forward = old_forward
-                self.prepare_inputs_for_generation = old_prepare_inputs_for_generation
-                self._adapters_disabled = False
+                if not was_disabled:
+                    self.forward = old_forward
+                    self.prepare_inputs_for_generation = old_prepare_inputs_for_generation
+                self._adapters_disabled = was_disabled
 
         elif self.peft_config[self.active_adapter].is_adaption_prompt:
+            # Snapshot the state from before this context was entered so that nested contexts don't clobber each
+            # other: only the outermost context that actually disabled the adapters should re-enable them, and a
+            # nested context should not try to remove the already-removed adapted attentions again.
+            was_disabled = getattr(self, "_adapters_disabled", False)
             try:
-                self.base_model.disable_adapter_layers()
+                if not was_disabled:
+                    self.base_model.disable_adapter_layers()
                 self._adapters_disabled = True
                 yield
             finally:
-                self.base_model.enable_adapter_layers()
-                self._adapters_disabled = False
+                if not was_disabled:
+                    self.base_model.enable_adapter_layers()
+                self._adapters_disabled = was_disabled
 
         else:  # LoRA, LoHa, etc.
             model_status = self.get_model_status()

--- a/tests/test_adaption_prompt.py
+++ b/tests/test_adaption_prompt.py
@@ -18,9 +18,9 @@ import tempfile
 import pytest
 import torch
 from torch.testing import assert_close
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, GPT2Config, GPT2LMHeadModel
 
-from peft import get_peft_model
+from peft import PromptTuningConfig, TaskType, get_peft_model
 from peft.peft_model import PeftModel
 from peft.tuners.adaption_prompt import AdaptionPromptConfig
 from peft.utils import infer_device
@@ -414,3 +414,63 @@ class TestAdaptionPrompt:
         with model.disable_adapter():
             output_peft_disabled = model(dummy_input).logits
         assert torch.allclose(output_before, output_peft_disabled)
+
+    def test_disable_adapter_nested_context_does_not_raise(self):
+        # Regression test for https://github.com/huggingface/peft/issues/3555
+        # Nesting `disable_adapter()` context managers used to raise `KeyError: 'default'` because the inner context
+        # tried to remove the already-removed adapted attentions a second time, and the outer context's cleanup then
+        # masked the original exception. This is a small, from-scratch model so no checkpoint download is needed.
+        gpt2_config = GPT2Config(
+            n_layer=2,
+            n_head=2,
+            n_embd=16,
+            n_positions=32,
+            n_ctx=32,
+            vocab_size=64,
+            bos_token_id=1,
+            eos_token_id=2,
+        )
+        model = get_peft_model(
+            GPT2LMHeadModel(gpt2_config),
+            AdaptionPromptConfig(adapter_layers=1, adapter_len=2, task_type="CAUSAL_LM"),
+        )
+
+        with model.disable_adapter():
+            assert model._adapters_disabled
+            with model.disable_adapter():
+                assert model._adapters_disabled
+            # still disabled, the inner context must not have re-enabled the adapter
+            assert model._adapters_disabled
+        # outer context restores the enabled state
+        assert not model._adapters_disabled
+
+    def test_prompt_tuning_disable_adapter_nested_context_preserves_state(self):
+        # Regression test for https://github.com/huggingface/peft/issues/3555
+        # For prompt learning methods, nested `disable_adapter()` contexts used to leave
+        # `has_active_enabled_adapter` reporting `True` once the inner context exited, even though the outer context
+        # was still active and forwarding should remain disabled. This is a small, from-scratch model so no
+        # checkpoint download is needed.
+        gpt2_config = GPT2Config(
+            n_layer=2,
+            n_head=2,
+            n_embd=16,
+            n_positions=32,
+            n_ctx=32,
+            vocab_size=64,
+            bos_token_id=1,
+            eos_token_id=2,
+        )
+        model = get_peft_model(
+            GPT2LMHeadModel(gpt2_config),
+            PromptTuningConfig(task_type=TaskType.CAUSAL_LM, num_virtual_tokens=2),
+        )
+
+        assert model.has_active_enabled_adapter
+        with model.disable_adapter():
+            assert not model.has_active_enabled_adapter
+            with model.disable_adapter():
+                assert not model.has_active_enabled_adapter
+            # still disabled, the inner context must not have re-enabled adapters early
+            assert not model.has_active_enabled_adapter
+        # outer context restores the enabled state
+        assert model.has_active_enabled_adapter


### PR DESCRIPTION
## Problem

`PeftModel.disable_adapter()` does not preserve nested/pre-disabled state in its two prompt-specific branches (prompt learning and AdaptionPrompt), unlike the regular tuner branch which already snapshots the model status before disabling.

1. **AdaptionPrompt**: entering a nested `disable_adapter()` context raises. The inner context calls `disable_adapter_layers()` again, which tries to remove the already-removed adapted attentions and raises `AttributeError: 'GPT2Attention' object has no attribute 'model'`. During unwinding, the `finally` block's `enable_adapter_layers()` also fails (`KeyError: 'default'`), masking the original exception.
2. **Prompt learning** (e.g. `PromptTuningConfig`): forwarding correctly remains disabled after the inner context exits, but `_adapters_disabled` is unconditionally reset to `False` on any exit, so `has_active_enabled_adapter` incorrectly reports `True` while the outer context is still active.

## Root cause

Both branches unconditionally mutate the disabled state on enter and exit, without checking whether the adapters were already disabled by an enclosing context. The regular tuner branch already guards against this via `model_status = self.get_model_status()` before disabling.

## Fix

Mirror that snapshot-and-restore pattern in the two prompt-specific branches: capture `was_disabled = getattr(self, "_adapters_disabled", False)` on entry, skip the layer transition (`disable_adapter_layers()` / method patching) if already disabled, and only restore on exit if this context is the one that actually performed the disable.

## Test plan

Added two regression tests to `tests/test_adaption_prompt.py` using small from-scratch `GPT2Config`/`GPT2LMHeadModel` models (no checkpoint download needed):
- `test_disable_adapter_nested_context_does_not_raise` (AdaptionPrompt)
- `test_prompt_tuning_disable_adapter_nested_context_preserves_state` (prompt tuning)

Both fail with the errors described above on `main` and pass with this fix.

```
python -m pytest tests/test_adaption_prompt.py -q
35 passed, 3 xfailed
```

Also ran the broader `disable_adapter`-related suites (`tests/test_custom_models.py -k disable_adapter`, 1292 passed) to confirm no regressions, and `ruff check` / `ruff format --check` pass.

Fixes #3555