### PR TITLE
FIX State dict round trip for directly injected shared tuners

### DIFF
--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -74,6 +74,8 @@ def inject_adapter_in_model(
             checkpoint was created without meta data. Note that the values from the `state_dict` are not used, only the
             keys are used to determine the correct layers that should be adapted.
     """
+    from .tuners.tuners_utils import _register_injected_tuner  # lazy import to avoid a circular import
+
     if (
         peft_config.is_prompt_learning
         or peft_config.is_adaption_prompt
@@ -92,5 +94,9 @@ def inject_adapter_in_model(
     peft_model = tuner_cls(
         model, peft_config, adapter_name=adapter_name, low_cpu_mem_usage=low_cpu_mem_usage, state_dict=state_dict
     )
+    # Only the wrapped model is returned here, but some PEFT methods keep model-level adapter state that is shared
+    # between the injected layers on the tuner (e.g. vera_A/vera_B of VeRA). Remember the tuner on the model, as this
+    # state could otherwise not be found anymore when saving and loading the adapter, see #3631.
+    _register_injected_tuner(peft_model.model, adapter_name, peft_model)
 
     return peft_model.model

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -1582,7 +1582,10 @@ class BaseTuner(nn.Module, ABC):
         prefixes = _get_tuner_state_dict_key_prefixes(model, adapter_name=adapter_name)
         checkpoint_key_to_model_key = {}
         peft_prefix = "base_model.model."
-        for model_key in _filter_state_dict_by_key_prefixes(model.state_dict(), prefixes):
+        model_state_dict = _filter_state_dict_by_key_prefixes(model.state_dict(), prefixes)
+        # the model-level adapter state of a directly injected adapter is not part of model.state_dict()
+        model_state_dict.update(_get_injected_tuner_state_dict(model, adapter_name))
+        for model_key in model_state_dict:
             # create the reverse mapping
             checkpoint_key = cls._remove_adapter_name_from_key(model_key, adapter_name)
             checkpoint_key_to_model_key[checkpoint_key] = model_key
@@ -1668,6 +1671,83 @@ class BasePromptEncoder(torch.nn.Module):
     def _load_adapter_state_dict(self, state_dict: dict[str, torch.Tensor]) -> None:
         """Load the checkpoint state_dict (as returned by `_get_adapter_state_dict`) into this prompt encoder."""
         self.embedding.load_state_dict({"weight": state_dict["prompt_embeddings"]}, strict=True)
+
+
+# Attribute under which `inject_adapter_in_model` stores the tuners it created, mapping the adapter name to the tuner.
+# It is set on the instance dict directly so that the tuners are not registered as submodules of the model, which would
+# result in the model containing itself (the tuner wraps the model in turn).
+_INJECTED_TUNERS_ATTR = "_peft_injected_tuners"
+
+
+def _register_injected_tuner(model: nn.Module, adapter_name: str, tuner: BaseTuner) -> None:
+    """Remember the tuner that injected the adapter of the given name into the model.
+
+    PEFT methods can keep model-level adapter state that is shared between the injected layers on the tuner itself
+    (e.g. `vera_A`/`vera_B` of VeRA). `inject_adapter_in_model` only returns the wrapped model, so without this
+    reference that state could no longer be found when saving and loading the adapter, see
+    `_get_injected_tuner_state_dict`.
+    """
+    tuners = model.__dict__.setdefault(_INJECTED_TUNERS_ATTR, {})
+    tuners[adapter_name] = tuner
+
+
+def _get_injected_tuner(model: nn.Module, adapter_name: str) -> Optional[BaseTuner]:
+    """Return the tuner that injected the adapter of the given name, or `None` if the adapter was not injected
+    directly, e.g. because the model is a `PeftModel`.
+
+    The lookup is performed on the instance dict instead of using `getattr`, since both `PeftModel` and `BaseTuner`
+    forward unknown attributes to the model they wrap, which would return the tuners of that model instead.
+    """
+    return model.__dict__.get(_INJECTED_TUNERS_ATTR, {}).get(adapter_name)
+
+
+def _get_injected_tuner_state_dict(model: nn.Module, adapter_name: str) -> dict[str, torch.Tensor]:
+    """Return the model-level adapter state of a directly injected adapter, keyed like a `PeftModel` state dict.
+
+    The model-level containers of a PEFT method are registered on the `BaseTuner` (e.g. `vera_A`/`vera_B` of VeRA),
+    which is `PeftModel.base_model` for a wrapped model but is not part of the module tree of a directly injected
+    model. Their entries are thus missing from `model.state_dict()` in the latter case, even though the state dict
+    hooks of the PEFT methods expect them under the `"base_model."` prefix. Returning them here allows those hooks to
+    work the same way for both, see `_load_injected_tuner_state_dict` for the counterpart used when loading.
+
+    Returns an empty dict if the adapter was not injected directly, as the entries are already part of
+    `model.state_dict()` then.
+    """
+    tuner = _get_injected_tuner(model, adapter_name)
+    if tuner is None:
+        return {}
+
+    to_return = {}
+    for name, module in tuner.named_children():
+        if name == "model":
+            # skip the wrapped model, whose state dict the caller already has
+            continue
+        to_return.update({f"base_model.{name}.{key}": value for key, value in module.state_dict().items()})
+    return to_return
+
+
+def _load_injected_tuner_state_dict(
+    model: nn.Module, adapter_name: str, state_dict: dict[str, torch.Tensor], assign: bool = False
+) -> tuple[list[str], list[str]]:
+    """Load the model-level adapter state of a directly injected adapter, the counterpart of
+    `_get_injected_tuner_state_dict`.
+
+    These entries cannot be loaded via `model.load_state_dict`, as they belong to the tuner and not to the model.
+    Returns the missing and unexpected keys so that they can be reported together with those of the model.
+    """
+    tuner = _get_injected_tuner(model, adapter_name)
+    if tuner is None:
+        return [], list(state_dict)
+
+    prefix = "base_model."
+    load_result = tuner.load_state_dict(
+        {k.removeprefix(prefix): v for k, v in state_dict.items()}, strict=False, assign=assign
+    )
+    # the tuner wraps the model, so all base model keys are reported as missing here; they are irrelevant, as they are
+    # covered by loading the state dict into the model itself
+    missing_keys = [f"{prefix}{k}" for k in load_result.missing_keys if not k.startswith("model.")]
+    unexpected_keys = [f"{prefix}{k}" for k in load_result.unexpected_keys]
+    return missing_keys, unexpected_keys
 
 
 def _remove_adapter_name_from_state_dict_key(key: str, adapter_name: str) -> str:

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -123,12 +123,19 @@ def get_peft_model_state_dict(
             sets the boolean flag. This only works for 🤗 transformers models.
 
     """
+    from peft.tuners.tuners_utils import _get_injected_tuner_state_dict  # lazy import to avoid a circular import
+
     if unwrap_compiled:
         model = getattr(model, "_orig_mod", model)
 
     config = model.peft_config[adapter_name]
     if state_dict is None:
         state_dict = model.state_dict()
+
+    # ADD THE MODEL-LEVEL ADAPTER STATE OF A DIRECTLY INJECTED ADAPTER
+    # It lives on the tuner and is thus not part of the state dict of the model. Add it here so that the tuner specific
+    # code below sees the same keys as it does for a PeftModel.
+    state_dict = {**_get_injected_tuner_state_dict(model, adapter_name), **state_dict}
 
     # FILTER FOR ADAPTER NAME
     unwanted_adapter_names = [name for name in model.peft_config if name != adapter_name]
@@ -284,13 +291,18 @@ def get_peft_model_state_dict(
 
 
 def _find_mismatched_keys(
-    model: torch.nn.Module, peft_model_state_dict: dict[str, torch.Tensor], ignore_mismatched_sizes: bool = False
+    model: torch.nn.Module,
+    peft_model_state_dict: dict[str, torch.Tensor],
+    ignore_mismatched_sizes: bool = False,
+    reference_state_dict: Optional[dict[str, torch.Tensor]] = None,
 ) -> tuple[dict[str, torch.Tensor], list[tuple[str, tuple[int, ...], tuple[int, ...]]]]:
     if not ignore_mismatched_sizes:
         return peft_model_state_dict, []
 
     mismatched = []
-    state_dict = model.state_dict()
+    # the entries to compare against are taken from the model, unless they are not part of its state dict, as is the
+    # case for the model-level adapter state of a directly injected adapter
+    state_dict = model.state_dict() if reference_state_dict is None else reference_state_dict
     for key, tensor in peft_model_state_dict.items():
         if key not in state_dict:
             continue
@@ -485,6 +497,9 @@ def set_peft_model_state_dict(
             A named tuple with `missing_keys` and `unexpected_keys` fields.
 
     """
+    # lazy imports to avoid a circular import
+    from peft.tuners.tuners_utils import _get_injected_tuner_state_dict, _load_injected_tuner_state_dict
+
     config = model.peft_config[adapter_name]
     state_dict = peft_model_state_dict.copy()
     if config.peft_type not in PEFT_TYPE_TO_TUNER_MAPPING:
@@ -539,9 +554,23 @@ def set_peft_model_state_dict(
     if not requires_prefix:
         peft_model_state_dict = {k.removeprefix(prefix): v for k, v in peft_model_state_dict.items()}
 
+    # The model-level adapter state of a directly injected adapter belongs to the tuner and not to the model, so it
+    # cannot be loaded via model.load_state_dict below and is loaded separately further down.
+    injected_tuner_state_dict = _get_injected_tuner_state_dict(model, adapter_name)
+    tuner_state_dict = {k: v for k, v in peft_model_state_dict.items() if k in injected_tuner_state_dict}
+    if tuner_state_dict:
+        peft_model_state_dict = {k: v for k, v in peft_model_state_dict.items() if k not in tuner_state_dict}
+
     peft_model_state_dict, mismatched_keys = _find_mismatched_keys(
         model, peft_model_state_dict, ignore_mismatched_sizes=ignore_mismatched_sizes
     )
+    tuner_state_dict, tuner_mismatched_keys = _find_mismatched_keys(
+        model,
+        tuner_state_dict,
+        ignore_mismatched_sizes=ignore_mismatched_sizes,
+        reference_state_dict=injected_tuner_state_dict,
+    )
+    mismatched_keys.extend(tuner_mismatched_keys)
     if low_cpu_mem_usage:
         load_result = model.load_state_dict(peft_model_state_dict, strict=False, assign=True)
         # ensure that the correct device is set
@@ -550,6 +579,13 @@ def set_peft_model_state_dict(
                 module._move_adapter_to_device_of_base_layer(adapter_name)
     else:
         load_result = model.load_state_dict(peft_model_state_dict, strict=False)
+
+    if tuner_state_dict:
+        missing_keys, unexpected_keys = _load_injected_tuner_state_dict(
+            model, adapter_name, tuner_state_dict, assign=low_cpu_mem_usage
+        )
+        load_result.missing_keys.extend(missing_keys)
+        load_result.unexpected_keys.extend(unexpected_keys)
 
     if config.is_prompt_learning:
         # The state of prompt learning methods lives on the prompt encoder, so it is not covered by

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -30,10 +30,16 @@ from transformers import (
 
 from peft import (
     AdaLoraConfig,
+    FrodConfig,
     IA3Config,
     LoKrConfig,
     LoraConfig,
+    PveraConfig,
     RandLoraConfig,
+    TinyLoraConfig,
+    UniLoraConfig,
+    VBLoRAConfig,
+    VeraConfig,
     get_base_model_state_dict,
     get_peft_model,
     get_peft_model_state_dict,
@@ -804,6 +810,218 @@ class TestPeftStateDict:
 
         assert tuple(state_dict) == keys_before
         assert all(state_dict[key] is value for key, value in values_before.items())
+
+
+class TestInjectedSharedTunerStateDict:
+    # Some PEFT methods keep model-level adapter state that is shared between the adapted layers on the tuner (e.g.
+    # vera_A/vera_B of VeRA) instead of on the layers themselves. For a model wrapped in a PeftModel, the tuner is
+    # PeftModel.base_model and this state is part of the model state_dict, but inject_adapter_in_model only returns the
+    # wrapped model. See #3631, where saving such an adapter either dropped this state silently or raised.
+    #
+    # The keys below are the model-level keys that the checkpoint must contain, i.e. those that used to be missing.
+    shared_tuner_configs = {
+        "tinylora": (
+            {"r": 2, "u": 16},
+            TinyLoraConfig,
+            ["base_model.tinylora_v.0"],
+        ),
+        "unilora": (
+            {"theta_d_length": 101},
+            UniLoraConfig,
+            ["base_model.unilora_theta_d"],
+        ),
+        "vera": ({}, VeraConfig, ["base_model.vera_A", "base_model.vera_B"]),
+        "pvera": ({}, PveraConfig, ["base_model.pvera_A", "base_model.pvera_B"]),
+        "vblora": (
+            {"vector_length": 2, "num_vectors": 5},
+            VBLoRAConfig,
+            ["base_model.vblora_vector_bank"],
+        ),
+        "frod": (
+            {"init_weights": False, "progressbar": False},
+            FrodConfig,
+            ["base_model.frod_V.lin0", "base_model.frod_s_indices.lin0", "base_model.frod_s_size.lin0"],
+        ),
+    }
+
+    @pytest.fixture
+    def x(self):
+        return torch.randn(3, 8)
+
+    def get_config(self, method, **kwargs):
+        config_kwargs, config_cls, _ = self.shared_tuner_configs[method]
+        return config_cls(target_modules=["lin0", "lin1"], **{**config_kwargs, **kwargs})
+
+    def get_model(self):
+        class MyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin0 = nn.Linear(8, 8)
+                self.lin1 = nn.Linear(8, 8)
+
+            def forward(self, x):
+                return self.lin1(self.lin0(x))
+
+        return MyModel()
+
+    def inject(self, method, seed=0, adapter_name="default", **kwargs):
+        # Returns a model with the adapter injected directly, with the adapter weights initialized from the given seed
+        # so that two models with different seeds are guaranteed to produce different outputs.
+        torch.manual_seed(0)
+        model = self.get_model()
+        torch.manual_seed(seed)
+        model = inject_adapter_in_model(self.get_config(method, **kwargs), model, adapter_name=adapter_name)
+        with torch.no_grad():
+            for param in model.parameters():
+                if param.requires_grad:
+                    param.add_(seed + 1)
+        return model.eval()
+
+    @pytest.mark.parametrize("method", list(shared_tuner_configs))
+    def test_injected_shared_tuner_state_dict_round_trip(self, method, x):
+        # The main regression test for #3631: saving must include the model-level adapter state and loading it into
+        # another injected model must restore the outputs.
+        source = self.inject(method, seed=0)
+        with torch.inference_mode():
+            source_out = source(x)
+
+        state_dict = get_peft_model_state_dict(source)
+        _, _, expected_keys = self.shared_tuner_configs[method]
+        assert set(expected_keys).issubset(state_dict)
+
+        target = self.inject(method, seed=1)
+        with torch.inference_mode():
+            # sanity check: without loading, the two models disagree
+            assert not torch.allclose(source_out, target(x))
+
+        result = set_peft_model_state_dict(target, state_dict)
+        assert not result.unexpected_keys
+        assert not [key for key in result.missing_keys if key in state_dict]
+
+        with torch.inference_mode():
+            assert torch.allclose(source_out, target(x))
+
+    @pytest.mark.parametrize("method", list(shared_tuner_configs))
+    def test_injected_shared_tuner_state_dict_matches_wrapper(self, method):
+        # The model-level keys of a directly injected adapter must be the same as those of the PeftModel wrapper, which
+        # is what makes the checkpoints of the two compatible.
+        injected_sd = get_peft_model_state_dict(self.inject(method))
+        torch.manual_seed(0)
+        wrapped_sd = get_peft_model_state_dict(get_peft_model(self.get_model(), self.get_config(method)))
+
+        # only the model-level keys can be compared: the keys of the adapted layers carry the "base_model.model."
+        # prefix of the PeftModel wrapper, which a directly injected model does not have
+        def model_level_keys(state_dict):
+            return {key for key in state_dict if key.startswith("base_model.") and "base_model.model." not in key}
+
+        assert model_level_keys(injected_sd) == model_level_keys(wrapped_sd)
+        assert model_level_keys(injected_sd)  # sanity check
+
+    @pytest.mark.parametrize("method", list(shared_tuner_configs))
+    def test_injected_shared_tuner_state_dict_round_trip_non_default_adapter_name(self, method, x):
+        # Same as the round trip above but with an adapter name other than "default", as the model-level keys contain
+        # the adapter name and it must be removed from and added back to the checkpoint keys correctly.
+        adapter_name = "other"
+        source = self.inject(method, seed=0, adapter_name=adapter_name)
+        with torch.inference_mode():
+            source_out = source(x)
+
+        state_dict = get_peft_model_state_dict(source, adapter_name=adapter_name)
+        assert not any(adapter_name in key for key in state_dict)
+
+        target = self.inject(method, seed=1, adapter_name=adapter_name)
+        result = set_peft_model_state_dict(target, state_dict, adapter_name=adapter_name)
+        assert not result.unexpected_keys
+
+        with torch.inference_mode():
+            assert torch.allclose(source_out, target(x))
+
+    # the methods whose model-level state are the projections that save_projection=False makes non-persistent
+    @pytest.mark.parametrize("method", ["vera", "pvera", "frod"])
+    def test_injected_shared_tuner_save_projection_false(self, method, recwarn):
+        # With save_projection=False, the projections are registered as non-persistent buffers and are regenerated
+        # instead of being loaded, so they must not end up in the checkpoint of a directly injected adapter either.
+        source = self.inject(method, seed=0, save_projection=False)
+        state_dict = get_peft_model_state_dict(source)
+
+        _, _, projection_keys = self.shared_tuner_configs[method]
+        assert not set(projection_keys) & set(state_dict)
+
+        target = self.inject(method, seed=1, save_projection=False)
+        result = set_peft_model_state_dict(target, state_dict)
+        assert not result.unexpected_keys
+
+    @pytest.mark.parametrize("method", list(shared_tuner_configs))
+    def test_injected_shared_tuner_missing_model_level_key_is_reported(self, method, recwarn):
+        # A checkpoint that lacks the model-level adapter state must not be loaded silently: either the entry is
+        # reported as missing or the PEFT method rejects the checkpoint outright.
+        source = self.inject(method, seed=0)
+        state_dict = get_peft_model_state_dict(source)
+        _, _, expected_keys = self.shared_tuner_configs[method]
+        for key in expected_keys:
+            del state_dict[key]
+
+        target = self.inject(method, seed=1)
+        try:
+            result = set_peft_model_state_dict(target, state_dict)
+        except ValueError as exc:  # VeRA, PVeRA and FRoD reject a checkpoint without projections
+            assert "not present" in str(exc)
+        else:
+            # the shared containers are registered on the adapted layers too, so they are reported as missing there
+            attr_name = expected_keys[0].split(".")[1]
+            assert any(f".{attr_name}." in key for key in result.missing_keys)
+
+    @pytest.mark.parametrize("method", list(shared_tuner_configs))
+    def test_injected_shared_tuner_unknown_model_level_key_is_reported(self, method):
+        # An entry that does not correspond to any model-level adapter state must be reported as unexpected instead of
+        # being routed to the tuner silently.
+        source = self.inject(method, seed=0)
+        state_dict = get_peft_model_state_dict(source)
+        state_dict["base_model.does_not_exist"] = torch.zeros(3)
+
+        result = set_peft_model_state_dict(self.inject(method, seed=1), state_dict)
+        assert "base_model.does_not_exist" in result.unexpected_keys
+
+    @pytest.mark.parametrize("method", list(shared_tuner_configs))
+    def test_injected_shared_tuner_ignore_mismatched_sizes(self, method):
+        # With ignore_mismatched_sizes=True, a model-level entry whose shape does not fit the model must be skipped
+        # with a warning instead of making the load fail, same as for the entries of the adapted layers.
+        source = self.inject(method, seed=0)
+        state_dict = get_peft_model_state_dict(source)
+        _, _, expected_keys = self.shared_tuner_configs[method]
+        for key in expected_keys:
+            state_dict[key] = torch.zeros(2, 3)
+
+        target = self.inject(method, seed=1)
+        with pytest.warns(UserWarning, match="ignored because you passed `ignore_mismatched_sizes=True`"):
+            result = set_peft_model_state_dict(target, state_dict, ignore_mismatched_sizes=True)
+        assert not result.unexpected_keys
+
+    def test_injected_adapter_without_model_level_state_unchanged(self, x):
+        # Control group: a PEFT method that keeps all of its state on the layers must not gain any model-level keys.
+        config = LoraConfig(target_modules=["lin0", "lin1"], init_lora_weights=False)
+
+        def inject_lora(seed):
+            torch.manual_seed(0)
+            model = self.get_model()
+            torch.manual_seed(seed)
+            return inject_adapter_in_model(config, model).eval()
+
+        source = inject_lora(seed=0)
+        with torch.inference_mode():
+            source_out = source(x)
+
+        state_dict = get_peft_model_state_dict(source)
+        assert not any(key.startswith("base_model.") for key in state_dict)
+
+        target = inject_lora(seed=1)
+        with torch.inference_mode():
+            assert not torch.allclose(source_out, target(x))  # sanity check
+
+        result = set_peft_model_state_dict(target, state_dict)
+        assert not result.unexpected_keys
+        with torch.inference_mode():
+            assert torch.allclose(source_out, target(x))
 
 
 class TestGetBaseModelStateDict:


### PR DESCRIPTION
Resolves #3631.

## The bug

Some PEFT methods keep adapter state that is *shared between the adapted layers* on the `BaseTuner` rather than on the layers. For a `PeftModel` the tuner is `PeftModel.base_model`, so that state shows up in the model state dict as `base_model.vera_A.<adapter>` etc., which is exactly the key the state dict hooks of those methods look up.

`inject_adapter_in_model` builds the same tuner but returns `peft_model.model`, so the returned model has no `base_model` node and those entries are missing from `model.state_dict()`. Saving a directly injected adapter therefore breaks, differently per method:

| method | `get_peft_model_state_dict` on an injected model |
| --- | --- |
| TinyLoRA | `tinylora_v` silently missing from the checkpoint |
| UniLoRA | `KeyError: "Expected UniLora parameter 'base_model.unilora_theta_d' ..."` |
| VeRA / PVeRA | `ValueError: Model was initialised to not save vera_A and vera_B ...` |
| VB-LoRA | `KeyError: 'base_model.vblora_vector_bank'` |
| FRoD | projections silently missing, the later load raises the projection-missing `ValueError` |

Where it fails silently the round trip changes the model output (0.85 in the report, 33.6 in my repro — it depends on the adapter weights). `get_peft_model` is unaffected.

## The fix

`inject_adapter_in_model` now remembers the tuner on the model it returns, and the state dict functions use it to fill in the model-level entries under the same `base_model.` prefix that the wrapper produces. **The per-method hooks are unchanged** and both paths now write the same model-level keys, so the checkpoints stay compatible.

The reference is kept in the instance `__dict__` so the tuner is not registered as a submodule — that would make the model contain itself, since the tuner wraps the model in turn. It is read back from `__dict__` rather than with `getattr`, because `PeftModel` and `BaseTuner` both forward unknown attributes to the model they wrap. `_get_injected_tuner_state_dict` returns `{}` for anything that is not a directly injected model, so the `get_peft_model` path is untouched.

`_find_mismatched_keys` gained an optional `reference_state_dict` so that `ignore_mismatched_sizes=True` also covers these entries instead of letting `load_state_dict` raise.

I first tried fixing the six hooks individually, i.e. falling back to the layer-scoped copy of the shared container. That does not work for FRoD, which deliberately keeps its projection buffers off the layers (`_set_shared_projection_buffers` uses `object.__setattr__`), so for FRoD they are not reachable from the returned model at all. It would also need a matching inverse in each `_remap_adapter_state_dict_for_load`, and the next method with shared state would hit the same bug again.

## Not addressed here

A checkpoint saved from an injected model still has no `base_model.model.` prefix on the keys of the adapted layers, so loading one into a `PeftModel` leaves those unexpected. That is pre-existing and not specific to these methods — it reproduces with plain LoRA on `main` — so I left it alone. The other direction (wrapper checkpoint into an injected model) works before and after.

## Tests

New `TestInjectedSharedTunerStateDict` in `tests/test_low_level_api.py`, parametrized over the six methods (40 tests): round trip, key parity with `get_peft_model`, non-default adapter name, `save_projection=False`, a missing model-level key, an unknown `base_model.*` key, `ignore_mismatched_sizes`, plus a LoRA control group that must gain no model-level keys.

With `src/peft` reverted and the tests kept: **29 failed, 5 passed**. With the fix: **40 passed**. The 5 that pass either way are the LoRA control group and the `save_projection=False` cases, which were already correct.

No regressions (CPU, torch 2.12.1, Python 3.11, Windows):

```
tests/test_custom_models.py                              17009 passed, 1738 skipped
tests/test_low_level_api.py + test_initialization.py       438 passed, 36 skipped, 3 xfailed
9 more suites (tuners_utils, mapping, other, mixed, ...)   462 passed, 22 skipped
tests/test_{vera,pvera,vblora,unilora,frod}.py              53 passed
```

`make quality` passes (`ruff check`, `ruff format --check`, `doc-builder style --check_only`, `check_doc_coverage.py`).

Also checked by hand that the reference does not misbehave elsewhere: `deepcopy` (the copy owns its own tuner), `torch.save`/`torch.load`, `.to(torch.float64)`, `gc.collect()`, two injected LoRA adapters, `low_cpu_mem_usage=True`, and injected and wrapped models side by side in one process.
