### PR TITLE
docs: fix a dead link and a malformed link

### DIFF
--- a/docs/source/package_reference/glora.md
+++ b/docs/source/package_reference/glora.md
@@ -103,6 +103,6 @@ model.merge_and_unload()
 - GLoRA supports all standard PEFT adapter management features (add, delete, switch, merge, etc).
 
 ## See Also
-- [Adapter conceptual guide](../conceptual_guides/adapter.md)
+- [LoRA reference](./lora.md)
 - [LoRA reference](./lora.md)
 - [Paper: https://huggingface.co/papers/2306.07967](https://huggingface.co/papers/2306.07967)

--- a/method_comparison/MetaMathQA/README.md
+++ b/method_comparison/MetaMathQA/README.md
@@ -6,7 +6,7 @@ This goal is to provide a benchmarking framework for the different PEFT methods 
 
 ## Dataset
 
-This task trains on the [MetaMathQA]((https://huggingface.co/datasets/meta-math/MetaMathQA)) dataset and validates/tests on the [GSM8K](https://huggingface.co/datasets/openai/gsm8k) dataset ("main").
+This task trains on the [MetaMathQA](https://huggingface.co/datasets/meta-math/MetaMathQA) dataset and validates/tests on the [GSM8K](https://huggingface.co/datasets/openai/gsm8k) dataset ("main").
 
 For the model to attain good accuracy, it needs to learn to adhere to the output format and it must express basic chain of thought reasoning capabilities to get to the correct result in the first place. The task is challenging for models in the sub 7B parameter range.
 


### PR DESCRIPTION
1. `docs/source/package_reference/glora.md`: the See-Also link pointed at `../conceptual_guides/adapter.md`, removed by the docs restructure (#3300). Per the repo's own `_redirects.yml` (`conceptual_guides/adapter → package_reference/lora`), repointed at the LoRA reference page — matching the style used on that page's own See-Also list.
2. `method_comparison/MetaMathQA/README.md`: `[MetaMathQA]((https://…))` had doubled parentheses, rendering as broken text rather than a link.