### PR TITLE
Reject direct injection for tuners with shared adapter state

### DIFF
--- a/docs/source/developer_guides/low_level_api.md
+++ b/docs/source/developer_guides/low_level_api.md
@@ -16,7 +16,7 @@ rendered properly in your Markdown viewer.
 
 # Adapter injection
 
-With PEFT, you can inject trainable adapters into any `torch` module which allows you to use adapter methods without relying on the modeling classes in PEFT. This works for all adapters except for those based on prompt learning (e.g. prefix tuning or p-tuning).
+With PEFT, you can inject trainable adapters into any `torch` module which allows you to use adapter methods without relying on the modeling classes in PEFT. This works for all adapters except for those based on prompt learning (e.g. prefix tuning or p-tuning) and adapters that keep state shared between multiple target layers.
 
 Check the table below to see when you should inject adapters.
 
@@ -24,6 +24,9 @@ Check the table below to see when you should inject adapters.
 |---|---|
 | the model is modified inplace, keeping all the original attributes and methods | manually write the `from_pretrained` and `save_pretrained` utility functions from Hugging Face to save and load adapters |
 | works for any `torch` module and modality | doesn't work with any of the utility methods provided by `PeftModel` such as disabling and merging adapters |
+
+> [!WARNING]
+> `inject_adapter_in_model` does not support PEFT methods that keep adapter state shared between multiple target layers. This currently includes TinyLoRA, UniLoRA, VeRA, PVeRA, VBLoRA, and FRoD. Use [`get_peft_model`] for these methods instead.
 
 ## Creating a new PEFT model
 

