### PR TITLE
docs: fix the GLoRA adapter-guide link to the real location

### DIFF
--- a/docs/source/package_reference/glora.md
+++ b/docs/source/package_reference/glora.md
@@ -103,6 +103,6 @@ model.merge_and_unload()
 - GLoRA supports all standard PEFT adapter management features (add, delete, switch, merge, etc).
 
 ## See Also
-- [Adapter conceptual guide](../conceptual_guides/adapter.md)
+- [Adapter guide](../guides/adapter.md)
 - [LoRA reference](./lora.md)
 - [Paper: https://huggingface.co/papers/2306.07967](https://huggingface.co/papers/2306.07967)


### PR DESCRIPTION
`package_reference/glora.md`'s See Also section links `../conceptual_guides/adapter.md` — `docs/source/conceptual_guides/` does not exist. The adapter guide lives at `docs/source/guides/adapter.md`; the link now points there.