### PR TITLE
Fold the MoE LoRA delta into a single `baddbmm`

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2205,9 +2205,12 @@ class _LoraParameterProxy(nn.Module):
     Intended to be used in conjunction with `nn.utils.parametrize`, see `ParamWrapper`.
     """
 
-    def __init__(self, delta_weight):
+    def __init__(self, delta_weight, delta_factors=None):
         super().__init__()
         self.delta_weight = delta_weight
+        # (lhs, rhs, scaling) for the single-adapter case, so that `W + scaling * lhs @ rhs`
+        # can be fused into one `baddbmm` instead of materialising the delta separately.
+        self.delta_factors = delta_factors
 
     @staticmethod
     def _low_prec_add(x, y):
@@ -2231,6 +2234,9 @@ class _LoraParameterProxy(nn.Module):
     def forward(self, W):
         if any(getattr(torch, dtype_name, None) == W.dtype for dtype_name in UPCAST_DTYPES):
             return self._low_prec_add(W, self.delta_weight)
+        if self.delta_factors is not None:
+            lhs, rhs, scaling = self.delta_factors
+            return torch.baddbmm(W, lhs, rhs, alpha=scaling)
         return W + self.delta_weight
 
 
@@ -2433,6 +2439,25 @@ class ParamWrapper(nn.Module, LoraLayer):
         param = getattr(self.get_base_layer(), self.parameter_name)
         return param
 
+    def get_delta_factors(self, adapter_name):
+        """`(lhs, rhs, scaling)` such that the delta weight is `scaling * lhs @ rhs`.
+
+        Keeping the two low-rank factors instead of their product lets the caller fold the
+        update into the base weight with a single `baddbmm`, which avoids materialising a
+        second tensor the size of the whole expert stack on every forward.
+        """
+        weight_A = self.lora_A[adapter_name].weight
+        weight_B = self.lora_B[adapter_name].weight
+        weight_A = weight_A.reshape(self.num_experts, -1, weight_A.shape[-1])  # (experts, rank, in)
+        weight_B = weight_B.reshape(weight_B.shape[0], -1, self.num_experts).permute(2, 0, 1)  # (experts, out, rank)
+        if not self._did_swap_in_out_features:
+            # weights are stored as (experts, in_features, out_features)
+            lhs, rhs = weight_A.transpose(-2, -1), weight_B.transpose(-2, -1)
+        else:
+            lhs, rhs = weight_B, weight_A
+        param = self.get_param()
+        return lhs.to(param.dtype), rhs.to(param.dtype), self.scaling[adapter_name]
+
     def get_delta_weight(self, adapter_name, *args, **kwargs):
         if self.num_experts == 1:
             # could actually be a normal layer or experts stacked block-diagonally, acting like a single layer
@@ -2467,19 +2492,21 @@ class ParamWrapper(nn.Module, LoraLayer):
             yield
             return
 
-        delta_weight = None
-        for active_adapter in active_adapters:
-            if active_adapter not in self.lora_A:
-                continue
-            if delta_weight is None:
-                delta_weight = self.get_delta_weight(active_adapter)
-            else:
-                delta_weight = delta_weight + self.get_delta_weight(active_adapter)
+        adapters = [a for a in active_adapters if a in self.lora_A]
+        delta_weight = delta_factors = None
+        if len(adapters) == 1 and self.num_experts > 1:
+            delta_factors = self.get_delta_factors(adapters[0])
+        else:
+            for active_adapter in adapters:
+                if delta_weight is None:
+                    delta_weight = self.get_delta_weight(active_adapter)
+                else:
+                    delta_weight = delta_weight + self.get_delta_weight(active_adapter)
 
         base_layer = self.get_base_layer()
         requires_grad_before = self.get_param().requires_grad
         nn.utils.parametrize.register_parametrization(
-            base_layer, self.parameter_name, _LoraParameterProxy(delta_weight)
+            base_layer, self.parameter_name, _LoraParameterProxy(delta_weight, delta_factors)
         )
         # set requires_grad, as it defaults to False
         base_layer.parametrizations[self.parameter_name].original.requires_grad_(requires_grad_before)

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2442,9 +2442,9 @@ class ParamWrapper(nn.Module, LoraLayer):
     def get_delta_factors(self, adapter_name):
         """`(lhs, rhs, scaling)` such that the delta weight is `scaling * lhs @ rhs`.
 
-        Keeping the two low-rank factors instead of their product lets the caller fold the
-        update into the base weight with a single `baddbmm`, which avoids materialising a
-        second tensor the size of the whole expert stack on every forward.
+        Keeping the two low-rank factors instead of their product lets the caller fold the update into the base weight
+        with a single `baddbmm`, which avoids materialising a second tensor the size of the whole expert stack on every
+        forward.
         """
         weight_A = self.lora_A[adapter_name].weight
         weight_B = self.lora_B[adapter_name].weight

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2205,12 +2205,9 @@ class _LoraParameterProxy(nn.Module):
     Intended to be used in conjunction with `nn.utils.parametrize`, see `ParamWrapper`.
     """
 
