### PR TITLE
FIX IncrementalPCA state leaking across fits

### DIFF
--- a/src/peft/utils/incremental_pca.py
+++ b/src/peft/utils/incremental_pca.py
@@ -73,7 +73,7 @@ class IncrementalPCA:
             if self.n_components is None:
                 raise ValueError("n_components must be specified when using lowrank mode with lowrank_q=None.")
             self.lowrank_q = self.n_components * 2
-        elif self.lowrank_q < self.n_components:
+        elif self.n_components is not None and self.lowrank_q < self.n_components:
             raise ValueError("lowrank_q must be greater than or equal to n_components.")
 
     def _svd_fn_full(self, X):
@@ -105,16 +105,18 @@ class IncrementalPCA:
             X = X.clone()
 
         n_samples, n_features = X.shape
-        if self.n_components is None:
+        # once fitted, validate against the resolved number of components, since n_components may be None
+        n_components = getattr(self, "n_components_", self.n_components)
+        if n_components is None:
             pass
-        elif self.n_components > n_features:
+        elif n_components > n_features:
             raise ValueError(
-                f"n_components={self.n_components} invalid for n_features={n_features}, "
+                f"n_components={n_components} invalid for n_features={n_features}, "
                 "need more rows than columns for IncrementalPCA processing."
             )
-        elif self.n_components > n_samples:
+        elif n_components > n_samples:
             raise ValueError(
-                f"n_components={self.n_components} must be less or equal to the batch number of samples {n_samples}"
+                f"n_components={n_components} must be less or equal to the batch number of samples {n_samples}"
             )
 
         if X.dtype not in valid_dtypes:
@@ -205,6 +207,25 @@ class IncrementalPCA:
         v *= signs.view(-1, 1)
         return u, v
 
+    def _reset(self):
+        """Discards the fitted state so that the next `partial_fit` is treated as a first pass."""
+        fitted_attributes = (
+            "components_",
+            "singular_values_",
+            "explained_variance_",
+            "explained_variance_ratio_",
+            "noise_variance_",
+            "mean_",
+            "var_",
+            "n_samples_seen_",
+            "n_components_",
+            "batch_size_",
+        )
+        for attribute in fitted_attributes:
+            if hasattr(self, attribute):
+                delattr(self, attribute)
+        self.n_features_ = None
+
     def fit(self, X, check_input=True):
         """
         Fits the model with data `X` using minibatches of size `batch_size`.
@@ -216,13 +237,15 @@ class IncrementalPCA:
         Returns:
             IncrementalPCA: The fitted IPCA model.
         """
+        # `fit` starts from scratch, otherwise a second call would keep accumulating on the previous fit
+        self._reset()
+
         if check_input:
             X = self._validate_data(X)
         n_samples, n_features = X.shape
-        if self.batch_size is None:
-            self.batch_size = 5 * n_features
+        self.batch_size_ = 5 * n_features if self.batch_size is None else self.batch_size
 
-        for batch in self.gen_batches(n_samples, self.batch_size, min_batch_size=self.n_components or 0):
+        for batch in self.gen_batches(n_samples, self.batch_size_, min_batch_size=self.n_components or 0):
             self.partial_fit(X[batch], check_input=False)
 
         return self
@@ -250,8 +273,7 @@ class IncrementalPCA:
             self.var_ = None  # Will be initialized properly in _incremental_mean_and_var based on data dimensions
             self.n_samples_seen_ = torch.tensor([0], device=X.device)
             self.n_features_ = n_features
