### PR TITLE
docs(oft): drop the copy-pasted Args block from get_weight

### DIFF
--- a/src/peft/tuners/oft/layer.py
+++ b/src/peft/tuners/oft/layer.py
@@ -285,11 +285,10 @@ class OFTRotationModule(nn.Module):
 
     def get_weight(self):
         """
-        Compute the delta weight for the given adapter.
+        Compute the delta weight for the current layer.
 
-        Args:
-            adapter (str):
-                The name of the adapter for which the delta weight should be computed.
+        Returns:
+            `torch.Tensor`: The delta weight applied by this OFT layer.
         """
         weight = self.weight
 


### PR DESCRIPTION
`OFTLayer.get_weight()` takes no parameters, but its docstring carries an `Args: adapter (str)` block copied from `get_delta_weight(self, adapter)` (whose identical wording is correct where it lives). Replaced with a short description + Returns section. Docs-only.