### PR TITLE
DOC Add troubleshooting section for hybrid architecture target_modules

### DIFF
--- a/docs/source/developer_guides/troubleshooting.md
+++ b/docs/source/developer_guides/troubleshooting.md
@@ -106,6 +106,8 @@ after = next(p for p in model.parameters() if p.requires_grad)
 print("weights updated:", not torch.allclose(before, after.detach().cpu()))
 ```
 
+### Missing forward or backward hooks
+
 If the weights did not move, a likely cause is that parameter references were captured before the parameters were materialized on their target device. This can happen when the base model is wrapped with [`get_peft_model`] while its parameters have not yet been moved to the target device, and a third-party library then registers forward/backward hooks (for example, per-sample gradient hooks from a differential privacy framework) or an optimizer is created before the first forward call. When the parameters are materialized later, those hooks and optimizer references point at stale tensors and every update becomes a silent no-op.
 
 To avoid this, use the following order:
@@ -114,9 +116,9 @@ To avoid this, use the following order:
 2. Wrap it with [`get_peft_model`].
 3. Only then register hooks or create the optimizer.
 
-## Target modules don't match the model
+### Target modules don't match the model
 
-If training runs without errors but the loss barely moves — or the model shows no improvement after fine-tuning — the configured `target_modules` may not match the actual module names in the model. This is common with hybrid architectures such as Mamba, Jamba, or NemotronH, which use different layer names than standard Transformer models.
+If training runs without errors but the loss barely moves — or the model shows no improvement after fine-tuning — the configured `target_modules` (or the default `target_modules` if not specified otherwise by the user) may not match the actual module names in the model. This is common with hybrid architectures such as Mamba, Jamba, or NemotronH, which use different layer names than standard Transformer models.
 
 PEFT raises an error only when *none* of the configured `target_modules` match any module in the model. If *some* match and *some* do not, the non-matching entries are silently skipped — there is no warning. A large fraction of the model can remain frozen without any indication.
 
@@ -130,23 +132,18 @@ model = get_peft_model(base_model, config)
 model.print_trainable_parameters()
 ```
 
-If the reported number is much lower than expected, list the model's linear layers and compare them against your `target_modules`:
+If the reported number is much lower than expected, inspect the adapter layers in the model:
 
 ```python
-import torch
-
-for name, module in model.named_modules():
-    if isinstance(module, torch.nn.Linear):
-        print(name)
+print(model.get_layer_status())
 ```
 
-Any `target_modules` entry that does not appear in this list is silently skipped. Update `target_modules` to match the actual module names in the model.
+This returns a list of `TunerLayerStatus` entries showing each adapter layer's name, module type, enabled state, and active adapters. Alternatively, printing the model repr (`print(model)`) gives an overview of the full module hierarchy, which is useful for identifying the correct layer names on unfamiliar architectures.
+
+Any `target_modules` entry that does not correspond to a module in the model is silently skipped. Update `target_modules` to match the actual module names.
 
 > [!TIP]
 > This issue affects all PEFT methods that use `target_modules` (LoRA, LoHa, IA³, etc.), not just LoRA. The diagnostic steps are the same regardless of the method. If you are unsure which module names a given architecture uses, check the model's documentation or inspect `model.named_modules()` before configuring the adapter.
-
-> [!TIP]
-> Some modules are forbidden by PEFT on certain architectures. For example, `out_proj` and `conv1d` are not allowed on Mamba-based models because the fused SSM kernels bypass adapter layers. PEFT raises a `ValueError` in these cases, so the error is visible — unlike the silent skipping described above.
 
 ## Bad results from a loaded PEFT model
 

--- a/docs/source/developer_guides/troubleshooting.md
+++ b/docs/source/developer_guides/troubleshooting.md
@@ -114,6 +114,40 @@ To avoid this, use the following order:
 2. Wrap it with [`get_peft_model`].
 3. Only then register hooks or create the optimizer.
 
+## Target modules don't match the model
+
+If training runs without errors but the loss barely moves — or the model shows no improvement after fine-tuning — the configured `target_modules` may not match the actual module names in the model. This is common with hybrid architectures such as Mamba, Jamba, or NemotronH, which use different layer names than standard Transformer models.
+
+PEFT raises an error only when *none* of the configured `target_modules` match any module in the model. If *some* match and *some* do not, the non-matching entries are silently skipped — there is no warning. A large fraction of the model can remain frozen without any indication.
+
+The first diagnostic is to check the trainable parameter count:
+
+```python
+from peft import LoraConfig, get_peft_model
+
+config = LoraConfig(target_modules=["q_proj", "v_proj", "gate_proj"])
+model = get_peft_model(base_model, config)
+model.print_trainable_parameters()
+```
+
+If the reported number is much lower than expected, list the model's linear layers and compare them against your `target_modules`:
+
+```python
+import torch
+
+for name, module in model.named_modules():
+    if isinstance(module, torch.nn.Linear):
+        print(name)
+```
+
+Any `target_modules` entry that does not appear in this list is silently skipped. Update `target_modules` to match the actual module names in the model.
+
+> [!TIP]
+> This issue affects all PEFT methods that use `target_modules` (LoRA, LoHa, IA³, etc.), not just LoRA. The diagnostic steps are the same regardless of the method. If you are unsure which module names a given architecture uses, check the model's documentation or inspect `model.named_modules()` before configuring the adapter.
+
+> [!TIP]
+> Some modules are forbidden by PEFT on certain architectures. For example, `out_proj` and `conv1d` are not allowed on Mamba-based models because the fused SSM kernels bypass adapter layers. PEFT raises a `ValueError` in these cases, so the error is visible — unlike the silent skipping described above.
+
 ## Bad results from a loaded PEFT model
 
 There can be several reasons for getting a poor result from a loaded PEFT model which are listed below. If you're still unable to troubleshoot the problem, see if anyone else had a similar [issue](https://github.com/huggingface/peft/issues) on GitHub, and if you can't find any, open a new issue.


### PR DESCRIPTION
Fixes #3554

## Summary

Adds a troubleshooting section for hybrid architectures (Mamba, Jamba, NemotronH) where `target_modules` entries that don't match any model layer are silently skipped, causing training to run with no learning.

## Why

As reported in #3554, users targeting only attention projections (`q_proj`, `k_proj`, `v_proj`, `o_proj`) on hybrid Mamba+Attention models such as `nemotron_h` can end up with only ~7% of layers trainable. PEFT raises an error only when *none* of the configured `target_modules` match; when some match and some don't, the non-matching names are silently skipped.

## What changed

- `docs/source/developer_guides/troubleshooting.md`: new subsection "Target modules don't match the model" under "Training runs but the model does not improve".

## Scope

Documentation only. No library code or tests changed.

## Related

- Issue: #3554
- Maintainer approval for docs fix: https://github.com/huggingface/peft/issues/3554#issuecomment-5326537060
- Closed, unmerged attempt with extra changes: #3600

## Checks run

- `python -m ruff check --fix src tests examples docs scripts docker` ✅
- `python -m ruff format src tests examples docs scripts docker` ✅
- `doc-builder style src/peft tests docs/source --max_len 119` ✅

## AI assistance

This PR was prepared with AI assistance and has been reviewed by the human submitter.