-            if not self.n_components:
-                self.n_components = min(n_samples, n_features)
+            self.n_components_ = self.n_components or min(n_samples, n_features)
 
         if n_features != self.n_features_:
             raise ValueError(
@@ -286,14 +308,14 @@ class IncrementalPCA:
         explained_variance_ratio = S**2 / torch.sum(col_var * n_total_samples)
 
         self.n_samples_seen_ = n_total_samples
-        self.components_ = Vt[: self.n_components]
-        self.singular_values_ = S[: self.n_components]
+        self.components_ = Vt[: self.n_components_]
+        self.singular_values_ = S[: self.n_components_]
         self.mean_ = col_mean
         self.var_ = col_var
-        self.explained_variance_ = explained_variance[: self.n_components]
-        self.explained_variance_ratio_ = explained_variance_ratio[: self.n_components]
-        if self.n_components not in (n_samples, n_features):
-            self.noise_variance_ = explained_variance[self.n_components :].mean()
+        self.explained_variance_ = explained_variance[: self.n_components_]
+        self.explained_variance_ratio_ = explained_variance_ratio[: self.n_components_]
+        if self.n_components_ not in (n_samples, n_features):
+            self.noise_variance_ = explained_variance[self.n_components_ :].mean()
         else:
             self.noise_variance_ = torch.tensor(0.0, device=X.device)
         return self
@@ -310,8 +332,10 @@ class IncrementalPCA:
         Returns:
             torch.Tensor: Transformed data tensor with shape (n_samples, n_components).
         """
+        dtype = X.dtype
+        # `self.mean_` is float64, so the subtraction below would otherwise promote the result
         X = X - self.mean_
-        return torch.mm(X.double(), self.components_.T).to(X.dtype)
+        return torch.mm(X.double(), self.components_.T).to(dtype)
 
     @staticmethod
     def gen_batches(n: int, batch_size: int, min_batch_size: int = 0):

--- a/tests/test_incremental_pca.py
+++ b/tests/test_incremental_pca.py
@@ -112,7 +112,9 @@ def test_n_components_none():
         # First partial_fit call, ipca.n_components_ is inferred from
         # min(X.shape)
         ipca.partial_fit(X)
-        assert ipca.n_components == min(X.shape)
+        assert ipca.n_components_ == min(X.shape)
+        # the constructor argument itself is left untouched
+        assert ipca.n_components is None
 
 
 def test_incremental_pca_num_features_change():
@@ -173,6 +175,57 @@ def test_incremental_pca_partial_fit():
     for i, j in pairwise(batch_itr):
         pipca.partial_fit(X[i:j, :])
     assert_close(ipca.components_, pipca.components_, rtol=1e-3, atol=1e-3)
+
+
+def test_incremental_pca_refit():
+    # Test that calling fit twice starts from scratch instead of accumulating.
+    n, p = 50, 3
+    X = torch.randn(n, p, dtype=torch.float64)
+
+    ipca = IncrementalPCA(n_components=2, batch_size=25)
+    ipca.fit(X)
+    n_samples_seen = ipca.n_samples_seen_.clone()
+    components = ipca.components_.clone()
+
+    ipca.fit(X)
+    assert_close(ipca.n_samples_seen_, n_samples_seen)
+    assert_close(ipca.components_, components)
+
+    # a fresh estimator on the same data must agree with the refitted one
+    reference = IncrementalPCA(n_components=2, batch_size=25).fit(X)
+    assert_close(ipca.components_, reference.components_)
+
+
+def test_incremental_pca_fit_does_not_mutate_params():
+    # Test that fit does not overwrite the constructor arguments.
+    ipca = IncrementalPCA()
+    ipca.fit(torch.randn(50, 8, dtype=torch.float64))
+    assert ipca.n_components is None
+    assert ipca.batch_size is None
+    assert ipca.n_components_ == 8
+    assert ipca.batch_size_ == 5 * 8
+
+    # the inferred batch size must follow the data of the current fit
+    ipca.fit(torch.randn(50, 4, dtype=torch.float64))
+    assert ipca.n_components_ == 4
+    assert ipca.batch_size_ == 5 * 4
+
+
+def test_incremental_pca_transform_preserves_dtype():
+    # Test that transform returns the dtype of its input.
+    X = torch.randn(50, 8, dtype=torch.float32)
+    ipca = IncrementalPCA(n_components=3).fit(X)
+    assert ipca.transform(X).dtype == torch.float32
+
+    X64 = X.double()
+    ipca64 = IncrementalPCA(n_components=3).fit(X64)
+    assert ipca64.transform(X64).dtype == torch.float64
+
+
+def test_incremental_pca_lowrank_q_without_n_components():
+    # Test that an explicit lowrank_q is accepted when n_components is None.
+    ipca = IncrementalPCA(n_components=None, lowrank=True, lowrank_q=4)
+    assert ipca.lowrank_q == 4
 
 
 def test_incremental_pca_lowrank(iris):


### PR DESCRIPTION
Fixes #3617

`IncrementalPCA` is documented as adapted from scikit-learn's `IncrementalPCA`, but the port dropped the state reset that `fit` does there. This PR restores it and fixes three smaller issues in the same class. They are bundled into one PR because they all live in `src/peft/utils/incremental_pca.py` and the contribution guidelines ask for related fixes to be grouped rather than split into individual small PRs.

### What was wrong

1. **`fit()` accumulated instead of refitting.** It never discarded the fitted state, so a second call kept adding to the first. Fitting the same 50 rows twice reported `n_samples_seen_ == 100` and shifted `explained_variance_ratio_`, with no error raised.
2. **`fit()` and `partial_fit()` overwrote the constructor arguments.** The inferred batch size and number of components were written back into `self.batch_size` and `self.n_components`. A refit therefore reused the batch size derived from the first dataset and failed on data with a different number of features.
3. **`transform()` always returned float64.** The trailing `.to(X.dtype)` was a no-op, because `X = X - self.mean_` had already rebound `X` to float64 (`mean_` is always float64).
4. **`lowrank_q` with `n_components=None` raised `TypeError`.** `_validate_lowrank_params` guards its first branch against `n_components` being `None` but not the `elif`.

### What changed

- `fit()` calls a new `_reset()` first, which drops the fitted attributes so that the next `partial_fit` is treated as a first pass. This mirrors what scikit-learn's `fit` does.
- The inferred values are stored as the fitted attributes `batch_size_` and `n_components_`, matching the scikit-learn naming, so `batch_size` and `n_components` stay the arguments the caller passed. `_validate_data` prefers `n_components_` once it exists, so validation of later `partial_fit` batches is unchanged.
- `transform()` captures the input dtype before the subtraction.
- The `lowrank_q` comparison is skipped when `n_components` is `None`.

`test_n_components_none` was updated to assert on `n_components_`. That test already carried the scikit-learn comment saying "ipca.n_components_ is inferred from min(X.shape)" while asserting on `ipca.n_components`, so the underscore appears to have been lost in the port.

### Backward compatibility

`n_components_` and `batch_size_` are new. The only in-repo consumer, `SVDHook` in `src/peft/tuners/lora/eva.py`, constructs a fresh `IncrementalPCA` per hook and only calls `partial_fit`, so it is unaffected apart from the `transform` dtype. Code outside the repo that read `n_components` back after fitting to discover the inferred value would need to read `n_components_` instead. I am happy to keep `n_components` mirroring the inferred value as well if you would prefer a fully additive change.

### Tests

New regression tests in `tests/test_incremental_pca.py`:

- `test_incremental_pca_refit`
- `test_incremental_pca_fit_does_not_mutate_params`
- `test_incremental_pca_transform_preserves_dtype`
- `test_incremental_pca_lowrank_q_without_n_components`

Commands run, on Python 3.12.10 with torch 2.13.0+cpu, CPU only:

- `pytest tests/test_incremental_pca.py` before the change: 9 passed
- `pytest tests/test_incremental_pca.py` after the change: 13 passed
- The new tests against the unpatched source: 5 failed, 8 passed, confirming they cover the reported behaviour
- `pytest tests/test_initialization.py`, which covers EVA: 342 passed, 36 skipped, 2 xfailed
- `ruff check` and `ruff format --check` on both changed files: clean

I could not run the GPU test suites, since I have no CUDA device available.

### Disclosure

I used AI assistance while investigating this and preparing the patch. I have reviewed every changed line, and I ran all of the commands listed above myself.
