### PR TITLE
Treat empty base_model_name_or_path as missing when saving adapters

### DIFF
--- a/src/peft/mapping_func.py
+++ b/src/peft/mapping_func.py
@@ -137,7 +137,8 @@ def get_peft_model(
             before training starts.
     """
     old_name = peft_config.base_model_name_or_path
-    new_name = model.__dict__.get("name_or_path", None)
+    # Transformers from-config models use name_or_path == ""; that is not a Hub id.
+    new_name = model.__dict__.get("name_or_path", None) or None
     peft_config.base_model_name_or_path = new_name
 
     # Especially in notebook environments there could be a case that a user wants to experiment with different

--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -376,7 +376,7 @@ class PeftModel(PushToHubMixin, torch.nn.Module):
                     self.base_model.__dict__.get("name_or_path", None)
                     if peft_config.is_prompt_learning
                     else self.base_model.model.__dict__.get("name_or_path", None)
-                )
+                ) or None
             inference_mode = peft_config.inference_mode
             peft_config.inference_mode = True
 

--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -238,7 +238,8 @@ def get_peft_model_state_dict(
         has_base_config = False
 
         # ensure that this check is not performed in HF offline mode, see #1452
-        if model_id is not None:
+        # empty name_or_path (from-config models) is not a Hub repo id
+        if model_id:
             local_config_exists = os.path.exists(os.path.join(model_id, "config.json"))
             exists = local_config_exists or check_file_exists_on_hf_hub(model_id, "config.json")
             if exists is None:

--- a/tests/test_hub_features.py
+++ b/tests/test_hub_features.py
@@ -16,7 +16,7 @@ import copy
 import pytest
 import torch
 from huggingface_hub import ModelCard
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer, GPT2Config, GPT2LMHeadModel
 
 from peft import AutoPeftModelForCausalLM, LoraConfig, PeftConfig, PeftModel, TaskType, get_peft_model
 
@@ -62,6 +62,26 @@ class TestLocalModel:
         peft_model = get_peft_model(base_model, peft_config)
         peft_model.save_pretrained(local_dir)
 
+        for warning in recwarn.list:
+            assert "Could not find a config file" not in warning.message.args[0]
+
+    def test_from_config_model_saving_skips_empty_name_or_path(self, recwarn, tmp_path):
+        # Transformers models built from a config have name_or_path == "". That empty string must not be treated as a
+        # Hub repo id when save_pretrained looks for config.json (see #1452 for the offline Hub lookup).
+        config = GPT2Config(
+            n_layer=1,
+            n_head=2,
+            n_embd=16,
+            n_positions=16,
+            n_ctx=16,
+            vocab_size=32,
+            bos_token_id=1,
+            eos_token_id=2,
+        )
+        peft_model = get_peft_model(GPT2LMHeadModel(config), LoraConfig(task_type=TaskType.CAUSAL_LM, r=4))
+        peft_model.save_pretrained(tmp_path)
+
+        assert peft_model.peft_config["default"].base_model_name_or_path is None
         for warning in recwarn.list:
             assert "Could not find a config file" not in warning.message.args[0]
 


### PR DESCRIPTION
Fixes #3646

## What
Transformers models built from a config have `name_or_path == ""`. PEFT copied that into `base_model_name_or_path`, so `save_pretrained` treated the empty string as a Hub repo id (`if model_id is not None`), looked up `config.json`, and warned `Could not find a config file in  - will assume that the vocabulary was not modified.`

Empty `name_or_path` is now treated as missing (`None`): skip the Hub lookup, do not warn, persist `null`.

## Tests
```
pytest tests/test_hub_features.py::TestLocalModel::test_from_config_model_saving_skips_empty_name_or_path -o addopts=
```
Passed locally on Mac/CPU with a from-config tiny GPT-2 (no GPU, no Hub download).

`ruff==0.16.4` on the four changed files: all checks passed.

I did not run `--regression` here: the related hub test downloads `peft-internal-testing/opt-125m` and this environment hits a SOCKS/`socksio` import error on that path.

## Coordination
Issue: https://github.com/huggingface/peft/issues/3646
This is a new bug report from me, not a claimed existing issue. Happy to adjust if maintainers want a narrower/wider fix.

## AI assistance
This PR was prepared with AI assistance. I reviewed every changed line and ran the test command above.


Made with [Cursor](https://cursor.com)