### PR TITLE
Fix Trainable Tokens output-head bias

### DIFF
--- a/src/peft/tuners/trainable_tokens/layer.py
+++ b/src/peft/tuners/trainable_tokens/layer.py
@@ -267,6 +267,7 @@ class TrainableTokensLayer(nn.Module, BaseTunerLayer):
                 result = F.linear(
                     input=x,
                     weight=W,
+                    bias=self.base_layer.bias,
                 )
             else:
                 raise ValueError(

--- a/tests/test_trainable_tokens.py
+++ b/tests/test_trainable_tokens.py
@@ -80,6 +80,16 @@ class ModelEmbedInNoGet(torch.nn.Module):
         return self.lin0(self.embed_in(x))
 
 
+class ModelWithOutputHead(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.query = torch.nn.Linear(4, 4)
+        self.lm_head = torch.nn.Linear(4, 7)
+
+    def forward(self, x):
+        return self.lm_head(self.query(x))
+
+
 class TestTrainableTokens:
     @pytest.fixture
     def model_id(self):
@@ -122,6 +132,32 @@ class TestTrainableTokens:
         trainable_tokens_layer.trainable_tokens_delta[adapter_name].data = torch.rand_like(
             trainable_tokens_layer.trainable_tokens_delta[adapter_name].data
         )
+
+    @pytest.mark.parametrize("standalone", [True, False])
+    def test_linear_output_preserves_bias(self, standalone):
+        base_model = ModelWithOutputHead().eval()
+        with torch.no_grad():
+            base_model.lm_head.bias.copy_(torch.arange(7))
+
+        inputs = torch.randn(3, 4)
+        expected = base_model(inputs)
+
+        if standalone:
+            config = TrainableTokensConfig(target_modules=["lm_head"], token_indices=[1, 4])
+        else:
+            config = LoraConfig(
+                target_modules=["query"],
+                trainable_token_indices={"lm_head": [1, 4]},
+            )
+
+        peft_model = get_peft_model(copy.deepcopy(base_model), config).eval()
+        torch.testing.assert_close(peft_model(inputs), expected)
+
+        with peft_model.disable_adapter():
+            torch.testing.assert_close(peft_model(inputs), expected)
+
+        merged_model = peft_model.merge_and_unload()
+        torch.testing.assert_close(merged_model(inputs), expected)
 
     def test_stand_alone_usage(self, model, tokenizer, tmp_path):
         original_model = copy.deepcopy(model)


### PR DESCRIPTION
## Summary

Trainable Tokens uses a functional Linear forward while an adapter is active. That path preserved the updated weight but omitted the wrapped output head's bias, so fresh adapters changed logits before merge.

Pass the existing bias to `F.linear` and add local regression coverage for both standalone Trainable Tokens and LoRA `trainable_token_indices`, including active, disabled, and merged states.

Closes #3649.

Coordination: #3649 contains the reproducer and proposed fix. BenjaminBossan confirmed that the original reporter has priority to implement it in https://github.com/huggingface/peft/pull/3651#issuecomment-5523292539.

## Tests

- `python -m pytest tests/test_trainable_tokens.py -q --no-cov --regression` — 62 passed
- `python -m pytest tests -k trainable_tokens -q --no-cov --regression` — 186 passed, 13 skipped; two unrelated existing CUDA `EmbConv1D` failures also reproduce on unchanged `origin/main`
- `uvx --from ruff==0.16.4 ruff check src/peft/tuners/trainable_tokens/layer.py tests/test_trainable_tokens.py`
- `uvx --from ruff==0.16.4 ruff format --check src/peft/tuners/trainable_tokens/layer.py tests/test_trainable_tokens.py`
- `git diff --check`

AI assistance was used. I reviewed every changed line, ran the tests above, understand the change end-to-end, and take responsibility for the contribution.