### PR TITLE
FIX ignore_mismatched_sizes crash on scalar adapter state entries

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -297,10 +297,15 @@ def _find_mismatched_keys(
             continue
 
         # see https://github.com/huggingface/transformers/blob/09f9f566de83eef1f13ee83b5a1bbeebde5c80c1/src/transformers/modeling_utils.py#L3858-L3864
-        if (state_dict[key].shape[-1] == 1) and (state_dict[key].numel() * 2 == tensor.numel()):
+        if (
+            state_dict[key].ndim > 0
+            and state_dict[key].shape[-1] == 1
+            and state_dict[key].numel() * 2 == tensor.numel()
+        ):
             # This skips size mismatches for 4-bit weights. Two 4-bit values share an 8-bit container, causing size
             # differences. Without matching with module type or parameter type it seems like a practical way to detect
-            # valid 4bit weights.
+            # valid 4bit weights. Scalar (0-dim) tensors like BatchNorm's num_batches_tracked have no last dim to
+            # index, so guard against that first.
             continue
 
         if state_dict[key].shape != tensor.shape:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -4511,6 +4511,22 @@ class TestPeftCustomModel(PeftCommonTester):
                 # windows error
                 pass
 
+    def test_ignore_mismatched_sizes_scalar_state_entry(self, tmp_path):
+        # issue #3676
+        # ignore_mismatched_sizes=True must not crash when the adapter state dict contains a scalar (0-dim) tensor.
+        # BatchNorm's num_batches_tracked buffer, preserved via modules_to_save, has torch.Size([]).
+        class ModelWithBN(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(3, 3)
+                self.norm = nn.BatchNorm1d(3)
+
+        config = LoraConfig(target_modules=["linear"], modules_to_save=["norm"])
+        model = get_peft_model(ModelWithBN(), config)
+        model.save_pretrained(tmp_path)
+
+        PeftModel.from_pretrained(ModelWithBN(), tmp_path, ignore_mismatched_sizes=True)
+
     def test_save_embedding_layers_excludes_similarly_named_sibling(self, tmp_path):
         # A module whose name merely starts with the embedding module name is not an embedding layer and must not be
         # swept into the checkpoint by the key selection.


### PR DESCRIPTION
Fixes #3676.

## What this fixes

`_find_mismatched_keys` unconditionally reads `state_dict[key].shape[-1]` when deciding whether the entry is a bitsandbytes 4-bit packed weight (two 4-bit values packed into an 8-bit container). For zero-dimensional tensors that indexing raises `IndexError: tuple index out of range`, so `PeftModel.from_pretrained(..., ignore_mismatched_sizes=True)` crashes whenever any entry of the adapter state dict is a scalar.

The realistic way to hit this is keeping a `BatchNorm` module through `modules_to_save` — its `num_batches_tracked` buffer is `torch.Size([])`.

## The fix

Guard the 4-bit branch by requiring `ndim > 0` before indexing the last dimension. Scalar tensors then fall through to the normal shape comparison unchanged, so their non-mismatched case still works and their mismatched case still populates `mismatched` (no silent skip).

The check is now split across three lines because a one-line `and` chain past 119 columns trips the line-length rule; I also extended the surrounding comment to spell out the guard and why it's there.

## Reproducer (from #3676)

```python
from tempfile import TemporaryDirectory
import torch
from peft import LoraConfig, PeftModel, get_peft_model

def make_model():
    return torch.nn.Sequential(
        torch.nn.Linear(3, 3),          # "0"
        torch.nn.BatchNorm1d(3),        # "1" — carries num_batches_tracked, a 0-dim buffer
    )

config = LoraConfig(target_modules=["0"], modules_to_save=["1"])

with TemporaryDirectory() as ckpt:
    get_peft_model(make_model(), config).save_pretrained(ckpt)
    PeftModel.from_pretrained(make_model(), ckpt, ignore_mismatched_sizes=True)
```

Before: `IndexError: tuple index out of range` on load.
After: loads cleanly.

## Test

Added `test_ignore_mismatched_sizes_scalar_state_entry` in `tests/test_custom_models.py` next to the existing `test_load_resized_embedding_ignore_mismatched_sizes`. It saves a LoRA-adapted model whose `modules_to_save` targets a `BatchNorm1d`, then reloads it with `ignore_mismatched_sizes=True`; before the fix the test raises `IndexError`, after the fix it passes.

```
$ pytest tests/test_custom_models.py -k ignore_mismatched_sizes -v
tests/test_custom_models.py::TestPeftCustomModel::test_load_resized_embedding_ignore_mismatched_sizes PASSED
tests/test_custom_models.py::TestPeftCustomModel::test_ignore_mismatched_sizes_scalar_state_entry PASSED
```

`make quality` is clean.
