### PR TITLE
FIX DoRA merge with multiple adapters on the same layer

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -144,6 +144,8 @@ class LoraLayer(BaseTunerLayer):
         self.lora_bias: dict[str, bool] = {}
         self.lora_magnitude_vector = torch.nn.ModuleDict()  # for DoRA
         self._caches: dict[str, Any] = {}  # small ad hoc cache; values are not part of the state_dict
+        # set while `_unmerged_base_weight` is active, not part of the state_dict
+        self._unmerged_base_weight_cache: Optional[torch.Tensor] = None
         self.ephemeral_gpu_offload: bool = ephemeral_gpu_offload
         # flag to enable/disable casting of input to weight dtype during forward call
         self.cast_input_dtype_enabled: bool = True
@@ -733,6 +735,39 @@ class LoraLayer(BaseTunerLayer):
 
         # Remove redundant fields
         del base_layer._peft_loraga_grad
+
+    @contextmanager
+    def _unmerged_base_weight(self, safe_merge: bool = False):
+        """Yield the base weight with the already merged adapters taken out of it.
+
+        `merge` applies the adapters one after another, so from the second adapter on, the weight already contains the
+        previously merged ones. Variants whose delta depends on the base weight need it unmerged, the same way
+        `forward` sees it, so the merged adapters are unmerged here and merged again afterwards. Nothing is kept
+        between calls to `merge`.
+
+        Merging the adapters again re-enters this method for each of them. They are given the weight recovered by the
+        outermost call, both because it is the weight they have to normalize against anyway and because unmerging per
+        adapter would make merging grow exponentially with their number.
+        """
+        if self._unmerged_base_weight_cache is not None:
+            yield self._unmerged_base_weight_cache
+            return
+
+        merged_adapters = self.merged_adapters[:]
+        try:
+            if merged_adapters:
+                self.unmerge()
+            self._unmerged_base_weight_cache = dequantize_module_weight(self.get_base_layer()).detach().clone()
+            yield self._unmerged_base_weight_cache
+        finally:
+            try:
+                # only the adapters that were actually unmerged, so that an unmerge that failed halfway does not
+                # merge anything twice
+                to_merge = [name for name in merged_adapters if name not in self.merged_adapters]
+                if to_merge:
+                    self.merge(safe_merge=safe_merge, adapter_names=to_merge)
+            finally:
+                self._unmerged_base_weight_cache = None
 
     def _cache_store(self, key: str, value: Any) -> None:
         # cache intermediate values, e.g. weight norm of DoRA

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -144,8 +144,6 @@ class LoraLayer(BaseTunerLayer):
         self.lora_bias: dict[str, bool] = {}
         self.lora_magnitude_vector = torch.nn.ModuleDict()  # for DoRA
         self._caches: dict[str, Any] = {}  # small ad hoc cache; values are not part of the state_dict
-        # set while `_unmerged_base_weight` is active, not part of the state_dict
-        self._unmerged_base_weight_cache: Optional[torch.Tensor] = None
         self.ephemeral_gpu_offload: bool = ephemeral_gpu_offload
         # flag to enable/disable casting of input to weight dtype during forward call
         self.cast_input_dtype_enabled: bool = True
@@ -749,16 +747,19 @@ class LoraLayer(BaseTunerLayer):
         outermost call, both because it is the weight they have to normalize against anyway and because unmerging per
         adapter would make merging grow exponentially with their number.
         """
-        if self._unmerged_base_weight_cache is not None:
-            yield self._unmerged_base_weight_cache
+        key = "unmerged_base_weight"
+        if key in self._caches:
+            yield self._caches[key]
             return
 
         merged_adapters = self.merged_adapters[:]
         try:
             if merged_adapters:
                 self.unmerge()
-            self._unmerged_base_weight_cache = dequantize_module_weight(self.get_base_layer()).detach().clone()
-            yield self._unmerged_base_weight_cache
+            # a copy, because merging a plain LoRA adapter below writes into the base weight in place
+            weight = dequantize_module_weight(self.get_base_layer()).detach().clone()
+            self._cache_store(key, weight)
+            yield weight
         finally:
             try:
                 # only the adapters that were actually unmerged, so that an unmerge that failed halfway does not
@@ -767,7 +768,7 @@ class LoraLayer(BaseTunerLayer):
                 if to_merge:
                     self.merge(safe_merge=safe_merge, adapter_names=to_merge)
             finally:
-                self._unmerged_base_weight_cache = None
+                self._caches.pop(key, None)
 
     def _cache_store(self, key: str, value: Any) -> None:
         # cache intermediate values, e.g. weight norm of DoRA

--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -740,12 +740,12 @@ class LoraLayer(BaseTunerLayer):
 
         `merge` applies the adapters one after another, so from the second adapter on, the weight already contains the
         previously merged ones. Variants whose delta depends on the base weight need it unmerged, the same way
-        `forward` sees it, so the merged adapters are unmerged here and merged again afterwards. Nothing is kept
-        between calls to `merge`.
+        `forward` sees it, so the merged adapters are unmerged here and merged again afterwards. The weight is dropped
+        again when the context exits.
 
-        Merging the adapters again re-enters this method for each of them. They are given the weight recovered by the
-        outermost call, both because it is the weight they have to normalize against anyway and because unmerging per
-        adapter would make merging grow exponentially with their number.
+        Merging the adapters again re-enters this method for each of them. They get the weight the outermost call
+        recovered, which is the one they need anyway. Unmerging again for each of them would make the number of merge
+        calls grow exponentially.
         """
         key = "unmerged_base_weight"
         if key in self._caches:
