### PR TITLE
FIX Preserve input state dict during adapter loading

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -486,7 +486,7 @@ def set_peft_model_state_dict(
 
     """
     config = model.peft_config[adapter_name]
-    state_dict = peft_model_state_dict
+    state_dict = peft_model_state_dict.copy()
     if config.peft_type not in PEFT_TYPE_TO_TUNER_MAPPING:
         raise ValueError(f"Unknown PEFT type passed: {config.peft_type}")
 
@@ -521,7 +521,7 @@ def set_peft_model_state_dict(
 
                 state_dict[store_key] = peft_model_state_dict[lookup_key]
 
-                # delete the old key from the previous `state_dict = peft_model_state_dict` statement.
+                # Delete the saved key after translating it to the wrapper's load key.
                 del state_dict[lookup_key]
 
     # Remapping the keys of the loaded state_dict to fit the model is method-specific and thus delegated to the tuner

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -789,6 +789,22 @@ class TestPeftStateDict:
         weight = target.base_model.model.lora_head.modules_to_save["default"].weight
         assert torch.allclose(weight, torch.full_like(weight, 123.0))
 
+    def test_set_peft_model_state_dict_preserves_input(self):
+        def create_model():
+            config = LoraConfig(target_modules=["linear"], modules_to_save=["linear2"])
+            return get_peft_model(DummyModel(), config)
+
+        # Regression test for #3592: loading must not consume caller-owned checkpoints.
+        state_dict = get_peft_model_state_dict(create_model())
+        keys_before = tuple(state_dict)
+        values_before = state_dict.copy()
+
+        for _ in range(2):
+            set_peft_model_state_dict(create_model(), state_dict)
+
+        assert tuple(state_dict) == keys_before
+        assert all(state_dict[key] is value for key, value in values_before.items())
+
 
 class TestGetBaseModelStateDict:
     # Tests for get_base_model_state_dict / set_base_model_state_dict. The per-method and per-model coverage lives in


### PR DESCRIPTION
## What does this PR do?

`set_peft_model_state_dict` aliased its caller-owned checkpoint dictionary before remapping `modules_to_save` keys. The first load therefore replaced and deleted keys in the input mapping, and reusing that checkpoint for a second model raised a `KeyError`.

This change makes a shallow copy before key remapping. Tensor storage remains shared. The regression loads one checkpoint into two fresh models, then verifies that its keys and tensor objects remain unchanged.

On pristine `main`, the regression fails on the second load with `KeyError: 'base_model.model.linear2.weight'`.

Fixes #3592.

The approach was approved in the [maintainer comment](https://github.com/huggingface/peft/issues/3592#issuecomment-5394397512).

## Tests

- `python -m pytest tests/test_low_level_api.py -q -k "set_peft_model_state_dict_preserves_input"` (1 passed, 55 deselected)
- `python -m pytest tests/test_low_level_api.py -q -k "set_peft_model_state_dict_preserves_input or trained_modules_to_save_module_named_like_peft_prefix_round_trip"` (2 passed, 54 deselected)
- `ruff check src tests examples docs scripts docker`
- `ruff format --check src tests examples docs scripts docker`

## AI assistance

OpenAI Codex assisted with repository auditing, diagnosis, implementation, local test execution, and PR drafting. I reviewed every changed line, ran the focused regression locally, and take responsibility for the contribution.