### PR TITLE
FIX ShadowPEFT last-token pooling with left padding

### DIFF
--- a/src/peft/tuners/shadow/layers.py
+++ b/src/peft/tuners/shadow/layers.py
@@ -38,6 +38,16 @@ def _sequence_classification_loss(logits: torch.Tensor, labels: torch.Tensor) ->
     return torch.nn.functional.binary_cross_entropy_with_logits(logits, labels)
 
 
+def _pool_last_token(hidden: torch.Tensor, attention_mask: Optional[torch.Tensor]) -> torch.Tensor:
+    """Pool the last non-padding token representation for sequence classification."""
+    if attention_mask is None:
+        return hidden[:, -1, :]
+    token_positions = torch.arange(attention_mask.shape[-1], device=attention_mask.device)
+    last_non_padding_token = (attention_mask.ne(0) * token_positions).argmax(dim=-1)
+    batch_idx = torch.arange(hidden.shape[0], device=hidden.device)
+    return hidden[batch_idx, last_non_padding_token]
+
+
 class ShadowCarrier:
     """Couples the base `hidden_states` with the parallel `shadow_states` so the pair rides the base decoder loop."""
 
@@ -444,15 +454,6 @@ class DetachedShadowModel(PreTrainedModel, GenerationMixin):
     def get_output_embeddings(self):
         return None if getattr(self, "is_classification", False) else self.head
 