@@ -756,7 +756,8 @@ class LoraLayer(BaseTunerLayer):
         try:
             if merged_adapters:
                 self.unmerge()
-            # a copy, because merging a plain LoRA adapter below writes into the base weight in place
+            # copy it, because the `finally` block replays a plain LoRA adapter by adding its delta to the
+            # base weight in place, which would change this tensor too
             weight = dequantize_module_weight(self.get_base_layer()).detach().clone()
             self._cache_store(key, weight)
             yield weight

--- a/src/peft/tuners/lora/variants.py
+++ b/src/peft/tuners/lora/variants.py
@@ -24,7 +24,7 @@ from torch import nn
 
 from peft.tuners._buffer_dict import BufferDict
 from peft.tuners.lora.config import BdLoraConfig, MontecloraConfig
-from peft.utils.integrations import gather_params_ctx
+from peft.utils.integrations import dequantize_module_weight, gather_params_ctx
 from peft.utils.other import transpose
 
 from .arrow import ArrowLoraLinearLayer
@@ -172,11 +172,17 @@ class DoraLinearVariant(LoraVariant):
         delta_weight = module.get_delta_weight(active_adapter)
 
         # since delta_weight already includes scaling, set it to 1 here
-        weight_norm = (
-            module.lora_magnitude_vector[active_adapter]
-            .get_weight_norm(orig_weight, transpose(delta_weight, module.fan_in_fan_out), scaling=1)
-            .detach()
-        )
+        # The weight norm has to be based on the unmerged weight, the same way `forward` computes it. When several
+        # DoRA adapters are merged in turn, the weight passed in already holds the previously merged ones.
+        with module._unmerged_base_weight(safe_merge=True) as base_weight:
+            weight_norm = (
+                module.lora_magnitude_vector[active_adapter]
+                .get_weight_norm(base_weight, transpose(delta_weight, module.fan_in_fan_out), scaling=1)
+                .detach()
+            )
+        # `merge` copied the weight before the replay above rebuilt it, and rebuilding is not bit exact in
+        # lower precisions, so continue from the weight the replay produced rather than from that copy.
+        orig_weight = dequantize_module_weight(module.get_base_layer())
         # We need to cache weight_norm because it has to be based on the original weights. We
         # cannot calculate it on the fly based on the merged weights when unmerging because its a
         # different value
@@ -191,11 +197,14 @@ class DoraLinearVariant(LoraVariant):
     def merge_unsafe(module: Linear, active_adapter: str, orig_weight: torch.Tensor) -> None:
         orig_dtype = orig_weight.dtype
         delta_weight = module.get_delta_weight(active_adapter)
-        weight_norm = (
-            module.lora_magnitude_vector[active_adapter]
-            .get_weight_norm(orig_weight, transpose(delta_weight, module.fan_in_fan_out), scaling=1)
-            .detach()
-        )
+        # The weight norm has to be based on the unmerged weight, the same way `forward` computes it. When several
+        # DoRA adapters are merged in turn, the weight passed in already holds the previously merged ones.
+        with module._unmerged_base_weight() as base_weight:
+            weight_norm = (
+                module.lora_magnitude_vector[active_adapter]
+                .get_weight_norm(base_weight, transpose(delta_weight, module.fan_in_fan_out), scaling=1)
+                .detach()
+            )
         # We need to cache weight_norm because it has to be based on the original weights. We
         # cannot calculate it on the fly based on the merged weights when unmerging because its a
         # different value
@@ -270,11 +279,17 @@ class DoraEmbeddingVariant(DoraLinearVariant):
         delta_weight = module.get_delta_weight(active_adapter)
 
         # since delta_weight already includes scaling, set it to 1 here
-        weight_norm = (
-            module.lora_magnitude_vector[active_adapter]
-            .get_weight_norm(orig_weight, delta_weight.T, scaling=1)
-            .detach()
-        )
+        # The weight norm has to be based on the unmerged weight, the same way `forward` computes it. When several
+        # DoRA adapters are merged in turn, the weight passed in already holds the previously merged ones.
+        with module._unmerged_base_weight(safe_merge=True) as base_weight:
+            weight_norm = (
+                module.lora_magnitude_vector[active_adapter]
+                .get_weight_norm(base_weight, delta_weight.T, scaling=1)
+                .detach()
+            )
+        # `merge` copied the weight before the replay above rebuilt it, and rebuilding is not bit exact in
+        # lower precisions, so continue from the weight the replay produced rather than from that copy.
+        orig_weight = dequantize_module_weight(module.get_base_layer())
         # We need to cache weight_norm because it has to be based on the original weights. We
         # cannot calculate it on the fly based on the merged weights when unmerging because its a
         # different value
