### PR TITLE
Keep failed ROAD safe merges from changing base layers

### DIFF
--- a/src/peft/tuners/road/bnb.py
+++ b/src/peft/tuners/road/bnb.py
@@ -97,15 +97,20 @@ if is_bnb_available():
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
+                    bias = self.get_base_layer().bias
+                    new_bias = None
+                    if bias is not None:
+                        orig_dtype = bias.dtype
+                        new_bias = torch.matmul(road_R, bias.data.to(road_R.dtype))
+                        if safe_merge and not torch.isfinite(new_bias).all():
+                            raise ValueError(
+                                f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
+                            )
+
                     self.get_base_layer().weight = bnb.nn.Int8Params(
                         w_data.to("cpu"), requires_grad=False, has_fp16_weights=weight.has_fp16_weights
                     ).to(weight.device)
-
-                    if self.get_base_layer().bias is not None:
-                        bias = self.get_base_layer().bias
-                        orig_dtype = bias.dtype
-                        bias_data = bias.data
-                        new_bias = torch.matmul(road_R, bias_data.to(road_R.dtype))
+                    if new_bias is not None:
                         bias.data = new_bias.to(orig_dtype)
 
                     state.reset_grads()
@@ -281,6 +286,16 @@ if is_bnb_4bit_available():
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
+                    bias = self.get_base_layer().bias
+                    new_bias = None
+                    if bias is not None:
+                        orig_dtype = bias.dtype
+                        new_bias = torch.matmul(road_R, bias.data.to(road_R.dtype))
+                        if safe_merge and not torch.isfinite(new_bias).all():
+                            raise ValueError(
+                                f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
+                            )
+
                     if "bnb_quantized" in kwargs:
                         kwargs["bnb_quantized"] = False
                     kwargs["requires_grad"] = False
@@ -289,11 +304,7 @@ if is_bnb_4bit_available():
                     kwargs = {k: v for k, v in kwargs.items() if not k.startswith("_")}
                     self.get_base_layer().weight = bnb.nn.Params4bit(w_data.to("cpu"), **kwargs).to(weight.device)
 
-                    if self.get_base_layer().bias is not None:
-                        bias = self.get_base_layer().bias
-                        orig_dtype = bias.dtype
-                        bias_data = bias.data
-                        new_bias = torch.matmul(road_R, bias_data.to(road_R.dtype))
+                    if new_bias is not None:
                         bias.data = new_bias.to(orig_dtype)
 
                     self.merged_adapters.append(active_adapter)

--- a/src/peft/tuners/road/layer.py
+++ b/src/peft/tuners/road/layer.py
@@ -256,26 +256,27 @@ class Linear(nn.Module, RoadLayer):
                 if safe_merge:
                     # Note that safe_merge will be slower than the normal merge
                     # because of the copy operation.
-                    orig_weight = base_layer.weight.data.clone()
-                    orig_weight = torch.matmul(road_R.to(orig_dtype), orig_weight)
+                    new_weight = base_layer.weight.data.clone()
+                    new_weight = torch.matmul(road_R.to(orig_dtype), new_weight)
 
-                    if not torch.isfinite(orig_weight).all():
+                    if not torch.isfinite(new_weight).all():
                         raise ValueError(
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
-                    base_layer.weight.data = orig_weight.contiguous().to(orig_dtype)
-
+                    new_bias = None
                     if base_layer.bias is not None:
-                        orig_bias = base_layer.bias.clone()
-                        orig_bias = torch.matmul(road_R.to(orig_dtype), orig_bias)
+                        new_bias = base_layer.bias.data.clone()
+                        new_bias = torch.matmul(road_R.to(orig_dtype), new_bias)
 
-                        if not torch.isfinite(orig_bias).all():
+                        if not torch.isfinite(new_bias).all():
                             raise ValueError(
                                 f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
                             )
 
-                        base_layer.bias.data = orig_bias.contiguous().to(orig_dtype)
+                    base_layer.weight.data = new_weight.contiguous().to(orig_dtype)
+                    if new_bias is not None:
+                        base_layer.bias.data = new_bias.contiguous().to(orig_dtype)
                 else:
                     orig_weight = base_layer.weight.data
                     orig_weight = torch.matmul(road_R.to(orig_dtype), orig_weight)

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -341,6 +341,35 @@ class PeftGPUCommonTests(unittest.TestCase):
         whisper_8bit = get_peft_model(whisper_8bit, config)
         assert isinstance(whisper_8bit.base_model.model.model.decoder.layers[0].self_attn.v_proj, RoadLinear8bitLt)
 
+    @parameterized.expand(["4bit", "8bit"])
+    @require_bitsandbytes
+    @pytest.mark.single_gpu_tests
+    def test_road_bnb_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self, quantization):
+        if quantization == "8bit":
+            base_layer = bnb.nn.Linear8bitLt(64, 64, bias=True, has_fp16_weights=False).to(self.device)
+            road_cls = RoadLinear8bitLt
+        else:
+            base_layer = bnb.nn.Linear4bit(64, 64, bias=True, compute_dtype=torch.float32, quant_type="nf4").to(
+                self.device
+            )
+            road_cls = RoadLinear4bit
+
+        base_layer(torch.randn(2, 64, device=self.device))
+        layer = road_cls(base_layer, "default", config=RoadConfig(group_size=2)).to(self.device)
+        layer.road_theta["default"].data.zero_()
+        layer.road_alpha["default"].data.fill_(2)
+        base_layer.bias.data.fill_(torch.finfo(base_layer.bias.dtype).max)
+
+        original_weight = base_layer.weight
+        original_bias = base_layer.bias.detach().clone()
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged bias"):
+            layer.merge(safe_merge=True)
+
+        assert base_layer.weight is original_weight
+        assert torch.equal(base_layer.bias, original_bias)
+        assert layer.merged_adapters == []
+
     @require_bitsandbytes
     @pytest.mark.multi_gpu_tests
     @pytest.mark.single_gpu_tests

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2622,6 +2622,24 @@ class TestPeftCustomModel(PeftCommonTester):
         assert torch.equal(model.base_model.model.lin0.base_layer.bias.data, orig_bias)
         assert model.base_model.model.lin0.merged_adapters == []
 
+    def test_road_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self):
+        model = get_peft_model(MLP(), RoadConfig(target_modules=["lin0"], group_size=2))
+        layer = model.base_model.model.lin0
+        base_layer = layer.base_layer
+
+        base_layer.bias.data.fill_(torch.finfo(base_layer.bias.dtype).max)
+        layer.road_theta["default"].data.zero_()
+        layer.road_alpha["default"].data.fill_(2)
+        original_weight = base_layer.weight.data.clone()
+        original_bias = base_layer.bias.data.clone()
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged bias"):
+            layer.merge(safe_merge=True)
+
+        assert torch.equal(base_layer.weight.data, original_weight)
+        assert torch.equal(base_layer.bias.data, original_bias)
+        assert layer.merged_adapters == []
+
     @pytest.mark.parametrize("module_type", ["linear", "conv2d"])
     def test_lora_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self, module_type):
         torch.manual_seed(0)


### PR DESCRIPTION
I noticed the same safe-merge ordering issue fixed for LoRA in #3611 also exists in ROAD. The regular layer writes the transformed weight before checking the transformed bias, while the 4-bit and 8-bit paths don't check the transformed bias at all.

This computes and validates both candidates before committing either one, and adds regression coverage for the regular, 4-bit, and 8-bit paths.

I ran the full ROAD test subset, all seven ROAD GPU tests on an A100, and the Ruff formatting/lint checks :)