### PR TITLE
Warn when rank_pattern / alpha_pattern keys match no targeted module

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1082,6 +1082,31 @@ class BaseTuner(nn.Module, ABC):
 
         # Now that the checks passed, merge this adapter's matches into the tuner-level bookkeeping. Duplicates
         # are skipped so that names stay unique when several adapters target the same modules.
+        #
+        # Before that, warn about rank_pattern / alpha_pattern entries that did not match any targeted module —
+        # without this check they would be silently ignored, which is easy to miss because the model trains fine
+        # with the default ranks/alphas (see #3582). The matching semantics are identical to `get_pattern_key`:
+        # user keys are treated as regexes matched against the end of the full module path, optionally preceded by
+        # a dot-separated prefix.
+        for pattern_attr in ("rank_pattern", "alpha_pattern"):
+            patterns = getattr(peft_config, pattern_attr, None)
+            if not patterns:
+                continue
+            matched = {
+                pattern_key
+                for pattern_key in patterns
+                if any(re.match(rf"(.*\.)?({pattern_key})$", module_name) for module_name in targeted_module_names)
+            }
+            unmatched = sorted(set(patterns) - matched)
+            if unmatched:
+                warnings.warn(
+                    f"The following {pattern_attr} keys did not match any targeted module and were ignored: "
+                    f"{unmatched}. Note that pattern keys are only matched against the end of a full module path "
+                    "(optionally after a dot-separated prefix), therefore regex anchors like '^' or fully-qualified "
+                    "paths may never match.",
+                    RuntimeWarning,
+                )
+
         _extend_unique(self.targeted_module_names, targeted_module_names)
         _extend_unique(self.targeted_parameter_names, targeted_parameter_names)
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1102,8 +1102,8 @@ class BaseTuner(nn.Module, ABC):
                 warnings.warn(
                     f"The following {pattern_attr} keys did not match any targeted module and were ignored: "
                     f"{unmatched}. Note that pattern keys are only matched against the end of a full module path "
-                    "(optionally after a dot-separated prefix), therefore regex anchors like '^' or fully-qualified "
-                    "paths may never match.",
+                    "(optionally after a dot-separated prefix), so a misplaced '^' anchor such as '^q_proj' or a "
+                    "typo may never match (fully-qualified anchored keys such as '^model\\.layers\\.0\\.' do match).",
                     RuntimeWarning,
                 )
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1080,14 +1080,9 @@ class BaseTuner(nn.Module, ABC):
                     RuntimeWarning,
                 )
 
-        # Now that the checks passed, merge this adapter's matches into the tuner-level bookkeeping. Duplicates
-        # are skipped so that names stay unique when several adapters target the same modules.
-        #
-        # Before that, warn about rank_pattern / alpha_pattern entries that did not match any targeted module —
-        # without this check they would be silently ignored, which is easy to miss because the model trains fine
-        # with the default ranks/alphas (see #3582). The matching semantics are identical to `get_pattern_key`:
-        # user keys are treated as regexes matched against the end of the full module path, optionally preceded by
-        # a dot-separated prefix.
+        # Warn about rank_pattern / alpha_pattern entries that matched no targeted module. Without
+        # this check they would be silently ignored, which is easy to miss because the model trains fine
+        # with the default ranks/alphas. The matching semantics are identical to `get_pattern_key`.
         for pattern_attr in ("rank_pattern", "alpha_pattern"):
             patterns = getattr(peft_config, pattern_attr, None)
             if not patterns:
@@ -1101,12 +1096,12 @@ class BaseTuner(nn.Module, ABC):
             if unmatched:
                 warnings.warn(
                     f"The following {pattern_attr} keys did not match any targeted module and were ignored: "
-                    f"{unmatched}. Note that pattern keys are only matched against the end of a full module path "
-                    "(optionally after a dot-separated prefix), so a misplaced '^' anchor such as '^q_proj' or a "
-                    "typo may never match (fully-qualified anchored keys such as '^model\\.layers\\.0\\.' do match).",
+                    f"{unmatched}.",
                     RuntimeWarning,
                 )
 
+        # Now that the checks passed, merge this adapter's matches into the tuner-level bookkeeping. Duplicates
+        # are skipped so that names stay unique when several adapters target the same modules.
         _extend_unique(self.targeted_module_names, targeted_module_names)
         _extend_unique(self.targeted_parameter_names, targeted_parameter_names)
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1080,9 +1080,8 @@ class BaseTuner(nn.Module, ABC):
                     RuntimeWarning,
                 )
 
-        # Warn about rank_pattern / alpha_pattern entries that matched no targeted module. Without
-        # this check they would be silently ignored, which is easy to miss because the model trains fine
-        # with the default ranks/alphas. The matching semantics are identical to `get_pattern_key`.
+        # Warn about rank_pattern / alpha_pattern entries that matched no targeted module. The
+        # matching semantics are identical to `get_pattern_key`.
         for pattern_attr in ("rank_pattern", "alpha_pattern"):
             patterns = getattr(peft_config, pattern_attr, None)
             if not patterns:

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -6353,3 +6353,49 @@ class TestTinyLoraInitialization:
         model_control = get_peft_model(mlp_control, config_b2, adapter_name="b")
 
         assert len(model.tinylora_v["b"]) == len(model_control.tinylora_v["b"]) == 1
