### PR TITLE
FIX ShadowPEFT last-token pooling with left padding

### DIFF
--- a/src/peft/tuners/shadow/layers.py
+++ b/src/peft/tuners/shadow/layers.py
@@ -449,9 +449,13 @@ class DetachedShadowModel(PreTrainedModel, GenerationMixin):
         """Pool the last non-padding token representation (used for sequence classification)."""
         if attention_mask is None:
             return hidden[:, -1, :]
-        token_counts = (attention_mask.long().sum(dim=1) - 1).clamp(min=0)
+        # `sum(dim=1) - 1` is the last index only for right padding. Weighting by position
+        # selects the final non-pad token for left-padded (and mixed) batches as well.
+        # See https://github.com/huggingface/peft/issues/3620
+        position_ids = torch.arange(hidden.size(1), device=hidden.device)
+        last_idx = (attention_mask.long() * position_ids).argmax(dim=1)
         batch_idx = torch.arange(hidden.size(0), device=hidden.device)
-        return hidden[batch_idx, token_counts]
+        return hidden[batch_idx, last_idx]
 
     def forward(
         self,

--- a/src/peft/tuners/shadow/model.py
+++ b/src/peft/tuners/shadow/model.py
@@ -223,9 +223,13 @@ def _pool_last_token(hidden: torch.Tensor, attention_mask: Optional[torch.Tensor
     """Pool the last non-padding token representation (used for sequence classification)."""
     if attention_mask is None:
         return hidden[:, -1, :]
-    token_counts = (attention_mask.long().sum(dim=1) - 1).clamp(min=0)
+    # `sum(dim=1) - 1` is the last index only for right padding. Weighting by position
+    # selects the final non-pad token for left-padded (and mixed) batches as well.
+    # See https://github.com/huggingface/peft/issues/3620
+    position_ids = torch.arange(hidden.size(1), device=hidden.device)
+    last_idx = (attention_mask.long() * position_ids).argmax(dim=1)
     batch_idx = torch.arange(hidden.size(0), device=hidden.device)
-    return hidden[batch_idx, token_counts]
+    return hidden[batch_idx, last_idx]
 
 
 # ------------------------------------------------------------------------------------------------------------- tuner

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -41,6 +41,7 @@ from peft import (
 from peft.tuners.shadow import DetachedShadowModel, ShadowCache
 from peft.tuners.shadow.diffusion_models import DetachedFluxShadowModel
 from peft.tuners.shadow.layers import ShadowLayer
+from peft.tuners.shadow.model import _pool_last_token
 from peft.utils.constants import SAFETENSORS_WEIGHTS_NAME
 
 from .testing_utils import hub_online_once
@@ -512,6 +513,39 @@ class TestShadowSequenceClassification:
             out = detached(input_ids=ids, attention_mask=am)
         assert isinstance(out, SequenceClassifierOutput)
         assert out.logits.shape == (4, 3)
+
+    def test_pool_last_token_left_padding(self):
+        # Regression test for https://github.com/huggingface/peft/issues/3620
+        hidden = torch.tensor(
+            [
+                [[10.0], [20.0], [30.0], [40.0]],
+                [[10.0], [20.0], [30.0], [40.0]],
+            ]
+        )
+        attention_mask = torch.tensor(
+            [
+                [0, 0, 1, 1],
+                [0, 1, 1, 1],
+            ]
+        )
+        pooled = _pool_last_token(hidden, attention_mask).squeeze(-1)
+        assert torch.equal(pooled, torch.tensor([40.0, 40.0]))
+        detached_pooled = DetachedShadowModel._pool_last_token(hidden, attention_mask).squeeze(-1)
+        assert torch.equal(detached_pooled, torch.tensor([40.0, 40.0]))
+
+    def test_pool_last_token_right_padding(self):
+        # Right padding must keep selecting the last non-pad token (issue 3620).
+        hidden = torch.tensor([[[10.0], [20.0], [30.0], [40.0]]])
+        attention_mask = torch.tensor([[1, 1, 0, 0]])
+        pooled = _pool_last_token(hidden, attention_mask).squeeze(-1)
+        assert torch.equal(pooled, torch.tensor([20.0]))
+        detached_pooled = DetachedShadowModel._pool_last_token(hidden, attention_mask).squeeze(-1)
+        assert torch.equal(detached_pooled, torch.tensor([20.0]))
+
+    def test_pool_last_token_without_mask_uses_final_position(self):
+        hidden = torch.tensor([[[10.0], [20.0], [30.0]]])
+        pooled = _pool_last_token(hidden, None).squeeze(-1)
+        assert torch.equal(pooled, torch.tensor([30.0]))
 
 
 class TestShadowBackboneVariants:


### PR DESCRIPTION
Fixes #3620

`_pool_last_token` indexed with `attention_mask.sum(dim=1) - 1`, which is the last **non-padding** token only for **right** padding. With left padding it lands in the pad region.

The helper now weights the mask by position and takes `argmax`, which selects the last non-pad token for left-padded, right-padded, and mixed batches. The same logic is used in both `peft.tuners.shadow.model._pool_last_token` and `DetachedShadowModel._pool_last_token`.

## Tests

```
pytest tests/test_shadow.py::TestShadowSequenceClassification::test_pool_last_token_left_padding tests/test_shadow.py::TestShadowSequenceClassification::test_pool_last_token_right_padding tests/test_shadow.py::TestShadowSequenceClassification::test_pool_last_token_without_mask_uses_final_position -v
```

All three passed locally.

## AI assistance

AI assistance was used to draft this change. I reviewed every line, reproduced the left-padding pooling bug from #3620, and ran the tests above. Coordination comment: https://github.com/huggingface/peft/issues/3620#issuecomment-5467966838
