### PR TITLE
docs: fix snippt typo and a missing space in the helpers docstring

### DIFF
--- a/docs/source/accelerate/fsdp.md
+++ b/docs/source/accelerate/fsdp.md
@@ -143,7 +143,7 @@ trainer.save_model()
 ```
 
 
-Here, one main thing to note currently when using FSDP with PEFT is that `use_orig_params` needs to be `False` to realize GPU memory savings. Due to `use_orig_params=False`, the auto wrap policy for FSDP needs to change so that trainable and non-trainable parameters are wrapped separately. This is done by the code snippt below which uses the util function `fsdp_auto_wrap_policy` from PEFT:
+Here, one main thing to note currently when using FSDP with PEFT is that `use_orig_params` needs to be `False` to realize GPU memory savings. Due to `use_orig_params=False`, the auto wrap policy for FSDP needs to change so that trainable and non-trainable parameters are wrapped separately. This is done by the code snippet below which uses the util function `fsdp_auto_wrap_policy` from PEFT:
 
 ```
 if getattr(trainer.accelerator.state, "fsdp_plugin", None):

--- a/src/peft/helpers.py
+++ b/src/peft/helpers.py
@@ -177,7 +177,7 @@ def rescale_adapter_scale(model: nn.Module, multiplier: Union[float, int]) -> It
 
     For LoRA, applying this context manager with multiplier in [0, 1] is strictly equivalent to applying
     [wise-ft](https://huggingface.co/papers/2109.01903) (see [#1940](https://github.com/huggingface/peft/issues/1940)
-    for details). It can improve the performances of the model if there is a distribution shiftbetween the training
+    for details). It can improve the performances of the model if there is a distribution shift between the training
     data used for fine-tuning, and the test data used during inference.
 
     Warning: It has been reported that when using Apple's MPS backend for PyTorch, it is necessary to add a short sleep


### PR DESCRIPTION
Two one-word doc fixes: `snippt` → `snippet` (docs/source/accelerate/fsdp.md) and `shiftbetween` → `shift between` (src/peft/helpers.py, public `rescale_adapter_scale` docstring).