+
+
+class TestPatternKeyZeroMatchWarning:
+    # Regression test for https://github.com/huggingface/peft/issues/3582:
+    # rank_pattern / alpha_pattern keys that match no targeted module used to be
+    # silently ignored (e.g. anchored keys like "^lin0", which can never match
+    # under the internal "(.*\.)?key$" suffix-matching rule).
+
+    @pytest.fixture
+    def small_mlp(self):
+        class Mlp(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin0 = nn.Linear(8, 8)
+                self.lin1 = nn.Linear(8, 8)
+
+        return Mlp()
+
+    def test_unmatched_alpha_pattern_key_warns(self, small_mlp):
+        # Fully-qualified anchored keys (as shown in the LoraConfig docstring) can never match a bare module
+        # path like "lin0"; previously they were silently ignored.
+        with pytest.warns(RuntimeWarning, match="alpha_pattern.*did not match any targeted module"):
+            get_peft_model(
+                small_mlp,
+                LoraConfig(target_modules=["lin0"], alpha_pattern={"^model\\.lin0$": 100}),
+            )
+
+    def test_unmatched_rank_pattern_key_warns(self, small_mlp):
+        with pytest.warns(RuntimeWarning, match="rank_pattern.*did not match any targeted module"):
+            get_peft_model(
+                small_mlp,
+                LoraConfig(target_modules=["lin0"], rank_pattern={"some.other.path.lin1": 2}),
+            )
+
+    def test_matched_pattern_keys_do_not_warn(self, small_mlp):
+        # A key that genuinely suffix-matches a targeted module must not trigger the warning.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            get_peft_model(
+                small_mlp,
+                LoraConfig(target_modules=["lin0"], alpha_pattern={"lin0": 100}),
+            )
+
+        assert not [w for w in caught if "did not match any targeted module" in str(w.message)], (
+            "matching pattern key should not warn"
+        )

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1809,17 +1809,57 @@ class TestLoraInitialization:
             )
 
     def test_matched_pattern_keys_do_not_warn(self):
-        # A key that genuinely suffix-matches a targeted module must not trigger the warning.
+        # Keys that genuinely suffix-match a targeted module must not trigger the warning.
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             get_peft_model(
                 self.get_model(),
-                LoraConfig(target_modules=["linear"], alpha_pattern={"linear": 100}),
+                LoraConfig(
+                    target_modules=["linear"],
+                    alpha_pattern={"linear": 100},
+                    rank_pattern={"linear": 2},
+                ),
             )
 
         assert not [w for w in caught if "did not match any targeted module" in str(w.message)], (
             "matching pattern key should not warn"
         )
+
+    def test_partially_matched_pattern_warns_for_unmatched_keys_only(self):
+        # When some keys match and others don't, the warning names exactly the unmatched ones.
+        with pytest.warns(RuntimeWarning, match=r"\['typo_key'\]") as record:
+            get_peft_model(
+                self.get_model(),
+                LoraConfig(
+                    target_modules=["linear"],
+                    alpha_pattern={"linear": 100, "typo_key": 100},
+                    rank_pattern={"linear": 2, "other.typo": 2},
+                ),
+            )
+        messages = [str(w.message) for w in record]
+        assert any("alpha_pattern" in m and "typo_key" in m for m in messages)
+        assert any("rank_pattern" in m and "other.typo" in m for m in messages)
+        assert not any("linear" in m.split("ignored:")[1] for m in messages if "ignored:" in m)
+
+    def test_misconfigured_second_adapter_warns_on_add_adapter(self):
+        # A valid first adapter stays silent; adding a misconfigured second adapter warns.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            model = get_peft_model(
+                self.get_model(),
+                LoraConfig(
+                    target_modules=["linear"],
+                    alpha_pattern={"linear": 100},
+                    rank_pattern={"linear": 2},
+                ),
+            )
+        assert not [w for w in caught if "did not match any targeted module" in str(w.message)]
+
+        with pytest.warns(RuntimeWarning, match="alpha_pattern.*did not match any targeted module"):
+            model.add_adapter(
+                "other",
+                LoraConfig(target_modules=["linear"], alpha_pattern={"typo_key": 100}),
+            )
 
 
 class TestLokrInitialization:

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1792,6 +1792,35 @@ class TestLoraInitialization:
         config2 = LoraConfig(target_modules=["linear"], bias="none")
         model.add_adapter("other", config2)  # does not raise
 
