### PR TITLE
Extend the `prepare_model_for_kbit_training` memory leak regression t…

### DIFF
--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -2214,6 +2214,7 @@ class TestPrepareModelForKbitTraining:
         model.is_loaded_in_8bit = True
         return model
 
+    # Keep this skip limited to CUDA/XPU because prepare_model_for_kbit_training only clears those caches today.
     @pytest.mark.skipif(not (torch.cuda.is_available() or is_xpu_available()), reason="test requires a GPU or XPU")
     def test_prepare_model_for_kbit_training_no_memory_leak(self):
         """CUDA/XPU: empty_cache() after bulk fp16→fp32 casts keeps reserved memory under 200 MB (issue #3265)."""

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -67,7 +67,6 @@ from .testing_utils import (
     require_deterministic_for_xpu,
     require_gptqmodel,
     require_non_cpu,
-    require_torch_gpu,
     require_torch_multi_accelerator,
 )
 
@@ -2215,26 +2214,29 @@ class TestPrepareModelForKbitTraining:
         model.is_loaded_in_8bit = True
         return model
 
-    @require_torch_gpu
+    @pytest.mark.skipif(not (torch.cuda.is_available() or is_xpu_available()), reason="test requires a GPU or XPU")
     def test_prepare_model_for_kbit_training_no_memory_leak(self):
-        """CUDA: empty_cache() after bulk fp16→fp32 casts keeps reserved memory under 200 MB (issue #3265)."""
-        model = self._make_fp16_model().cuda()
+        """CUDA/XPU: empty_cache() after bulk fp16→fp32 casts keeps reserved memory under 200 MB (issue #3265)."""
+        device = torch.accelerator.current_accelerator().type
+        model = self._make_fp16_model().to(device)
 
-        torch.cuda.synchronize()
-        torch.cuda.reset_peak_memory_stats()
-        mem_before = torch.cuda.memory_reserved()
+        torch.accelerator.synchronize()
+        torch.accelerator.reset_peak_memory_stats()
+        mem_before = torch.accelerator.memory_reserved()
 
         prepare_model_for_kbit_training(model, use_gradient_checkpointing=False)
 
-        torch.cuda.synchronize()
-        mem_after = torch.cuda.memory_reserved()
+        torch.accelerator.synchronize()
+        mem_after = torch.accelerator.memory_reserved()
 
         delta_mb = (mem_after - mem_before) / (1024**2)
-        assert delta_mb < 200, f"CUDA reserved memory grew by {delta_mb:.1f} MB after prepare_model_for_kbit_training"
+        assert delta_mb < 200, (
+            f"{device.upper()} reserved memory grew by {delta_mb:.1f} MB after prepare_model_for_kbit_training"
+        )
 
         # Confirm empty_cache() was actually called: a second call should not further reduce reserved memory.
-        torch.cuda.empty_cache()
-        mem_after_extra_empty = torch.cuda.memory_reserved()
+        torch.accelerator.empty_cache()
+        mem_after_extra_empty = torch.accelerator.memory_reserved()
         assert mem_after == mem_after_extra_empty, (
             "Reserved memory changed after a second empty_cache(), meaning the first call was not made"
         )


### PR DESCRIPTION
…est to cover XPU in addition to CUDA.

The test is generalized to run on CUDA or XPU via torch.accelerator, and was validated on XPU.