### PR TITLE
FIX AdaMSS, PSOFT: fork the RNG of the actual device

### DIFF
--- a/src/peft/tuners/adamss/utils.py
+++ b/src/peft/tuners/adamss/utils.py
@@ -43,9 +43,14 @@ def slice_pca(tensor, r, device, dtype=torch.float32, random_seed=0):
     # torch.svd_lowrank draws a random projection internally, so its result (and hence the downstream
     # clustering and scatter_index) depends on the RNG state. Seed a forked RNG with the configurable
     # random_seed so the result is deterministic (torch.svd_lowrank does not accept a generator argument);
-    # fork_rng leaves the global RNG stream untouched.
-    fork_devices = [device] if torch.device(device).type == "cuda" else []
-    with torch.random.fork_rng(devices=fork_devices):
+    # fork_rng leaves the global RNG stream untouched. Note that torch.manual_seed re-seeds all
+    # accelerators, so the fork must cover the device the SVD runs on, not just cuda.
+    fork_device = torch.device(device)
+    if fork_device.type == "cpu":
+        fork_kwargs = {"devices": []}
+    else:
+        fork_kwargs = {"devices": [fork_device], "device_type": fork_device.type}
+    with torch.random.fork_rng(**fork_kwargs):
         torch.manual_seed(random_seed)
         for i in range(B):
             for j in range(C):

--- a/src/peft/tuners/psoft/layer.py
+++ b/src/peft/tuners/psoft/layer.py
@@ -326,8 +326,13 @@ class PsoftLayer(BaseTunerLayer):
             # torch.svd_lowrank uses a random projection, so the A/B initialization it produces depends on the
             # RNG state. Seed a forked RNG with the configurable random_seed to make it deterministic
             # (torch.svd_lowrank does not accept a generator argument); fork_rng leaves the global RNG untouched.
-            fork_devices = [weight.device] if weight.device.type == "cuda" else []
-            with torch.random.fork_rng(devices=fork_devices):
+            # Note that torch.manual_seed re-seeds all accelerators, so the fork must cover the device the SVD
+            # runs on, not just cuda.
+            if weight.device.type == "cpu":
+                fork_kwargs = {"devices": []}
+            else:
+                fork_kwargs = {"devices": [weight.device], "device_type": weight.device.type}
+            with torch.random.fork_rng(**fork_kwargs):
                 torch.manual_seed(random_seed)
                 U, S, V = svd_lowrank(weight.data, q=r, niter=niter)  # V: (in, r)
             Vr = U[:, :r]

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -374,8 +374,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -710,8 +710,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 device_map=DEVICE_MAP_MAP[self.seq2seq_model_id],
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             tokenizer = AutoTokenizer.from_pretrained(self.seq2seq_model_id)
             model = prepare_model_for_kbit_training(model)
@@ -995,8 +995,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -1113,8 +1113,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -1469,8 +1469,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -1529,8 +1529,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -1589,8 +1589,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -1649,8 +1649,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -1817,8 +1817,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -1877,8 +1877,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -2041,8 +2041,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_8bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -2099,8 +2099,8 @@ class PeftBnbGPUExampleTests(unittest.TestCase):
                 quantization_config=BitsAndBytesConfig(load_in_4bit=True),
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -2598,8 +2598,8 @@ class PeftGPTQGPUTests(unittest.TestCase):
                 quantization_config=self.quantization_config,
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -4409,8 +4409,8 @@ class PeftEetqGPUTests(unittest.TestCase):
             except FileNotFoundError:
                 pytest.skip("There is no kernel for EETQ on this architecture, skipping this test.")
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
 
@@ -4691,8 +4691,8 @@ class TestPeftTorchao:
                 dtype=torch.bfloat16,
             )
 
-            assert set(model.hf_device_map.values()) == set(range(device_count))
-            assert {p.device.index for p in model.parameters()} == set(range(device_count))
+            assert set(model.hf_device_map.values()) == {0, 1}
+            assert {p.device.index for p in model.parameters()} == {0, 1}
 
             model = prepare_model_for_kbit_training(model)
             model.model_parallel = True
@@ -4772,8 +4772,8 @@ class TestPeftTorchao:
             dtype=torch.bfloat16,
         )
 
-        assert set(model.hf_device_map.values()) == set(range(device_count))
-        assert {p.device.index for p in model.parameters()} == set(range(device_count))
+        assert set(model.hf_device_map.values()) == {0, 1}
+        assert {p.device.index for p in model.parameters()} == {0, 1}
 
         model = prepare_model_for_kbit_training(model)
         model.model_parallel = True

--- a/tests/test_gpu_examples.py
+++ b/tests/test_gpu_examples.py
@@ -7050,8 +7050,8 @@ def test_kappatune_with_4bit_model():
     model = AutoModelForCausalLM.from_pretrained(
         "hf-internal-testing/tiny-random-LlamaForCausalLM",
         quantization_config=quantization_config,
-        device_map="cuda",
-        torch_dtype=torch.float16,
+        device_map=torch_device,
+        dtype=torch.float16,
     )
 
     # Run KappaTune


### PR DESCRIPTION
## Why

`slice_pca` (AdaMSS) and `_compute_svd_factors` (PSOFT) wrap `torch.svd_lowrank` in
`fork_rng()` + `manual_seed()` to make initialization deterministic, but only listed the
device in `fork_rng(devices=...)` when it was a CUDA device.

`fork_rng` only restores the generators it was given, while `manual_seed` re-seeds *all*
backends. So on any non-CUDA accelerator the seed leaks into the global RNG stream. Every
`update_layer` call then resets it to the same point and subsequent adapters get identical
random initialization. On XPU two AdaMSS adapters came out bit-identical, failing
`test_merge_layers_multi` on `assert not torch.allclose(...)` (output diff `0.0` on XPU vs
`0.339` on CPU; `1.211` after the fix).

`fork_rng` also needs `device_type`, otherwise it falls back to `"cuda"`.

## Test fixes included

Two test-only changes for machines with more than two accelerators:

- Tests that load a model with an explicit two-device map from `DEVICE_MAP_MAP` asserted
  `== set(range(device_count))`, which is self-contradictory and only passes on 2-GPU CI.
  Same change as #3225 did for the AWQ test.
- `test_kappatune_with_4bit_model` hardcoded `device_map="cuda"`.

## Validation

8x Intel Arc Pro B60, `torch 2.13.0+xpu`:

- `TestMultipleActiveAdapters`: 292 passed, 28 skipped
- `test_custom_models.py -k "adamss or psoft"`: 872 passed, 69 skipped
- `test_kappatune_with_4bit_model`: 1 passed

## Known issue, not addressed here

`test_lora_causal_lm_multi_gpu_inference` and `test_causal_lm_training_multi_gpu` use
`device_map="balanced"` / `"auto"` with the same `set(range(device_count))` assertion. Those
are not self-contradictory, they fail because the model is too small to fill every card
(`facebook/opt-350m` lands on devices 0-6 of 8). Happy to relax them to `len(set(...)) > 1`
in a follow-up if that matches the intent.
