### PR TITLE
Preserve LN Tuning adapter devices when adding adapters

### DIFF
--- a/src/peft/tuners/ln_tuning/model.py
+++ b/src/peft/tuners/ln_tuning/model.py
@@ -74,7 +74,10 @@ class LNTuningModel(BaseTuner):
         parent: Module,
         current_key: str,
     ) -> None:
-        # replace the original module with a same new module
+        if isinstance(target, LNTuningLayer):
+            target.update_layer(target.base_layer, adapter_name, config=peft_config)
+            return
+
         new_module = self._create_new_module(peft_config, target, adapter_name)
         if adapter_name != self.active_adapter:
             new_module.requires_grad_(False)
@@ -86,12 +89,7 @@ class LNTuningModel(BaseTuner):
         target: Module,
         adapter_name: str,
     ) -> Module:
-        if not isinstance(target, LNTuningLayer):
-            new_module = LNTuningLayer(target, adapter_name, config=peft_config)
-        else:
-            new_module = target
-            new_module.update_layer(target.base_layer, adapter_name, config=peft_config)
-        return new_module
+        return LNTuningLayer(target, adapter_name, config=peft_config)
 
     def _unloading_checks(self, adapter_names: Optional[list[str]]):
         adapters_to_consider = adapter_names or self.active_adapters

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -2012,7 +2012,6 @@ class TestSameAdapterDifferentDevices:
         assert model.lin0.base_layer.weight.device.type == self.device
         assert model.lin0.ia3_l.other.device.type == self.device
 
-    @pytest.mark.xfail(reason="LN Tuning handling of multiple adapters may not be correct", strict=True)
     def test_ln_tuning_add_new_adapter_does_not_change_device(self, mlp):
         # same as first test, but using LN tuning
         config = LNTuningConfig(target_modules=["lin0"])


### PR DESCRIPTION
## Summary

Fixes #3612.

Adding an adapter to an existing `LNTuningLayer` now updates the wrapper in place instead of passing it through the generic module-replacement path. This preserves the device placement of adapters that were already present while creating the new adapter on the base layer's device.

The existing strict xfail is enabled as a passing GPU regression.

The implementation was coordinated in #3612 and explicitly approved by a maintainer in https://github.com/huggingface/peft/issues/3612#issuecomment-5451639897.

## Validation

- `python -m pytest tests/test_common_gpu.py::TestSameAdapterDifferentDevices -q --no-cov`: 17 passed
- `python -m pytest tests/ -k "ln_tuning" -q --no-cov --regression`: 5 passed, 2 skipped, 36300 deselected
- `python -m ruff check src/peft/tuners/ln_tuning/model.py tests/test_common_gpu.py`
- `python -m ruff format --check src/peft/tuners/ln_tuning/model.py tests/test_common_gpu.py`
- `git diff --check`

## AI assistance disclosure

AI assistance was used for source analysis, implementation, and test execution. I reviewed every changed line and understand and can defend the change end to end.