@@ -289,11 +304,14 @@ class DoraEmbeddingVariant(DoraLinearVariant):
     def merge_unsafe(module: Embedding, active_adapter: str, orig_weight: torch.Tensor) -> None:
         orig_dtype = orig_weight.dtype
         delta_weight = module.get_delta_weight(active_adapter)
-        weight_norm = (
-            module.lora_magnitude_vector[active_adapter]
-            .get_weight_norm(orig_weight, delta_weight.T, scaling=1)
-            .detach()
-        )
+        # The weight norm has to be based on the unmerged weight, the same way `forward` computes it. When several
+        # DoRA adapters are merged in turn, the weight passed in already holds the previously merged ones.
+        with module._unmerged_base_weight() as base_weight:
+            weight_norm = (
+                module.lora_magnitude_vector[active_adapter]
+                .get_weight_norm(base_weight, delta_weight.T, scaling=1)
+                .detach()
+            )
         # We need to cache weight_norm because it has to be based on the original weights. We
         # cannot calculate it on the fly based on the merged weights when unmerging because its a
         # different value
@@ -366,9 +384,17 @@ class _DoraConvNdVariant(LoraVariant):
         delta_weight = module.get_delta_weight(active_adapter)
 
         # since delta_weight already includes scaling, set it to 1 here
-        weight_norm = (
-            module.lora_magnitude_vector[active_adapter].get_weight_norm(orig_weight, delta_weight, scaling=1).detach()
-        )
+        # The weight norm has to be based on the unmerged weight, the same way `forward` computes it. When several
+        # DoRA adapters are merged in turn, the weight passed in already holds the previously merged ones.
+        with module._unmerged_base_weight(safe_merge=True) as base_weight:
+            weight_norm = (
+                module.lora_magnitude_vector[active_adapter]
+                .get_weight_norm(base_weight, delta_weight, scaling=1)
+                .detach()
+            )
+        # `merge` copied the weight before the replay above rebuilt it, and rebuilding is not bit exact in
+        # lower precisions, so continue from the weight the replay produced rather than from that copy.
+        orig_weight = dequantize_module_weight(module.get_base_layer())
         # We need to cache weight_norm because it has to be based on the original weights. We
         # cannot calculate it on the fly based on the merged weights when unmerging because its a
         # different value
@@ -383,9 +409,14 @@ class _DoraConvNdVariant(LoraVariant):
         orig_dtype = orig_weight.dtype
         delta_weight = module.get_delta_weight(active_adapter)
         # since delta_weight already includes scaling, set it to 1 here
-        weight_norm = (
-            module.lora_magnitude_vector[active_adapter].get_weight_norm(orig_weight, delta_weight, scaling=1).detach()
-        )
+        # The weight norm has to be based on the unmerged weight, the same way `forward` computes it. When several
+        # DoRA adapters are merged in turn, the weight passed in already holds the previously merged ones.
+        with module._unmerged_base_weight() as base_weight:
+            weight_norm = (
+                module.lora_magnitude_vector[active_adapter]
+                .get_weight_norm(base_weight, delta_weight, scaling=1)
+                .detach()
+            )
         # We need to cache weight_norm because it has to be based on the original weights. We
         # cannot calculate it on the fly based on the merged weights when unmerging because its a
         # different value

--- a/src/peft/tuners/lora/variants.py
+++ b/src/peft/tuners/lora/variants.py
@@ -180,8 +180,8 @@ class DoraLinearVariant(LoraVariant):
                 .get_weight_norm(base_weight, transpose(delta_weight, module.fan_in_fan_out), scaling=1)
                 .detach()
             )
-        # `merge` copied the weight before the replay above rebuilt it, and rebuilding is not bit exact in
-        # lower precisions, so continue from the weight the replay produced rather than from that copy.
+        # `merge` copied the weight before the replay rebuilt it, and in lower precisions the copy and the
+        # rebuilt weight differ, so carry on from the rebuilt one.
         orig_weight = dequantize_module_weight(module.get_base_layer())
         # We need to cache weight_norm because it has to be based on the original weights. We
         # cannot calculate it on the fly based on the merged weights when unmerging because its a
@@ -287,8 +287,8 @@ class DoraEmbeddingVariant(DoraLinearVariant):
                 .get_weight_norm(base_weight, delta_weight.T, scaling=1)
                 .detach()
             )
-        # `merge` copied the weight before the replay above rebuilt it, and rebuilding is not bit exact in
-        # lower precisions, so continue from the weight the replay produced rather than from that copy.
+        # `merge` copied the weight before the replay rebuilt it, and in lower precisions the copy and the
+        # rebuilt weight differ, so carry on from the rebuilt one.
         orig_weight = dequantize_module_weight(module.get_base_layer())
         # We need to cache weight_norm because it has to be based on the original weights. We
         # cannot calculate it on the fly based on the merged weights when unmerging because its a
@@ -392,8 +392,8 @@ class _DoraConvNdVariant(LoraVariant):
                 .get_weight_norm(base_weight, delta_weight, scaling=1)
                 .detach()
             )
