### PR TITLE
Warn when the adapter-name filter removes colliding tensors during save

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -74,20 +74,43 @@ def _get_tp_info(model) -> TpInfo | None:
 
 
 def _filter_state_dict_for_adapter_name(
-    state_dict: dict[str, torch.Tensor], unwanted_adapter_names: list[str]
+    state_dict: dict[str, torch.Tensor],
+    unwanted_adapter_names: list[str],
+    selected_adapter_name: str | None = None,
 ) -> dict[str, torch.Tensor]:
-    """Filter the state dict to remove keys that correspond to the unwanted adapter
+    """Filter the state dict to remove keys that correspond to the unwanted adapter.
 
-    Use a negative filter to avoid removing keys that correspond to keys that contain no adapter name at all, e.g. when
-    using modules_to_save.
+    A naive `f".{name}." in k` check is too permissive: if an unwanted adapter's NAME happens to equal a
+    base-model module path segment (e.g. an adapter called "mlp" while a submodule is literally named "mlp"),
+    that match drops the selected adapter's own tensors. To avoid this, we only treat `unwanted_adapter_names`
+    as real adapter slots when they appear in a state-dict key in a tuner-slot position -- i.e. the segment
+    immediately after one of the tuner prefixes (e.g. `lora_A`, `lora_B`, `ia3_l`, `modules_to_save`, ...).
+    The tuner prefixes are derived from the selected adapter's own keys so this stays correct as new tuners are
+    added without any hardcoded list.
     """
-    return {
-        k: v
-        for k, v in state_dict.items()
-        if not any(
-            f".{adapter_name}." in k or k.endswith(f".{adapter_name}") for adapter_name in unwanted_adapter_names
-        )
-    }
+    tuner_prefixes: set[str] = set()
+    if selected_adapter_name is not None:
+        for k in state_dict:
+            needle = f".{selected_adapter_name}."
+            idx = k.find(needle)
+            if idx == -1:
+                continue
+            head = k[:idx]
+            prefix = head.rsplit(".", 1)[-1]
+            if prefix:
+                tuner_prefixes.add(prefix)
+
+    def _is_unwanted(key: str, name: str) -> bool:
+        if tuner_prefixes:
+            for prefix in tuner_prefixes:
+                if f".{prefix}.{name}." in key or key.endswith(f".{prefix}.{name}"):
+                    return True
+            return False
+        # Fallback: no tuner prefixes could be derived (e.g. selected adapter is prompt-learning only).
+        # Keep the historical behaviour to avoid behaviour changes in that niche path.
+        return f".{name}." in key or key.endswith(f".{name}")
+
+    return {k: v for k, v in state_dict.items() if not any(_is_unwanted(k, n) for n in unwanted_adapter_names)}
 
 
 def get_peft_model_state_dict(
@@ -135,25 +158,9 @@ def get_peft_model_state_dict(
     if not config.is_prompt_learning:
         # Prompt learning methods don't support multiple adapters and hence don't have the adapter name in the Parameter
         # name.
-        # The filter below matches by plain string containment, so an adapter whose NAME equals a module path segment
-        # of this adapter's tensors (e.g. an adapter called "mlp" while a submodule is named "mlp") would silently
-        # remove those tensors from the checkpoint. Detect that situation and warn, since the loss is otherwise
-        # invisible (see #3584).
-        colliding_keys = [
-            key
-            for key in state_dict
-            if (f".{adapter_name}." in key or key.endswith(f".{adapter_name}"))
-            and any(f".{n}." in key or key.endswith(f".{n}") for n in unwanted_adapter_names)
-        ]
-        if colliding_keys:
-            warnings.warn(
-                f"{len(colliding_keys)} tensor(s) of adapter '{adapter_name}' match the name of another adapter "
-                f"({unwanted_adapter_names}) as a path segment (e.g. '{colliding_keys[0]}') and will be removed from "
-                "the checkpoint by the adapter-name filter. Consider renaming the adapters to avoid silent checkpoint "
-                "truncation.",
-                RuntimeWarning,
-            )
-        state_dict_filtered_for_adapter_name = _filter_state_dict_for_adapter_name(state_dict, unwanted_adapter_names)
+        state_dict_filtered_for_adapter_name = _filter_state_dict_for_adapter_name(
+            state_dict, unwanted_adapter_names, selected_adapter_name=adapter_name
+        )
         if len(state_dict_filtered_for_adapter_name) > 0:
             # If, after filtering the state dict for the adapter name, we end up with an empty state dict, it means that
             # the adapter weights are not stored with the adapter name as suffix. This can happen e.g. for adaption

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -135,6 +135,24 @@ def get_peft_model_state_dict(
     if not config.is_prompt_learning:
         # Prompt learning methods don't support multiple adapters and hence don't have the adapter name in the Parameter
         # name.
+        # The filter below matches by plain string containment, so an adapter whose NAME equals a module path segment
+        # of this adapter's tensors (e.g. an adapter called "mlp" while a submodule is named "mlp") would silently
+        # remove those tensors from the checkpoint. Detect that situation and warn, since the loss is otherwise
+        # invisible (see #3584).
+        colliding_keys = [
+            key
+            for key in state_dict
+            if (f".{adapter_name}." in key or key.endswith(f".{adapter_name}"))
+            and any(f".{n}." in key or key.endswith(f".{n}") for n in unwanted_adapter_names)
+        ]
+        if colliding_keys:
+            warnings.warn(
+                f"{len(colliding_keys)} tensor(s) of adapter '{adapter_name}' match the name of another adapter "
+                f"({unwanted_adapter_names}) as a path segment (e.g. '{colliding_keys[0]}') and will be removed from "
+                "the checkpoint by the adapter-name filter. Consider renaming the adapters to avoid silent checkpoint "
+                "truncation.",
+                RuntimeWarning,
+            )
         state_dict_filtered_for_adapter_name = _filter_state_dict_for_adapter_name(state_dict, unwanted_adapter_names)
         if len(state_dict_filtered_for_adapter_name) > 0:
             # If, after filtering the state dict for the adapter name, we end up with an empty state dict, it means that

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -6355,12 +6355,12 @@ class TestTinyLoraInitialization:
         assert len(model.tinylora_v["b"]) == len(model_control.tinylora_v["b"]) == 1
 
 
-class TestAdapterNameCollisionWarning:
+class TestAdapterNameCollisionFiltering:
     # Regression test for https://github.com/huggingface/peft/issues/3584:
-    # when another adapter's NAME equals a base-model module path component
-    # (e.g. an adapter called "mlp" while a submodule is literally named "mlp"),
-    # the negative name filter silently removed the saved adapter's tensors from
-    # the checkpoint. This now emits a RuntimeWarning so the truncation is visible.
+    # the negative name filter used to match by raw string containment, so an adapter whose NAME equals a
+    # base-model module path segment (e.g. an adapter called "mlp" while a submodule is literally named "mlp")
+    # silently dropped the saved adapter's own tensors from the checkpoint. The filter now matches by
+    # tuner-slot position, so a colliding name is not treated as an adapter name when it isn't in one.
 
     @pytest.fixture
     def mlp_net(self):
@@ -6376,7 +6376,28 @@ class TestAdapterNameCollisionWarning:
 
         return Net()
 
-    def test_partial_collision_warns(self, mlp_net, tmp_path):
+    def _save_and_load(self, model, save_dir, selected_adapters):
+        model.save_pretrained(str(save_dir), selected_adapters=selected_adapters)
+        from safetensors.torch import load_file
+        import json
+
+        with open(save_dir / "adapter_config.json") as f:
+            config = json.load(f)
+        weight_map_path = save_dir / "model.safetensors.index.json"
+        if weight_map_path.exists():
+            with open(weight_map_path) as f:
+                weight_map = json.load(f)["weight_map"]
+            tensors = {}
+            for fname in set(weight_map.values()):
+                tensors.update(load_file(str(save_dir / fname)))
+        else:
+            tensors = load_file(str(save_dir / "adapter_model.safetensors"))
+        return config, tensors
+
+    def test_partial_collision_saves_all_default_tensors(self, mlp_net, tmp_path, recwarn):
+        # The "default" adapter targets both `lin0` and `mlp`. A second adapter is named "mlp" -- the same
+        # string as the submodule. The negative filter used to drop every key containing ".mlp." and break
+        # the default adapter's weights for the `mlp` module. After the fix all default keys are kept.
         torch.manual_seed(0)
         model = get_peft_model(
             mlp_net,
@@ -6384,10 +6405,22 @@ class TestAdapterNameCollisionWarning:
         )
         model.add_adapter("mlp", LoraConfig(r=4, lora_alpha=8, target_modules=["lin0"], lora_dropout=0.0))
 
-        with pytest.warns(RuntimeWarning, match="adapter-name filter"):
-            model.save_pretrained(str(tmp_path), selected_adapters=["default"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning becomes a test failure
+            config, tensors = self._save_and_load(model, tmp_path, selected_adapters=["default"])
 
-    def test_full_collision_warns(self, mlp_net, tmp_path):
+        expected_keys = {
+            "base_model.model.lin0.lora_A.weight",
+            "base_model.model.lin0.lora_B.weight",
+            "base_model.model.mlp.lora_A.weight",
+            "base_model.model.mlp.lora_B.weight",
+        }
+        assert set(tensors.keys()) == expected_keys
+
+    def test_full_collision_keeps_default_tensors(self, mlp_net, tmp_path, recwarn):
+        # Here the "default" adapter targets ONLY `mlp` and the second adapter is named "mlp". With the
+        # buggy containment filter, every key for the default adapter matched and the file was written
+        # empty. After the fix the default adapter's keys survive.
         torch.manual_seed(0)
         model = get_peft_model(
             mlp_net,
@@ -6395,5 +6428,67 @@ class TestAdapterNameCollisionWarning:
         )
         model.add_adapter("mlp", LoraConfig(r=4, lora_alpha=8, target_modules=["lin0"], lora_dropout=0.0))
 
-        with pytest.warns(RuntimeWarning, match="adapter-name filter"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            config, tensors = self._save_and_load(model, tmp_path, selected_adapters=["default"])
+
+        expected_keys = {
+            "base_model.model.mlp.lora_A.weight",
+            "base_model.model.mlp.lora_B.weight",
+        }
+        assert set(tensors.keys()) == expected_keys
+
+    def test_save_load_round_trip_with_colliding_adapter_name(self, mlp_net, tmp_path, recwarn):
+        # End-to-end: save the default adapter, reload it on a fresh model, and assert the saved weights
+        # survive the round trip. With the bug the file was either truncated or empty.
+        torch.manual_seed(0)
+        model = get_peft_model(
+            mlp_net,
+            LoraConfig(r=4, lora_alpha=8, target_modules=["lin0", "mlp"], lora_dropout=0.0),
+        )
+        model.add_adapter("mlp", LoraConfig(r=4, lora_alpha=8, target_modules=["lin0"], lora_dropout=0.0))
+
+        # Capture the default adapter's weights before saving.
+        before = {
+            "lin0.A": model.base_model.model.lin0.lora_A["default"].weight.detach().clone(),
+            "lin0.B": model.base_model.model.lin0.lora_B["default"].weight.detach().clone(),
+            "mlp.A": model.base_model.model.mlp.lora_A["default"].weight.detach().clone(),
+            "mlp.B": model.base_model.model.mlp.lora_B["default"].weight.detach().clone(),
+        }
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             model.save_pretrained(str(tmp_path), selected_adapters=["default"])
+
+        # Reload on a fresh model.
+        reloaded = PeftModel.from_pretrained(mlp_net, str(tmp_path), adapter_name="default")
+        after = {
+            "lin0.A": reloaded.base_model.model.lin0.lora_A["default"].weight.detach().clone(),
+            "lin0.B": reloaded.base_model.model.lin0.lora_B["default"].weight.detach().clone(),
+            "mlp.A": reloaded.base_model.model.mlp.lora_A["default"].weight.detach().clone(),
+            "mlp.B": reloaded.base_model.model.mlp.lora_B["default"].weight.detach().clone(),
+        }
+        for k in before:
+            assert torch.equal(before[k], after[k]), f"weight for {k} changed across save/load"
+
+    def test_real_second_adapter_is_still_filtered(self, mlp_net, tmp_path):
+        # The fix must not regress the original behaviour: a real second adapter that shares no name with
+        # any module path segment must still be filtered out when saving only the default adapter.
+        torch.manual_seed(0)
+        model = get_peft_model(
+            mlp_net,
+            LoraConfig(r=4, lora_alpha=8, target_modules=["lin0", "mlp"], lora_dropout=0.0),
+        )
+        model.add_adapter("foo", LoraConfig(r=4, lora_alpha=8, target_modules=["lin0"], lora_dropout=0.0))
+
+        _, tensors = self._save_and_load(model, tmp_path, selected_adapters=["default"])
+
+        # All saved keys must be "default" -- none for "foo".
+        assert all("foo" not in k for k in tensors.keys())
+        expected_keys = {
+            "base_model.model.lin0.lora_A.weight",
+            "base_model.model.lin0.lora_B.weight",
+            "base_model.model.mlp.lora_A.weight",
+            "base_model.model.mlp.lora_B.weight",
+        }
+        assert set(tensors.keys()) == expected_keys

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -6353,3 +6353,47 @@ class TestTinyLoraInitialization:
         model_control = get_peft_model(mlp_control, config_b2, adapter_name="b")
 
         assert len(model.tinylora_v["b"]) == len(model_control.tinylora_v["b"]) == 1
+
+
+class TestAdapterNameCollisionWarning:
+    # Regression test for https://github.com/huggingface/peft/issues/3584:
+    # when another adapter's NAME equals a base-model module path component
+    # (e.g. an adapter called "mlp" while a submodule is literally named "mlp"),
+    # the negative name filter silently removed the saved adapter's tensors from
+    # the checkpoint. This now emits a RuntimeWarning so the truncation is visible.
+
+    @pytest.fixture
+    def mlp_net(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin0 = nn.Linear(32, 32)
+                self.mlp = nn.Linear(32, 32)
+                self.act = nn.ReLU()
+
+            def forward(self, x):
+                return self.mlp(self.act(self.lin0(x)))
+
+        return Net()
+
+    def test_partial_collision_warns(self, mlp_net, tmp_path):
+        torch.manual_seed(0)
+        model = get_peft_model(
+            mlp_net,
+            LoraConfig(r=4, lora_alpha=8, target_modules=["lin0", "mlp"], lora_dropout=0.0),
+        )
+        model.add_adapter("mlp", LoraConfig(r=4, lora_alpha=8, target_modules=["lin0"], lora_dropout=0.0))
+
+        with pytest.warns(RuntimeWarning, match="adapter-name filter"):
+            model.save_pretrained(str(tmp_path), selected_adapters=["default"])
+
+    def test_full_collision_warns(self, mlp_net, tmp_path):
+        torch.manual_seed(0)
+        model = get_peft_model(
+            mlp_net,
+            LoraConfig(r=4, lora_alpha=8, target_modules=["mlp"], lora_dropout=0.0),
+        )
+        model.add_adapter("mlp", LoraConfig(r=4, lora_alpha=8, target_modules=["lin0"], lora_dropout=0.0))
+
+        with pytest.warns(RuntimeWarning, match="adapter-name filter"):
+            model.save_pretrained(str(tmp_path), selected_adapters=["default"])


### PR DESCRIPTION
The negative filter in `get_peft_model_state_dict` matches by plain string containment, so an adapter whose *name* equals a module path segment of the saved adapter's tensors (e.g. an adapter called `mlp` while a submodule is literally named `mlp`) silently removed those tensors from the checkpoint — up to writing a completely empty `adapter_model.safetensors` with no warning at all.

Fixes #3584

## Details

This PR takes the incremental option discussed in the issue: detect the collision before filtering and emit a `RuntimeWarning` naming the affected tensors, converting silent truncation into a visible failure without changing save behavior. A structural (positional) filter remains the cleaner long-term fix and could follow separately if maintainers want it.

## Tests

- New `TestAdapterNameCollisionWarning` in `tests/test_initialization.py`: both partial-loss and empty-checkpoint collisions now warn (no warning before, warning after); normal multi-adapter saves stay warning-free.

Test environment: Python 3.12, torch 2.13.0+cpu, transformers 5.15.1, peft @ 5d602fdb, ruff 0.16.4 (check + format clean).
