### PR TITLE
DOC Fix broken docstring examples in peft_model and tuner models

### DIFF
--- a/src/peft/peft_model.py
+++ b/src/peft/peft_model.py
@@ -1783,7 +1783,6 @@ class PeftModelForSequenceClassification(PeftModel):
         ...     "num_layers": 12,
         ...     "encoder_hidden_size": 768,
         ...     "prefix_projection": False,
-        ...     "postprocess_past_key_value_function": None,
         ... }
 
         >>> peft_config = get_peft_config(config)
@@ -2031,7 +2030,6 @@ class PeftModelForCausalLM(PeftModel):
         ...     "num_layers": 36,
         ...     "encoder_hidden_size": 1280,
         ...     "prefix_projection": False,
-        ...     "postprocess_past_key_value_function": None,
         ... }
 
         >>> peft_config = get_peft_config(config)
@@ -2371,7 +2369,6 @@ class PeftModelForSeq2SeqLM(PeftModel):
         ...     "lora_alpha": 32,
         ...     "lora_dropout": 0.1,
         ...     "fan_in_fan_out": False,
-        ...     "enable_lora": None,
         ...     "bias": "none",
         ... }
 
@@ -2627,7 +2624,7 @@ class PeftModelForTokenClassification(PeftModel):
     Example:
 
         ```py
-        >>> from transformers import AutoModelForSequenceClassification
+        >>> from transformers import AutoModelForTokenClassification
         >>> from peft import PeftModelForTokenClassification, get_peft_config
 
         >>> config = {
@@ -2641,7 +2638,6 @@ class PeftModelForTokenClassification(PeftModel):
         ...     "num_layers": 12,
         ...     "encoder_hidden_size": 768,
         ...     "prefix_projection": False,
-        ...     "postprocess_past_key_value_function": None,
         ... }
 
         >>> peft_config = get_peft_config(config)

--- a/src/peft/tuners/beft/model.py
+++ b/src/peft/tuners/beft/model.py
@@ -43,16 +43,15 @@ class BeftModel(BaseTuner):
 
         ```py
         >>> from transformers import AutoModelForSeq2SeqLM
-        >>> from peft import BeftModel, BeftConfig
+        >>> from peft import BeftConfig, get_peft_model
 
         >>> config = BeftConfig(
-        ...     peft_type="Beft",
         ...     task_type="SEQ_2_SEQ_LM",
         ...     target_modules=["v"],
         ... )
 
         >>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-base")
-        >>> beft_model = BeftModel(model, config, adapter_name="default")
+        >>> beft_model = get_peft_model(model, config)
         ```
 
     **Attributes**:

--- a/src/peft/tuners/hira/model.py
+++ b/src/peft/tuners/hira/model.py
@@ -66,7 +66,7 @@ class HiraModel(BaseTuner):
 
         ```py
         >>> from transformers import AutoModelForSeq2SeqLM
-        >>> from peft import HiraModel, HiraConfig
+        >>> from peft import HiraConfig, get_peft_model
 
         >>> config = HiraConfig(
         ...     task_type="SEQ_2_SEQ_LM",
@@ -76,13 +76,13 @@ class HiraModel(BaseTuner):
         ... )
 
         >>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-base")
-        >>> hira_model = HiraModel(model, config, "default")
+        >>> hira_model = get_peft_model(model, config)
         ```
 
         ```py
         >>> import torch
         >>> import transformers
-        >>> from peft import HiraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+        >>> from peft import HiraConfig, get_peft_model, prepare_model_for_kbit_training
 
         >>> rank = ...
         >>> target_modules = ["q_proj", "k_proj", "v_proj", "out_proj", "fc_in", "fc_out", "wte"]