-        # `merge` copied the weight before the replay above rebuilt it, and rebuilding is not bit exact in
-        # lower precisions, so continue from the weight the replay produced rather than from that copy.
+        # `merge` copied the weight before the replay rebuilt it, and in lower precisions the copy and the
+        # rebuilt weight differ, so carry on from the rebuilt one.
         orig_weight = dequantize_module_weight(module.get_base_layer())
         # We need to cache weight_norm because it has to be based on the original weights. We
         # cannot calculate it on the fly based on the merged weights when unmerging because its a

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -5163,11 +5163,8 @@ class TestMultipleActiveAdapters:
         "model_cls, module_name",
         [(MLP, "lin0"), (ModelEmbConv1D, "emb"), (ModelConv2D, "conv2d")],
     )
-    @pytest.mark.parametrize("num_adapters", [2, 3])
     @pytest.mark.parametrize("safe_merge", [False, True])
-    def test_multiple_active_dora_adapters_merge_matches_forward(
-        self, model_cls, module_name, num_adapters, safe_merge
-    ):
+    def test_multiple_active_dora_adapters_merge_matches_forward(self, model_cls, module_name, safe_merge):
         # DoRA normalizes by the norm of the unmerged base weight. Adapters are merged one after another, so from the
         # second adapter on, the weight being merged into already holds the previously merged ones; taking the norm
         # from it makes the merged model differ from the unmerged forward pass. The adapters have to share a target
@@ -5183,7 +5180,7 @@ class TestMultipleActiveAdapters:
 
         peft_model = get_peft_model(model, config(), adapter_name="adapter_0").eval()
         adapters = ["adapter_0"]
-        for i in range(1, num_adapters):
+        for i in range(1, 3):
             peft_model.add_adapter(f"adapter_{i}", config())
             adapters.append(f"adapter_{i}")
 
@@ -5199,18 +5196,22 @@ class TestMultipleActiveAdapters:
         with peft_model.disable_adapter():
             assert torch.allclose(peft_model(**X), base_output, atol=1e-4)
 
+    @pytest.mark.parametrize(
+        "model_cls, module_name",
+        [(MLP, "lin0"), (ModelEmbConv1D, "emb"), (ModelConv2D, "conv2d")],
+    )
     @pytest.mark.parametrize("safe_merge", [False, True])
-    def test_plain_lora_and_dora_adapters_merge_matches_forward(self, safe_merge):
+    def test_plain_lora_and_dora_adapters_merge_matches_forward(self, model_cls, module_name, safe_merge):
         # A plain LoRA adapter merges into the base weight in place, so the DoRA adapters that follow have to work on
         # a copy of the unmerged weight, not on the weight itself.
         torch.manual_seed(0)
 
-        model = MLP().to(self.torch_device).eval()
+        model = model_cls().to(self.torch_device).eval()
         X = self.prepare_inputs_for_testing()
         base_output = model(**X)
 
         def config(use_dora):
-            return LoraConfig(target_modules=["lin0"], init_lora_weights=False, use_dora=use_dora)
+            return LoraConfig(target_modules=[module_name], init_lora_weights=False, use_dora=use_dora)
 
         peft_model = get_peft_model(model, config(use_dora=False), adapter_name="adapter_0").eval()
         peft_model.add_adapter("adapter_1", config(use_dora=True))
@@ -5229,16 +5230,20 @@ class TestMultipleActiveAdapters:
         with peft_model.disable_adapter():
             assert torch.allclose(peft_model(**X), base_output, atol=1e-4)
 
-    def test_multiple_active_dora_adapters_safe_and_unsafe_merge_agree(self):
+    @pytest.mark.parametrize(
+        "model_cls, module_name",
+        [(MLP, "lin0"), (ModelEmbConv1D, "emb"), (ModelConv2D, "conv2d")],
+    )
+    def test_multiple_active_dora_adapters_safe_and_unsafe_merge_agree(self, model_cls, module_name):
         # Taking the already merged adapters out of the base weight and putting them back rebuilds that weight, and it
         # is the rebuilt one that ends up in the layer. The safe path has to carry on from it as well, otherwise the
         # two paths merge into different weights.
         def merged_weight(safe_merge):
             torch.manual_seed(0)
-            model = MLP().to(self.torch_device).eval()
+            model = model_cls().to(self.torch_device).eval()
 
             def config():
-                return LoraConfig(target_modules=["lin0"], init_lora_weights=False, use_dora=True)
+                return LoraConfig(target_modules=[module_name], init_lora_weights=False, use_dora=True)
 
             peft_model = get_peft_model(model, config(), adapter_name="adapter_0").eval()
             adapters = ["adapter_0"]
@@ -5248,7 +5253,7 @@ class TestMultipleActiveAdapters:
 
             self.set_multiple_active_adapters(peft_model, adapters)
             peft_model.merge_adapter(safe_merge=safe_merge)
-            return peft_model.base_model.model.lin0.get_base_layer().weight.data.clone()
+            return peft_model.base_model.model.get_submodule(module_name).get_base_layer().weight.data.clone()
 
         assert torch.equal(merged_weight(safe_merge=True), merged_weight(safe_merge=False))
 
@@ -5630,16 +5635,10 @@ class TestRequiresGrad:
             "base_model.model.lin0.ia3_l.adapter1",
         )
 
-    @pytest.mark.xfail(strict=True)
     def test_requires_grad_adalora_different_targets(self):
         # test two different AdaLora adapters that target different modules
+        # adding an inference-only adapter must not freeze the active adapter, see #3487
 
