### PR TITLE
don't mutate caller state dict when loading modules_to_save adapters

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -486,7 +486,9 @@ def set_peft_model_state_dict(
 
     """
     config = model.peft_config[adapter_name]
-    state_dict = peft_model_state_dict
+    # Copy first: modules_to_save remapping inserts/deletes keys, and callers
+    # reuse the same checkpoint dict across model instances.
+    state_dict = dict(peft_model_state_dict)
     if config.peft_type not in PEFT_TYPE_TO_TUNER_MAPPING:
         raise ValueError(f"Unknown PEFT type passed: {config.peft_type}")
 

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -789,6 +789,27 @@ class TestPeftStateDict:
         weight = target.base_model.model.lora_head.modules_to_save["default"].weight
         assert torch.allclose(weight, torch.full_like(weight, 123.0))
 
+    def test_set_peft_model_state_dict_does_not_mutate_modules_to_save_checkpoint(self):
+        class Tiny(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = nn.Linear(4, 4)
+                self.head = nn.Linear(4, 2)
+
+            def forward(self, x):
+                return self.head(self.proj(x))
+
+        config = LoraConfig(target_modules=["proj"], modules_to_save=["head"])
+        source = get_peft_model(Tiny(), config)
+        state_dict = get_peft_model_state_dict(source)
+        keys_before = tuple(state_dict)
+
+        set_peft_model_state_dict(get_peft_model(Tiny(), config), state_dict)
+        assert tuple(state_dict) == keys_before
+
+        # Same in-memory checkpoint used to KeyError on a second load.
+        set_peft_model_state_dict(get_peft_model(Tiny(), config), state_dict)
+
 
 class TestGetBaseModelStateDict:
     # Tests for get_base_model_state_dict / set_base_model_state_dict. The per-method and per-model coverage lives in


### PR DESCRIPTION
Fixes #3592

`set_peft_model_state_dict` rewrites `modules_to_save` keys on the dict the caller passed in. After the first load those keys are gone, so a second `set_peft_model_state_dict` on the same checkpoint raises KeyError.

That's annoying if you keep one in-memory adapter dict and stamp it onto a few model copies (e.g. workers). Plain LoRA checkpoints don't hit this; classification heads and other `modules_to_save` adapters do.

Fix is a shallow copy before the remap. Tensors stay shared. Test loads twice from the same dict and checks the keys didn't move.
