### PR TITLE
Add HiRA experiment and results to image-gen benchmark

### DIFF
--- a/method_comparison/image-gen/experiments/hira/flux2-klein-default/adapter_config.json
+++ b/method_comparison/image-gen/experiments/hira/flux2-klein-default/adapter_config.json
@@ -1,0 +1,31 @@
+{
+  "auto_mapping": null,
+  "base_model_name_or_path": null,
+  "exclude_modules": null,
+  "fan_in_fan_out": false,
+  "hira_dropout": 0.0,
+  "inference_mode": false,
+  "init_weights": true,
+  "layers_pattern": null,
+  "layers_to_transform": null,
+  "modules_to_save": null,
+  "peft_type": "HIRA",
+  "peft_version": "0.20.1.dev0@UNKNOWN",
+  "r": 32,
+  "rank_pattern": {},
+  "revision": null,
+  "target_modules": [
+    "linear_out",
+    "add_v_proj",
+    "to_qkv_mlp_proj",
+    "to_out.0",
+    "linear_in",
+    "add_k_proj",
+    "add_q_proj",
+    "to_add_out",
+    "to_k",
+    "to_v",
+    "to_q"
+  ],
+  "task_type": null
+}


### PR DESCRIPTION
Adds a HiRA experiment (`flux2-klein-default` setup) to the image-gen benchmark. `target_modules` match the existing LoRA/OFT/BEFT configs for a fair comparison.

Full reasoning, setup, and results comparison discussed in [#3522](https://github.com/huggingface/peft/discussions/3522).

Summary: HiRA matches LoRA's exact trainable parameter budget (38,338,560, r=32) but scores lower on subject fidelity (DINOv2 0.5550 vs ~0.70 for LoRA) while showing notably lower drift (0.1454 vs ~0.262). The runtime overhead vs LoRA is real and hardware-independent — confirmed with a same-GPU LoRA rerun, HiRA is ~2.78x slower, consistent with its Hadamard-product formulation needing to materialize a full d×k update matrix rather than chaining low-rank matmuls the way LoRA does. The validation curve doesn't look converged at 750 steps, so part of the quality gap may be a training-budget artifact rather than a hard ceiling — flagged as an open question, with a learning-rate follow-up planned per [@BenjaminBossan](https://github.com/BenjaminBossan)'s suggestion that HiRA might need a higher LR than the shared default.

Files:

* `method_comparison/image-gen/experiments/hira/flux2-klein-default/adapter_config.json`
* `method_comparison/image-gen/results/hira--flux2-klein-default.json`
* `method_comparison/image-gen/sample-images/results/hira--flux2-klein-default_01.png`, `_02.png`, `_03.png`, `_04.png`, `_05.png`

Context: [#3522](https://github.com/huggingface/peft/discussions/3522)

Results:

* DINOv2 cosine similarity: 0.5550
* Drift: 0.1454
* Max memory reserved: 10914 MB
* Runtime: ~53.8 mins (3229.4 seconds)
* Adapter checkpoint size: 146.3 MB (38,338,560 trainable params, same as LoRA)

[hira--flux2-klein-default.json](https://github.com/user-attachments/files/31700025/hira--flux2-klein-default.json)

<img width="512" height="512" alt="hira--flux2-klein-default_01" src="https://github.com/user-attachments/assets/7dd39658-b382-449b-bfc6-f50897d359a4" />
<img width="512" height="512" alt="hira--flux2-klein-default_02" src="https://github.com/user-attachments/assets/599c0b74-f872-4095-b236-876713fa8dbe" />
<img width="512" height="512" alt="hira--flux2-klein-default_03" src="https://github.com/user-attachments/assets/a724afa7-86d1-4dd1-9ba6-c9aee7a780eb" />
<img width="512" height="512" alt="hira--flux2-klein-default_04" src="https://github.com/user-attachments/assets/696952a3-d98a-41ef-94b4-99f8ed0937c2" />
<img width="512" height="512" alt="hira--flux2-klein-default_05" src="https://github.com/user-attachments/assets/13bf001b-c272-4726-9d32-c5beb5fb0f05" />