-        # Note: This test is expected to fail because first loading one adapter, then the next adapter with
-        # inference_mode=True incorrectly leads to the requires_grad of the first adapter being turned to False. This is
-        # of course not desired but has yet to be fixed. In practice, it's unlikely that a user would pass
-        # inference_mode=True for add_adapter, this flag is mostly being used when calling PeftModel.from_pretrained, so
-        # we accept this issue for now. Note that only for AdaLoRA do we even need to pass inference_mode=True here,
-        # other PEFT methods don't require this.
         config0 = AdaLoraConfig(target_modules=["lin0"], total_step=1)
         peft_model = get_peft_model(MLP(), config0)
 
@@ -5685,16 +5684,9 @@ class TestRequiresGrad:
             "base_model.model.lin1.lora_E.adapter1",
         )
 
-    @pytest.mark.xfail(strict=True)
     def test_requires_grad_adalora_same_targets(self):
         # same as previous test, except that AdaLora adapters target the same layer
 
-        # Note: This test is expected to fail because first loading one adapter, then the next adapter with
-        # inference_mode=True incorrectly leads to the requires_grad of the first adapter being turned to False. This is
-        # of course not desired but has yet to be fixed. In practice, it's unlikely that a user would pass
-        # inference_mode=True for add_adapter, this flag is mostly being used when calling PeftModel.from_pretrained, so
-        # we accept this issue for now. Note that only for AdaLoRA do we even need to pass inference_mode=True here,
-        # other PEFT methods don't require this.
         config0 = AdaLoraConfig(target_modules=["lin0"], total_step=1)
         peft_model = get_peft_model(MLP(), config0)
 
@@ -6998,15 +6990,58 @@ class TestRequiresGrad:
             return
         model.load_adapter(tmp_path, adapter_name="other", is_trainable=is_trainable)
         if is_trainable:
+            expected_trainable_adapters = ("default", "other")
             for name, param in model.named_parameters():
                 if skip_ranknum and "ranknum" in name:
                     continue
-                if ".default" in name:
+                if any(f".{adapter_name}" in name for adapter_name in expected_trainable_adapters):
                     assert param.requires_grad
                 else:
                     assert not param.requires_grad
         else:
             assert all(not p.requires_grad for p in model.parameters())
+
+        # load a third adapter with the opposite trainability; it is not automatically activated
+        model.load_adapter(tmp_path, adapter_name="opposite", is_trainable=not is_trainable)
+        expected_trainable_adapters = ("default", "other") if is_trainable else ("opposite",)
+        for name, param in model.named_parameters():
+            if skip_ranknum and "ranknum" in name:
+                continue
+            if any(f".{adapter_name}" in name for adapter_name in expected_trainable_adapters):
+                assert param.requires_grad
+            else:
+                assert not param.requires_grad
+
+        if config_cls is AdaLoraConfig:
+            # AdaLoRA structurally rejects adding another training-mode config.
+            return
+
+        # add_adapter does not request trainability; the new adapter stays frozen and existing state is unchanged
+        model.add_adapter(adapter_name="added", peft_config=config)
+        for name, param in model.named_parameters():
+            if skip_ranknum and "ranknum" in name:
+                continue
+            if any(f".{adapter_name}" in name for adapter_name in expected_trainable_adapters):
+                assert param.requires_grad
+            else:
+                assert not param.requires_grad
+
+    def test_loading_adapter_preserves_custom_requires_grad(self, tmp_path):
+        config = LoraConfig(target_modules=["layers.0.lin0"])
+        source_model = get_peft_model(DeepMLP(size=256), config)
+        source_model.save_pretrained(tmp_path)
+
+        model = get_peft_model(DeepMLP(size=256), config)
+        # Emulate a user fine-tuning one base-model weight while intentionally freezing one adapter parameter.
+        model.base_model.model.layers[0].lin0.base_layer.weight.requires_grad = True
+        model.base_model.model.layers[0].lin0.lora_A["default"].weight.requires_grad = False
+        existing_requires_grad = {name: param.requires_grad for name, param in model.named_parameters()}
+
+        model.load_adapter(tmp_path, adapter_name="other", is_trainable=False)
+
+        for name, requires_grad in existing_requires_grad.items():
+            assert model.get_parameter(name).requires_grad is requires_grad
+        assert all(not param.requires_grad for name, param in model.named_parameters() if ".other" in name)
 
     @pytest.mark.parametrize("config_cls", ALL_PEFT_CONFIG_CLASSES)
     @pytest.mark.parametrize("is_trainable", [False, True])  # note: default is False
@@ -7051,10 +7086,11 @@ class TestRequiresGrad:
             return
         model.load_adapter(tmp_path, adapter_name="other", is_trainable=is_trainable)
         if is_trainable:
+            expected_trainable_adapters = ("default", "other")
             for name, param in model.named_parameters():
                 if skip_ranknum and "ranknum" in name:
                     continue
-                if ".default" in name:
+                if any(f".{adapter_name}" in name for adapter_name in expected_trainable_adapters):
                     assert param.requires_grad
                 else:
                     assert not param.requires_grad
@@ -7085,67 +7121,14 @@ class TestRequiresGrad:
         # load one more adapter
         model.load_adapter(tmp_path, adapter_name="other", is_trainable=is_trainable)
         if is_trainable:
