### PR TITLE
Fix PeftModelFor* docstring examples that fail on removed config fields

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1783,7 +1783,6 @@ class PeftModelForSequenceClassification(PeftModel):
         ...     "num_layers": 12,
         ...     "encoder_hidden_size": 768,
         ...     "prefix_projection": False,
-        ...     "postprocess_past_key_value_function": None,
         ... }
 
         >>> peft_config = get_peft_config(config)
@@ -2031,7 +2030,6 @@ class PeftModelForCausalLM(PeftModel):
         ...     "num_layers": 36,
         ...     "encoder_hidden_size": 1280,
         ...     "prefix_projection": False,
-        ...     "postprocess_past_key_value_function": None,
         ... }
 
         >>> peft_config = get_peft_config(config)
@@ -2371,7 +2369,6 @@ class PeftModelForSeq2SeqLM(PeftModel):
         ...     "lora_alpha": 32,
         ...     "lora_dropout": 0.1,
         ...     "fan_in_fan_out": False,
-        ...     "enable_lora": None,
         ...     "bias": "none",
         ... }
 
@@ -2627,7 +2624,7 @@ class PeftModelForTokenClassification(PeftModel):
     Example:
 
         ```py
-        >>> from transformers import AutoModelForSequenceClassification
+        >>> from transformers import AutoModelForTokenClassification
         >>> from peft import PeftModelForTokenClassification, get_peft_config
 
         >>> config = {
@@ -2641,7 +2638,6 @@ class PeftModelForTokenClassification(PeftModel):
         ...     "num_layers": 12,
         ...     "encoder_hidden_size": 768,
         ...     "prefix_projection": False,
-        ...     "postprocess_past_key_value_function": None,
         ... }
 
         >>> peft_config = get_peft_config(config)


### PR DESCRIPTION
Fixes #3644.

Four of the six `PeftModelFor*` docstring examples in `src/peft/peft_model.py` raise `TypeError` when run as written, because they pass config fields that were removed from the library in 2023:

- `postprocess_past_key_value_function` was removed in `a7dd0347` (2023-02-08). It appears in the `PeftModelForSequenceClassification`, `PeftModelForCausalLM` and `PeftModelForTokenClassification` examples.
- `enable_lora` was removed in `c21afbe8` (2023-03-28). It appears in the `PeftModelForSeq2SeqLM` example.

Running any of the four verbatim gives:

```
TypeError: PrefixTuningConfig.__init__() got an unexpected keyword argument 'postprocess_past_key_value_function'
TypeError: LoraConfig.__init__() got an unexpected keyword argument 'enable_lora'
```

Since all six classes are pulled into the API reference through `[[autodoc]]`, these are the examples a reader copies off the documentation site.

Both fields were deleted rather than renamed, so there is no replacement key to substitute and the lines are simply removed. The keys that remain still describe the configuration each example is demonstrating, so the examples read the same as before.

The `PeftModelForTokenClassification` example had a second problem behind the first one: it imported `AutoModelForSequenceClassification` but then called `AutoModelForTokenClassification`, so it would have failed with a `NameError` even after the config was valid. That import is corrected to match the class the example is about.

Testing:

To confirm the fix covers every example rather than just the four reported, I extracted the config dict out of all six docstrings programmatically and passed each one through `get_peft_config`. Before the change, four raised the `TypeError` above; after it, all six construct:

```
PeftModelForSequenceClassification       OK
PeftModelForCausalLM                     OK
PeftModelForSeq2SeqLM                    OK
PeftModelForTokenClassification          OK
PeftModelForQuestionAnswering            OK
PeftModelForFeatureExtraction            OK
```

Also run:

```
ruff check src/peft/peft_model.py          -> All checks passed!
ruff format --check src/peft/peft_model.py -> 1 file already formatted
./scripts/check_doc_coverage.py            -> 131/131 (100.0%)
pytest tests/test_config.py                -> 1250 passed, 25 failed, 12 skipped
```

The 25 failures are all `AdamssConfig` version/commit-hash tests. They reproduce identically on a clean checkout of `main` in my environment, so they are unrelated to this change.

No library code is touched, only docstrings.
