### PR TITLE
FIX IA3 grouped convolution feedforward merge

### DIFF
--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -219,6 +219,22 @@ class _ConvNd(nn.Module, IA3Layer):
         self._move_adapter_to_device_of_base_layer(adapter_name)
         self.set_adapter(self.active_adapters, inference_mode=inference_mode)
 
+    def _get_ia3_scaling_for_weight(self, ia3_scaling: torch.Tensor) -> torch.Tensor:
+        if not self.is_feedforward:
+            return ia3_scaling.transpose(0, 1)
+
+        base_layer = self.get_base_layer()
+        if base_layer.groups == 1:
+            return ia3_scaling
+
+        in_channels_per_group = base_layer.in_channels // base_layer.groups
+        out_channels_per_group = base_layer.out_channels // base_layer.groups
+        ia3_scaling = ia3_scaling.reshape(base_layer.groups, 1, in_channels_per_group, *ia3_scaling.shape[2:])
+        ia3_scaling = ia3_scaling.expand(
+            base_layer.groups, out_channels_per_group, in_channels_per_group, *ia3_scaling.shape[3:]
+        )
+        return ia3_scaling.reshape(base_layer.out_channels, in_channels_per_group, *ia3_scaling.shape[3:])
+
     def merge(self, safe_merge: bool = False, adapter_names: Optional[list[str]] = None) -> None:
         """
         Merge the active adapter weights into the base weights
@@ -241,9 +257,7 @@ class _ConvNd(nn.Module, IA3Layer):
             if active_adapter in self.ia3_l.keys():
                 base_layer = self.get_base_layer()
                 orig_dtype = base_layer.weight.data.dtype
-                ia3_scaling = self.ia3_l[active_adapter].data
-                if not self.is_feedforward:
-                    ia3_scaling = ia3_scaling.transpose(0, 1)
+                ia3_scaling = self._get_ia3_scaling_for_weight(self.ia3_l[active_adapter].data)
 
                 if safe_merge:
                     output_weight = torch.mul(base_layer.weight.data, ia3_scaling).clone()
@@ -278,9 +292,7 @@ class _ConvNd(nn.Module, IA3Layer):
                 base_layer = self.get_base_layer()
                 orig_dtype = base_layer.weight.data.dtype
                 # divide by (IA)^3 vector. Add tolerace to avoid division by zero
-                ia3_scaling = self.ia3_l[active_adapter].data
-                if not self.is_feedforward:
-                    ia3_scaling = ia3_scaling.transpose(0, 1)
+                ia3_scaling = self._get_ia3_scaling_for_weight(self.ia3_l[active_adapter].data)
                 base_layer.weight.data = torch.div(base_layer.weight.data, ia3_scaling + 1e-8).to(orig_dtype)
 
                 if not self.is_feedforward and (base_layer.bias is not None):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2465,6 +2465,39 @@ class TestPeftCustomModel(PeftCommonTester):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_safe_merge(model_id, config_cls, config_kwargs)
 
+    @pytest.mark.parametrize("conv_cls", [nn.Conv2d, nn.Conv3d])
+    @pytest.mark.parametrize("safe_merge", [False, True])
+    def test_ia3_grouped_conv_feedforward_merge(self, conv_cls, safe_merge):
+        # Regression test for #3511: feedforward IA3 scales all input channels, while grouped
+        # convolution weights store only the input channels belonging to each group.
+        class GroupedConvModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = conv_cls(4, 6, kernel_size=3, groups=2)
+
+            def forward(self, x):
+                return self.conv(x)
+
+        torch.manual_seed(0)
+        input_shape = (2, 4, 5, 5) if conv_cls is nn.Conv2d else (2, 4, 5, 5, 5)
+        inputs = torch.randn(input_shape)
+        config = IA3Config(target_modules=["conv"], feedforward_modules=["conv"], init_ia3_weights=False)
+        model = get_peft_model(GroupedConvModel(), config).eval()
+        ia3_scaling = model.base_model.model.conv.ia3_l["default"]
+        ia3_scaling.data.copy_(torch.tensor([0.5, 1.0, 1.5, 2.0]).reshape_as(ia3_scaling))
+        original_weight = model.base_model.model.conv.base_layer.weight.data.clone()
+
+        with torch.inference_mode():
+            output_unmerged = model(inputs)
+            model.merge_adapter(safe_merge=safe_merge)
+            output_merged = model(inputs)
+            model.unmerge_adapter()
+            output_unmerged_again = model(inputs)
+
+        assert torch.allclose(output_unmerged, output_merged, atol=1e-6, rtol=1e-6)
+        assert torch.allclose(output_unmerged, output_unmerged_again, atol=1e-6, rtol=1e-6)
+        assert torch.allclose(model.base_model.model.conv.base_layer.weight.data, original_weight)
+
     def test_glora_safe_merge_does_not_corrupt_base_layer_on_non_finite_adapter(self):
         # Regression test: GLoRA's merge() used to accumulate the merged weights directly onto
         # base_layer.weight.data/bias.data *before* the safe_merge isfinite check, so a broken

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2483,8 +2483,6 @@ class TestPeftCustomModel(PeftCommonTester):
         inputs = torch.randn(input_shape)
         config = IA3Config(target_modules=["conv"], feedforward_modules=["conv"], init_ia3_weights=False)
         model = get_peft_model(GroupedConvModel(), config).eval()
-        ia3_scaling = model.base_model.model.conv.ia3_l["default"]
-        ia3_scaling.data.copy_(torch.tensor([0.5, 1.0, 1.5, 2.0]).reshape_as(ia3_scaling))
         original_weight = model.base_model.model.conv.base_layer.weight.data.clone()
 
         with torch.inference_mode():


### PR DESCRIPTION
Fixes #3511

Coordination was approved by a PEFT collaborator in [the issue discussion](https://github.com/huggingface/peft/issues/3511#issuecomment-5341659544).

## Summary

Grouped Conv2d and Conv3d feedforward IA3 adapters scale input channels, but convolution weights store only the per-group input-channel partition. Merge and unmerge now reshape the IA3 vector by group before applying it to the stored weights.

The regression test covers Conv2d and Conv3d with both regular and safe merge, and verifies merge parity, unmerge restoration, and unchanged base weights. All four cases fail on main before the fix and pass with this change.

## Validation

- `PYTHONPATH=src python -m pytest tests/ -k ia3 -q` — 1427 passed, 203 skipped
- `uvx --from ruff==0.16.2 ruff check src/peft/tuners/ia3/layer.py tests/test_custom_models.py` — passed
- `uvx --from ruff==0.16.2 ruff format --check src/peft/tuners/ia3/layer.py tests/test_custom_models.py` — passed
- `git diff --check` — passed

## AI assistance

Codex was used to investigate the grouped-convolution layout, prepare the implementation and regression tests, and run validation. I reviewed every changed line, understand the change end-to-end, and take responsibility for the contribution.