+            expected_trainable_adapters = ("default", "other")
             for name, param in model.named_parameters():
-                if ".default" in name:
+                if any(f".{adapter_name}" in name for adapter_name in expected_trainable_adapters):
                     assert param.requires_grad
                 else:
                     assert not param.requires_grad
         else:
             assert all(not p.requires_grad for p in model.parameters())
-
-    @pytest.mark.xfail(strict=True)
-    @pytest.mark.parametrize("config_cls", [LoraConfig])  # no need to check each method, they all fail
-    def test_loading_model_requires_grad_set_correctly_switch_inference_mode(self, config_cls, tmp_path):
-        # Same as test_loading_model_requires_grad_set_correctly but this time we first load with is_trainable=False and
-        # then with is_trainable=True. Loading the second adapter should not affect the requires_grad of the first
-        # adapter, but it does. The reason is that is_training/inference_mode is taken from the current PEFT config, but
-        # that config does not necessarily belong to the active adapter, creating a mismatch.
-        # When/If this is fixed, the check can be integrated into test_loading_model_requires_grad_set_correctly and
-        # this test can be deleted.
-        model = DeepMLP(size=256)  # a size that works with all adapters
-        extra_kwargs = {}
-        config = config_cls(target_modules=["layers.0.lin0"])
-        model = get_peft_model(model, config)
-        model.save_pretrained(tmp_path)
-        del model
-
-        model = DeepMLP(size=256)
-        model = PeftModel.from_pretrained(model, tmp_path, is_trainable=False)
-        assert all(not p.requires_grad for p in model.parameters())
-
-        # load one more adapter; this adapter is not automatically activated
-        model.load_adapter(tmp_path, adapter_name="other", is_trainable=True)
-        params_with_grad = [n for n, p in model.named_parameters() if p.requires_grad]
-        expected = [
-            "base_model.model.layers.0.lin0.lora_A.other.weight",
-            "base_model.model.layers.0.lin0.lora_B.other.weight",
-        ]
-        # this fails, instead with get ...lora_A.default.weight and ...lora_B.default.weight
-        assert params_with_grad == expected
-
-    @pytest.mark.xfail(strict=True)
-    @pytest.mark.parametrize("config_cls", [LoraConfig])  # no need to check each method, they all fail
-    def test_loading_model_requires_grad_load_adapter_then_add_adapter(self, config_cls, tmp_path):
-        # When adding a new adapter with model.add_adapter, through the set_adapter call in update_layer, we activate
-        # the gradients of the first adapter, even if it's not desired. Since there is no is_trainable argument on
-        # add_adapter, there is no way to disable that at the moment.
-        # When/If this is fixed, the check can be integrated into test_loading_model_requires_grad_set_correctly and
-        # this test can be deleted.
-        model = DeepMLP(size=256)  # a size that works with all adapters
-        extra_kwargs = {}
-        config = config_cls(target_modules=["layers.0.lin0"])
-        model = get_peft_model(model, config)
-        model.save_pretrained(tmp_path)
-        del model
-
-        model = DeepMLP(size=256)
-        model = PeftModel.from_pretrained(model, tmp_path, is_trainable=False)
-        assert all(not p.requires_grad for p in model.parameters())
-
-        # add a new adapter
-        model.add_adapter(adapter_name="other", peft_config=config)
-        params_with_grad = [n for n, p in model.named_parameters() if p.requires_grad]
-        assert all(not p.requires_grad for p in model.parameters())
 
 
 # this is for PEFT methods that support mixed adapter batches.

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -5019,53 +5019,6 @@ class TestMultipleActiveAdapters:
         assert torch.allclose(disabled_adapter_output, base_output, atol=1e-4)
 
     @pytest.mark.parametrize(
-        "model_cls, module_name",
-        [(MLP, "lin0"), (ModelEmbConv1D, "emb"), (ModelConv2D, "conv2d")],
-    )
-    @pytest.mark.parametrize("num_adapters", [2, 3])
-    @pytest.mark.parametrize("safe_merge", [False, True])
-    def test_multiple_active_dora_adapters_merge_matches_forward(
-        self, model_cls, module_name, num_adapters, safe_merge
-    ):
-        # DoRA normalizes by the norm of the unmerged base weight. Adapters are merged one after another, so from the
-        # second adapter on, the weight being merged into already holds the previously merged ones; taking the norm
-        # from it makes the merged model differ from the unmerged forward pass. The adapters have to share a target
-        # module for this to show up.
-        torch.manual_seed(0)
-
-        model = model_cls().to(self.torch_device).eval()
-        X = self.prepare_inputs_for_testing()
-        base_output = model(**X)
-
-        def config():
-            return LoraConfig(target_modules=[module_name], init_lora_weights=False, use_dora=True)
-
-        peft_model = get_peft_model(model, config(), adapter_name="adapter_0").eval()
-        adapters = ["adapter_0"]
-        for i in range(1, num_adapters):
-            peft_model.add_adapter(f"adapter_{i}", config())
-            adapters.append(f"adapter_{i}")
-
-        # the DoRA magnitude equals the weight norm at initialization, which makes the factor 1 no matter which weight
-        # it was computed from; move it away from that value to emulate a trained adapter
-        for module in peft_model.modules():
-            if isinstance(module, lora.LoraLayer) and module.lora_magnitude_vector:
-                for magnitude in module.lora_magnitude_vector.values():
-                    magnitude.weight.data += 0.5
-
-        self.set_multiple_active_adapters(peft_model, adapters)
-        combined_output = peft_model(**X)
-
-        peft_model.merge_adapter(safe_merge=safe_merge)
-        assert torch.allclose(peft_model(**X), combined_output, atol=1e-4)
-
-        peft_model.unmerge_adapter()
-        assert torch.allclose(peft_model(**X), combined_output, atol=1e-4)
-
-        with peft_model.disable_adapter():
-            assert torch.allclose(peft_model(**X), base_output, atol=1e-4)
-
-    @pytest.mark.parametrize(
         "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES
     )
     def test_merge_layers_multi(self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2):
