### PR TITLE
FIX BOFT Conv2d safe_merge skipping the non-finite check

### DIFF
--- a/src/peft/tuners/boft/layer.py
+++ b/src/peft/tuners/boft/layer.py
@@ -839,6 +839,11 @@ class Conv2d(nn.Module, BOFTLayer):
                         self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[0]
                     )
 
+                    if not torch.isfinite(orig_weight).all():
+                        raise ValueError(
+                            f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
+                        )
+
                     self.set_base_weight(orig_weight.contiguous().to(orig_dtype))
                 else:
                     butterfly_oft_mat, boft_s = self.get_delta_weight(active_adapter)

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2602,6 +2602,30 @@ class TestPeftCustomModel(PeftCommonTester):
         assert torch.equal(model.base_model.model.lin0.base_layer.bias.data, orig_bias)
         assert model.base_model.model.lin0.merged_adapters == []
 
+    def test_boft_conv2d_safe_merge_does_not_corrupt_base_layer_on_non_finite_adapter(self):
+        # Regression test: BOFT's Conv2d.merge() had a safe_merge branch that was identical to the
+        # normal one -- the isfinite check that Linear.merge() does was missing -- so a broken
+        # (non-finite) adapter wrote non-finite weights straight into the base layer and recorded
+        # the merge as successful, instead of raising.
+        torch.manual_seed(0)
+        model = ModelConv2D()
+        orig_weight = model.conv2d.weight.data.clone()
+
+        config = BOFTConfig(target_modules=["conv2d"], boft_block_size=45, boft_block_num=0, boft_n_butterfly_factor=1)
+        model = get_peft_model(model, config)
+        conv2d = model.base_model.model.conv2d
+
+        # Deliberately break the adapter (e.g. a corrupted checkpoint or an fp16 overflow) so that
+        # the merged weights would contain non-finite values.
+        conv2d.boft_s["default"].data.fill_(float("inf"))
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged weights"):
+            conv2d.merge(safe_merge=True)
+
+        # The base layer must be untouched after the failed safe_merge.
+        assert torch.equal(conv2d.base_layer.weight.data, orig_weight)
+        assert conv2d.merged_adapters == []
+
     @pytest.mark.parametrize("safe_merge", [False, True])
     @pytest.mark.parametrize("module_type", ["linear", "conv2d"])
     def test_merge_with_lora_bias_when_base_layer_has_no_bias_warns_and_raises(self, safe_merge, module_type):


### PR DESCRIPTION
## What

`BOFT` `Conv2d.merge`'s `safe_merge` branch is identical to the normal branch apart from a comment, with the `torch.isfinite` check missing. So `safe_merge=True` on a BOFT `Conv2d` layer does nothing: a broken adapter writes non-finite weights straight into the base layer and the merge is recorded as successful, which is the opposite of what the docstring promises ("check for NaNs before merging the weights"). `Linear.merge` in the same file does the check.

Reproducer on `main`, the same broken adapter once on `Conv2d` and once on `Linear`:

```
Conv2d: merge(safe_merge=True) returned WITHOUT raising
        base weight finite afterwards?  False
        base weight unchanged?          False
        merged_adapters                 ['default']

Linear: raised ValueError "NaNs detected in the merged weights..."
        base weight unchanged?          True
        merged_adapters                 []
```

With the patch the `Conv2d` rows match the `Linear` ones.

The fix is the same four lines `Linear.merge` already has, placed before `set_base_weight` so the base layer is never touched on a failed merge. Same shape as #3411 for GLoRA.

On the "fix all of them in one PR" rule: I checked every `if safe_merge:` block in `src/peft` by walking the AST, and this is the only one without a finiteness check, so there is nothing else to bundle in.

Coordination: opened as #3682 with the reproducer. Keeping this a draft until a maintainer confirms they want
the fix done this way. It came out of an audit rather than a bug report, and no open PR touches it.

## Tests

- Added `test_boft_conv2d_safe_merge_does_not_corrupt_base_layer_on_non_finite_adapter` next to the GLoRA test from #3411. It fails on `main` with `DID NOT RAISE ValueError` and passes with the fix.
- `pytest tests/ -k "boft or BOFT"`: 669 passed, 13 skipped on `main` plus the new test failing, then 670 passed, 13 skipped with the fix. No other test changes.
- `ruff check` and `ruff format --check` on both changed files with the 0.16.4 pinned in `setup.py`: clean.
- Not run: the MetaMathQA benchmark and the state-dict regression tests. The change adds a guard in `merge()` and touches no `forward`, parameter, buffer, `state_dict` or config default, so nothing about existing checkpoints or training output changes.

Environment: torch 2.11.0, transformers 5.9.0, CPU.

## AI assistance

Disclosing as the contribution guidelines ask: I used AI assistance as a tool here, mainly to write the AST scan that checks every `safe_merge` branch in `src/peft` and to speed up the test boilerplate. The diagnosis, the fix and the test runs above are mine, and I can defend the change.
