### PR TITLE
Fix LN Tuning KeyError when active adapter does not target every layer (#3574)

### DIFF
--- a/src/peft/tuners/ln_tuning/layer.py
+++ b/src/peft/tuners/ln_tuning/layer.py
@@ -71,6 +71,10 @@ class LNTuningLayer(nn.Module, BaseTunerLayer):
     def merge(self, adapter_names: Optional[list[str]] = None, safe_merge: bool = False):
         # note that there is no actual merging, so whether safe_merge is True or False is irrelevant
         adapter_names = check_adapters_to_merge(self, adapter_names)
+        # Only merge adapters that actually target this layer. When several adapters target different
+        # modules, the active adapter may not be present on this layer, in which case there is nothing
+        # to merge (the layer falls back to its base layer instead).
+        adapter_names = [name for name in adapter_names if name in self.ln_tuning_layers]
         if not adapter_names:
             # no adapter to merge
             return
@@ -117,7 +121,12 @@ class LNTuningLayer(nn.Module, BaseTunerLayer):
                     f"adapters, but LN tuning does not allow inference with more than one adapter at a time"
                 )
             active_adapter = self.active_adapters[0]
-            result = self.ln_tuning_layers[active_adapter](x, *args, **kwargs)
+            if active_adapter in self.ln_tuning_layers:
+                result = self.ln_tuning_layers[active_adapter](x, *args, **kwargs)
+            else:
+                # The active adapter does not target this layer. Fall back to the base layer, the same
+                # way other PEFT methods (e.g. LoRA) skip adapters that are not present on a layer.
+                result = self.base_layer(x, *args, **kwargs)
 
         return result
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -6419,6 +6419,11 @@ class TestRequiresGrad:
         assert out_merged.shape == (2, 2)
         peft_model.unmerge_adapter()
 
+        # Symmetric direction: the default adapter targets layernorm0 only, so layernorm1 is untargeted.
+        peft_model.set_adapter("default")
+        out_default = peft_model(x)
+        assert out_default.shape == (2, 2)
+
     def test_requires_grad_vera_different_targets(self):
         # Test two different VeRA adapters that target different modules. Most notably, ensure that vera_A and vera_B
         # don't require grads.

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -6395,6 +6395,30 @@ class TestRequiresGrad:
             "base_model.model.layernorm0.ln_tuning_layers.adapter1.bias",
         )
 
+    def test_lntuning_different_targets_forward_and_merge(self):
+        # Regression test for #3574: when multiple LN tuning adapters target different modules, activating
+        # one adapter must not raise a KeyError on the layers that are not targeted by it.
+        config0 = LNTuningConfig(target_modules=["layernorm0"])
+        peft_model = get_peft_model(MLP_LayerNorm(), config0)
+
+        config1 = LNTuningConfig(target_modules=["layernorm1"])
+        peft_model.add_adapter("adapter1", config1)
+
+        # Activate the adapter that only targets layernorm1; layernorm0 has no "adapter1" layer.
+        peft_model.set_adapter("adapter1")
+
+        x = torch.randn(2, 10)
+
+        # Forward must fall back to the base layer for layernorm0 instead of indexing a missing layer.
+        out = peft_model(x)
+        assert out.shape == (2, 2)
+
+        # Merging the active adapter must skip layers that don't target it instead of raising.
+        peft_model.merge_adapter()
+        out_merged = peft_model(x)
+        assert out_merged.shape == (2, 2)
+        peft_model.unmerge_adapter()
+
     def test_requires_grad_vera_different_targets(self):
         # Test two different VeRA adapters that target different modules. Most notably, ensure that vera_A and vera_B
         # don't require grads.


### PR DESCRIPTION
## Summary
Fixes https://github.com/huggingface/peft/issues/3574.

When an `LN_TUNING` model is trained with `target_modules` that do not cover every layer (a documented and supported configuration — e.g. hybrid architectures, or skipping the first/last layers), loading a second adapter whose `target_modules` differ from the first raised a `KeyError` in both `forward` and `merge`:

```
KeyError: '<adapter_name>'   # adapter not present in ln_tuning_layers for an untargeted layer
```

### Root cause
`LNTuningLayer.forward` and `LNTuningLayer.merge` assumed the active adapter is present in `self.ln_tuning_layers` for **every** wrapped layer. For layers the active adapter does not target, the adapter simply isn't in `self.ln_tuning_layers`, so the lookup fails.

### Fix
- `forward`: when the active adapter is not in `self.ln_tuning_layers`, fall back to `self.base_layer` (the adapter does not modify that layer, so the base layer is the correct computation). This mirrors how other tuners (e.g. LoRA) behave for modules an adapter does not target.
- `merge`: only iterate over `adapter_names` that are actually present in `self.ln_tuning_layers`, skipping untargeted adapters (they contribute no delta).

### Test
Added `test_lntuning_different_targets_forward_and_merge` in `tests/test_custom_models.py`. It reproduces the two-adapter, mismatched-`target_modules` scenario in **both** directions (adapter1 active → layernorm0 untargeted, and default active → layernorm1 untargeted) and asserts that `forward` and `merge`/`unmerge` both succeed. The test fails on `main` with the reported `KeyError` and passes with the fix.

## Verification
- `pytest tests/ -k lntuning` → 255 passed, 58 skipped (includes the regression test in both directions).
- `ruff check` and `ruff format --check` → clean.
- `doc-builder style src/peft/tuners/ln_tuning/layer.py --check_only` → OK.

## Design decision / known limitation
This PR fixes the crash and makes the untargeted layer fall back to the base layer. It intentionally does **not** change the separate, pre-existing behavior of what happens if you `merge` one adapter and then `set_adapter` to a different adapter without first `unmerge`-ing: in that (already-unusual) state the previously merged weights remain on the layer. That cross-adapter "intended semantics" question was explicitly left for later by the maintainers on #3574, so it is out of scope here and would be a separate, broader change.

## Scope / note
This PR is intentionally **single-concern**: it only fixes the LN Tuning `KeyError` for #3574 and adds a regression test. It does not touch documentation or other tuners.

It supersedes the closed #3597. #3597 was closed as part of a batch alongside a separate, preemptive docs PR (#3600, for #3554, whose reporter had already signaled they would open the docs PR — now #3603). This PR is **not** preemptive: #3574's reporter did not claim the fix, and a maintainer had welcomed a PR there ("Happy to see a PR for this").