@@ -5205,6 +5158,99 @@ class TestMultipleActiveAdapters:
             unmerged_output = model(**X)
 
         assert torch.allclose(unmerged_output, base_output, atol=1e-3, rtol=1e-3)
+
+    @pytest.mark.parametrize(
+        "model_cls, module_name",
+        [(MLP, "lin0"), (ModelEmbConv1D, "emb"), (ModelConv2D, "conv2d")],
+    )
+    @pytest.mark.parametrize("num_adapters", [2, 3])
+    @pytest.mark.parametrize("safe_merge", [False, True])
+    def test_multiple_active_dora_adapters_merge_matches_forward(
+        self, model_cls, module_name, num_adapters, safe_merge
+    ):
+        # DoRA normalizes by the norm of the unmerged base weight. Adapters are merged one after another, so from the
+        # second adapter on, the weight being merged into already holds the previously merged ones; taking the norm
+        # from it makes the merged model differ from the unmerged forward pass. The adapters have to share a target
+        # module for this to show up.
+        torch.manual_seed(0)
+
+        model = model_cls().to(self.torch_device).eval()
+        X = self.prepare_inputs_for_testing()
+        base_output = model(**X)
+
+        def config():
+            return LoraConfig(target_modules=[module_name], init_lora_weights=False, use_dora=True)
+
+        peft_model = get_peft_model(model, config(), adapter_name="adapter_0").eval()
+        adapters = ["adapter_0"]
+        for i in range(1, num_adapters):
+            peft_model.add_adapter(f"adapter_{i}", config())
+            adapters.append(f"adapter_{i}")
+
+        self.set_multiple_active_adapters(peft_model, adapters)
+        combined_output = peft_model(**X)
+
+        peft_model.merge_adapter(safe_merge=safe_merge)
+        assert torch.allclose(peft_model(**X), combined_output, atol=1e-4)
+
+        peft_model.unmerge_adapter()
+        assert torch.allclose(peft_model(**X), combined_output, atol=1e-4)
+
+        with peft_model.disable_adapter():
+            assert torch.allclose(peft_model(**X), base_output, atol=1e-4)
+
+    @pytest.mark.parametrize("safe_merge", [False, True])
+    def test_plain_lora_and_dora_adapters_merge_matches_forward(self, safe_merge):
+        # A plain LoRA adapter merges into the base weight in place, so the DoRA adapters that follow have to work on
+        # a copy of the unmerged weight, not on the weight itself.
+        torch.manual_seed(0)
+
+        model = MLP().to(self.torch_device).eval()
+        X = self.prepare_inputs_for_testing()
+        base_output = model(**X)
+
+        def config(use_dora):
+            return LoraConfig(target_modules=["lin0"], init_lora_weights=False, use_dora=use_dora)
+
+        peft_model = get_peft_model(model, config(use_dora=False), adapter_name="adapter_0").eval()
+        peft_model.add_adapter("adapter_1", config(use_dora=True))
+        peft_model.add_adapter("adapter_2", config(use_dora=True))
+        adapters = ["adapter_0", "adapter_1", "adapter_2"]
+
+        self.set_multiple_active_adapters(peft_model, adapters)
+        combined_output = peft_model(**X)
+
+        peft_model.merge_adapter(safe_merge=safe_merge)
+        assert torch.allclose(peft_model(**X), combined_output, atol=1e-4)
+
+        peft_model.unmerge_adapter()
+        assert torch.allclose(peft_model(**X), combined_output, atol=1e-4)
+
+        with peft_model.disable_adapter():
+            assert torch.allclose(peft_model(**X), base_output, atol=1e-4)
+
+    def test_multiple_active_dora_adapters_safe_and_unsafe_merge_agree(self):
+        # Taking the already merged adapters out of the base weight and putting them back rebuilds that weight, and it
+        # is the rebuilt one that ends up in the layer. The safe path has to carry on from it as well, otherwise the
+        # two paths merge into different weights.
+        def merged_weight(safe_merge):
+            torch.manual_seed(0)
+            model = MLP().to(self.torch_device).eval()
+
+            def config():
+                return LoraConfig(target_modules=["lin0"], init_lora_weights=False, use_dora=True)
+
+            peft_model = get_peft_model(model, config(), adapter_name="adapter_0").eval()
+            adapters = ["adapter_0"]
+            for i in range(1, 3):
+                peft_model.add_adapter(f"adapter_{i}", config())
+                adapters.append(f"adapter_{i}")
+
+            self.set_multiple_active_adapters(peft_model, adapters)
+            peft_model.merge_adapter(safe_merge=safe_merge)
+            return peft_model.base_model.model.lin0.get_base_layer().weight.data.clone()
+
+        assert torch.equal(merged_weight(safe_merge=True), merged_weight(safe_merge=False))
 
 
 class MLP_2x_same_shape(nn.Module):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -5019,6 +5019,53 @@ class TestMultipleActiveAdapters:
         assert torch.allclose(disabled_adapter_output, base_output, atol=1e-4)
 
     @pytest.mark.parametrize(
+        "model_cls, module_name",
+        [(MLP, "lin0"), (ModelEmbConv1D, "emb"), (ModelConv2D, "conv2d")],
+    )
+    @pytest.mark.parametrize("num_adapters", [2, 3])
+    @pytest.mark.parametrize("safe_merge", [False, True])
+    def test_multiple_active_dora_adapters_merge_matches_forward(
+        self, model_cls, module_name, num_adapters, safe_merge
+    ):
+        # DoRA normalizes by the norm of the unmerged base weight. Adapters are merged one after another, so from the
+        # second adapter on, the weight being merged into already holds the previously merged ones; taking the norm
+        # from it makes the merged model differ from the unmerged forward pass. The adapters have to share a target
+        # module for this to show up.
+        torch.manual_seed(0)
+
+        model = model_cls().to(self.torch_device).eval()
+        X = self.prepare_inputs_for_testing()
+        base_output = model(**X)
+
+        def config():
+            return LoraConfig(target_modules=[module_name], init_lora_weights=False, use_dora=True)
+
+        peft_model = get_peft_model(model, config(), adapter_name="adapter_0").eval()
+        adapters = ["adapter_0"]
+        for i in range(1, num_adapters):
+            peft_model.add_adapter(f"adapter_{i}", config())
+            adapters.append(f"adapter_{i}")
+
+        # the DoRA magnitude equals the weight norm at initialization, which makes the factor 1 no matter which weight
+        # it was computed from; move it away from that value to emulate a trained adapter
+        for module in peft_model.modules():
+            if isinstance(module, lora.LoraLayer) and module.lora_magnitude_vector:
+                for magnitude in module.lora_magnitude_vector.values():
+                    magnitude.weight.data += 0.5
+
+        self.set_multiple_active_adapters(peft_model, adapters)
+        combined_output = peft_model(**X)
+
+        peft_model.merge_adapter(safe_merge=safe_merge)
+        assert torch.allclose(peft_model(**X), combined_output, atol=1e-4)
+
+        peft_model.unmerge_adapter()
+        assert torch.allclose(peft_model(**X), combined_output, atol=1e-4)
+
+        with peft_model.disable_adapter():
+            assert torch.allclose(peft_model(**X), base_output, atol=1e-4)
+
+    @pytest.mark.parametrize(
         "test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2", MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES
     )
     def test_merge_layers_multi(self, test_name, tuner_method, config_cls, config_kwargs_1, config_kwargs_2):