-    def __init__(self, delta_weight, delta_factors=None):
+    def __init__(self, delta_weight):
         super().__init__()
         self.delta_weight = delta_weight
-        # (lhs, rhs, scaling) for the single-adapter case, so that `W + scaling * lhs @ rhs`
-        # can be fused into one `baddbmm` instead of materialising the delta separately.
-        self.delta_factors = delta_factors
 
     @staticmethod
     def _low_prec_add(x, y):
@@ -2234,10 +2231,25 @@ class _LoraParameterProxy(nn.Module):
     def forward(self, W):
         if any(getattr(torch, dtype_name, None) == W.dtype for dtype_name in UPCAST_DTYPES):
             return self._low_prec_add(W, self.delta_weight)
-        if self.delta_factors is not None:
-            lhs, rhs, scaling = self.delta_factors
-            return torch.baddbmm(W, lhs, rhs, alpha=scaling)
         return W + self.delta_weight
+
+
+class _LoraFactorsProxy(nn.Module):
+    """This proxies an `nn.Parameter` that is targeted with a single LoRA adapter, keeping the low-rank factors.
+
+    Folding `W + scaling * lhs @ rhs` into one `baddbmm` avoids materialising a delta the size of the full parameter
+    (e.g. a whole expert stack) on every forward. Intended to be used in conjunction with `nn.utils.parametrize`, see
+    `ParamWrapper`.
+    """
+
+    def __init__(self, lhs, rhs, scaling):
+        super().__init__()
+        self.lhs = lhs
+        self.rhs = rhs
+        self.scaling = scaling
+
+    def forward(self, W):
+        return torch.baddbmm(W, self.lhs, self.rhs, alpha=self.scaling)
 
 
 # copied from:
@@ -2493,21 +2505,22 @@ class ParamWrapper(nn.Module, LoraLayer):
             return
 
         adapters = [a for a in active_adapters if a in self.lora_A]
-        delta_weight = delta_factors = None
-        if len(adapters) == 1 and self.num_experts > 1:
-            delta_factors = self.get_delta_factors(adapters[0])
+        param = self.get_param()
+        is_low_precision = any(getattr(torch, dtype_name, None) == param.dtype for dtype_name in UPCAST_DTYPES)
+        if len(adapters) == 1 and self.num_experts > 1 and not is_low_precision:
+            proxy = _LoraFactorsProxy(*self.get_delta_factors(adapters[0]))
         else:
+            delta_weight = None
             for active_adapter in adapters:
                 if delta_weight is None:
                     delta_weight = self.get_delta_weight(active_adapter)
                 else:
                     delta_weight = delta_weight + self.get_delta_weight(active_adapter)
+            proxy = _LoraParameterProxy(delta_weight)
 
         base_layer = self.get_base_layer()
-        requires_grad_before = self.get_param().requires_grad
-        nn.utils.parametrize.register_parametrization(
-            base_layer, self.parameter_name, _LoraParameterProxy(delta_weight, delta_factors)
-        )
+        requires_grad_before = param.requires_grad
+        nn.utils.parametrize.register_parametrization(base_layer, self.parameter_name, proxy)
         # set requires_grad, as it defaults to False
         base_layer.parametrizations[self.parameter_name].original.requires_grad_(requires_grad_before)
         try:

--- a/tests/test_target_parameters.py
+++ b/tests/test_target_parameters.py
@@ -423,10 +423,10 @@ class TestTargetParameters:
                 weights.append(W)
                 return orig_forward(self, W)
 
-            from peft.tuners.lora.layer import _LoraParameterProxy
+            from peft.tuners.lora.layer import _LoraFactorsProxy
 
-            orig_forward = _LoraParameterProxy.forward
-            monkeypatch.setattr(_LoraParameterProxy, "forward", mock_forward)
+            orig_forward = _LoraFactorsProxy.forward
+            monkeypatch.setattr(_LoraFactorsProxy, "forward", mock_forward)
 
             num_steps = 3
             with torch.inference_mode():
@@ -557,9 +557,9 @@ class TestTargetParameters:
             return wrapper
 
         monkeypatch.setattr(
-            peft.tuners.lora.layer._LoraParameterProxy,
+            peft.tuners.lora.layer._LoraFactorsProxy,
             "forward",
-            store_tensors_deco(peft.tuners.lora.layer._LoraParameterProxy.forward),
+            store_tensors_deco(peft.tuners.lora.layer._LoraFactorsProxy.forward),
         )
 
         with hub_online_once(model_id):


### PR DESCRIPTION
`ParamWrapper` adapts a MoE's fused 3-D expert parameter by registering a parametrization that returns `W + delta_weight`, where `delta_weight` is the full `scaling * B @ A` product. That materialises a second tensor the size of the entire expert stack on every forward, and again on every gradient-checkpoint recompute.

When there is exactly one active adapter and the parameter really is a stack of experts, the two low-rank factors can be kept instead of their product and folded into the base weight with a single `torch.baddbmm`:

```python
if self.delta_factors is not None:
    lhs, rhs, scaling = self.delta_factors
    return torch.baddbmm(W, lhs, rhs, alpha=scaling)
return W + self.delta_weight
```

