### PR TITLE
Update HiRA experiment with tuned learning rate

### DIFF
--- a/method_comparison/image-gen/experiments/hira/flux2-klein-default/training_params.json
+++ b/method_comparison/image-gen/experiments/hira/flux2-klein-default/training_params.json
@@ -1,0 +1,6 @@
+{
+  "optimizer_kwargs": {
+    "lr": 0.0005,
+    "weight_decay": 0.0001
+  }
+}


### PR DESCRIPTION
Updates the HiRA experiment (`flux2-klein-default`) with a tuned learning rate. `target_modules` unchanged.

Full reasoning and results comparison discussed in [#3522](https://github.com/huggingface/peft/discussions/3522).

Summary: with lr=5e-4 (up from the shared 1e-4 default), DINOv2 similarity improves from 0.5550 to 0.7075, edging past LoRA (0.6815 on the same GPU) with comparable drift. `weight_decay` is kept explicit at the shared default (0.0001) in `training_params.json` to avoid falling back to AdamW's own default.

Files:
* `method_comparison/image-gen/experiments/hira/flux2-klein-default/training_params.json`

Context: [#3522](https://github.com/huggingface/peft/discussions/3522)

Results:

* DINOv2 cosine similarity: 0.7075
* Drift: 0.2626
* Max memory reserved: 10910 MB
* Runtime: ~50.7 mins (3042.8 seconds)
* Adapter checkpoint size: 146.3 MB (38,338,560 trainable params)