### PR TITLE
Reject mixed Supertuning save_precomputed_indices across adapters

### DIFF
--- a/src/peft/tuners/supertuning/layer.py
+++ b/src/peft/tuners/supertuning/layer.py
@@ -76,9 +76,9 @@ class SupertuningLayer(BaseTunerLayer):
         self.base_layer = base_layer
         # Trainable sparse quantities, one 1-D parameter per adapter.
         self.supertuning_values = nn.ParameterDict({})
-        # Flat positions of the sparse support inside the weight. Persistent iff the first-configured adapter
-        # requested save_precomputed_indices=True; when False, the indices are recomputed from base weight
-        # magnitudes at load time (deterministic given identical base weights).
+        # Flat positions of the sparse support inside the weight. Persistent iff save_precomputed_indices=True;
+        # when False, the indices are recomputed from base weight magnitudes at load time (deterministic given
+        # identical base weights). Mixed values across adapters are rejected by SupertuningModel._check_new_adapter_config.
         self.supertuning_indices = BufferDict(persistent=save_precomputed_indices)
         # Per-adapter Supra rank / scaling. Rank 0 (falsy) → pure Super for that adapter.
         self.supertuning_rank: dict[str, int] = {}

--- a/src/peft/tuners/supertuning/model.py
+++ b/src/peft/tuners/supertuning/model.py
@@ -18,6 +18,7 @@ import torch
 from peft.tuners.tuners_utils import BaseTuner, BaseTunerLayer
 from peft.utils import TRANSFORMERS_MODELS_TO_SUPERTUNING_TARGET_MODULES_MAPPING
 
+from .config import SupertuningConfig
 from .layer import Linear, SupertuningLayer
 
 
@@ -81,6 +82,17 @@ class SupertuningModel(BaseTuner):
                 f"Target module {target} is not supported. Currently, only `torch.nn.Linear` is supported."
             )
         return new_module
+
+    def _check_new_adapter_config(self, config: SupertuningConfig) -> None:
+        """Ensure per-adapter configs that must be layer-wide stay consistent across adapters."""
+        super()._check_new_adapter_config(config)
+
+        save_precomputed_indices_values = sorted({conf.save_precomputed_indices for conf in self.peft_config.values()})
+        if len(save_precomputed_indices_values) > 1:
+            raise ValueError(
+                "Supertuning save_precomputed_indices must be the same for all adapters, but got multiple different "
+                f"values: {save_precomputed_indices_values}"
+            )
 
     def _create_and_replace(
         self,

--- a/tests/test_supertuning.py
+++ b/tests/test_supertuning.py
@@ -136,3 +136,61 @@ class TestSupertuning:
                 assert mod.supertuning_lora_A["default"].weight.requires_grad
                 assert mod.supertuning_lora_B["default"].weight.requires_grad
                 break
+
+    def test_supertuning_rejects_mixed_save_precomputed_indices_false_then_true(self):
+        """A later adapter cannot opt into saved indices when the first adapter opted out."""
+        torch.manual_seed(0)
+        model = self._prepare_trainable_model(save_precomputed_indices=False)
+        with pytest.raises(ValueError, match="save_precomputed_indices must be the same"):
+            model.add_adapter(
+                "saved",
+                SupertuningConfig(
+                    target_modules=["q_proj", "v_proj"],
+                    sparsity=0.5,
+                    save_precomputed_indices=True,
+                ),
+            )
+
+    def test_supertuning_rejects_mixed_save_precomputed_indices_true_then_false(self):
+        """A later adapter cannot opt out of saved indices when the first adapter opted in."""
+        torch.manual_seed(0)
+        model = self._prepare_trainable_model(save_precomputed_indices=True)
+        with pytest.raises(ValueError, match="save_precomputed_indices must be the same"):
+            model.add_adapter(
+                "nosave",
+                SupertuningConfig(
+                    target_modules=["q_proj", "v_proj"],
+                    sparsity=0.5,
+                    save_precomputed_indices=False,
+                ),
+            )
+
+    def test_supertuning_same_save_precomputed_indices_across_adapters(self, tmp_path):
+        """Adapters with the same save_precomputed_indices value can coexist, and persistence matches it."""
+        torch.manual_seed(0)
+        model_true = self._prepare_trainable_model(save_precomputed_indices=True)
+        model_true.add_adapter(
+            "saved",
+            SupertuningConfig(
+                target_modules=["q_proj", "v_proj"],
+                sparsity=0.5,
+                save_precomputed_indices=True,
+            ),
+        )
+        model_true.save_pretrained(tmp_path / "true")
+        state_dict_true = load_file(tmp_path / "true" / "adapter_model.safetensors")
+        assert any("supertuning_indices" in key for key in state_dict_true)
+
+        torch.manual_seed(0)
+        model_false = self._prepare_trainable_model(save_precomputed_indices=False)
+        model_false.add_adapter(
+            "saved",
+            SupertuningConfig(
+                target_modules=["q_proj", "v_proj"],
+                sparsity=0.5,
+                save_precomputed_indices=False,
+            ),
+        )
+        model_false.save_pretrained(tmp_path / "false")
+        state_dict_false = load_file(tmp_path / "false" / "adapter_model.safetensors")
+        assert not any("supertuning_indices" in key for key in state_dict_false)


### PR DESCRIPTION
Fixes #3660.

`SupertuningLayer` stores sparse-support indices in a single `BufferDict` whose persistence is set when the first adapter wraps a layer. Because later adapters reuse the same dictionary, their individual `save_precomputed_indices` values were silently ignored. This PR follows the same approach used by VeRA/RandLoRA/FRoD and rejects mixed values via `_check_new_adapter_config`.

Changes:
- Added `SupertuningModel._check_new_adapter_config` that raises `ValueError` when adapters are configured with different `save_precomputed_indices` values.
- Updated the `BufferDict` comment to reflect that mixed values are now rejected rather than falling back to the first adapter.
- Added regression tests covering both insertion orders and a same-value multi-adapter case.

Tests run locally:
```
pytest tests/test_supertuning.py -v
```
Result: 7 passed, 1 skipped.

AI assistance: I used an AI coding assistant to help implement the change and draft this description. I reviewed the diff and ran the tests myself.