+    def test_unmatched_alpha_pattern_key_warns(self):
+        # Only LoRA is tested here, but the check lives in BaseTuner and therefore applies to every
+        # pattern-consuming tuner. A key that matches no targeted module used to be silently ignored.
+        with pytest.warns(RuntimeWarning, match="alpha_pattern.*did not match any targeted module"):
+            get_peft_model(
+                self.get_model(),
+                LoraConfig(target_modules=["linear"], alpha_pattern={"typo_key": 100}),
+            )
+
+    def test_unmatched_rank_pattern_key_warns(self):
+        with pytest.warns(RuntimeWarning, match="rank_pattern.*did not match any targeted module"):
+            get_peft_model(
+                self.get_model(),
+                LoraConfig(target_modules=["linear"], rank_pattern={"some.other.path": 2}),
+            )
+
+    def test_matched_pattern_keys_do_not_warn(self):
+        # A key that genuinely suffix-matches a targeted module must not trigger the warning.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            get_peft_model(
+                self.get_model(),
+                LoraConfig(target_modules=["linear"], alpha_pattern={"linear": 100}),
+            )
+
+        assert not [w for w in caught if "did not match any targeted module" in str(w.message)], (
+            "matching pattern key should not warn"
+        )
+
 
 class TestLokrInitialization:
     torch_device = infer_device()
@@ -6353,49 +6382,3 @@ class TestTinyLoraInitialization:
         model_control = get_peft_model(mlp_control, config_b2, adapter_name="b")
 
         assert len(model.tinylora_v["b"]) == len(model_control.tinylora_v["b"]) == 1
-
-
-class TestPatternKeyZeroMatchWarning:
-    # Regression test for https://github.com/huggingface/peft/issues/3582:
-    # rank_pattern / alpha_pattern keys that match no targeted module used to be
-    # silently ignored (e.g. anchored keys like "^lin0", which can never match
-    # under the internal "(.*\.)?key$" suffix-matching rule).
-
-    @pytest.fixture
-    def small_mlp(self):
-        class Mlp(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.lin0 = nn.Linear(8, 8)
-                self.lin1 = nn.Linear(8, 8)
-
-        return Mlp()
-
-    def test_unmatched_alpha_pattern_key_warns(self, small_mlp):
-        # Fully-qualified anchored keys (as shown in the LoraConfig docstring) can never match a bare module
-        # path like "lin0"; previously they were silently ignored.
-        with pytest.warns(RuntimeWarning, match="alpha_pattern.*did not match any targeted module"):
-            get_peft_model(
-                small_mlp,
-                LoraConfig(target_modules=["lin0"], alpha_pattern={"^model\\.lin0$": 100}),
-            )
-
-    def test_unmatched_rank_pattern_key_warns(self, small_mlp):
-        with pytest.warns(RuntimeWarning, match="rank_pattern.*did not match any targeted module"):
-            get_peft_model(
-                small_mlp,
-                LoraConfig(target_modules=["lin0"], rank_pattern={"some.other.path.lin1": 2}),
-            )
-
-    def test_matched_pattern_keys_do_not_warn(self, small_mlp):
-        # A key that genuinely suffix-matches a targeted module must not trigger the warning.
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            get_peft_model(
-                small_mlp,
-                LoraConfig(target_modules=["lin0"], alpha_pattern={"lin0": 100}),
-            )
-
-        assert not [w for w in caught if "did not match any targeted module" in str(w.message)], (
-            "matching pattern key should not warn"
-        )


### PR DESCRIPTION
Unmatched `rank_pattern` / `alpha_pattern` keys silently fall back to the default rank/alpha, training a different model than intended with no signal (e.g. a typo'd key). This adds a `RuntimeWarning` naming the ignored keys.

Scope note (corrected per review on #3582): `^q_proj`-style bare anchors are user error, and fully-qualified anchored keys such as `^model\.layers\.0\.self_attn\.q_proj` DO match — verified (layer-0 scaling 12.5, no warning, no false positive). What never matches is a misplaced `^` or a typo, and those are exactly what this warns about.

Fixes #3582

## Details

The check lives centrally in `BaseTuner.inject_adapter` using the exact same matching semantics as `get_pattern_key` (`re.match(r"(.*\.)?(key)$", module)` per targeted module), so it covers every pattern-consuming tuner (LoRA, LoKr, LoHa, HiRA, DeLoRA) and any future ones, rather than being duplicated per tuner. On the "impossible" concern: the check never decomposes regexes — it tests whole-match per key with byte-identical semantics, so it cannot false-positive on keys that genuinely match.

## Tests

- Three tests in `TestLoraInitialization` (LoRA-only, sufficient since the check lives in `BaseTuner`): unmatched alpha/rank keys warn, genuinely-matching key does not.
- `filterwarnings` only escalates transformers warnings in this repo, so existing suites are unaffected.
- Repro (tiny Llama, CPU): typo key warns + scaling stays 1.0/1.0 on base silently; anchored key gives 12.5/1.0 with no warning on both base and this branch.

Test environment: Python 3.12, torch 2.13.0+cpu, transformers 5.15.1, peft @ 3c8da73e, ruff 0.16.4 (check + format clean). Note: `tests/test_tuners_utils.py` is not runnable in this env (missing `parameterized` module, pre-existing gap).