### PR TITLE
CI Don't install EETQ in Dockerfile as it conflicts with torch 2.14

### DIFF
--- a/docker/peft-gpu/Dockerfile
+++ b/docker/peft-gpu/Dockerfile
@@ -49,11 +49,14 @@ RUN conda run -n peft pip install --no-cache-dir bitsandbytes optimum
 # TODO pcre, which is used by gptqmodel, is resulting in a core dump, remove once it's resolved
 # RUN CUDA_ARCH_LIST=8.9 conda run -n peft pip install "gptqmodel>=7.0.0"
 
-RUN \
+# TODO: EETQ uses `-std=c++17` but starting with PyTorch 2.14, the min C++ version is 20. Therefore, don't install
+# EETQ and let its tests skip. In the future, either EETQ gets updated and we can start testing it again, or
+# remove EETQ support from PEFT completely if it's abandoned.
+# RUN \
     # Add eetq for quantization testing; needs to run without build isolation since the setup
     # script directly imports torch from the environment which would fail with isolation.
     # Ninja should speed up build time.
-    conda run -n peft pip install ninja && conda run -n peft pip install --no-build-isolation git+https://github.com/NetEase-FuXi/EETQ.git
+    # conda run -n peft pip install ninja && conda run -n peft pip install --no-build-isolation git+https://github.com/NetEase-FuXi/EETQ.git
 
 # TODO: Importing TE results in: undefined symbol: cublasLtGroupedMatrixLayoutInit_internal, version libcublasLt.so.13
 # Reinstate TE when the issue is resolved (probably this one: https://github.com/NVIDIA/TransformerEngine/issues/2504)


### PR DESCRIPTION
The GPU [docker build currently fails](https://github.com/huggingface/peft/actions/runs/33703435594/job/100487428358#step:5:3792) because of EETQ. With the new PyTorch 2.14 release, the minimum C++ version is 20:

> Enforce C++20 headers and add safer integer conversions and
borrowed-range support (`#178150, #190092, #186635`)

https://github.com/pytorch/pytorch/releases/tag/v2.14.0

EETQ uses `-std=c++17`

https://github.com/NetEase-FuXi/EETQ/blob/f3476354e1e129bea724aa00e1bcc8756a519de2/setup.py#L110

Comment out the EETQ install to make the Docker build pass. Associated tests should automatically be skipped. If EETQ is updated, we can re-enable the installation. If not, we should deprecate and remove EETQ support.