### PR TITLE
Validate Super-Tuning index persistence across adapters

### DIFF
--- a/src/peft/tuners/supertuning/model.py
+++ b/src/peft/tuners/supertuning/model.py
@@ -18,6 +18,7 @@ import torch
 from peft.tuners.tuners_utils import BaseTuner, BaseTunerLayer
 from peft.utils import TRANSFORMERS_MODELS_TO_SUPERTUNING_TARGET_MODULES_MAPPING
 
+from .config import SupertuningConfig
 from .layer import Linear, SupertuningLayer
 
 
@@ -66,6 +67,16 @@ class SupertuningModel(BaseTuner):
     prefix: str = "supertuning_"
     tuner_layer_cls = SupertuningLayer
     target_module_mapping = TRANSFORMERS_MODELS_TO_SUPERTUNING_TARGET_MODULES_MAPPING
+
+    def _check_new_adapter_config(self, config: SupertuningConfig) -> None:
+        super()._check_new_adapter_config(config)
+
+        save_indices_values = sorted({config.save_precomputed_indices for config in self.peft_config.values()})
+        if len(save_indices_values) > 1:
+            raise ValueError(
+                "Super-Tuning indices must be saved for all adapters or none, but got multiple different values: "
+                f"{save_indices_values}"
+            )
 
     @staticmethod
     def _create_new_module(supertuning_config, adapter_name, target, **kwargs):

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -2984,6 +2984,32 @@ class TestBeftInitialization:
 class TestSupertuningInitialization:
     """Test class to check the initialization of Super-Tuning / Supra adapters."""
 
+    @pytest.mark.parametrize("save_precomputed_indices", [False, True])
+    def test_supertuning_multiple_adapters_same_save_precomputed_indices(self, save_precomputed_indices):
+        model = nn.Sequential(nn.Linear(10, 10))
+        config = SupertuningConfig(
+            target_modules=["0"], sparsity=0.5, save_precomputed_indices=save_precomputed_indices
+        )
+        model = get_peft_model(model, config)
+        model.add_adapter("other", config)
+
+        index_keys = [key for key in model.state_dict() if "supertuning_indices" in key]
+        assert bool(index_keys) is save_precomputed_indices
+
+    @pytest.mark.parametrize("first_value,second_value", [(False, True), (True, False)])
+    def test_supertuning_mixing_save_precomputed_indices_raises(self, first_value, second_value):
+        model = nn.Sequential(nn.Linear(10, 10))
+        config = SupertuningConfig(target_modules=["0"], sparsity=0.5, save_precomputed_indices=first_value)
+        model = get_peft_model(model, config)
+        config = SupertuningConfig(target_modules=["0"], sparsity=0.5, save_precomputed_indices=second_value)
+
+        msg = re.escape(
+            "Super-Tuning indices must be saved for all adapters or none, but got multiple different values: "
+            "[False, True]"
+        )
+        with pytest.raises(ValueError, match=msg):
+            model.add_adapter("other", config)
+
     def test_supertuning_config_validation(self):
         # Invalid sparsity
         with pytest.raises(ValueError, match="sparsity must be"):


### PR DESCRIPTION
## Summary

- reject adding Super-Tuning adapters with conflicting `save_precomputed_indices` values, because index persistence is shared by the model's buffer dictionary
- keep multiple adapters with one consistent persistence setting supported
- cover both persistence values and both mixed insertion orders with regression tests

Closes #3660.

## Coordination

Approved by @BenjaminBossan in https://github.com/huggingface/peft/issues/3660#issuecomment-5538720375.

## Tests

- Before the fix, the two mixed-value regression cases failed while the three consistent cases passed.
- `pytest tests/test_initialization.py -k TestSupertuningInitialization -q --no-cov --regression` (5 passed)
- `pytest tests/ -k supertuning -q --no-cov --regression` (697 passed, 227 skipped, 35476 deselected)
- Ruff 0.16.4 check and format check passed
- `git diff --check` passed

## AI assistance

I used Codex to help investigate, draft, and test this change. I reviewed every changed line, understand and can defend the change, and ran the tests listed above.