### PR TITLE
Fix LoRA on FSDP2-sharded models: shape inference and module hooks

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -174,8 +174,14 @@ def _get_in_out_features(module: nn.Module) -> tuple[int, int] | tuple[None, Non
     """
     if isinstance(module, nn.Linear):
         if _torch_supports_distributed and isinstance(module.weight, torch.distributed.tensor.DTensor):
-            # If Tensor Parallel is used, the weight is sharded, so we need to get the local shape
-            out_features, in_features = module.weight.to_local().shape
+            # Sharded weight. Under Tensor Parallel the module computes on its local shard, so the LoRA
+            # layers must match the local shape. Under FSDP2 (a mesh dimension named "fsdp") the storage is
+            # sharded but the module still computes the full projection, so the full shape is the right one.
+            mesh_dim_names = module.weight.device_mesh.mesh_dim_names or ()
+            if set(mesh_dim_names) <= {"fsdp"}:
+                in_features, out_features = module.in_features, module.out_features
+            else:
+                out_features, in_features = module.weight.to_local().shape
         else:
             in_features, out_features = module.in_features, module.out_features
     elif isinstance(module, (nn.Conv1d, nn.Conv2d, nn.Conv3d)):
@@ -344,7 +350,9 @@ class BaseTuner(nn.Module, ABC):
         return self.active_adapter
 
     def forward(self, *args: Any, **kwargs: Any):
-        return self.model.forward(*args, **kwargs)
+        # Call the module, not `.forward()`, so module hooks fire — FSDP2 applied to the wrapped model
+        # (e.g. transformers `DistributedConfig(fsdp_size=...)`) registers its root pre-forward hook there.
+        return self.model(*args, **kwargs)
 
     def _pre_injection_hook(self, model: nn.Module, config: PeftConfig, adapter_name: str) -> None:
         r"""

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -177,6 +177,8 @@ def _get_in_out_features(module: nn.Module) -> tuple[int, int] | tuple[None, Non
             # Sharded weight. Under Tensor Parallel the module computes on its local shard, so the LoRA
             # layers must match the local shape. Under FSDP2 (a mesh dimension named "fsdp") the storage is
             # sharded but the module still computes the full projection, so the full shape is the right one.
+            # A mesh with no dimension names comes from plain `fully_shard(model)`, which builds its default
+            # mesh unnamed, so it is FSDP-sharded as well.
             mesh_dim_names = module.weight.device_mesh.mesh_dim_names or ()
             if set(mesh_dim_names) <= {"fsdp"}:
                 in_features, out_features = module.in_features, module.out_features

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -350,8 +350,7 @@ class BaseTuner(nn.Module, ABC):
         return self.active_adapter
 
     def forward(self, *args: Any, **kwargs: Any):
-        # Call the module, not `.forward()`, so module hooks fire — FSDP2 applied to the wrapped model
-        # (e.g. transformers `DistributedConfig(fsdp_size=...)`) registers its root pre-forward hook there.
+        # Call the module, not `.forward()`, so module hooks fire
         return self.model(*args, **kwargs)
 
     def _pre_injection_hook(self, model: nn.Module, config: PeftConfig, adapter_name: str) -> None:

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -352,7 +352,6 @@ class BaseTuner(nn.Module, ABC):
         return self.active_adapter
 
     def forward(self, *args: Any, **kwargs: Any):
-        # Call the module, not `.forward()`, so module hooks fire
         return self.model(*args, **kwargs)
 
     def _pre_injection_hook(self, model: nn.Module, config: PeftConfig, adapter_name: str) -> None:


### PR DESCRIPTION
Two fixes for applying LoRA to a model whose parameters are already FSDP2-sharded (`fully_shard`) when `get_peft_model` runs, e.g. a model loaded with transformers' `DistributedConfig(fsdp_size=..., tp_size=..., enable_expert_parallel=True)`, which shards inside `from_pretrained` (huggingface/transformers#48204).

### 1. `_get_in_out_features` reads the local shard shape on FSDP2 weights

https://github.com/huggingface/peft/blob/5d602fdbff04c33c1c4de55cda9d4ae1d7cb7e40/src/peft/tuners/tuners_utils.py#L176-L178

This is correct for TP, where the module computes on its local shard. Under FSDP2 the *storage* is sharded (`Shard(0)`) but the module still computes the full projection, so LoRA B gets built with `out_features / fsdp_size` and the forward crashes:

```
RuntimeError: The size of tensor a (4096) must match the size of tensor b (2048) at non-singleton dimension 2
```

(Qwen3-30B-A3B `q_proj`: 2048 → 4096, FSDP2-sharded 2-way → local shape (2048, 2048), so `lora_B` was created 16 → 2048 against a 4096-dim base output.)

Minimal reproduction — stock transformers main, 2 GPUs (any model whose targeted projection is non-square):

```python
# torchrun --nproc_per_node 2 repro.py
import torch
from peft import LoraConfig, get_peft_model

from transformers import AutoModelForCausalLM
from transformers.distributed import DistributedConfig

model = AutoModelForCausalLM.from_pretrained(
    "Qwen/Qwen3-0.6B",
    dtype=torch.bfloat16,
    distributed_config=DistributedConfig(fsdp_size=2),
)
model = get_peft_model(model, LoraConfig(r=8, target_modules=["q_proj"]))
ids = torch.randint(0, 1000, (1, 16), device="cuda")
model(input_ids=ids)
```

```
RuntimeError: The size of tensor a (2048) must match the size of tensor b (1024) at non-singleton dimension 2
```

(Qwen3-0.6B `q_proj` is 1024 → 2048; with this PR the same script runs.)

Fix: when the weight's mesh has only a `fsdp` dimension (or no named dimensions), use the module's `in_features`/`out_features`; keep the local-shape path for TP meshes.

### 2. `BaseTuner.forward` skips module hooks

Calling `.forward()` directly bypasses `nn.Module.__call__`, so no module hooks run on the wrapped model, including the root pre-forward hook `fully_shard` registers. FSDP2's lazy init then never sees its root and a later non-root state fails with:

```
RuntimeError: FSDP requires a single root module but got (FSDPQwen3MoeRMSNorm((2048,), eps=1e-06), FSDPLinear(in_features=2048, out_features=151936, bias=False))
```

Fix: simply call `self.model(*args, **kwargs)`.

### Validation

With both fixes (and the transformers 2-D draft), LoRA fine-tuning of Qwen3-30B-A3B under FSDP2 × expert parallelism on 4×H100 trains with healthy losses and finite gradient norms for 8/8 steps (losses ~12.85, grad norms ~1.0). Without fix 1 the first forward crashes with the shape mismatch above; with fix 1 but not fix 2, FSDP2 lazy init raises the single-root error.
