### PR TITLE
Resolve ZeRO-3 partitioned shapes in lora.ParamWrapper

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2302,17 +2302,23 @@ class ParamWrapper(nn.Module, LoraLayer):
         # For ParamWrapper, we don't derive the in_features and out_features based on the base layer type, but directly
         # from the targeted parameter.
         param = self.get_param()
-        if param.ndim == 3:
-            num_experts, in_features, out_features = param.shape
+        # Under DeepSpeed ZeRO-3 the parameter is already partitioned, so `param.shape` is empty and the real shape
+        # lives in `ds_shape` -- the same handling `tuners_utils`, `deft` and `randlora` already use.
+        shape = getattr(param, "ds_shape", param.shape)
+        if len(shape) == 3:
+            num_experts, in_features, out_features = shape
+        elif len(shape) == 2:
+            num_experts, in_features, out_features = 1, shape[1], shape[0]
         else:
-            num_experts, in_features, out_features = 1, param.shape[1], param.shape[0]
-        if param.ndim not in (2, 3):
             raise ValueError(
-                f"lora.{self.__class__.__name__} was initialized with {param.ndim} dimensional Parameter, but only 2d "
+                f"lora.{self.__class__.__name__} was initialized with {len(shape)} dimensional Parameter, but only 2d "
                 "and 3d are supported."
             )
         # we have to store the num_experts attribute here, as the parent class only stores in_features and out_features.
         self.num_experts = num_experts
+        # store the rank too: `update_layer` needs it, and by then reading `param.ndim` under ZeRO-3 would see the
+        # partitioned (empty) shape rather than the real one.
+        self._param_ndim = len(shape)
         return in_features, out_features
 
     def update_layer(
@@ -2339,7 +2345,7 @@ class ParamWrapper(nn.Module, LoraLayer):
 
         # for some MoE layers, the order is (experts, out_features, in_features)
         is_transposed = getattr(self.get_base_layer(), "is_transposed", False)
-        swap_in_out_features = (self.get_param().ndim == 3) and not is_transposed
+        swap_in_out_features = (self._param_ndim == 3) and not is_transposed
         if swap_in_out_features and not self._did_swap_in_out_features:
             self.in_features, self.out_features = self.out_features, self.in_features
             self._did_swap_in_out_features = True


### PR DESCRIPTION
Any LoRA config using `target_parameters` crashes at adapter-injection time under DeepSpeed ZeRO-3:

```
  File "peft/tuners/lora/layer.py", line 154, in __init__
    in_features, out_features = self._get_in_out_features(base_layer)
  File "peft/tuners/lora/layer.py", line 2308, in _get_in_out_features
    num_experts, in_features, out_features = 1, param.shape[1], param.shape[0]
IndexError: tuple index out of range
```

Under ZeRO-3 with `zero3_init_flag: true`, parameters are partitioned as the model is built, so by the time PEFT wraps them `param.shape` is `torch.Size([])` and the real shape lives on `param.ds_shape`. `ParamWrapper._get_in_out_features` reads `param.shape` and `param.ndim` directly, so both the 2-D and 3-D branches break.

This is not a new convention, PEFT already resolves `ds_shape` in three other places:

https://github.com/huggingface/peft/blob/09ba20c4fc2613dc0450cd5fbb174a9a774cdfe1/src/peft/tuners/tuners_utils.py#L187
https://github.com/huggingface/peft/blob/09ba20c4fc2613dc0450cd5fbb174a9a774cdfe1/src/peft/tuners/deft/layer.py#L75
https://github.com/huggingface/peft/blob/09ba20c4fc2613dc0450cd5fbb174a9a774cdfe1/src/peft/tuners/randlora/model.py#L120

`ParamWrapper` was simply missed. It matters more than it looks: `target_parameters` is *the* way to put LoRA on the experts of a modern MoE (the experts are one fused 3-D parameter, not a `ModuleList` of `nn.Linear`), so this makes ZeRO-3 + MoE + LoRA impossible.

## Fix

Resolve the shape through `ds_shape`, and carry the resolved rank forward instead of re-reading `param.ndim` later in `update_layer` (where it would hit the same problem)

## Repro

```bash
accelerate launch --config_file ds3.yaml --num_processes 2 repro_zero3_paramwrapper.py
```

<details><summary><code>repro_zero3_paramwrapper.py</code></summary>

```python
import torch
from datasets import Dataset
from peft import LoraConfig
from trl import SFTConfig, SFTTrainer

ds = Dataset.from_dict({"text": ["The capital of France is Paris."] * 32})

trainer = SFTTrainer(
    model="Qwen/Qwen3-0.6B",
    args=SFTConfig(
        output_dir="/tmp/zero3-repro",
        per_device_train_batch_size=1,
        max_steps=2,
        report_to=[],
        bf16=True,
        model_init_kwargs={"dtype": torch.bfloat16},
    ),
    train_dataset=ds,
    peft_config=LoraConfig(r=8, target_modules=[], target_parameters=["mlp.down_proj.weight"]),
)
trainer.train()
print("OK: trainable params =", sum(p.numel() for p in trainer.model.parameters() if p.requires_grad))
```

</details>

<details><summary><code>ds3.yaml</code></summary>

```yaml
compute_environment: LOCAL_MACHINE
debug: false
deepspeed_config:
  deepspeed_multinode_launcher: standard
  offload_optimizer_device: none
  offload_param_device: none
  zero3_init_flag: true
  zero3_save_16bit_model: true
  zero_stage: 3
distributed_type: DEEPSPEED
downcast_bf16: 'no'
machine_rank: 0
main_training_function: main
mixed_precision: bf16
num_machines: 1
num_processes: 8
rdzv_backend: static
same_network: true
tpu_env: []
tpu_use_cluster: false
tpu_use_sudo: false
use_cpu: false
```

</details>

On `main` (2xH100), both ranks die at adapter injection with the `IndexError` above:

```
Root Cause (first observed failure):
[0]:
  rank      : 1 (local_rank: 1)
  exitcode  : 1 (pid: 959392)
torch.distributed.elastic.multiprocessing.errors.ChildFailedError
```

With this patch, the same command trains:

```
100%|##########| 2/2 [00:05<00:00,  2.68s/it]
{'train_runtime': '5.756', 'train_loss': '5.032', 'mean_token_accuracy': '0.5714', 'epoch': '0.125'}
OK: trainable params = 917504
```

## Non-regression

The non-ZeRO-3 path is untouched: `getattr(param, "ds_shape", param.shape)` returns `param.shape` when DeepSpeed is not partitioning, and `len(shape)` equals `param.ndim`. PEFT's own `target_parameters` suite is green.

## Note on what this does *not* fix

With the crash gone, ZeRO-3 gets as far as the forward pass and then OOMs inside the MoE experts on Qwen3.6-35B-A3B at 8xH100 / seq 4096 / batch 4, where FSDP2 runs the same config at 45.9 GB peak. That is a separate DeepSpeed-vs-FSDP2 memory question, not a PEFT one; this PR only removes the `IndexError` that stops you from getting there at all.
