### PR TITLE
Match root layers patterns

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -158,7 +158,7 @@ If the description is too long to fit in one line (more than 119 characters in t
 before writing the description after the argument.
 
 Finally, to maintain uniformity if any *one* description is too long to fit on one line, the 
-rest of the parameters should follow suit and have an indention before their description.
+rest of the parameters should follow suit and have an indentation before their description.
 
 Here's an example showcasing everything so far:
 

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -2352,11 +2352,11 @@ def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
             if layers_pattern is None or len(layers_pattern) == 0:
                 # Lazy .*? matches the first numbered segment (the layer index), not the last one; a greedy .* would
                 # wrongly pick up nested indices such as the expert index in MoE models ("...layers.1.experts.0...").
-                layer_index = re.match(r".*?\.[^.]*\.(\d+)\.", key)
+                layer_index = re.match(r"(?:^|.*?\.)[^.]*\.(\d+)\.", key)
             else:
                 layers_pattern = [layers_pattern] if isinstance(layers_pattern, str) else layers_pattern
                 for pattern in layers_pattern:
-                    layer_index = re.match(rf".*?\.{pattern}\.(\d+)\.", key)
+                    layer_index = re.match(rf"(?:^|.*?\.){pattern}\.(\d+)\.", key)
                     if layer_index is not None:
                         break
 

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -94,6 +94,7 @@ REGEX_TEST_CASES = [
     ("foobar", ".*oba.*", None, None, True),
     # with layers_to_transform
     ("foo.bar.1.baz", ["baz"], [1], ["bar"], True),
+    ("layers.1.self_attn.q_proj", ["q_proj"], [1], ["layers"], True),
     ("foo.bar.1.baz", ["baz"], [0], ["bar"], False),
     ("foo.bar.1.baz", ["baz"], [2], ["bar"], False),
     ("foo.bar.10.baz", ["baz"], [0], ["bar"], False),


### PR DESCRIPTION
Allow layers_pattern to match a ModuleList at the model root.

Test: python3 -m py_compile src/peft/tuners/tuners_utils.py tests/test_tuners_utils.py

AI assistance was used.