### PR TITLE
docs: fix GraLoRA config docstring typos

### DIFF
--- a/src/peft/tuners/gralora/config.py
+++ b/src/peft/tuners/gralora/config.py
@@ -36,7 +36,7 @@ class GraloraConfig(PeftConfig):
             List of module names or regex expression of the module names to replace with GraLoRA. For example, ['q',
             'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$'. This can also be a wildcard 'all-linear'
             which matches all linear/Conv1D (if the model is a PreTrainedModel, the output layer excluded). If not
-            specified, modules will be chosen according to the model architecture. if the architecture is not known, an
+            specified, modules will be chosen according to the model architecture. If the architecture is not known, an
             error will be raised -- in this case, you should specify the target modules manually.
         alpha (`int`): GraLoRA alpha.
             GraLoRA alpha is the scaling factor for the GraLoRA adapter. Scale becomes alpha / (r + hybrid_r).
@@ -78,7 +78,7 @@ class GraloraConfig(PeftConfig):
         metadata={
             "help": (
                 "GraLoRA attention dimension determines the rank of the GraLoRA adapter. "
-                "The total parameter count of the GraLoRA adapter is same as LoRA with same rank r, while the expressivitiy is multiplied by gralora_k."
+                "The total parameter count of the GraLoRA adapter is same as LoRA with same rank r, while the expressivity is multiplied by gralora_k."
             )
         },
     )

--- a/src/peft/tuners/gralora/config.py
+++ b/src/peft/tuners/gralora/config.py
@@ -27,7 +27,7 @@ class GraloraConfig(PeftConfig):
     Args:
         r (`int`):
             GraLoRA attention dimension determines the rank of the GraLoRA adapter. The total parameter count of the
-            GraLoRA adapter is same as LoRA with same rank r, while the expressivitiy is multiplied by gralora_k.
+            GraLoRA adapter is same as LoRA with same rank r, while the expressivity is multiplied by gralora_k.
         hybrid_r (`int`):
             Hybrid GraLoRA rank determines the rank allocated to vanilla LoRA method when using Hybrid GraLoRA method.
             Hybrid GraLoRA, a combination of GraLoRA and vanilla LoRA, becomes available when hybrid_r > 0. The
@@ -36,7 +36,7 @@ class GraloraConfig(PeftConfig):
             List of module names or regex expression of the module names to replace with GraLoRA. For example, ['q',
             'v'] or '.*decoder.*(SelfAttention|EncDecAttention).*(q|v)$'. This can also be a wildcard 'all-linear'
             which matches all linear/Conv1D (if the model is a PreTrainedModel, the output layer excluded). If not
-            specified, modules will be chosen according to the model architecture. If the architecture is not known, an
+            specified, modules will be chosen according to the model architecture. if the architecture is not known, an
             error will be raised -- in this case, you should specify the target modules manually.
         alpha (`int`): GraLoRA alpha.
             GraLoRA alpha is the scaling factor for the GraLoRA adapter. Scale becomes alpha / (r + hybrid_r).


### PR DESCRIPTION
## Summary

Addresses the remaining typo fixes requested in #3562 (the stray concatenation quotes and the 	arget_parameters sentence referenced in the issue were already resolved on main, so this commit covers the leftover typos the maintainer asked to fix):

- expressivitiy → expressivity
- If the architecture is not known → if the architecture is not known (mid-sentence capitalization inherited from the source string)

## Test plan

Documentation-only change in src/peft/tuners/gralora/config.py; no code affected.