### PR TITLE
fix(tuners_utils): match layers_pattern when nn.ModuleList is at root of model

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -2365,11 +2365,11 @@ def check_target_module_exists(config, key: str) -> bool | re.Match[str] | None:
             if layers_pattern is None or len(layers_pattern) == 0:
                 # Lazy .*? matches the first numbered segment (the layer index), not the last one; a greedy .* would
                 # wrongly pick up nested indices such as the expert index in MoE models ("...layers.1.experts.0...").
-                layer_index = re.match(r".*?\.[^.]*\.(\d+)\.", key)
+                layer_index = re.match(r"(?:^|.*?\.)[^.]*\.(\d+)\.", key)
             else:
                 layers_pattern = [layers_pattern] if isinstance(layers_pattern, str) else layers_pattern
                 for pattern in layers_pattern:
-                    layer_index = re.match(rf".*?\.{pattern}\.(\d+)\.", key)
+                    layer_index = re.match(rf"(?:^|.*?\.){pattern}\.(\d+)\.", key)
                     if layer_index is not None:
                         break
 

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -124,14 +124,13 @@ REGEX_TEST_CASES = [
     # other corner cases. For ex, below is a case where layers_pattern
     # is one of the target nn.modules
     ("foo.bar.1.baz", ["baz"], [1], ["baz"], False),
-    # here, layers_pattern is 'bar', but only keys that contain '.bar' are valid.
-    ("bar.1.baz", ["baz"], [1], ["bar"], False),
+    # here, layers_pattern is 'bar', matching both root-level and prefixed patterns
+    ("bar.1.baz", ["baz"], [1], ["bar"], True),
     ("foo.bar.001.baz", ["baz"], [1], ["bar"], True),
     ("foo.bar.1.spam.2.baz", ["baz"], [1], ["bar"], True),
     ("foo.bar.2.spam.1.baz", ["baz"], [1], ["bar"], False),
-    # some realistic examples: module using nn.Sequential
-    # for the below test case, key should contain '.blocks' to be valid, because of how layers_pattern is matched
-    ("blocks.1.weight", ["weight"], [1], ["blocks"], False),
+    # some realistic examples: module using nn.Sequential or root-level ModuleList
+    ("blocks.1.weight", ["weight"], [1], ["blocks"], True),
     ("blocks.1.bias", ["weight"], [1], ["blocks"], False),
     ("mlp.blocks.1.weight", ["weight"], [1], ["blocks"], True),
     ("mlp.blocks.1.bias", ["weight"], [1], ["blocks"], False),


### PR DESCRIPTION
Fixes #3610

### Problem
When a model structure has the layer list at root (for instance `AutoModel.from_pretrained(...)` producing keys like `layers.0.self_attn.q_proj`), `check_target_module_exists` failed to extract the layer index because the regex `rf".*?\.{pattern}\.(\d+)\."` required a leading dot `\.`.

### Solution
- Updated regex in `check_target_module_exists` to `rf"(?:^|.*?\.){pattern}\.(\d+)\."` (and `r"(?:^|.*?\.)[^.]*\.(\d+)\."` for empty patterns) to support matching both root-level and prefixed `layers_pattern` modules while preserving first-match priority over nested indices.
- Updated regex test cases in `tests/test_tuners_utils.py`.