### PR TITLE
Warn when target_modules match unevenly across layers

### DIFF
--- a/src/peft/tuners/tuners_utils.py
+++ b/src/peft/tuners/tuners_utils.py
@@ -20,6 +20,7 @@ import re
 import textwrap
 import warnings
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Sequence
 from contextlib import contextmanager, nullcontext
 from typing import Any, Optional, Union, overload
@@ -1102,6 +1103,37 @@ class BaseTuner(nn.Module, ABC):
                     f"target_parameters={peft_config.target_parameters} were set but no parameter was matched.",
                     RuntimeWarning,
                 )
+            elif (
+                targeted_module_names
+                and isinstance(peft_config.target_modules, (list, set, tuple))
+                and len(peft_config.target_modules) > 1
+            ):
+                # Suffix matching can hit a name on some layers and miss it on others (Gemma 4
+                # omits v_proj on global-attention layers). Raise only when nothing matched; here
+                # at least one module did, so warn when coverage is uneven across the listed names.
+                # See https://github.com/huggingface/peft/issues/3658.
+                match_counts: Counter[str] = Counter()
+                unmatched_targets: list[str] = []
+                for target in peft_config.target_modules:
+                    n_matches = sum(
+                        1 for name in targeted_module_names if name == target or name.endswith(f".{target}")
+                    )
+                    if n_matches:
+                        match_counts[str(target)] = n_matches
+                    else:
+                        unmatched_targets.append(str(target))
+                matched_counts = list(match_counts.values())
+                uneven = bool(matched_counts) and (min(matched_counts) != max(matched_counts) or unmatched_targets)
+                if uneven:
+                    details = ", ".join(f"{name}: {count}" for name, count in sorted(match_counts.items()))
+                    if unmatched_targets:
+                        extra = f"unmatched: {unmatched_targets}"
+                        details = f"{details}; {extra}" if details else extra
+                    warnings.warn(
+                        f"target_modules coverage is uneven ({details}). Some listed modules exist "
+                        "on fewer layers than others. Inspect the adapted layers with get_layer_status().",
+                        UserWarning,
+                    )
 
         # Now that the checks passed, merge this adapter's matches into the tuner-level bookkeeping. Duplicates
         # are skipped so that names stay unique when several adapters target the same modules.

--- a/tests/test_tuners_utils.py
+++ b/tests/test_tuners_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import dataclasses
 import re
+import warnings
 from copy import deepcopy
 
 import diffusers
@@ -495,6 +496,38 @@ class TestTargetedModuleNames:
         model = MLP()
         model = get_peft_model(model, LoraConfig(target_modules=["lin0", "lin1"]))
         assert model.targeted_module_names == ["lin0", "lin1"]
+
+    def test_uneven_target_module_coverage_warns(self):
+        # Gemma 4 (and similar) omit v_proj on some layers. Suffix matching still builds an adapter
+        # from the layers that do have it, with no signal that coverage is asymmetric.
+        # See https://github.com/huggingface/peft/issues/3658.
+
+        class Block(nn.Module):
+            def __init__(self, with_v: bool = True):
+                super().__init__()
+                self.q_proj = nn.Linear(4, 4)
+                self.k_proj = nn.Linear(4, 4)
+                if with_v:
+                    self.v_proj = nn.Linear(4, 4)
+                self.o_proj = nn.Linear(4, 4)
+
+        class TinyGemmaLike(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = nn.ModuleList([Block(with_v=(i != 1)) for i in range(3)])
+
+        with pytest.warns(UserWarning, match="target_modules coverage is uneven"):
+            get_peft_model(
+                TinyGemmaLike(),
+                LoraConfig(target_modules=["q_proj", "k_proj", "v_proj", "o_proj"]),
+            )
+
+    def test_even_target_module_coverage_does_not_warn(self):
+        model = MLP()
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always")
+            get_peft_model(model, LoraConfig(target_modules=["lin0", "lin1"]))
+        assert not any("coverage is uneven" in str(w.message) for w in recorded)
 
     def test_ia3_targeted_module_regex(self):
         model = MLP()


### PR DESCRIPTION
## Summary
- `target_modules` is suffix-matched and only errors when the whole list matches nothing.
- Some architectures omit a listed projection on a subset of layers (Gemma 4 drops `v_proj` on global-attention layers). The adapter is built anyway, with no signal that coverage is asymmetric.
- After a successful inject, if `target_modules` is a list of more than one name and the match counts are not all equal, emit a `UserWarning` with the per-name counts. Regex / `all-linear` is unchanged.

## Test plan
- [x] a tiny model missing `v_proj` on one of three layers warns
- [x] even coverage (`lin0` and `lin1` on `MLP`) does not warn
- [x] existing exclude-module unused warning still fires

Fixes #3658
