### PR TITLE
CI Fix ruff version to 0.16.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.2
+    rev: v0.16.4
     hooks:
       - id: ruff
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ target-version = ['py310']
 target-version = "py310"
 line-length = 119
 extend-exclude = ["*.ipynb", "docs/**/*.md", "examples/**/*.md"]
-required-version = "~=0.16.2"
+required-version = "==0.16.4"
 
 [tool.ruff.lint]
 preview = true

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras["quality"] = [
     "black",  # doc-builder has an implicit dependency on Black, see huggingface/doc-builder#434
     "hf-doc-builder",
     # when upgrading this, also upgrade required version in pyproject.toml and pre-commit-config.yaml
-    "ruff~=0.16.2",
+    "ruff==0.16.4",
     "griffe",  # for ./scripts/check_doc_coverage.py
 ]
 extras["docs_specific"] = [


### PR DESCRIPTION
Ruff 0.16.5 introduces/enables new rules that break with PEFT. The changes are not trivial to fix, so pinning ruff to 0.16.4 for now.

I did not expect that patch releases would add new rules, which is why the exact version was not pinned so far. The ruff release notes also don't mention new rules:

https://github.com/astral-sh/ruff/releases/tag/0.16.5

New rules (56 errors total):

- https://docs.astral.sh/ruff/rules/abstract-base-class-without-abstract-method
- https://docs.astral.sh/ruff/rules/escape-sequence-in-docstring
- https://docs.astral.sh/ruff/rules/if-exp-instead-of-or-operator
- https://docs.astral.sh/ruff/rules/none-not-at-end-of-union
- https://docs.astral.sh/ruff/rules/numpy-legacy-random
- https://docs.astral.sh/ruff/rules/pytest-raises-ambiguous-pattern
- https://docs.astral.sh/ruff/rules/pytest-raises-with-multiple-statements
- https://docs.astral.sh/ruff/rules/single-item-membership-test