--- a/src/peft/tuners/lora/model.py
+++ b/src/peft/tuners/lora/model.py
@@ -107,7 +107,7 @@ class LoraModel(BaseTuner):
 
         ```py
         >>> from transformers import AutoModelForSeq2SeqLM
-        >>> from peft import LoraModel, LoraConfig
+        >>> from peft import LoraConfig, get_peft_model
 
         >>> config = LoraConfig(
         ...     task_type="SEQ_2_SEQ_LM",
@@ -118,13 +118,13 @@ class LoraModel(BaseTuner):
         ... )
 
         >>> model = AutoModelForSeq2SeqLM.from_pretrained("t5-base")
-        >>> lora_model = LoraModel(model, config, "default")
+        >>> lora_model = get_peft_model(model, config)
         ```
 
         ```py
         >>> import torch
         >>> import transformers
-        >>> from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
+        >>> from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
 
         >>> rank = ...
         >>> target_modules = ["q_proj", "k_proj", "v_proj", "out_proj", "fc_in", "fc_out", "wte"]


### PR DESCRIPTION
Fixes #3644. Approved by @BenjaminBossan in
https://github.com/huggingface/peft/issues/3644#issuecomment-5528243044.

Docstrings only. No runtime code is touched.

### `peft_model.py` — four examples that cannot run

Four of the six `PeftModelFor*` examples raise `TypeError` when run as
written, because they pass config fields that were removed in 2023:

- `postprocess_past_key_value_function`, removed in `a7dd0347` (2023-02-08),
  appears in the `PeftModelForSequenceClassification`, `PeftModelForCausalLM`
  and `PeftModelForTokenClassification` examples.
- `enable_lora`, removed in `c21afbe8` (2023-03-28), appears in the
  `PeftModelForSeq2SeqLM` example.

```
TypeError: PrefixTuningConfig.__init__() got an unexpected keyword argument 'postprocess_past_key_value_function'
TypeError: LoraConfig.__init__() got an unexpected keyword argument 'enable_lora'
```

Both fields were deleted rather than renamed, so there is no replacement key
and the lines are simply removed. The remaining keys still describe the
configuration each example demonstrates.

All six classes are pulled into the API reference via `[[autodoc]]`, so these
are the examples a reader copies off the docs site.

`PeftModelForTokenClassification` had a second problem behind the first: it
imported `AutoModelForSequenceClassification` but called
`AutoModelForTokenClassification`, so it would still have failed with a
`NameError` once the config was valid. The import now matches the class.

### `lora`, `hira`, `beft` — examples that mislead

These three construct the tuner class directly:

```py
>>> lora_model = LoraModel(model, config, "default")
```

That silently writes a base-model checkpoint instead of an adapter: `BaseTuner.__getattr__` forwards to the wrapped module, so `save_pretrained` resolves to  `PreTrainedModel.save_pretrained` rather than failing. Switched to `get_peft_model`, matching the form you asked for in the #3254 review for `ia3` and `adalora`; these three were never swept.

Also removed the unused `PeftModel` import from the `lora` and `hira` k-bit
examples.

`beft` additionally passed `peft_type="Beft"`, which `BeftConfig.__post_init__`
overwrites with `PeftType.BEFT`. It was the only example where the value was
also wrong — the enum is `"BEFT"`, not `"Beft"`, and the mismatch is silent.
The same redundant `peft_type=` appears in `prompt_tuning`, `p_tuning`,
`ia3`, `adalora` and `prefix_tuning`, but there the string matches the enum,
so I left them out of scope. Happy to remove those too if you'd prefer.

### Testing

Nothing in CI executes these examples — `make test` runs `pytest tests/`, and
no doctest collection touches `src/`. That is why they sat broken since 2023.
So I ran them directly.

Before: 4 of 6 fail with the `TypeError`s above. After: all six build their
config, and five run end to end. The sixth, `PeftModelForCausalLM`, needs
`gpt2-large`, which is not in my local cache.

The three tuner examples were run as edited too. Each now returns a `PeftModel`, so `save_pretrained` writes an adapter. The direct form resolves `save_pretrained` to `PreTrainedModel.save_pretrained` and writes a base-model checkpoint instead — no error either way.

Also run: `make quality` (ruff, format, doc-builder, doc coverage 131/131) and
`pytest tests/test_config.py tests/test_decoder_models.py` — 7064 passed,
2718 skipped.

Per the issue discussion, no test that executes the examples was added —
@BenjaminBossan said it wasn't needed.

*AI assistance: I used Claude Code to help audit and draft this. I reviewed
every changed line, ran every command above myself, and can defend the change
end-to-end.*