-    @staticmethod
-    def _pool_last_token(hidden: torch.Tensor, attention_mask: Optional[torch.Tensor]) -> torch.Tensor:
-        """Pool the last non-padding token representation (used for sequence classification)."""
-        if attention_mask is None:
-            return hidden[:, -1, :]
-        token_counts = (attention_mask.long().sum(dim=1) - 1).clamp(min=0)
-        batch_idx = torch.arange(hidden.size(0), device=hidden.device)
-        return hidden[batch_idx, token_counts]
-
     def forward(
         self,
         input_ids: Optional[torch.Tensor] = None,
@@ -476,7 +477,7 @@ class DetachedShadowModel(PreTrainedModel, GenerationMixin):
             return hidden
 
         if self.is_classification:
-            pooled = self._pool_last_token(hidden, attention_mask)
+            pooled = _pool_last_token(hidden, attention_mask)
             logits = self.head(pooled)
             loss = None
             if labels is not None:

--- a/src/peft/tuners/shadow/layers.py
+++ b/src/peft/tuners/shadow/layers.py
@@ -39,13 +39,13 @@ def _sequence_classification_loss(logits: torch.Tensor, labels: torch.Tensor) ->
 
 
 def _pool_last_token(hidden: torch.Tensor, attention_mask: Optional[torch.Tensor]) -> torch.Tensor:
-    """Pool the last non-padding token representation for sequence classification."""
+    """Return the hidden state of the last non-padding token for both left- and right-padded sequences."""
     if attention_mask is None:
         return hidden[:, -1, :]
     token_positions = torch.arange(attention_mask.shape[-1], device=attention_mask.device)
-    last_non_padding_token = (attention_mask.ne(0) * token_positions).argmax(dim=-1)
+    last_non_padding_token_indices = (attention_mask.ne(0) * token_positions).argmax(dim=-1)
     batch_idx = torch.arange(hidden.shape[0], device=hidden.device)
-    return hidden[batch_idx, last_non_padding_token]
+    return hidden[batch_idx, last_non_padding_token_indices]
 
 
 class ShadowCarrier:

--- a/src/peft/tuners/shadow/model.py
+++ b/src/peft/tuners/shadow/model.py
@@ -30,7 +30,14 @@ from peft.utils import TaskType
 
 from .config import ShadowConfig
 from .diffusion_models import get_diffusion_shadow_backend
-from .layers import DetachedShadowModel, ShadowCache, ShadowCarrier, ShadowLayer, _sequence_classification_loss
+from .layers import (
+    DetachedShadowModel,
+    ShadowCache,
+    ShadowCarrier,
+    ShadowLayer,
+    _pool_last_token,
+    _sequence_classification_loss,
+)
 
 
 # --------------------------------------------------------------------------------------------------- backbone helpers
@@ -217,15 +224,6 @@ def _shifted_ce_loss(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor
     shift_logits = logits[..., :-1, :].contiguous()
     shift_labels = labels[..., 1:].contiguous()
     return F.cross_entropy(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1), ignore_index=-100)
-
-
-def _pool_last_token(hidden: torch.Tensor, attention_mask: Optional[torch.Tensor]) -> torch.Tensor:
-    """Pool the last non-padding token representation (used for sequence classification)."""
-    if attention_mask is None:
-        return hidden[:, -1, :]
-    token_counts = (attention_mask.long().sum(dim=1) - 1).clamp(min=0)
-    batch_idx = torch.arange(hidden.size(0), device=hidden.device)
-    return hidden[batch_idx, token_counts]
 
 
 # ------------------------------------------------------------------------------------------------------------- tuner

--- a/tests/test_shadow.py
+++ b/tests/test_shadow.py
@@ -29,7 +29,7 @@ from transformers import (
     LlamaConfig,
     LlamaModel,
 )
-from transformers.modeling_outputs import SequenceClassifierOutput
+from transformers.modeling_outputs import BaseModelOutput, SequenceClassifierOutput
 
 from peft import (
     PeftModel,
@@ -496,6 +496,57 @@ class TestShadowSequenceClassification:
         model = get_peft_model(make_llama_seqcls(num_labels=3), ShadowConfig(task_type="SEQ_CLS"))
         trainable = {n for n, p in model.named_parameters() if p.requires_grad}
         assert any("shadow_head" in n for n in trainable)
+
+    def test_classification_pooling_respects_padding_side(self, monkeypatch):
+        # Regression test for https://github.com/huggingface/peft/issues/3620.
+        config = LlamaConfig(
+            vocab_size=32,
+            hidden_size=8,
+            intermediate_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            num_labels=3,
+        )
+        base = AutoModelForSequenceClassification.from_config(config)
+        model = get_peft_model(
+            base,
+            ShadowConfig(task_type="SEQ_CLS", shadow_num_hidden_layers=1),
+        )
+        tuner = model.base_model
+        tuner.shadow_head["default"] = torch.nn.Identity()
+
+        hidden = torch.arange(24, dtype=torch.float32).reshape(2, 4, 3)
+        labels = torch.tensor([0, 2])
+        detached = tuner.unload_shadow()
+        detached.shadow_hidden_projection = torch.nn.Identity()
+        detached.head = torch.nn.Identity()
+        monkeypatch.setattr(
+            detached.backbone,
+            "forward",
+            lambda *args, **kwargs: BaseModelOutput(last_hidden_state=hidden),
+        )
+
+        cases = (
+            (torch.tensor([[0, 0, 1, 1], [0, 1, 1, 1]]), torch.tensor([3, 3])),
+            (torch.tensor([[1, 1, 0, 0], [1, 1, 1, 0]]), torch.tensor([1, 2])),
+            (torch.tensor([[0, 0, 0, 0], [1, 1, 1, 1]]), torch.tensor([0, 3])),
+            (None, torch.tensor([3, 3])),
+        )
+        batch_idx = torch.arange(hidden.shape[0])
+        for attention_mask, expected_indices in cases:
+            expected_logits = hidden[batch_idx, expected_indices]
+
+            tuner._seed_shadow_state = hidden
+            actual_loss = tuner.shadow_auxiliary_loss(labels, attention_mask=attention_mask)
+            expected_loss = torch.nn.functional.cross_entropy(expected_logits, labels)
+            torch.testing.assert_close(actual_loss, expected_loss)
+
+            output = detached(
+                inputs_embeds=torch.zeros(2, 4, config.hidden_size),
+                attention_mask=attention_mask,
+            )
+            torch.testing.assert_close(output.logits, expected_logits)
 
     def test_unload_shadow_is_a_classifier(self):
         # For SEQ_CLS the standalone shadow model pools the last token and returns per-example class logits (not


### PR DESCRIPTION
Fixes #3620.

## Summary

ShadowPEFT sequence classification derived the pooled index from the number of valid tokens. That selects the correct token for right padding, but it can select a padding position when valid tokens are left padded.

This change selects the rightmost non-padding position instead. A shared functional helper now owns the pooling rule used by both the auxiliary training loss and `DetachedShadowModel`, which keeps training and standalone inference consistent. The existing behavior for right padding, an all-padding row, and a missing attention mask remains unchanged.

## Coordination

- Issue discussion: https://github.com/huggingface/peft/issues/3620
- Maintainer approval: https://github.com/huggingface/peft/issues/3620#issuecomment-5476438684

## Tests

- `ruff check src/peft/tuners/shadow/layers.py src/peft/tuners/shadow/model.py tests/test_shadow.py` passed with Ruff 0.16.4.
- `ruff format --check src/peft/tuners/shadow/layers.py src/peft/tuners/shadow/model.py tests/test_shadow.py` passed with Ruff 0.16.4.
- `git diff --check` passed.
- `pytest tests/test_shadow.py -k classification_pooling_respects_padding_side -v` was not run locally because this checkout has no compatible Torch test environment. The focused regression is included for CI validation.

## AI assistance

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.

The contributor reviewed every changed line. The focused runtime regression remains for CI validation.
