### PR TITLE
FIX LN Tuning: fall back to base layer when active adapter does not target a layer

### DIFF
--- a/src/peft/tuners/ln_tuning/layer.py
+++ b/src/peft/tuners/ln_tuning/layer.py
@@ -71,6 +71,10 @@ class LNTuningLayer(nn.Module, BaseTunerLayer):
     def merge(self, adapter_names: Optional[list[str]] = None, safe_merge: bool = False):
         # note that there is no actual merging, so whether safe_merge is True or False is irrelevant
         adapter_names = check_adapters_to_merge(self, adapter_names)
+        # Only merge adapters that actually target this layer. When several adapters target different
+        # modules, the active adapter may not be present on this layer, in which case there is nothing
+        # to merge (the layer falls back to its base layer instead).
+        adapter_names = [name for name in adapter_names if name in self.ln_tuning_layers]
         if not adapter_names:
             # no adapter to merge
             return
@@ -117,7 +121,12 @@ class LNTuningLayer(nn.Module, BaseTunerLayer):
                     f"adapters, but LN tuning does not allow inference with more than one adapter at a time"
                 )
             active_adapter = self.active_adapters[0]
-            result = self.ln_tuning_layers[active_adapter](x, *args, **kwargs)
+            if active_adapter in self.ln_tuning_layers:
+                result = self.ln_tuning_layers[active_adapter](x, *args, **kwargs)
+            else:
+                # The active adapter does not target this layer. Fall back to the base layer, the same
+                # way other PEFT methods (e.g. LoRA) skip adapters that are not present on a layer.
+                result = self.base_layer(x, *args, **kwargs)
 
         return result
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -6364,6 +6364,30 @@ class TestRequiresGrad:
             "base_model.model.layernorm0.ln_tuning_layers.adapter1.bias",
         )
 
+    def test_lntuning_different_targets_forward_and_merge(self):
+        # Regression test for #3574: when multiple LN tuning adapters target different modules, activating
+        # one adapter must not raise a KeyError on the layers that are not targeted by it.
+        config0 = LNTuningConfig(target_modules=["layernorm0"])
+        peft_model = get_peft_model(MLP_LayerNorm(), config0)
+
+        config1 = LNTuningConfig(target_modules=["layernorm1"])
+        peft_model.add_adapter("adapter1", config1)
+
+        # Activate the adapter that only targets layernorm1; layernorm0 has no "adapter1" layer.
+        peft_model.set_adapter("adapter1")
+
+        x = torch.randn(2, 10)
+
+        # Forward must fall back to the base layer for layernorm0 instead of indexing a missing layer.
+        out = peft_model(x)
+        assert out.shape == (2, 2)
+
+        # Merging the active adapter must skip layers that don't target it instead of raising.
+        peft_model.merge_adapter()
+        out_merged = peft_model(x)
+        assert out_merged.shape == (2, 2)
+        peft_model.unmerge_adapter()
+
     def test_requires_grad_vera_different_targets(self):
         # Test two different VeRA adapters that target different modules. Most notably, ensure that vera_A and vera_B
         # don't require grads.


### PR DESCRIPTION
## Summary

Resolves #3574.

When multiple LN Tuning adapters target different modules, activating one adapter raised a `KeyError` on the layers that it does **not** target:

- `forward` indexed `self.ln_tuning_layers[active_adapter]`, which does not exist for layers not targeted by the active adapter.
- `merge` indexed `adapter_names[0]` after `check_adapters_to_merge`, which does not filter out adapters absent from a given layer.

### Changes

- `src/peft/tuners/ln_tuning/layer.py`
  - In `forward`, when the active adapter is not present on a layer, fall back to the `base_layer` instead of raising — mirroring how other PEFT methods (e.g. LoRA) skip adapters absent from a layer.
  - In `merge`, skip adapters that are not present on a layer so merging an active adapter across a model does not raise on untargeted layers.
- `tests/test_custom_models.py`
  - Added `test_lntuning_different_targets_forward_and_merge`, a regression test that sets up two LN Tuning adapters targeting different modules, activates one, and asserts that `forward` and `merge_adapter` work without raising.

## Test plan

- New regression test fails on `main` (KeyError) and passes with the fix.
- Full LN Tuning test selection (`pytest tests/test_custom_models.py -k lntuning`) passes: 227 passed.
- `ruff check` / `ruff format` pass on the changed files.

The reproducer from #3574 now runs without error.