--- a/src/peft/mapping.py
+++ b/src/peft/mapping.py
@@ -54,7 +54,8 @@ def inject_adapter_in_model(
     r"""
     Create PEFT layers and inject them into the model in-place.
 
-    Currently the API does not support prompt learning methods and adaption prompt.
+    Currently the API does not support prompt learning methods, adaption prompt, or tuners that keep adapter state
+    shared between multiple target layers. Use [`get_peft_model`] for the latter.
 
     This function is similar to [`get_peft_model`] but it does not return a [`PeftModel`] instance. Instead, it returns
     the original, mutated instance of the passed model.
@@ -87,6 +88,12 @@ def inject_adapter_in_model(
         )
 
     tuner_cls = PEFT_TYPE_TO_TUNER_MAPPING[peft_config.peft_type]
+
+    if tuner_cls.uses_shared_state:
+        raise ValueError(
+            f"`inject_adapter_in_model` does not support {peft_config.peft_type} because it uses shared state "
+            "stored on the tuner. Please use `get_peft_model` instead."
+        )
 
     # By instantiating a peft model we are injecting randomly initialized LoRA layers into the model's modules.
     peft_model = tuner_cls(

--- a/src/peft/tuners/frod/model.py
+++ b/src/peft/tuners/frod/model.py
@@ -99,6 +99,7 @@ def _projection_from_weights(matrices: list[torch.Tensor], regularization_alpha:
 
 
 class FrodModel(BaseTuner):
+    uses_shared_state: bool = True
     prefix: str = "frod_"
     tuner_layer_cls = FrodLayer
     target_module_mapping = TRANSFORMERS_MODELS_TO_FROD_TARGET_MODULES_MAPPING

--- a/src/peft/tuners/pvera/model.py
+++ b/src/peft/tuners/pvera/model.py
@@ -62,6 +62,7 @@ class PveraModel(BaseTuner):
         - **peft_config** ([`PveraConfig`]): The configuration of the PVeRA model.
     """
 
+    uses_shared_state: bool = True
     prefix: str = "pvera_lambda_"
     tuner_layer_cls = PveraLayer
     target_module_mapping = TRANSFORMERS_MODELS_TO_PVERA_TARGET_MODULES_MAPPING

--- a/src/peft/tuners/tinylora/model.py
+++ b/src/peft/tuners/tinylora/model.py
@@ -63,6 +63,7 @@ class TinyLoraModel(BaseTuner):
         - **peft_config** ([`TinyLoraConfig`]): The configuration of the TinyLoRA model.
     """
 
+    uses_shared_state: bool = True
     prefix: str = "tinylora_"
     tuner_layer_cls = TinyLoraLayer
     target_module_mapping = TRANSFORMERS_MODELS_TO_TINYLORA_TARGET_MODULES_MAPPING

--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -296,6 +296,10 @@ class BaseTuner(nn.Module, ABC):
 
     # Required attributes for child classes:
 
+    # Whether the tuner stores adapter state shared between multiple injected layers. Direct injection returns only the
+    # wrapped model, so tuners with shared state cannot be used through `inject_adapter_in_model`.
+    uses_shared_state: bool = False
+
     # The unique prefix for this PEFT method, e.g. 'lora_' for LoRA.
     prefix: str
     # The class of the tuner layer, e.g. `LoraLayer` for LoRA.

--- a/src/peft/tuners/unilora/model.py
+++ b/src/peft/tuners/unilora/model.py
@@ -31,6 +31,7 @@ from .layer import Linear, UniLoraLayer
 class UniLoraModel(BaseTuner):
     """Creates a UniLora adapter around a pretrained model."""
 
+    uses_shared_state: bool = True
     prefix: str = "unilora_"
     tuner_layer_cls = UniLoraLayer
     target_module_mapping = TRANSFORMERS_MODELS_TO_UNILORA_TARGET_MODULES_MAPPING

--- a/src/peft/tuners/vblora/model.py
+++ b/src/peft/tuners/vblora/model.py
@@ -65,6 +65,7 @@ class VBLoRAModel(BaseTuner):
         - **peft_config** ([`VBLoRAConfig`]): The configuration of the VBLoRAConfig model.
     """
 
+    uses_shared_state: bool = True
     prefix: str = "vblora_"
     tuner_layer_cls = VBLoRALayer
     target_module_mapping = TRANSFORMERS_MODELS_TO_VBLORA_TARGET_MODULES_MAPPING

--- a/src/peft/tuners/vera/model.py
+++ b/src/peft/tuners/vera/model.py
@@ -105,6 +105,7 @@ class VeraModel(BaseTuner):
         - **peft_config** ([`VeraConfig`]): The configuration of the Vera model.
     """
 
+    uses_shared_state: bool = True
     prefix: str = "vera_lambda_"
     tuner_layer_cls = VeraLayer
     target_module_mapping = TRANSFORMERS_MODELS_TO_VERA_TARGET_MODULES_MAPPING

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2464,8 +2464,7 @@ class TestPeftCustomModel(PeftCommonTester):
             model = inject_adapter_in_model(config, model)
         except ValueError as error:
             # Shared-state tuners must reject direct injection, so there is no round-trip to run for them. Match the
-            # specific error to avoid masking unrelated failures; if a future tuner forgets the marker, it will reach
-            # the round-trip below and expose the missing shared state.
+            # specific error to avoid masking unrelated failures.
             if "shared state" not in str(error) or "get_peft_model" not in str(error):
                 raise
             return

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -75,6 +75,7 @@ from peft import (
     WaveFTConfig,
     get_peft_model,
     get_peft_model_state_dict,
+    inject_adapter_in_model,
     set_peft_model_state_dict,
 )
 from peft.tuners import lora
@@ -2447,6 +2448,41 @@ class TestPeftCustomModel(PeftCommonTester):
     def test_save_pretrained(self, test_name, model_id, config_cls, config_kwargs):
         config_kwargs = set_init_weights_false(config_cls, config_kwargs)
         self._test_save_pretrained(model_id, config_cls, config_kwargs)
+
+    @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
+    def test_save_load_roundtrip_direct_injection(self, test_name, model_id, config_cls, config_kwargs):
+        X = self.prepare_inputs_for_testing()
+        config_kwargs = set_init_weights_false(config_cls, config_kwargs)
+        config = config_cls(
+            base_model_name_or_path=model_id,
+            **config_kwargs,
+        )
+
+        model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+        torch.manual_seed(0)
+        try:
+            model = inject_adapter_in_model(config, model)
+        except ValueError as error:
+            if "shared state" not in str(error) or "get_peft_model" not in str(error):
+                raise
+            return
+        model.eval()
+        with torch.inference_mode():
+            output_before = model(**X)
+
+        state_dict = get_peft_model_state_dict(model)
+        del model
+
+        model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+        torch.manual_seed(54321)
+        model = inject_adapter_in_model(config_cls(base_model_name_or_path=model_id, **config_kwargs), model)
+        model.eval()
+        load_result = set_peft_model_state_dict(model, state_dict)
+        assert not load_result.unexpected_keys
+
+        with torch.inference_mode():
+            output_after = model(**X)
+        assert torch.allclose(output_before, output_after)
 
     @pytest.mark.parametrize("test_name, model_id, config_cls, config_kwargs", TEST_CASES)
     def test_save_pretrained_pickle(self, test_name, model_id, config_cls, config_kwargs):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2463,6 +2463,9 @@ class TestPeftCustomModel(PeftCommonTester):
         try:
             model = inject_adapter_in_model(config, model)
         except ValueError as error:
+            # Shared-state tuners must reject direct injection, so there is no round-trip to run for them. Match the
+            # specific error to avoid masking unrelated failures; if a future tuner forgets the marker, it will reach
+            # the round-trip below and expose the missing shared state.
             if "shared state" not in str(error) or "get_peft_model" not in str(error):
                 raise
             return

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -30,10 +30,16 @@ from transformers import (
 
 from peft import (
     AdaLoraConfig,
+    FrodConfig,
     IA3Config,
     LoKrConfig,
     LoraConfig,
+    PveraConfig,
     RandLoraConfig,
+    TinyLoraConfig,
+    UniLoraConfig,
+    VBLoRAConfig,
+    VeraConfig,
     get_base_model_state_dict,
     get_peft_model,
     get_peft_model_state_dict,
@@ -60,6 +66,35 @@ class DummyModel(torch.nn.Module):
         x = self.linear(x)
         x = self.lm_head(x)
         return x
+
+
+SHARED_STATE_TUNER_CONFIGS = [
+    pytest.param(TinyLoraConfig, {"r": 2, "u": 4}, id="TinyLoRA"),
+    pytest.param(UniLoraConfig, {"r": 2, "theta_d_length": 16}, id="UniLoRA"),
+    pytest.param(VeraConfig, {"r": 2}, id="VeRA"),
+    pytest.param(PveraConfig, {"r": 2}, id="PVeRA"),
+    pytest.param(VBLoRAConfig, {"r": 2, "num_vectors": 8, "vector_length": 2}, id="VBLoRA"),
+    pytest.param(FrodConfig, {"progressbar": False}, id="FRoD"),
+]
+
+
+@pytest.mark.parametrize("config_cls, config_kwargs", SHARED_STATE_TUNER_CONFIGS)
+def test_inject_adapter_in_model_rejects_shared_state_tuners(config_cls, config_kwargs):
+    config = config_cls(target_modules=["linear"], **config_kwargs)
+    model = DummyModel()
+    original_module_names = [name for name, _ in model.named_modules()]
+
+    with pytest.raises(ValueError, match="shared state.*get_peft_model"):
+        inject_adapter_in_model(config, model)
+
+    assert [name for name, _ in model.named_modules()] == original_module_names
+
+
+@pytest.mark.parametrize("config_cls, config_kwargs", SHARED_STATE_TUNER_CONFIGS)
+def test_get_peft_model_supports_shared_state_tuners(config_cls, config_kwargs):
+    config = config_cls(target_modules=["linear"], **config_kwargs)
+
+    get_peft_model(DummyModel(), config)
 
 
 class TestLowLevelFunctional:

--- a/tests/test_low_level_api.py
+++ b/tests/test_low_level_api.py
@@ -68,35 +68,6 @@ class DummyModel(torch.nn.Module):
         return x
 
 
-SHARED_STATE_TUNER_CONFIGS = [
-    pytest.param(TinyLoraConfig, {"r": 2, "u": 4}, id="TinyLoRA"),
-    pytest.param(UniLoraConfig, {"r": 2, "theta_d_length": 16}, id="UniLoRA"),
-    pytest.param(VeraConfig, {"r": 2}, id="VeRA"),
-    pytest.param(PveraConfig, {"r": 2}, id="PVeRA"),
-    pytest.param(VBLoRAConfig, {"r": 2, "num_vectors": 8, "vector_length": 2}, id="VBLoRA"),
-    pytest.param(FrodConfig, {"progressbar": False}, id="FRoD"),
-]
-
-
-@pytest.mark.parametrize("config_cls, config_kwargs", SHARED_STATE_TUNER_CONFIGS)
-def test_inject_adapter_in_model_rejects_shared_state_tuners(config_cls, config_kwargs):
-    config = config_cls(target_modules=["linear"], **config_kwargs)
-    model = DummyModel()
-    original_module_names = [name for name, _ in model.named_modules()]
-
-    with pytest.raises(ValueError, match="shared state.*get_peft_model"):
-        inject_adapter_in_model(config, model)
-
-    assert [name for name, _ in model.named_modules()] == original_module_names
-
-
-@pytest.mark.parametrize("config_cls, config_kwargs", SHARED_STATE_TUNER_CONFIGS)
-def test_get_peft_model_supports_shared_state_tuners(config_cls, config_kwargs):
-    config = config_cls(target_modules=["linear"], **config_kwargs)
-
-    get_peft_model(DummyModel(), config)
-
-
 class TestLowLevelFunctional:
     # Some simple tests for the low level API
     @pytest.fixture
@@ -121,6 +92,27 @@ class TestLowLevelFunctional:
             if name == "linear":
                 assert hasattr(module, "lora_A")
                 assert hasattr(module, "lora_B")
+
+    @pytest.mark.parametrize(
+        "config_cls, config_kwargs",
+        [
+            pytest.param(TinyLoraConfig, {"r": 2, "u": 4}, id="TinyLoRA"),
+            pytest.param(UniLoraConfig, {"r": 2, "theta_d_length": 16}, id="UniLoRA"),
+            pytest.param(VeraConfig, {"r": 2}, id="VeRA"),
+            pytest.param(PveraConfig, {"r": 2}, id="PVeRA"),
+            pytest.param(VBLoRAConfig, {"r": 2, "num_vectors": 8, "vector_length": 2}, id="VBLoRA"),
+            pytest.param(FrodConfig, {"progressbar": False}, id="FRoD"),
+        ],
+    )
+    def test_inject_adapter_in_model_rejects_shared_state_tuners(self, config_cls, config_kwargs):
+        config = config_cls(target_modules=["linear"], **config_kwargs)
+        model = DummyModel()
+        original_module_names = [name for name, _ in model.named_modules()]
+
+        with pytest.raises(ValueError, match="shared state.*get_peft_model"):
+            inject_adapter_in_model(config, model)
+
+        assert [name for name, _ in model.named_modules()] == original_module_names
 
     def test_get_peft_model_state_dict(self, model):
         peft_state_dict = get_peft_model_state_dict(model)

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -65,6 +65,7 @@ from peft import (
     set_peft_model_state_dict,
 )
 from peft.import_utils import is_transformers_ge_v5
+from peft.mapping import PEFT_TYPE_TO_TUNER_MAPPING
 from peft.tuners._buffer_dict import BufferDict
 from peft.tuners.lora import LoraLayer
 from peft.tuners.tuners_utils import BaseTunerLayer
@@ -296,6 +297,12 @@ class PeftCommonTester:
             # also test injecting directly
             del model
             model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
+            tuner_cls = PEFT_TYPE_TO_TUNER_MAPPING[config.peft_type]
+            if tuner_cls.uses_shared_state:
+                with pytest.raises(ValueError, match="shared state.*get_peft_model"):
+                    inject_adapter_in_model(config, model, low_cpu_mem_usage=True)
+                return
+
             inject_adapter_in_model(config, model, low_cpu_mem_usage=True)  # check that there is no error
 
             if not isinstance(config, LNTuningConfig):

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -299,6 +299,8 @@ class PeftCommonTester:
             model = self.transformers_class.from_pretrained(model_id).to(self.torch_device)
             tuner_cls = PEFT_TYPE_TO_TUNER_MAPPING[config.peft_type]
             if tuner_cls.uses_shared_state:
+                # Direct injection is unsupported for shared-state tuners. The expected error completes this branch;
+                # the meta-device assertion below applies only to tuners that support direct injection.
                 with pytest.raises(ValueError, match="shared state.*get_peft_model"):
                     inject_adapter_in_model(config, model, low_cpu_mem_usage=True)
                 return


### PR DESCRIPTION
Related to #3631

## Summary

- Add a BaseTuner.uses_shared_state capability marker for tuners that keep adapter state shared across multiple target layers.
- Reject direct injection for TinyLoRA, UniLoRA, VeRA, PVeRA, VBLoRA, and FRoD before the model is modified.
- Keep get_peft_model support unchanged and document the limitation in the low-level API guide.

inject_adapter_in_model returns the mutated base model, while these tuners store shared adapter state on the tuner object. The direct API therefore cannot reliably support state-dict round-tripping. This change fails early with a clear error and points users to get_peft_model.

## Tests

- 12 passed: shared-state low-level API tests
- 385 passed, 1 xfailed: core tuner and low-level API tests
- 39 passed: shared-tuner low-memory loading tests
- make quality passed
- Full make test was started; the local run was stopped after an unrelated numerical failure in tests/test_custom_models.py::TestPeftCustomModel::test_merge_layers[Conv1d LOHA 3-Conv1dBigger-LoHaConfig-config_kwargs91] (torch.allclose during LoHa Conv1D merge).