### PR TITLE
Fix LoRA target_parameters raising a dtype error under autocast

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -2249,7 +2249,10 @@ class _LoraFactorsProxy(nn.Module):
         self.scaling = scaling
 
     def forward(self, W):
-        return torch.baddbmm(W, self.lhs, self.rhs, alpha=self.scaling)
+        # autocast would cast the baddbmm down to the autocast dtype, but a parametrization may not change the dtype of
+        # the parameter, so the fold is performed in the dtype of W (which is also what the non-folded path does).
+        with torch.autocast(device_type=W.device.type, enabled=False):
+            return torch.baddbmm(W, self.lhs, self.rhs, alpha=self.scaling)
 
 
 # copied from:

--- a/tests/test_target_parameters.py
+++ b/tests/test_target_parameters.py
@@ -470,6 +470,37 @@ class TestTargetParameters:
             for key in lora_weights_before.keys():
                 assert not torch.allclose(lora_weights_before[key], lora_weights_after[key], atol=atol, rtol=rtol)
 
+    def test_target_parameters_forward_under_autocast(self, monkeypatch):
+        # Folding the LoRA update into the parameter uses baddbmm, which autocast casts down to the autocast dtype.
+        # Since a parametrization may not change the dtype of the parameter, registering it then failed, see #3601.
+        torch.manual_seed(0)
+        model_id = "trl-internal-testing/tiny-Llama4ForCausalLM"
+        with hub_online_once(model_id):
+            model = MyAutoModelForCausalLM.from_pretrained(model_id)
+            x = torch.arange(10).view(2, 5)
+            config = LoraConfig(target_parameters=["feed_forward.experts.gate_up_proj"], init_lora_weights=False)
+            model = get_peft_model(model, config)
+
+            # log the dtypes of the folded weights seen during the forward call
+            dtypes = []
+
+            def mock_forward(self, W):
+                out = orig_forward(self, W)
+                dtypes.append(out.dtype)
+                return out
+
+            from peft.tuners.lora.layer import _LoraFactorsProxy
+
+            orig_forward = _LoraFactorsProxy.forward
+            monkeypatch.setattr(_LoraFactorsProxy, "forward", mock_forward)
+
+            with torch.inference_mode(), torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+                model(x)
+
+            # the fold must preserve the dtype of the targeted parameter, even under autocast
+            assert dtypes
+            assert set(dtypes) == {torch.float32}
+
     def test_target_parameters_works_with_existing_parametrization(self):
         # When a parameter is already parametrized, we want the LoRA parametrization to work with it correctly.
         class MyLinear(nn.Linear):


### PR DESCRIPTION
This PR fixes LoRA with `target_parameters` raising a `ValueError` on the first forward pass when the model runs under autocast, which is the case for any mixed precision training run.

Fix #3601.

### Motivation

Since #3577, a single-adapter MoE parameter is folded with `torch.baddbmm` instead of materializing the delta weight. `baddbmm` is autocast-eligible, so under `torch.autocast(dtype=torch.bfloat16)` it returns bf16 even though the base weight and both low-rank factors are fp32. `nn.utils.parametrize.register_parametrization` invokes the parametrization once at registration time and rejects any dtype change, so the forward pass fails:

> ValueError: Registering a parametrization may not change the dtype of the tensor, unless `unsafe` flag is enabled.
> unparametrized dtype: torch.float32
> parametrized dtype: torch.bfloat16

Beyond the error, the fold also silently lost precision: it used to accumulate in the parameter dtype, whereas under autocast `baddbmm` accumulates the base weight in bf16.

### Solution

Perform the fold with autocast disabled, so it runs in the dtype of the parameter. This restores both the dtype invariant that `register_parametrization` requires and the accumulation precision of the previous `_LoraParameterProxy` path, while keeping the single-`baddbmm` memory saving that #3577 introduced.

### Changes

- Disable autocast around the `baddbmm` fold in `_LoraFactorsProxy.forward`
- Add a regression test asserting that the folded weight keeps the dtype of the targeted parameter when the forward pass runs under autocast