Multiple adapters, `num_experts == 1`, and the low-precision `UPCAST_DTYPES` path all keep the existing behaviour.

## Numbers

128 experts x `hidden=2048` x `intermediate=768`, LoRA r=16, 4096 tokens, bf16, fwd+bwd, single H100:

| | fwd+bwd | peak memory |
|---|---|---|
| main | 4.97 ms | 2.02 GB |
| **this PR** | **2.56 ms (1.94x)** | **1.30 GB (-36%)** |

<details>
<summary>bench_lora_delta.py — the script that produced the table</summary>

```python
# bench_lora_delta.py — cost of materialising the MoE LoRA delta, and whether fusing it changes the result.
import argparse
import statistics
import time

import torch
import torch.nn as nn
from peft import LoraConfig, get_peft_model

EXPERTS, HIDDEN, INTER, RANK, TOKENS = 128, 2048, 768, 16, 4096


class Experts(nn.Module):
    def __init__(self):
        super().__init__()
        self.gate_up_proj = nn.Parameter(torch.randn(EXPERTS, HIDDEN, INTER, dtype=torch.bfloat16) * 0.02)

    def forward(self, x):  # (experts, tokens_per_expert, hidden)
        return torch.bmm(x, self.gate_up_proj)


class Model(nn.Module):
    def __init__(self):
        super().__init__()
        self.experts = Experts()

    def forward(self, x):
        return self.experts(x)


ap = argparse.ArgumentParser()
ap.add_argument("--dump")
a = ap.parse_args()

torch.manual_seed(0)
model = get_peft_model(
    Model().cuda(),
    LoraConfig(r=RANK, lora_alpha=2 * RANK, lora_dropout=0.0, target_modules=[], target_parameters=["gate_up_proj"]),
)
for n, p in model.named_parameters():  # make the adapters non-trivial
    if "lora_B" in n:
        torch.nn.init.normal_(p, std=0.02)
x = torch.randn(EXPERTS, TOKENS // EXPERTS, HIDDEN, device="cuda", dtype=torch.bfloat16, requires_grad=True)


def run():
    torch.cuda.synchronize()
    t = time.perf_counter()
    out = model(x)
    out.sum().backward()
    torch.cuda.synchronize()
    return time.perf_counter() - t, out


for _ in range(5):
    run()
times = [run()[0] for _ in range(20)]
torch.cuda.reset_peak_memory_stats()
_, out = run()
print(f"{statistics.median(times) * 1e3:6.2f} ms/iter   {torch.cuda.max_memory_allocated() / 2**30:5.2f} GB peak")

if a.dump:
    grads = {n: p.grad.detach().float().cpu() for n, p in model.named_parameters() if p.grad is not None}
    torch.save({"out": out.detach().float().cpu(), "grads": grads}, a.dump)
```

</details>

## Numerics

The fused path is **not** bit-identical to materialising the delta: the outputs differ by `1.9e-03` relative in bf16. That is rounding, not a behaviour change: measured against an fp32 reference, both paths are the **same distance from the truth**.

```
today (materialised delta)     weight rel err 1.706e-03   output rel err 1.703e-03
this PR (fused baddbmm)        weight rel err 1.706e-03   output rel err 1.703e-03
```

Identical to four significant figures. The two differ from each other only because they round in different places, and `1.9e-03` is the scale of bf16 epsilon (`~7.8e-03`). Neither is more accurate.

<details>
<summary>lora_delta_accuracy.py — the script that produced those two lines</summary>

```python
# Which is closer to the truth: materialising the bf16 delta, or fusing it into one baddbmm?
import torch

torch.manual_seed(0)
E, H, I, R, T = 128, 2048, 768, 16, 32
W = (torch.randn(E, H, I, dtype=torch.bfloat16, device="cuda") * 0.02)
A = (torch.randn(E, R, H, dtype=torch.bfloat16, device="cuda") * 0.02)   # (experts, rank, in)
B = (torch.randn(E, I, R, dtype=torch.bfloat16, device="cuda") * 0.02)   # (experts, out, rank)
x = torch.randn(E, T, H, dtype=torch.bfloat16, device="cuda")
scaling = 2.0

lhs, rhs = A.transpose(-2, -1), B.transpose(-2, -1)          # (experts, in, rank), (experts, rank, out)

ref = W.float() + scaling * (lhs.float() @ rhs.float())      # fp32 ground truth
today = W + (scaling * (lhs @ rhs)).to(W.dtype)              # materialise the delta in bf16, then add
fused = torch.baddbmm(W, lhs, rhs, alpha=scaling)            # one fused op

for name, w in (("today (materialised delta)", today), ("this PR (fused baddbmm)", fused)):
    err_w = (w.float() - ref).norm() / ref.norm()
    out = torch.bmm(x.float(), w.float())
    out_ref = torch.bmm(x.float(), ref)
    print(f"{name:30s} weight rel err {err_w:.3e}   output rel err {(out - out_ref).norm() / out_ref.norm():.3e}")
```

</details>
