### PR TITLE
TST Accelerate mixed adapter batches tests

### DIFF
--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -873,6 +873,18 @@ class PeftCommonTester:
         dummy_input = self.prepare_inputs_for_testing()
         # ensure that we have at least 3 samples for this test
         dummy_input = {k: torch.cat([v for _ in range(3)]) for k, v in dummy_input.items()}
+
+        # Run with mixed adapter batches first: layers that don't support the feature raise immediately, sparing us the
+        # reference outputs below whose results would never be used.
+        # Alternate between base model, adapter0, and adapter1
+        adapters = ["__base__", "adapter0", "adapter1"]
+        adapter_names = [adapters[i % 3] for i in (range(len(dummy_input["input_ids"])))]
+        with torch.inference_mode():
+            output_mixed = model(**dummy_input, adapter_names=adapter_names)[0]
+            logits_mixed = model.generate(
+                **dummy_input, adapter_names=adapter_names, return_dict_in_generate=True, output_scores=True
+            ).scores[0]
+
         with torch.inference_mode(), model.disable_adapter():
             output_base = model(**dummy_input)[0]
             logits_base = model.generate(**dummy_input, return_dict_in_generate=True, output_scores=True).scores[0]
@@ -897,13 +909,6 @@ class PeftCommonTester:
         assert not torch.allclose(logits_base, logits_adapter0, atol=atol, rtol=rtol)
         assert not torch.allclose(logits_base, logits_adapter1, atol=atol, rtol=rtol)
         assert not torch.allclose(logits_adapter0, logits_adapter1, atol=atol, rtol=rtol)
-
-        # alternate between base model, adapter0, and adapter1
-        adapters = ["__base__", "adapter0", "adapter1"]
-        dummy_input["adapter_names"] = [adapters[i % 3] for i in (range(len(dummy_input["input_ids"])))]
-        with torch.inference_mode():
-            output_mixed = model(**dummy_input)[0]
-            logits_mixed = model.generate(**dummy_input, return_dict_in_generate=True, output_scores=True).scores[0]
 
         assert torch.allclose(output_base[::3], output_mixed[::3], atol=atol, rtol=rtol)
         assert torch.allclose(output_adapter0[1::3], output_mixed[1::3], atol=atol, rtol=rtol)
@@ -948,7 +953,18 @@ class PeftCommonTester:
             dummy_input = self.prepare_inputs_for_testing()
             # ensure that we have at least 3 samples for this test
             dummy_input = {k: torch.cat([v for _ in range(3)]) for k, v in dummy_input.items()}
-            gen_kwargs = {**dummy_input, "max_length": 20, "num_beams": 10, "early_stopping": True}
+            # note: don't lower num_beams and max_length too much, or else the generations of different adapters could
+            # coincidentally be identical, tripping up the sanity checks below
+            gen_kwargs = {**dummy_input, "max_length": 15, "num_beams": 4, "early_stopping": True}
+
+            # Generate with mixed adapter batches first: layers that don't support the feature raise immediately,
+            # sparing us the expensive reference generations below whose results would never be used.
+            # Alternate between base model, adapter0, and adapter1
+            adapters = ["__base__", "adapter0", "adapter1"]
+            adapter_names = [adapters[i % 3] for i in (range(len(dummy_input["input_ids"])))]
+            with torch.inference_mode():
+                gen_mixed = model.generate(**gen_kwargs, adapter_names=adapter_names)
+
             with torch.inference_mode(), model.disable_adapter():
                 gen_base = model.generate(**gen_kwargs)
 
@@ -987,13 +1003,6 @@ class PeftCommonTester:
         assert not gens_are_same(gen_base, gen_adapter0)
         assert not gens_are_same(gen_base, gen_adapter1)
         assert not gens_are_same(gen_adapter0, gen_adapter1)
-
-        # alternate between base model, adapter0, and adapter1
-        adapters = ["__base__", "adapter0", "adapter1"]
-        gen_kwargs["adapter_names"] = [adapters[i % 3] for i in (range(len(dummy_input["input_ids"])))]
-
-        with torch.inference_mode():
-            gen_mixed = model.generate(**gen_kwargs)
 
         assert gens_are_same(gen_base[::3], gen_mixed[::3])
         assert gens_are_same(gen_adapter0[1::3], gen_mixed[1::3])


### PR DESCRIPTION
The mixed adapter batches tests are relatively slow on CI, especially with MoE models. They constitute 4 out of the 5 slowest tests, with ~100 sec total:

```
27.26s call     tests/test_target_parameters.py::TestDecoderModelsTargetParameters::test_generate_with_mixed_adapter_batches[trl-internal-testing/tiny-GptOssForCausalLM-LoraConfig-config_kwargs7]
26.66s call     tests/test_poly.py::TestPoly::test_poly
26.38s call     tests/test_target_parameters.py::TestDecoderModelsTargetParameters::test_generate_with_mixed_adapter_batches[trl-internal-testing/tiny-GptOssForCausalLM-LoraConfig-config_kwargs4]
26.14s call     tests/test_target_parameters.py::TestDecoderModelsTargetParameters::test_generate_with_mixed_adapter_batches[trl-internal-testing/tiny-GptOssForCausalLM-LoraConfig-config_kwargs6]
25.44s call     tests/test_target_parameters.py::TestDecoderModelsTargetParameters::test_generate_with_mixed_adapter_batches[trl-internal-testing/tiny-GptOssForCausalLM-LoraConfig-config_kwargs5]
```

https://github.com/huggingface/peft/actions/runs/33380424434/job/99451723715#step:8:1512

The tests are a bit wasteful right now for MoE LoRA because `target_parameters` does not support this feature, so we check that trying to use it raises an appropriate error. The problem is that before checking that, we first run 3 expensive generate calls, which are not required to check the error.

This PR reorders the generate calls to call with mixed adapter batches first, triggering the error immediately. This is fine, as the order does not affect the results.

In my local testing on CPU, the total test time for this test went down from >90 sec to 30 sec, of which 20 sec are for test discovery.

To help a little more with speeding things up, I also decreased the max length and number of beams.

The `test_mixed_adapter_batches` test was updated too, mainly for consistency.