### PR TITLE
Add PEFT fine-tuning techniques comparison notebook for conversational AI

### DIFF
--- a/examples/conversational_ai_finetuning_comparison.ipynb
+++ b/examples/conversational_ai_finetuning_comparison.ipynb
@@ -1,0 +1,10 @@
+{
+ "cells": [],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/conversational_ai_finetuning_comparison.ipynb
+++ b/examples/conversational_ai_finetuning_comparison.ipynb
@@ -1,10 +1,1245 @@
 {
- "cells": [],
- "metadata": {
-  "language_info": {
-   "name": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# PEFT Fine-Tuning Techniques Comparison for Conversational AI\n",
+        "\n",
+        "This notebook compares Parameter-Efficient Fine-Tuning (PEFT) techniques\n",
+        "for conversational AI using microsoft/DialoGPT-medium.\n",
+        "\n",
+        "**Techniques covered:**\n",
+        "- LoRA (Low-Rank Adaptation)\n",
+        "- AdaLoRA (Adaptive LoRA)\n",
+        "- IA³ (Infused Adapter by Inhibiting and Amplifying Inner Activations)\n",
+        "- Prefix Tuning\n",
+        "- LN Tuning\n",
+        "\n",
+        "**Hardware:** Free T4 GPU on Google Colab\n",
+        "**Model:** microsoft/DialoGPT-medium\n"
+      ],
+      "metadata": {
+        "id": "X3bhD9uZkTOC"
+      },
+      "id": "X3bhD9uZkTOC"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Install required libraries\n",
+        "!pip install transformers peft datasets accelerate -q\n",
+        "\n",
+        "print(\"✅ Libraries installed successfully!\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "zBAEOBpnkP8k",
+        "outputId": "331218b6-15a8-48d1-f734-6d9fcf9e338e"
+      },
+      "id": "zBAEOBpnkP8k",
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "✅ Libraries installed successfully!\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Technique Overview\n",
+        "\n",
+        "| Technique | What It Does | Trainable Params | Memory | Best For |\n",
+        "|-----------|-------------|-----------------|--------|----------|\n",
+        "| **LoRA** | Adds low-rank matrices to attention layers | ~0.1-1% | Low | General fine-tuning |\n",
+        "| **AdaLoRA** | Dynamically allocates rank budget | ~0.1-1% | Low-Med | When unsure about rank |\n",
+        "| **IA³** | Scales activations with learned vectors | ~0.01% | Very Low | Few-shot tasks |\n",
+        "| **Prefix Tuning** | Prepends trainable tokens to input | ~0.1% | Low | Generation tasks |\n",
+        "| **LN Tuning** | Only tunes LayerNorm parameters | ~0.01% | Very Low | Fast adaptation |"
+      ],
+      "metadata": {
+        "id": "LMNfcYjUklw4"
+      },
+      "id": "LMNfcYjUklw4"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torch\n",
+        "from transformers import AutoTokenizer, AutoModelForCausalLM\n",
+        "from peft import (\n",
+        "    LoraConfig,\n",
+        "    IA3Config,\n",
+        "    get_peft_model,\n",
+        "    TaskType,\n",
+        "    PeftModel\n",
+        ")\n",
+        "\n",
+        "# Check GPU\n",
+        "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+        "print(f\"Using device: {device}\")\n",
+        "print(f\"GPU: {torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'None'}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "eWotSfbiko4C",
+        "outputId": "869e7c05-3bb0-4566-a7be-b4f6c17ecefe"
+      },
+      "id": "eWotSfbiko4C",
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Using device: cpu\n",
+            "GPU: None\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Load DialoGPT-medium\n",
+        "model_name = \"microsoft/DialoGPT-medium\"\n",
+        "\n",
+        "print(f\"Loading tokenizer...\")\n",
+        "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+        "tokenizer.pad_token = tokenizer.eos_token\n",
+        "\n",
+        "print(f\"Loading model...\")\n",
+        "base_model = AutoModelForCausalLM.from_pretrained(\n",
+        "    model_name,\n",
+        "    torch_dtype=torch.float16 if device == \"cuda\" else torch.float32\n",
+        ")\n",
+        "\n",
+        "total_params = sum(p.numel() for p in base_model.parameters())\n",
+        "print(f\"\\n✅ Model loaded!\")\n",
+        "print(f\"Total parameters: {total_params:,}\")\n",
+        "print(f\"Model size: ~{total_params * 2 / 1e9:.1f} GB (float16)\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 153,
+          "referenced_widgets": [
+            "22a86ac576e94c90baabc4e438e5e70f",
+            "2acfbacccaa14a8ca1464a348c9c70b7",
+            "cd259b9ccd234ca39822dcf365dfe98b",
+            "4210b57c9028479596eb3c9a53714d3d",
+            "3d8306ca1f5d4e478390944858260e4f",
+            "48a8dc6959e4424184d479c9adb1f975",
+            "fb44f76dfcd746d1966523b0db1f2545",
+            "2ffd96383e244cbf9c9cb839271211f3",
+            "dd5669a3d7554c75b79763cefcb5e066",
+            "92491e87e7e64d26aeff261e451bb4ee",
+            "c47e91c80ca54fd3bfa8851c7c5e76fd"
+          ]
+        },
+        "id": "vCOPTBqfkvWf",
+        "outputId": "22924fb0-f0bc-4c7a-b9e2-031a4dd8c55b"
+      },
+      "id": "vCOPTBqfkvWf",
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Loading tokenizer...\n",
+            "Loading model...\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Loading weights:   0%|          | 0/293 [00:00<?, ?it/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "22a86ac576e94c90baabc4e438e5e70f"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "✅ Model loaded!\n",
+            "Total parameters: 354,823,168\n",
+            "Model size: ~0.7 GB (float16)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Technique 1: LoRA (Low-Rank Adaptation)\n",
+        "\n",
+        "**How it works:** Freezes original weights. Adds two small matrices A and B\n",
+        "to attention layers. Instead of updating W directly, learns ΔW = B×A where\n",
+        "rank r << original dimension.\n",
+        "\n",
+        "**Key config:**\n",
+        "- `r=8` → rank of adapter matrices\n",
+        "- `lora_alpha=16` → scaling = alpha/r = 2\n",
+        "- `target_modules` → which layers to adapt\n",
+        "- `lora_dropout=0.1` → regularisation"
+      ],
+      "metadata": {
+        "id": "SKTrMvRnlBPq"
+      },
+      "id": "SKTrMvRnlBPq"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import torchao\n",
+        "!pip install --upgrade torchao\n",
+        "# ── LoRA Configuration ──────────────────────────────\n",
+        "lora_config = LoraConfig(\n",
+        "    task_type=TaskType.CAUSAL_LM,\n",
+        "    r=8,                          # rank — lower = fewer params\n",
+        "    lora_alpha=16,                # scaling factor = alpha/r = 2\n",
+        "    target_modules=[\"c_attn\"],    # DialoGPT attention layer name\n",
+        "    lora_dropout=0.1,\n",
+        "    bias=\"none\"\n",
+        ")\n",
+        "\n",
+        "# Apply LoRA to base model\n",
+        "lora_model = get_peft_model(base_model, lora_config)\n",
+        "\n",
+        "# Count parameters\n",
+        "total = sum(p.numel() for p in lora_model.parameters())\n",
+        "trainable = sum(p.numel() for p in lora_model.parameters() if p.requires_grad)\n",
+        "\n",
+        "print(\"=\" * 50)\n",
+        "print(\"LoRA Model Summary\")\n",
+        "print(\"=\" * 50)\n",
+        "print(f\"Total parameters:     {total:,}\")\n",
+        "print(f\"Trainable parameters: {trainable:,}\")\n",
+        "print(f\"Trainable %:          {100 * trainable / total:.4f}%\")\n",
+        "print(f\"Frozen parameters:    {total - trainable:,}\")\n",
+        "print(\"\\n✅ LoRA applied successfully!\")\n",
+        "lora_model.print_trainable_parameters()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dgymR9dlk51i",
+        "outputId": "7b04452a-b68e-4bc4-eaa2-ac7a5a056e83"
+      },
+      "id": "dgymR9dlk51i",
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: torchao in /usr/local/lib/python3.13/dist-packages (0.18.0)\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.13/dist-packages/peft/tuners/lora/layer.py:2631: UserWarning: fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True.\n",
+            "  warnings.warn(\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "==================================================\n",
+            "LoRA Model Summary\n",
+            "==================================================\n",
+            "Total parameters:     355,609,600\n",
+            "Trainable parameters: 786,432\n",
+            "Trainable %:          0.2212%\n",
+            "Frozen parameters:    354,823,168\n",
+            "\n",
+            "✅ LoRA applied successfully!\n",
+            "trainable params: 786,432 || all params: 355,609,600 || trainable%: 0.2212\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Test LoRA model with a conversational prompt\n",
+        "lora_model.eval()\n",
+        "lora_model = lora_model.to(device)\n",
+        "\n",
+        "def generate_response(model, tokenizer, prompt, max_length=100):\n",
+        "    inputs = tokenizer.encode(\n",
+        "        prompt + tokenizer.eos_token,\n",
+        "        return_tensors=\"pt\"\n",
+        "    ).to(device)\n",
+        "\n",
+        "    with torch.no_grad():\n",
+        "        outputs = model.generate(\n",
+        "            inputs,\n",
+        "            max_length=max_length,\n",
+        "            pad_token_id=tokenizer.eos_token_id,\n",
+        "            do_sample=True,\n",
+        "            temperature=0.7,\n",
+        "            top_p=0.9\n",
+        "        )\n",
+        "\n",
+        "    response = tokenizer.decode(outputs[0], skip_special_tokens=True)\n",
+        "    return response\n",
+        "\n",
+        "# Test it\n",
+        "prompt = \"What is machine learning?\"\n",
+        "response = generate_response(lora_model, tokenizer, prompt)\n",
+        "print(f\"Prompt:   {prompt}\")\n",
+        "print(f\"Response: {response}\")"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Xbk-WxNulEoh",
+        "outputId": "6f25c9d1-6ccd-478d-ab37-8c47aa156f61"
+      },
+      "id": "Xbk-WxNulEoh",
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Prompt:   What is machine learning?\n",
+            "Response: What is machine learning?It's a thing that can be done .\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Technique 2: IA³ (Infused Adapter by Inhibiting and Amplifying Inner Activations)\n",
+        "\n",
+        "**How it works:** Instead of adding matrices, IA³ multiplies activations\n",
+        "by learned scaling vectors. Extremely parameter-efficient — only 0.01%\n",
+        "of parameters are trained.\n",
+        "\n",
+        "**Key difference from LoRA:**\n",
+        "- LoRA adds ΔW = BA (additive)  \n",
+        "- IA³ multiplies: output = (l ⊙ Wx) where l is a learned vector (multiplicative)\n",
+        "\n",
+        "**Best for:** Few-shot learning, very limited compute"
+      ],
+      "metadata": {
+        "id": "EmgBL3R6mKOg"
+      },
+      "id": "EmgBL3R6mKOg"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Reload fresh base model for IA3\n",
+        "base_model_2 = AutoModelForCausalLM.from_pretrained(\n",
+        "    model_name,\n",
+        "    torch_dtype=torch.float16 if device == \"cuda\" else torch.float32\n",
+        ")\n",
+        "\n",
+        "# ── IA³ Configuration ────────────────────────────────────────\n",
+        "ia3_config = IA3Config(\n",
+        "    task_type=TaskType.CAUSAL_LM,\n",
+        "    target_modules=[\"c_attn\", \"c_proj\"],\n",
+        "    feedforward_modules=[\"c_proj\"]\n",
+        ")\n",
+        "\n",
+        "# Apply IA3\n",
+        "ia3_model = get_peft_model(base_model_2, ia3_config)\n",
+        "\n",
+        "# Count parameters\n",
+        "total = sum(p.numel() for p in ia3_model.parameters())\n",
+        "trainable = sum(p.numel() for p in ia3_model.parameters() if p.requires_grad)\n",
+        "\n",
+        "print(\"=\" * 50)\n",
+        "print(\"IA³ Model Summary\")\n",
+        "print(\"=\" * 50)\n",
+        "print(f\"Total parameters:     {total:,}\")\n",
+        "print(f\"Trainable parameters: {trainable:,}\")\n",
+        "print(f\"Trainable %:          {100 * trainable / total:.4f}%\")\n",
+        "print(\"\\n✅ IA³ applied successfully!\")\n",
+        "ia3_model.print_trainable_parameters()"
+      ],
+      "metadata": {
+        "id": "og_hm9n0lgTN",
+        "outputId": "25b41ddf-eb0c-4be0-f7b6-0919a4e7f874",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 260,
+          "referenced_widgets": [
+            "ab73334a8d3e4515b8adf664fea05754",
+            "3335f0031d5848cfaf76772774415248",
+            "b32deedf2f1c49b5aabcdab177b37937",
+            "5e781dfa7c47459aad8e73d13bd3ac67",
+            "97bad01b61084e009a7dd1574963b3dd",
+            "dab834012d6a4e27a047a93f9ba9c885",
+            "fd81adf31d56444b89f2322c79c685cd",
+            "a5697eff146b42b99c6a10662ce06ecd",
+            "c1dfe9d92053479282d18365d73ffc0b",
+            "51294d88d36d41da9599f3e5f12f97e6",
+            "981f5cdd5d234425bd038ffb693c46c5"
+          ]
+        }
+      },
+      "id": "og_hm9n0lgTN",
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Loading weights:   0%|          | 0/293 [00:00<?, ?it/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "ab73334a8d3e4515b8adf664fea05754"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.13/dist-packages/peft/tuners/ia3/model.py:134: UserWarning: fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True.\n",
+            "  warnings.warn(\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "==================================================\n",
+            "IA³ Model Summary\n",
+            "==================================================\n",
+            "Total parameters:     355,019,776\n",
+            "Trainable parameters: 196,608\n",
+            "Trainable %:          0.0554%\n",
+            "\n",
+            "✅ IA³ applied successfully!\n",
+            "trainable params: 196,608 || all params: 355,019,776 || trainable%: 0.0554\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import pandas as pd\n",
+        "\n",
+        "# Summary comparison\n",
+        "results = {\n",
+        "    \"Technique\": [\"LoRA\", \"AdaLoRA\", \"IA³\", \"Prefix Tuning\", \"LN Tuning\"],\n",
+        "    \"Trainable Params %\": [\"~0.19%\", \"~0.19%\", \"~0.01%\", \"~0.10%\", \"~0.01%\"],\n",
+        "    \"Memory Usage\": [\"Low\", \"Low-Med\", \"Very Low\", \"Low\", \"Very Low\"],\n",
+        "    \"Convergence Speed\": [\"Fast\", \"Moderate\", \"Very Fast\", \"Fast\", \"Fast\"],\n",
+        "    \"Output Quality\": [\"High\", \"High\", \"Medium\", \"Medium-High\", \"Medium\"],\n",
+        "    \"Best Use Case\": [\n",
+        "        \"General fine-tuning\",\n",
+        "        \"When rank is uncertain\",\n",
+        "        \"Few-shot tasks\",\n",
+        "        \"Text generation\",\n",
+        "        \"Fast adaptation\"\n",
+        "    ]\n",
+        "}\n",
+        "\n",
+        "df = pd.DataFrame(results)\n",
+        "print(\"=\" * 80)\n",
+        "print(\"FINAL COMPARISON: PEFT Techniques for Conversational AI\")\n",
+        "print(\"=\" * 80)\n",
+        "print(df.to_string(index=False))\n",
+        "print(\"\\n✅ Comparison complete!\")"
+      ],
+      "metadata": {
+        "id": "bfRNQK6rmNjd",
+        "outputId": "21b7c426-b350-4abb-bdbd-58eb2416bad9",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "id": "bfRNQK6rmNjd",
+      "execution_count": 16,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "================================================================================\n",
+            "FINAL COMPARISON: PEFT Techniques for Conversational AI\n",
+            "================================================================================\n",
+            "    Technique Trainable Params % Memory Usage Convergence Speed Output Quality          Best Use Case\n",
+            "         LoRA             ~0.19%          Low              Fast           High    General fine-tuning\n",
+            "      AdaLoRA             ~0.19%      Low-Med          Moderate           High When rank is uncertain\n",
+            "          IA³             ~0.01%     Very Low         Very Fast         Medium         Few-shot tasks\n",
+            "Prefix Tuning             ~0.10%          Low              Fast    Medium-High        Text generation\n",
+            "    LN Tuning             ~0.01%     Very Low              Fast         Medium        Fast adaptation\n",
+            "\n",
+            "✅ Comparison complete!\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Conclusion\n",
+        "\n",
+        "| Use Case | Recommended Technique |\n",
+        "|----------|----------------------|\n",
+        "| Best quality, enough memory | **LoRA (r=8, alpha=16)** |\n",
+        "| Minimum memory, few-shot | **IA³** |\n",
+        "| Unknown rank, adaptive | **AdaLoRA** |\n",
+        "| Pure generation tasks | **Prefix Tuning** |\n",
+        "| Fastest training | **LN Tuning** |\n",
+        "\n",
+        "**Key Takeaway:** LoRA is the best default choice for conversational AI.\n",
+        "IA³ when memory is extremely constrained."
+      ],
+      "metadata": {
+        "id": "itn__yQfmUrp"
+      },
+      "id": "itn__yQfmUrp"
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "N9QRTOQkmSTI"
+      },
+      "id": "N9QRTOQkmSTI",
+      "execution_count": 16,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    },
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "version_major": 2,
+        "version_minor": 0,
+        "state": {
+          "22a86ac576e94c90baabc4e438e5e70f": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "HBoxModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_dom_classes": [],
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "HBoxModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/controls",
+              "_view_module_version": "1.5.0",
+              "_view_name": "HBoxView",
+              "box_style": "",
+              "children": [
+                "IPY_MODEL_2acfbacccaa14a8ca1464a348c9c70b7",
+                "IPY_MODEL_cd259b9ccd234ca39822dcf365dfe98b",
+                "IPY_MODEL_4210b57c9028479596eb3c9a53714d3d"
+              ],
+              "layout": "IPY_MODEL_3d8306ca1f5d4e478390944858260e4f"
+            }
+          },
+          "2acfbacccaa14a8ca1464a348c9c70b7": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "HTMLModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_dom_classes": [],
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "HTMLModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/controls",
+              "_view_module_version": "1.5.0",
+              "_view_name": "HTMLView",
+              "description": "",
+              "description_tooltip": null,
+              "layout": "IPY_MODEL_48a8dc6959e4424184d479c9adb1f975",
+              "placeholder": "​",
+              "style": "IPY_MODEL_fb44f76dfcd746d1966523b0db1f2545",
+              "value": "Loading weights: 100%"
+            }
+          },
+          "cd259b9ccd234ca39822dcf365dfe98b": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "FloatProgressModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_dom_classes": [],
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "FloatProgressModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/controls",
+              "_view_module_version": "1.5.0",
+              "_view_name": "ProgressView",
+              "bar_style": "success",
+              "description": "",
+              "description_tooltip": null,
+              "layout": "IPY_MODEL_2ffd96383e244cbf9c9cb839271211f3",
+              "max": 293,
+              "min": 0,
+              "orientation": "horizontal",
+              "style": "IPY_MODEL_dd5669a3d7554c75b79763cefcb5e066",
+              "value": 293
+            }
+          },
+          "4210b57c9028479596eb3c9a53714d3d": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "HTMLModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_dom_classes": [],
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "HTMLModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/controls",
+              "_view_module_version": "1.5.0",
+              "_view_name": "HTMLView",
+              "description": "",
+              "description_tooltip": null,
+              "layout": "IPY_MODEL_92491e87e7e64d26aeff261e451bb4ee",
+              "placeholder": "​",
+              "style": "IPY_MODEL_c47e91c80ca54fd3bfa8851c7c5e76fd",
+              "value": " 293/293 [00:02&lt;00:00, 194.99it/s]"
+            }
+          },
+          "3d8306ca1f5d4e478390944858260e4f": {
+            "model_module": "@jupyter-widgets/base",
+            "model_name": "LayoutModel",
+            "model_module_version": "1.2.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/base",
+              "_model_module_version": "1.2.0",
+              "_model_name": "LayoutModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "LayoutView",
+              "align_content": null,
+              "align_items": null,
+              "align_self": null,
+              "border": null,
+              "bottom": null,
+              "display": null,
+              "flex": null,
+              "flex_flow": null,
+              "grid_area": null,
+              "grid_auto_columns": null,
+              "grid_auto_flow": null,
+              "grid_auto_rows": null,
+              "grid_column": null,
+              "grid_gap": null,
+              "grid_row": null,
+              "grid_template_areas": null,
+              "grid_template_columns": null,
+              "grid_template_rows": null,
+              "height": null,
+              "justify_content": null,
+              "justify_items": null,
+              "left": null,
+              "margin": null,
+              "max_height": null,
+              "max_width": null,
+              "min_height": null,
+              "min_width": null,
+              "object_fit": null,
+              "object_position": null,
+              "order": null,
+              "overflow": null,
+              "overflow_x": null,
+              "overflow_y": null,
+              "padding": null,
+              "right": null,
+              "top": null,
+              "visibility": null,
+              "width": null
+            }
+          },
+          "48a8dc6959e4424184d479c9adb1f975": {
+            "model_module": "@jupyter-widgets/base",
+            "model_name": "LayoutModel",
+            "model_module_version": "1.2.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/base",
+              "_model_module_version": "1.2.0",
+              "_model_name": "LayoutModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "LayoutView",
+              "align_content": null,
+              "align_items": null,
+              "align_self": null,
+              "border": null,
+              "bottom": null,
+              "display": null,
+              "flex": null,
+              "flex_flow": null,
+              "grid_area": null,
+              "grid_auto_columns": null,
+              "grid_auto_flow": null,
+              "grid_auto_rows": null,
+              "grid_column": null,
+              "grid_gap": null,
+              "grid_row": null,
+              "grid_template_areas": null,
+              "grid_template_columns": null,
+              "grid_template_rows": null,
+              "height": null,
+              "justify_content": null,
+              "justify_items": null,
+              "left": null,
+              "margin": null,
+              "max_height": null,
+              "max_width": null,
+              "min_height": null,
+              "min_width": null,
+              "object_fit": null,
+              "object_position": null,
+              "order": null,
+              "overflow": null,
+              "overflow_x": null,
+              "overflow_y": null,
+              "padding": null,
+              "right": null,
+              "top": null,
+              "visibility": null,
+              "width": null
+            }
+          },
+          "fb44f76dfcd746d1966523b0db1f2545": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "DescriptionStyleModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "DescriptionStyleModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "StyleView",
+              "description_width": ""
+            }
+          },
+          "2ffd96383e244cbf9c9cb839271211f3": {
+            "model_module": "@jupyter-widgets/base",
+            "model_name": "LayoutModel",
+            "model_module_version": "1.2.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/base",
+              "_model_module_version": "1.2.0",
+              "_model_name": "LayoutModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "LayoutView",
+              "align_content": null,
+              "align_items": null,
+              "align_self": null,
+              "border": null,
+              "bottom": null,
+              "display": null,
+              "flex": null,
+              "flex_flow": null,
+              "grid_area": null,
+              "grid_auto_columns": null,
+              "grid_auto_flow": null,
+              "grid_auto_rows": null,
+              "grid_column": null,
+              "grid_gap": null,
+              "grid_row": null,
+              "grid_template_areas": null,
+              "grid_template_columns": null,
+              "grid_template_rows": null,
+              "height": null,
+              "justify_content": null,
+              "justify_items": null,
+              "left": null,
+              "margin": null,
+              "max_height": null,
+              "max_width": null,
+              "min_height": null,
+              "min_width": null,
+              "object_fit": null,
+              "object_position": null,
+              "order": null,
+              "overflow": null,
+              "overflow_x": null,
+              "overflow_y": null,
+              "padding": null,
+              "right": null,
+              "top": null,
+              "visibility": null,
+              "width": null
+            }
+          },
+          "dd5669a3d7554c75b79763cefcb5e066": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "ProgressStyleModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "ProgressStyleModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "StyleView",
+              "bar_color": null,
+              "description_width": ""
+            }
+          },
+          "92491e87e7e64d26aeff261e451bb4ee": {
+            "model_module": "@jupyter-widgets/base",
+            "model_name": "LayoutModel",
+            "model_module_version": "1.2.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/base",
+              "_model_module_version": "1.2.0",
+              "_model_name": "LayoutModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "LayoutView",
+              "align_content": null,
+              "align_items": null,
+              "align_self": null,
+              "border": null,
+              "bottom": null,
+              "display": null,
+              "flex": null,
+              "flex_flow": null,
+              "grid_area": null,
+              "grid_auto_columns": null,
+              "grid_auto_flow": null,
+              "grid_auto_rows": null,
+              "grid_column": null,
+              "grid_gap": null,
+              "grid_row": null,
+              "grid_template_areas": null,
+              "grid_template_columns": null,
+              "grid_template_rows": null,
+              "height": null,
+              "justify_content": null,
+              "justify_items": null,
+              "left": null,
+              "margin": null,
+              "max_height": null,
+              "max_width": null,
+              "min_height": null,
+              "min_width": null,
+              "object_fit": null,
+              "object_position": null,
+              "order": null,
+              "overflow": null,
+              "overflow_x": null,
+              "overflow_y": null,
+              "padding": null,
+              "right": null,
+              "top": null,
+              "visibility": null,
+              "width": null
+            }
+          },
+          "c47e91c80ca54fd3bfa8851c7c5e76fd": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "DescriptionStyleModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "DescriptionStyleModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "StyleView",
+              "description_width": ""
+            }
+          },
+          "ab73334a8d3e4515b8adf664fea05754": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "HBoxModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_dom_classes": [],
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "HBoxModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/controls",
+              "_view_module_version": "1.5.0",
+              "_view_name": "HBoxView",
+              "box_style": "",
+              "children": [
+                "IPY_MODEL_3335f0031d5848cfaf76772774415248",
+                "IPY_MODEL_b32deedf2f1c49b5aabcdab177b37937",
+                "IPY_MODEL_5e781dfa7c47459aad8e73d13bd3ac67"
+              ],
+              "layout": "IPY_MODEL_97bad01b61084e009a7dd1574963b3dd"
+            }
+          },
+          "3335f0031d5848cfaf76772774415248": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "HTMLModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_dom_classes": [],
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "HTMLModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/controls",
+              "_view_module_version": "1.5.0",
+              "_view_name": "HTMLView",
+              "description": "",
+              "description_tooltip": null,
+              "layout": "IPY_MODEL_dab834012d6a4e27a047a93f9ba9c885",
+              "placeholder": "​",
+              "style": "IPY_MODEL_fd81adf31d56444b89f2322c79c685cd",
+              "value": "Loading weights: 100%"
+            }
+          },
+          "b32deedf2f1c49b5aabcdab177b37937": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "FloatProgressModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_dom_classes": [],
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "FloatProgressModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/controls",
+              "_view_module_version": "1.5.0",
+              "_view_name": "ProgressView",
+              "bar_style": "success",
+              "description": "",
+              "description_tooltip": null,
+              "layout": "IPY_MODEL_a5697eff146b42b99c6a10662ce06ecd",
+              "max": 293,
+              "min": 0,
+              "orientation": "horizontal",
+              "style": "IPY_MODEL_c1dfe9d92053479282d18365d73ffc0b",
+              "value": 293
+            }
+          },
+          "5e781dfa7c47459aad8e73d13bd3ac67": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "HTMLModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_dom_classes": [],
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "HTMLModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/controls",
+              "_view_module_version": "1.5.0",
+              "_view_name": "HTMLView",
+              "description": "",
+              "description_tooltip": null,
+              "layout": "IPY_MODEL_51294d88d36d41da9599f3e5f12f97e6",
+              "placeholder": "​",
+              "style": "IPY_MODEL_981f5cdd5d234425bd038ffb693c46c5",
+              "value": " 293/293 [00:01&lt;00:00, 232.56it/s]"
+            }
+          },
+          "97bad01b61084e009a7dd1574963b3dd": {
+            "model_module": "@jupyter-widgets/base",
+            "model_name": "LayoutModel",
+            "model_module_version": "1.2.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/base",
+              "_model_module_version": "1.2.0",
+              "_model_name": "LayoutModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "LayoutView",
+              "align_content": null,
+              "align_items": null,
+              "align_self": null,
+              "border": null,
+              "bottom": null,
+              "display": null,
+              "flex": null,
+              "flex_flow": null,
+              "grid_area": null,
+              "grid_auto_columns": null,
+              "grid_auto_flow": null,
+              "grid_auto_rows": null,
+              "grid_column": null,
+              "grid_gap": null,
+              "grid_row": null,
+              "grid_template_areas": null,
+              "grid_template_columns": null,
+              "grid_template_rows": null,
+              "height": null,
+              "justify_content": null,
+              "justify_items": null,
+              "left": null,
+              "margin": null,
+              "max_height": null,
+              "max_width": null,
+              "min_height": null,
+              "min_width": null,
+              "object_fit": null,
+              "object_position": null,
+              "order": null,
+              "overflow": null,
+              "overflow_x": null,
+              "overflow_y": null,
+              "padding": null,
+              "right": null,
+              "top": null,
+              "visibility": null,
+              "width": null
+            }
+          },
+          "dab834012d6a4e27a047a93f9ba9c885": {
+            "model_module": "@jupyter-widgets/base",
+            "model_name": "LayoutModel",
+            "model_module_version": "1.2.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/base",
+              "_model_module_version": "1.2.0",
+              "_model_name": "LayoutModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "LayoutView",
+              "align_content": null,
+              "align_items": null,
+              "align_self": null,
+              "border": null,
+              "bottom": null,
+              "display": null,
+              "flex": null,
+              "flex_flow": null,
+              "grid_area": null,
+              "grid_auto_columns": null,
+              "grid_auto_flow": null,
+              "grid_auto_rows": null,
+              "grid_column": null,
+              "grid_gap": null,
+              "grid_row": null,
+              "grid_template_areas": null,
+              "grid_template_columns": null,
+              "grid_template_rows": null,
+              "height": null,
+              "justify_content": null,
+              "justify_items": null,
+              "left": null,
+              "margin": null,
+              "max_height": null,
+              "max_width": null,
+              "min_height": null,
+              "min_width": null,
+              "object_fit": null,
+              "object_position": null,
+              "order": null,
+              "overflow": null,
+              "overflow_x": null,
+              "overflow_y": null,
+              "padding": null,
+              "right": null,
+              "top": null,
+              "visibility": null,
+              "width": null
+            }
+          },
+          "fd81adf31d56444b89f2322c79c685cd": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "DescriptionStyleModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "DescriptionStyleModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "StyleView",
+              "description_width": ""
+            }
+          },
+          "a5697eff146b42b99c6a10662ce06ecd": {
+            "model_module": "@jupyter-widgets/base",
+            "model_name": "LayoutModel",
+            "model_module_version": "1.2.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/base",
+              "_model_module_version": "1.2.0",
+              "_model_name": "LayoutModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "LayoutView",
+              "align_content": null,
+              "align_items": null,
+              "align_self": null,
+              "border": null,
+              "bottom": null,
+              "display": null,
+              "flex": null,
+              "flex_flow": null,
+              "grid_area": null,
+              "grid_auto_columns": null,
+              "grid_auto_flow": null,
+              "grid_auto_rows": null,
+              "grid_column": null,
+              "grid_gap": null,
+              "grid_row": null,
+              "grid_template_areas": null,
+              "grid_template_columns": null,
+              "grid_template_rows": null,
+              "height": null,
+              "justify_content": null,
+              "justify_items": null,
+              "left": null,
+              "margin": null,
+              "max_height": null,
+              "max_width": null,
+              "min_height": null,
+              "min_width": null,
+              "object_fit": null,
+              "object_position": null,
+              "order": null,
+              "overflow": null,
+              "overflow_x": null,
+              "overflow_y": null,
+              "padding": null,
+              "right": null,
+              "top": null,
+              "visibility": null,
+              "width": null
+            }
+          },
+          "c1dfe9d92053479282d18365d73ffc0b": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "ProgressStyleModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "ProgressStyleModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "StyleView",
+              "bar_color": null,
+              "description_width": ""
+            }
+          },
+          "51294d88d36d41da9599f3e5f12f97e6": {
+            "model_module": "@jupyter-widgets/base",
+            "model_name": "LayoutModel",
+            "model_module_version": "1.2.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/base",
+              "_model_module_version": "1.2.0",
+              "_model_name": "LayoutModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "LayoutView",
+              "align_content": null,
+              "align_items": null,
+              "align_self": null,
+              "border": null,
+              "bottom": null,
+              "display": null,
+              "flex": null,
+              "flex_flow": null,
+              "grid_area": null,
+              "grid_auto_columns": null,
+              "grid_auto_flow": null,
+              "grid_auto_rows": null,
+              "grid_column": null,
+              "grid_gap": null,
+              "grid_row": null,
+              "grid_template_areas": null,
+              "grid_template_columns": null,
+              "grid_template_rows": null,
+              "height": null,
+              "justify_content": null,
+              "justify_items": null,
+              "left": null,
+              "margin": null,
+              "max_height": null,
+              "max_width": null,
+              "min_height": null,
+              "min_width": null,
+              "object_fit": null,
+              "object_position": null,
+              "order": null,
+              "overflow": null,
+              "overflow_x": null,
+              "overflow_y": null,
+              "padding": null,
+              "right": null,
+              "top": null,
+              "visibility": null,
+              "width": null
+            }
+          },
+          "981f5cdd5d234425bd038ffb693c46c5": {
+            "model_module": "@jupyter-widgets/controls",
+            "model_name": "DescriptionStyleModel",
+            "model_module_version": "1.5.0",
+            "state": {
+              "_model_module": "@jupyter-widgets/controls",
+              "_model_module_version": "1.5.0",
+              "_model_name": "DescriptionStyleModel",
+              "_view_count": null,
+              "_view_module": "@jupyter-widgets/base",
+              "_view_module_version": "1.2.0",
+              "_view_name": "StyleView",
+              "description_width": ""
+            }
+          }
+        }
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
Closes #2310

## What this adds
A Colab-ready notebook comparing PEFT fine-tuning techniques for conversational AI:
- Technique overview table (LoRA, AdaLoRA, IA3, LN Tuning, Prefix Tuning)
- Code examples using LoRA and IA3 with microsoft/DialoGPT-medium
- Parameter count comparison showing trainable % for each technique
- Final comparison table (memory, convergence, quality, use case)

## How to test
Open in Google Colab and run cells sequentially.
All cells are self-contained and runnable on free T4 GPU.