### PR TITLE
Update BEFT experiment with expanded target_modules

### DIFF
--- a/method_comparison/image-gen/experiments/beft/flux2-klein-default/adapter_config.json
+++ b/method_comparison/image-gen/experiments/beft/flux2-klein-default/adapter_config.json
@@ -7,18 +7,6 @@
   "peft_type": "BEFT",
   "peft_version": "0.20.1.dev0@UNKNOWN",
   "revision": null,
-  "target_modules": [
-    "to_add_out",
-    "linear_in",
-    "to_qkv_mlp_proj",
-    "to_out.0",
-    "to_v",
-    "to_k",
-    "to_q",
-    "add_v_proj",
-    "linear_out",
-    "add_k_proj",
-    "add_q_proj"
-  ],
+  "target_modules": "transformer_blocks\\.\\d+\\.(attn\\.(to_q|to_k|to_v|to_out\\.0|add_q_proj|add_k_proj|add_v_proj|to_add_out)|ff(_context)?\\.(linear_in|linear_out))|single_transformer_blocks\\.\\d+\\.attn\\.(to_qkv_mlp_proj|to_out)",
   "task_type": null
 }


### PR DESCRIPTION
Updates the BEFT experiment (`flux2-klein-default`) with expanded `target_modules`. 

Full reasoning and results comparison discussed in [#3522](https://github.com/huggingface/peft/discussions/3522).

Summary: `to_out` in the single-stream transformer blocks is a bare `Linear`, unlike the double-stream blocks where it's `to_out.0` inside a `ModuleList` — so the original target_modules list was silently missing the single-stream output projection across all 20 of those blocks. Added it (as a regex, since list-mode suffix matching can't tell it apart from the
double-stream `ModuleList` container by name alone). DINOv2 similarity improves from 0.5227 to 0.6015 (+15%) for +61,440 trainable params, with no meaningful runtime cost.

Files:
* `method_comparison/image-gen/experiments/beft/flux2-klein-default/adapter_config.json`

Context: [#3522](https://github.com/huggingface/peft/discussions/3522)

Results:

* DINOv2 cosine similarity: 0.6015
* Drift: 0.1082
* Max memory reserved: 9458 MB
* Runtime: ~16.5 mins (989.5 seconds)
* Adapter checkpoint size: 3.65 MB (952,320 trainable params)