### PR TITLE
CHORE Add triage bot for GitHub PRs

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -30,6 +30,13 @@ Read the contribution guideline at `docs/source/developer_guides/contributing.md
 - If you plan to add a completely new feature, first create an issue and ask for approval.
 - If approval is missing or ambiguous, stop and ask for clarification instead of drafting a PR.
 
+### Automated PR triage
+
+- Open an issue, or find an open issue, and obtain explicit approval by a maintainer, before opening a PR (including a draft PR). Approval is a comment by a listed PEFT maintainer or public member of the `huggingface` organization containing `@peft-triage approved` on its own line, outside code fences.
+- Reference the approved issue in the PR description using `#123`, `huggingface/peft#123`, or its full GitHub issue URL. References must point to an issue in `huggingface/peft`, not another PR. If several issues are referenced, approval on one is sufficient.
+- PRs without verified approval are closed with an explanation. Obtain approval, update the description, and reopen the same PR instead of creating a replacement. If the closure seems incorrect, ping the maintainers on the PR.
+- Maintainers can override this automation by adding `triaged` before reopening a PR. The label does not exempt items from the independent stale bot. This workflow does not assign users or change issues.
+
 ### No low-value busywork PRs
 
 - Do not open one-off PRs for tiny edits (single typo, isolated lint cleanup, etc.).

--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -32,7 +32,7 @@ Read the contribution guideline at `docs/source/developer_guides/contributing.md
 
 ### Automated PR triage
 
-- Open an issue, or find an open issue, and obtain explicit approval by a maintainer, before opening a PR (including a draft PR). Approval is a comment by a listed PEFT maintainer or public member of the `huggingface` organization containing `@peft-triage approved` on its own line, outside code fences.
+- Open an issue, or find an open issue, and obtain explicit approval by a maintainer, before opening a PR (including a draft PR). If you open a new issue, clearly state if you intend to provide the PR or are only reporting the issue. Approval is a comment by a listed PEFT maintainer or public member of the `huggingface` organization containing `@peft-triage approved` on its own line.
 - Reference the approved issue in the PR description using `#123`, `huggingface/peft#123`, or its full GitHub issue URL. References must point to an issue in `huggingface/peft`, not another PR. If several issues are referenced, approval on one is sufficient.
 - PRs without verified approval are closed with an explanation. Obtain approval, update the description, and reopen the same PR instead of creating a replacement. If the closure seems incorrect, ping the maintainers on the PR.
 - Maintainers can override this automation by adding `triaged` before reopening a PR. The label does not exempt items from the independent stale bot. This workflow does not assign users or change issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+# PR description
+
+<!--
+If this PR was authored by a human, add the following line verbatim (without quotation marks) to the description:
+
+"This PR was authored by a human."
+
+This is also fine if you used AI to assist with the PR, e.g. to answer questions or for auto-completion. Do not include this sentence if the PR was mainly written by an AI.
+-->

--- a/.github/workflows/triage_prs.yml
+++ b/.github/workflows/triage_prs.yml
@@ -1,0 +1,70 @@
+# Checks open PRs (including drafts) every four hours, starting with
+# PRs created on September 9, 2026, at 00:00 UTC. PRs labeled
+# "triaged" are skipped.
+#
+# Listed maintainers, public Hugging Face members, and allowlisted
+# contributors receive "triaged" automatically. Others must link a
+# PEFT issue in their PR description, approved by a listed maintainer
+# or public Hugging Face member with "@peft-triage approved" on its
+# own line outside a code block.  Accepted references: #123,
+# huggingface/peft#123, or the full GitHub issue URL.  Contributor
+# allowlists do not grant approval authority. Only public organization
+# membership is checked; private members need an individual allowlist
+# entry.
+#
+# PRs without approval are closed with an explanation. Contributors
+# can obtain approval and reopen the same PR, or ping maintainers
+# about an incorrect closure.  Maintainers can override by adding
+# "triaged" before reopening.  Issue assignments and the independent
+# stale bot are unaffected.
+#
+# First-time setup: Create the "triaged" label and review the cutoff,
+# maintainers, and allowlists in scripts/triage_prs.py.
+#
+# Use Actions > PR triage > Run workflow to preview decisions
+# (dry_run=true, the manual default), or set dry_run=false to apply
+# them. Previews use the same cutoff. Failed checks leave affected PRs
+# open; review the Actions logs and rerun.
+name: PR triage
+
+on:
+  # TODO: set up automatic cron job
+  # schedule:
+  #   - cron: "17 */4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log decisions without labeling, commenting, or closing PRs
+        type: boolean
+        default: true
+
+permissions: {}
+
+concurrency:
+  group: peft-pr-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    if: github.repository == 'huggingface/peft' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.13"
+      - name: Install script dependency
+        run: python -m pip install requests
+      - name: Triage open PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+        run: python scripts/triage_prs.py