### PR DESCRIPTION
Fixes #3608.

DoRA normalizes the merged weight by the norm of the unmerged base weight. `Linear.merge` applies the
adapters one after another and hands each variant the live base weight, so from the second adapter on
the norm is taken from a weight that already contains the previously merged adapters. The forward pass
passes `base_layer=module.get_base_layer()` for every adapter, so it always norms against the unmerged
weight. Merging two DoRA adapters that share a target module therefore gives a different model than the
unmerged forward pass: 2.57% relative output difference in the reproducer in #3608, up to 13.86% for
larger adapter weights. A single DoRA adapter, adapters on disjoint modules, and plain LoRA are all
unaffected, and unmerging was already a correct inverse of merging.

`LoraLayer._get_base_weight_before_merge` takes a snapshot of the base weight while no adapter is
merged, and the Linear, Embedding and ConvNd DoRA variants take the weight norm from that snapshot. The
snapshot is refreshed whenever no adapter is merged, so it stays correct across merge/unmerge cycles.
This follows what was done for the same problem in FRoD, HiRA and PEANuT in #3482.

Why it wasn't caught: `test_multiple_active_adapters_merge_and_unmerge` already asserts this invariant,
but `MULTIPLE_ACTIVE_ADAPTERS_TEST_CASES` has no `use_dora=True` entry. Adding DoRA to that list also
fails `test_multiple_active_adapters_forward` at the `add_weighted_adapter` assertion, including for
disjoint modules, which looks like a separate problem (#3111 is in that area), so the regression test is
a dedicated one instead.

Tests run:
- `pytest tests/test_custom_models.py -k test_multiple_active_dora_adapters_merge_matches_forward` — 2
  passed; both cases fail on main without the fix.
- `pytest tests/test_custom_models.py tests/test_lora_variants.py tests/test_tuners_utils.py -k "not
  Adamss"` — 17607 passed, 1015 skipped, 0 failed. The deselected AdaMSS cases fail on main as well and
  are unrelated.
- `make quality` — clean.
