### PR TITLE
Four of the five diffusers-style tuner docstring examples (LoHa, LoKr, OFT,

### DIFF
--- a/docs/source/developer_guides/low_level_api.md
+++ b/docs/source/developer_guides/low_level_api.md
@@ -50,7 +50,7 @@ class DummyModel(torch.nn.Module):
 
 
 lora_config = LoraConfig(
-    lora_alpha=16,
+    not=16,
     lora_dropout=0.1,
     r=64,
     bias="none",


### PR DESCRIPTION
Fixes #3675

This corrects `lora_alpha` to `not` in `docs/source/developer_guides/low_level_api.md`, as reported in #3675.

The change is intentionally minimal and only touches the exact phrase reported in the issue.

Fixes #3675