--- a/docs/source/developer_guides/contributing.md
+++ b/docs/source/developer_guides/contributing.md
@@ -20,13 +20,13 @@ We are happy to accept contributions to PEFT. If you plan to contribute, please 
 
 ## Discuss and obtain approval before opening a PR
 
-Before opening a pull request (including a draft), open or find an issue in [huggingface/peft](https://github.com/huggingface/peft/issues) and discuss your proposed contribution. Check whether someone is already working on it, has declared their intent to work on it, or has an open PR. Wait for a PEFT maintainer or Hugging Face member to explicitly approve the proposal. If you open an issue, keep the length and complexity of the description in proportion with the complexity of the issue. Often, a short description with a reproducer is more valuable than a long description.
+Before opening a pull request (including a draft), open or find an issue in [huggingface/peft](https://github.com/huggingface/peft/issues) and discuss your proposed contribution. If there is an existing issue and someone is already working on it, has declared their intent to work on it, or has an open PR, you should not submit a separate PR. Wait for a PEFT maintainer or Hugging Face member to explicitly approve the proposal. If you open an issue, keep the length and complexity of the description in proportion with the complexity of the issue. Often, a short description with a reproducer is more valuable than a long description.
 
-Link the approved issue in your PR description using `#123`, `huggingface/peft#123`, or `https://github.com/huggingface/peft/issues/123`. For example, write `Fixes #123`. The reference must point to an issue in this repository, not another PR. If you reference several issues, approval on one is sufficient.
+Link the approved issue in your PR description using `#123`, `huggingface/peft#123`, or `https://github.com/huggingface/peft/issues/123`. For example, write `Fixes #123`. The reference must point to an issue in the PEFT repository. If you reference several issues, approval on one is sufficient.
 
 An automated workflow checks PRs for corresponding issues with approvals. PRs without verified approval are automatically closed with an explanation. You can obtain approval, update the PR description, and reopen the same PR; please do not create a replacement. If you believe your PR was closed incorrectly, ping the maintainers on the PR.
 
-This workflow does not change issues or assignments. The independent stale bot can still close inactive items labeled `triaged`. The [workflow comments](https://github.com/huggingface/peft/blob/main/.github/workflows/triage_prs.yml) document setup and configuration.
+The independent stale bot can still close inactive items, even if labeled as `triaged`. If you feel like the maintainers have overlooked your contribution, you may ping them, but not earlier than before two weeks of inactivity.
 
 ## Installation
 

--- a/docs/source/developer_guides/contributing.md
+++ b/docs/source/developer_guides/contributing.md
@@ -18,6 +18,16 @@ rendered properly in your Markdown viewer.
 
 We are happy to accept contributions to PEFT. If you plan to contribute, please read this to make the process as smooth as possible.
 
+## Discuss and obtain approval before opening a PR
+
+Before opening a pull request (including a draft), open or find an issue in [huggingface/peft](https://github.com/huggingface/peft/issues) and discuss your proposed contribution. Check whether someone is already working on it, has declared their intent to work on it, or has an open PR. Wait for a PEFT maintainer or Hugging Face member to explicitly approve the proposal. If you open an issue, keep the length and complexity of the description in proportion with the complexity of the issue. Often, a short description with a reproducer is more valuable than a long description.
+
+Link the approved issue in your PR description using `#123`, `huggingface/peft#123`, or `https://github.com/huggingface/peft/issues/123`. For example, write `Fixes #123`. The reference must point to an issue in this repository, not another PR. If you reference several issues, approval on one is sufficient.
+
+An automated workflow checks PRs for corresponding issues with approvals. PRs without verified approval are automatically closed with an explanation. You can obtain approval, update the PR description, and reopen the same PR; please do not create a replacement. If you believe your PR was closed incorrectly, ping the maintainers on the PR.
+
+This workflow does not change issues or assignments. The independent stale bot can still close inactive items labeled `triaged`. The [workflow comments](https://github.com/huggingface/peft/blob/main/.github/workflows/triage_prs.yml) document setup and configuration.
+
 ## Installation
 
 Follow these steps to start contributing:
@@ -101,7 +111,7 @@ It can happen that while you’re working on your PR, the underlying code base c
 
 ## PR description
 
-When opening a PR, please provide a nice description of the change you're proposing. If it relates to other issues or PRs, please reference them. Providing a good description not only helps the reviewers review your code better and faster, it can also be used later (as a basis) for the commit message which helps with long term maintenance of the project.
+When opening a PR, please provide a nice description of the change you're proposing and reference the approved issue as described above. If it relates to other issues or PRs, please reference them as well. Providing a good description not only helps the reviewers review your code better and faster, it can also be used later (as a basis) for the commit message which helps with long term maintenance of the project.
 
 Keep the length and complexity of the PR description in line with the change. We don't need ten paragraphs of explanation for a trivial one-line change. Don't restate what is obvious from looking at the diff (e.g. "Fixed the typo in 'foobaar').
 
@@ -134,13 +144,13 @@ Please refrain from sending pull requests that *only* correct typing errors as t
 New parameter-efficient fine-tuning methods are developed all the time. If you would like to add a new and promising method to PEFT, please follow these steps.
 
 1. If you're _not_ an author of the original paper, check for existing implementations and double check with the authors that they don't plan to submit a PR themselves.
-2. Start with the core integration work listed below.
+2. Open a proposal issue and wait for explicit approval as described above, before starting the core integration work listed below.
 3. Check recent commits for new PEFT methods being added to take as inspiration.
-4. It can be useful to open a draft PR early once the method basically works and first tests pass, then ask for feedback.
+4. After the proposal is approved, it can be useful to open a draft PR early once the method basically works and first tests pass, then ask for feedback. Reference the approved issue in the draft PR description.
 
 ### Core integration of a new PEFT method
 
-- [ ] Open a proposal issue on `huggingface/peft` before investing too much work.
+- [ ] Open an issue on `huggingface/peft` and obtain explicit approval before investing too much work.
 - [ ] Link the source of the method, usually the final paper or another stable primary reference. We want to avoid work that is still under review, as the implementation should be stable.
 - [ ] Add a new `PeftType` entry in `src/peft/utils/peft_types.py`.
 - [ ] Create a new tuner package under `src/peft/tuners/` with the files your method needs (typically:  `config.py`, `model.py`, `layer.py`, and `__init__.py`).
@@ -163,9 +173,14 @@ New parameter-efficient fine-tuning methods are developed all the time. If you w
 - [ ] Check the benchmarks in `method_comparison/` and add experiment settings for your new method. This is a good place to sanity check that the PEFT method trains as expected. Include one or two reasonable benchmark configurations (one default, one optimized for the benchmark).
 - [ ] Recommended: Add generic quantization support. Instead of having to explicitly add quantization layer types for each quantization method, support generic quantization. As an example, check how it's implemented in [BOFT](https://github.com/huggingface/peft/tree/main/src/peft/tuners/boft). Extend https://github.com/huggingface/peft/blob/main/tests/test_quantization.py by adding your PEFT method there. Ask maintainers for help if needed.
 
+
+## Making changes to existing PEFT methods
+
+If you make a change to a PEFT method that could potentially change its outputs, thus invalidating already trained checkpoints, we need to take extra precautions. Please check the description at https://github.com/huggingface/peft/blob/main/.ai/skills/peft-method-changes/SKILL.md for details. The instructions there are meant for both humans and AI.
+
 ## Add other features
 
-It is best if you first open an issue on GitHub with a proposal to add the new feature. This way, you can discuss with the maintainers if it makes sense to add the feature before spending too much time on implementing it.
+First open an issue on GitHub with a proposal to add the new feature and wait for explicit approval as described above. This way, you can discuss with the maintainers if it makes sense to add the feature before spending too much time on implementing it.
 
 New features should generally be accompanied by tests and documentation or examples. Without the latter, users will have a hard time discovering your cool new feature.
 

--- a/scripts/triage_prs.py
+++ b/scripts/triage_prs.py
@@ -125,12 +125,20 @@ class GitHubClient:
         return {member["id"] for member in self.list_items(f"/orgs/{organization}/public_members", public=True)}
 
 
+def strip_html_comments(body):
+    """Remove HTML comments, including unclosed comments extending to the end of the body."""
+    # Keep surrounding text separated instead of joining tokens across a comment.
+    return re.sub(r"<!--.*?(?:-->|\Z)", " ", body or "", flags=re.DOTALL)
+
+
 def extract_issue_numbers(body, repository):
     """Extract local #123, owner/repo#123 and GitHub issue URLs in description order."""
     numbers = []
     # Consume whole URLs and qualified references so foreign references cannot be
     # mistaken for local issue numbers (including URL fragments).
-    references = re.finditer(r"https?://[^\s<>`]+|(?<![\w/.-])(?:[\w.-]+/[\w.-]+)?#[1-9][0-9]*", body or "")
+    references = re.finditer(
+        r"https?://[^\s<>`]+|(?<![\w/.-])(?:[\w.-]+/[\w.-]+)?#[1-9][0-9]*", strip_html_comments(body)
+    )
     for reference in references:
         text = reference.group().rstrip(".,;:)]}")
         if text.startswith(("https://", "http://")):
@@ -157,10 +165,10 @@ def extract_issue_numbers(body, repository):
     return numbers
 
 
-def contains_approval(body, bot_name):
-    """Require the command on its own line, outside Markdown code fences."""
+def iter_unfenced_lines(body):
+    """Yield lines outside HTML comments and Markdown code fences."""
     fence = None
-    for line in (body or "").splitlines():
+    for line in strip_html_comments(body).splitlines():
         if fence is not None:
             # A shorter fence or one with trailing text cannot close a code block.
             if re.fullmatch(rf" {{0,3}}{fence[0]}{{{len(fence)},}}[ \t]*", line):
@@ -170,10 +178,15 @@ def contains_approval(body, bot_name):
         opening = re.match(r" {0,3}(`{3,}|~{3,})", line)
         if opening:
             fence = opening[1]
-        elif re.fullmatch(rf" {{0,3}}@{re.escape(bot_name)} approved[ \t]*", line):
-            return True
+        else:
+            yield line
 
-    return False
+
+def contains_approval(body, bot_name):
+    """Require the command on its own line, outside HTML comments and Markdown code fences."""
+    return any(
+        re.fullmatch(rf" {{0,3}}@{re.escape(bot_name)} approved[ \t]*", line) for line in iter_unfenced_lines(body)
+    )
 
 
 def is_eligible_pr(pr, since):
@@ -225,8 +238,9 @@ class PullRequestTriage:
         return False
 
     def is_human_author(self, body):
-        body = body or ""
-        return HUMAN_MARKER.lower() in body.lower()
+        """Require a standalone declaration or checked checkbox outside comments and code fences."""
+        pattern = rf" {{0,3}}(?:[-*+] \[x\][ \t]+)?{re.escape(HUMAN_MARKER)}\.?[ \t]*"
+        return any(re.fullmatch(pattern, line, flags=re.IGNORECASE) for line in iter_unfenced_lines(body))
 
     def closure_message(self):
         return CLOSURE_MESSAGE.format(
@@ -244,9 +258,9 @@ class PullRequestTriage:
             return
 
         approved = (
-            self.is_exempt_author(pr["user"]["id"])
+            self.is_human_author(pr["body"])
+            or self.is_exempt_author(pr["user"]["id"])
             or self.has_approved_issue(pr["body"])
-            or self.is_human_author(pr["body"])
         )
         comments = [] if approved else self.client.list_items(f"{self.path}/issues/{number}/comments")
         current = self.client.get(f"{self.path}/pulls/{number}")

--- a/scripts/triage_prs.py
+++ b/scripts/triage_prs.py
@@ -243,7 +243,11 @@ class PullRequestTriage:
         if not is_eligible_pr(pr, self.since):
             return
 
-        approved = self.is_exempt_author(pr["user"]["id"]) or self.has_approved_issue(pr["body"]) or self.is_human_author(pr["body"])
+        approved = (
+            self.is_exempt_author(pr["user"]["id"])
+            or self.has_approved_issue(pr["body"])
+            or self.is_human_author(pr["body"])
+        )
         comments = [] if approved else self.client.list_items(f"{self.path}/issues/{number}/comments")
         current = self.client.get(f"{self.path}/pulls/{number}")
         if not is_eligible_pr(current, self.since) or current["updated_at"] != pr["updated_at"]:

--- a/scripts/triage_prs.py
+++ b/scripts/triage_prs.py
@@ -24,6 +24,7 @@ import requests
 
 TRIAGED_LABEL = "triaged"
 CLOSURE_MARKER = "<!-- peft-pr-triage: approval-required -->"
+HUMAN_MARKER = "This PR was authored by a human"
 REPOSITORY = "huggingface/peft"
 START_DATE = "2026-09-09"  # Inclusive creation date in UTC.
 BOT_NAME = "peft-triage"
@@ -223,6 +224,10 @@ class PullRequestTriage:
 
         return False
 
+    def is_human_author(self, body):
+        body = body or ""
+        return HUMAN_MARKER.lower() in body.lower()
+
     def closure_message(self):
         return CLOSURE_MESSAGE.format(
             closure_marker=CLOSURE_MARKER, bot_name=self.bot_name, repository=self.repository
@@ -238,7 +243,7 @@ class PullRequestTriage:
         if not is_eligible_pr(pr, self.since):
             return
 
-        approved = self.is_exempt_author(pr["user"]["id"]) or self.has_approved_issue(pr["body"])
+        approved = self.is_exempt_author(pr["user"]["id"]) or self.has_approved_issue(pr["body"]) or self.is_human_author(pr["body"])
         comments = [] if approved else self.client.list_items(f"{self.path}/issues/{number}/comments")
         current = self.client.get(f"{self.path}/pulls/{number}")
         if not is_eligible_pr(current, self.since) or current["updated_at"] != pr["updated_at"]:

--- a/scripts/triage_prs.py
+++ b/scripts/triage_prs.py
@@ -1,0 +1,297 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Enforce issue approval for new PRs. Setup and policy are documented in triage_prs.yml."""
+
+import os
+import re
+from datetime import datetime, timezone
+from functools import cache
+from urllib.parse import urlsplit
+
+import requests
+
+
+TRIAGED_LABEL = "triaged"
+CLOSURE_MARKER = "<!-- peft-pr-triage: approval-required -->"
+REPOSITORY = "huggingface/peft"
+START_DATE = "2026-09-09"  # Inclusive creation date in UTC.
+BOT_NAME = "peft-triage"
+
+# see: https://api.github.com/users/<user-id>
+MAINTAINERS = {"BenjaminBossan": 6229650, "githubnemo": 264196}
+ALLOW_LIST_USERS = {"dependabot[bot]": 49699333, "peft-jambot": 295153068}
+ALLOW_LIST_ORGANIZATIONS = {}  # Organization name -> immutable organization ID.
+# see: https://api.github.com/orgs/huggingface
+HF_ORGANIZATION_ID = 25720743
+GITHUB_ACTIONS_BOT_ID = 41898282
+MAX_ISSUE_REFERENCES = 10
+
+CLOSURE_MESSAGE = (
+    "{closure_marker}\n\n"
+    "Thank you for your interest in contributing to PEFT. This PR is being closed because its description "
+    "does not reference a PEFT issue with explicit approval from a maintainer or public Hugging Face "
+    "organization member.\n\n"
+    "Please open or find an issue, discuss the proposed contribution, and wait for an authorized person to "
+    "comment `@{bot_name} approved` on its own line before opening a PR. "
+    "Once approved, reference the issue in this PR's description (for example, `Fixes #123`) and reopen it; "
+    "there is no need to create another PR.\n\n"
+    "If you believe this PR was closed incorrectly, please ping the maintainers here.\n\n"
+    "See the [contribution guidelines]"
+    "(https://github.com/{repository}/blob/main/docs/source/developer_guides/contributing.md)."
+)
+
+
+def str_to_bool(value: str) -> bool:
+    """
+    Converts a string representation of truth to `True` (1) or `False` (0).
+
+    True values are `y`, `yes`, `t`, `true`, `on`, and `1`; False value are `n`, `no`, `f`, `false`, `off`, and `0`;
+    """
+    # Same as function as in accelerate.utils, which replaces the deprecated distutils.util.strtobool, and returns bool
+    # instead of int.
+    value = value.lower()
+    if value in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif value in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value {value}")
+
+
+class GitHubClient:
+    """Small REST client; failed or incomplete reads propagate before any dependent writes."""
+
+    def __init__(self, token):
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        )
+
+    def request(self, method, path, *, public=False, **kwargs):
+        # Public membership needs no organization credential. Do not follow redirects or URLs supplied in contribution
+        # text with the repository token.
+        response = self.session.request(
+            method,
+            f"https://api.github.com{path}",
+            headers={"Authorization": None} if public else {},
+            timeout=30,
+            allow_redirects=False,
+            **kwargs,
+        )
+        response.raise_for_status()
+        if not 200 <= response.status_code < 300:
+            raise RuntimeError(f"Unexpected GitHub status {response.status_code} for {path}")
+        return response
+
+    def get(self, path):
+        return self.request("GET", path).json()
+
+    def list_items(self, path, *, public=False, **params):
+        """Read every page before returning, including when later pages fail."""
+        items = []
+        page = 1
+        per_page = 100
+        while True:
+            batch = self.request(
+                "GET", path, public=public, params={**params, "per_page": per_page, "page": page}
+            ).json()
+            items.extend(batch)
+            if len(batch) < per_page:  # hit the end
+                return items
+            page += 1
+
+    @cache  # # ruff: ignore[B019]
+    def public_members(self, organization, organization_id):
+        # An organization's old name can be claimed by someone else after a rename.
+        metadata = self.request("GET", f"/orgs/{organization}", public=True).json()
+        if metadata["id"] != organization_id:
+            raise RuntimeError(f"Organization ID mismatch for {organization}; review the configured identity.")
+        return {member["id"] for member in self.list_items(f"/orgs/{organization}/public_members", public=True)}
+
+
+def extract_issue_numbers(body, repository):
+    """Extract local #123, owner/repo#123 and GitHub issue URLs in description order."""
+    numbers = []
+    # Consume whole URLs and qualified references so foreign references cannot be
+    # mistaken for local issue numbers (including URL fragments).
+    references = re.finditer(r"https?://[^\s<>`]+|(?<![\w/.-])(?:[\w.-]+/[\w.-]+)?#[1-9][0-9]*", body or "")
+    for reference in references:
+        text = reference.group().rstrip(".,;:)]}")
+        if text.startswith(("https://", "http://")):
+            url = urlsplit(text)
+            match = re.fullmatch(r"/([^/]+/[^/]+)/issues/([1-9][0-9]*)/?", url.path)
+            if url.netloc.lower() != "github.com" or not match or match[1].lower() != repository.lower():
+                continue
+            number = match[2]
+        else:
+            repo, number = text.split("#")
+            if repo and repo.lower() != repository.lower():
+                continue
+
+        # Bound integer conversion and API work on contributor-controlled input.
+        if len(number) > 20:
+            raise ValueError("Issue reference exceeds the supported number length.")
+
+        number = int(number)
+        if number not in numbers:
+            numbers.append(number)
+            if len(numbers) > MAX_ISSUE_REFERENCES:
+                raise ValueError(f"More than {MAX_ISSUE_REFERENCES} issue references; manual triage required.")
+
+    return numbers
+
+
+def contains_approval(body, bot_name):
+    """Require the command on its own line, outside Markdown code fences."""
+    fence = None
+    for line in (body or "").splitlines():
+        if fence is not None:
+            # A shorter fence or one with trailing text cannot close a code block.
+            if re.fullmatch(rf" {{0,3}}{fence[0]}{{{len(fence)},}}[ \t]*", line):
+                fence = None
+            continue
+
+        opening = re.match(r" {0,3}(`{3,}|~{3,})", line)
+        if opening:
+            fence = opening[1]
+        elif re.fullmatch(rf" {{0,3}}@{re.escape(bot_name)} approved[ \t]*", line):
+            return True
+
+    return False
+
+
+def is_eligible_pr(pr, since):
+    return (
+        pr["state"] == "open"
+        and datetime.fromisoformat(pr["created_at"].replace("Z", "+00:00")) >= since
+        and not any(label["name"].lower() == TRIAGED_LABEL for label in pr["labels"])
+    )
+
+
+class PullRequestTriage:
+    def __init__(self, client, repository, since, bot_name, maintainers, allowed_users=(), allowed_organizations=()):
+        self.client = client
+        self.repository = repository
+        self.path = f"/repos/{repository}"
+        self.since = since
+        self.bot_name = bot_name
+        self.maintainers = set(maintainers)
+        self.allowed_users = set(allowed_users)
+        self.allowed_organizations = dict(allowed_organizations)
+
+    def can_approve(self, user_id):
+        return user_id in self.maintainers or user_id in self.client.public_members("huggingface", HF_ORGANIZATION_ID)
+
+    def is_exempt_author(self, user_id):
+        return (
+            user_id in self.maintainers
+            or user_id in self.allowed_users
+            or user_id in self.client.public_members("huggingface", HF_ORGANIZATION_ID)
+            or any(
+                user_id in self.client.public_members(org, org_id)
+                for org, org_id in sorted(self.allowed_organizations.items())
+            )
+        )
+
+    def has_approved_issue(self, body):
+        for number in extract_issue_numbers(body, self.repository):
+            issue = self.client.get(f"{self.path}/issues/{number}")
+            if "pull_request" in issue:
+                continue
+
+            comments = self.client.list_items(f"{self.path}/issues/{number}/comments")
+            if any(
+                contains_approval(comment["body"], self.bot_name) and self.can_approve(comment["user"]["id"])
+                for comment in comments
+            ):
+                return True
+
+        return False
+
+    def closure_message(self):
+        return CLOSURE_MESSAGE.format(
+            closure_marker=CLOSURE_MARKER, bot_name=self.bot_name, repository=self.repository
+        )
+
+    def triage_pr(self, pr, *, dry_run=False):
+        if not is_eligible_pr(pr, self.since):
+            return
+
+        number = pr["number"]
+        # Fetch current labels, state and description before making the decision.
+        pr = self.client.get(f"{self.path}/pulls/{number}")
+        if not is_eligible_pr(pr, self.since):
+            return
+
+        approved = self.is_exempt_author(pr["user"]["id"]) or self.has_approved_issue(pr["body"])
+        comments = [] if approved else self.client.list_items(f"{self.path}/issues/{number}/comments")
+        current = self.client.get(f"{self.path}/pulls/{number}")
+        if not is_eligible_pr(current, self.since) or current["updated_at"] != pr["updated_at"]:
+            print(f"Skipping PR #{number}: changed during triage; will reconsider next run.")
+            return
+
+        action = "label triaged" if approved else "close: missing issue approval"
+        print(f"{'Would' if dry_run else 'Will'} {action} on PR #{number}")
+        if dry_run:
+            return
+
+        if approved:
+            self.client.request("POST", f"{self.path}/issues/{number}/labels", json={"labels": [TRIAGED_LABEL]})
+            return
+
+        if not any(
+            comment["user"]["id"] == GITHUB_ACTIONS_BOT_ID and CLOSURE_MARKER in (comment["body"] or "")
+            for comment in comments
+        ):
+            self.client.request("POST", f"{self.path}/issues/{number}/comments", json={"body": self.closure_message()})
+        # Recheck after commenting as well; the comment itself updates updated_at.
+        current = self.client.get(f"{self.path}/pulls/{number}")
+        if is_eligible_pr(current, self.since) and current["body"] == pr["body"]:
+            self.client.request("PATCH", f"{self.path}/pulls/{number}", json={"state": "closed"})
+
+    def run(self, *, dry_run=False):
+        # Snapshot all pages before closing PRs, which changes pagination of open PRs.
+        prs = self.client.list_items(f"{self.path}/pulls", state="open")
+        failures = []
+        for pr in prs:
+            try:
+                self.triage_pr(pr, dry_run=dry_run)
+            except (requests.RequestException, RuntimeError, ValueError) as error:
+                failures.append(pr["number"])
+                # Escape newlines and both current and legacy Actions command delimiters.
+                message = repr(error).replace("::", ": :").replace("##[", "# #[")
+                print(f"Failed to triage PR #{pr['number']}: {message}")
+        if failures:
+            raise RuntimeError(f"Triage failed for PRs {failures}; see earlier errors. Rerun after resolving them.")
+
+
+def main():
+    triage = PullRequestTriage(
+        client=GitHubClient(os.environ["GITHUB_TOKEN"]),
+        repository=REPOSITORY,
+        since=datetime.strptime(START_DATE, "%Y-%m-%d").replace(tzinfo=timezone.utc),
+        bot_name=BOT_NAME,
+        maintainers=MAINTAINERS.values(),
+        allowed_users=ALLOW_LIST_USERS.values(),
+        allowed_organizations=ALLOW_LIST_ORGANIZATIONS,
+    )
+    triage.run(dry_run=str_to_bool(os.environ.get("DRY_RUN", "false")))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/triage_prs.py
+++ b/scripts/triage_prs.py
@@ -26,7 +26,7 @@ TRIAGED_LABEL = "triaged"
 CLOSURE_MARKER = "<!-- peft-pr-triage: approval-required -->"
 HUMAN_MARKER = "This PR was authored by a human"
 REPOSITORY = "huggingface/peft"
-START_DATE = "2026-09-09"  # Inclusive creation date in UTC.
+START_DATE = "2026-09-10"  # Apply triage only to PRs from this date, inclusive, or later (UTC)
 BOT_NAME = "peft-triage"
 
 # see: https://api.github.com/users/<user-id>


### PR DESCRIPTION
Adds a bot that automates triaging open PRs with the intent of reducing the review load of maintainers by first requiring approval.

If the PR is from a maintainer, a (public) HF member, or an allow-listed user, it gets the 'triaged' label and nothing happens. If the PR not from such a user, it is checked if there is an associated issue. If there is, the issue must have an explicit approval from a maintainer, in which case the PR gets the 'triaged' label and is ready to be worked on:

`@peft-triage approved`

If no such issue with maintainer approval is found, the PR is autoclosed with a message to explain why.

Right now, the GH action needs to be manually triggered. This allows to first test if it works as intended. If we agree, we can setup a cron schedule to run it every few hours. The 'triaged' label has yet to be created, in case we decide to proceed with this PR.

Note that this automation does _not_ check if the submitter of the PR is the same person who offered to work on in in the issue. Therefore, it can still happen that another user opens a PR for an approved issue, or that a user submits a PR and references an unrelated issue, to prevent the PR from being autoclosed. Right now, I assume that the contributors generally are not behaving maliciously and further precautions are not required, but we can revisit this if the assumption proves wrong.