### PR TITLE
docs: clarify ignore_mismatched_sizes docstring wording

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -476,7 +476,7 @@ def set_peft_model_state_dict(
         adapter_name (`str`, *optional*, defaults to `"default"`):
             The name of the adapter whose state dict should be set.
         ignore_mismatched_sizes (`bool`, *optional*, defaults to `False`):
-            Whether to ignore mismatched in the state dict.
+            Whether to ignore mismatched sizes in the state dict.
         low_cpu_mem_usage (`bool`, `optional`, defaults to `False`):
             This argument must be `True` if the `model` was loaded with adapter weights on the meta device, e.g. after
             calling `inject_adapter_in_model` with `low_cpu_mem_usage=True`. Otherwise, leave it as `False`.


### PR DESCRIPTION
The `ignore_mismatched_sizes` docstring read "Whether to ignore mismatched in the state dict." — missing the noun; now "ignore mismatched sizes".