### PR TITLE
Validate IA3 bias before committing safe merges

### DIFF
--- a/src/peft/tuners/ia3/layer.py
+++ b/src/peft/tuners/ia3/layer.py
@@ -117,21 +117,32 @@ class Linear(nn.Module, IA3Layer):
                 ia3_l = transpose(self.ia3_l[active_adapter].data, self.fan_in_fan_out)
                 orig_dtype = base_layer.weight.data.dtype
                 if safe_merge:
-                    orig_weights = base_layer.weight.data
-                    orig_weights = torch.mul(orig_weights, ia3_l)
+                    output_weight = torch.mul(base_layer.weight.data, ia3_l)
 
-                    if not torch.isfinite(orig_weights).all():
+                    if not torch.isfinite(output_weight).all():
                         raise ValueError(
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
-                    base_layer.weight.data = orig_weights.to(orig_dtype)
+
+                    output_bias = None
+                    if not self.is_feedforward and (base_layer.bias is not None):
+                        scaling = self.ia3_l[active_adapter].reshape(base_layer.bias.shape)
+                        output_bias = torch.mul(base_layer.bias.data, scaling.data)
+                        if not torch.isfinite(output_bias).all():
+                            raise ValueError(
+                                f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
+                            )
+
+                    base_layer.weight.data = output_weight.to(orig_dtype)
+                    if output_bias is not None:
+                        base_layer.bias.data = output_bias.to(base_layer.bias.data.dtype)
                 else:
                     base_layer.weight.data = torch.mul(base_layer.weight.data, ia3_l).to(orig_dtype)
 
-                if not self.is_feedforward and (base_layer.bias is not None):
-                    scaling = self.ia3_l[active_adapter].reshape(base_layer.bias.shape)
-                    orig_dtype = base_layer.bias.data.dtype
-                    base_layer.bias.data = torch.mul(base_layer.bias.data, scaling.data).to(orig_dtype)
+                    if not self.is_feedforward and (base_layer.bias is not None):
+                        scaling = self.ia3_l[active_adapter].reshape(base_layer.bias.shape)
+                        bias_dtype = base_layer.bias.data.dtype
+                        base_layer.bias.data = torch.mul(base_layer.bias.data, scaling.data).to(bias_dtype)
 
                 self.merged_adapters.append(active_adapter)
 
@@ -267,13 +278,24 @@ class _ConvNd(nn.Module, IA3Layer):
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
+                    output_bias = None
+                    if not self.is_feedforward and (base_layer.bias is not None):
+                        scaling = self.ia3_l[active_adapter].reshape(base_layer.bias.shape)
+                        output_bias = torch.mul(base_layer.bias.data, scaling.data)
+                        if not torch.isfinite(output_bias).all():
+                            raise ValueError(
+                                f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
+                            )
+
                     base_layer.weight.data = output_weight.to(orig_dtype)
+                    if output_bias is not None:
+                        base_layer.bias.data = output_bias.to(orig_dtype)
                 else:
                     base_layer.weight.data = torch.mul(base_layer.weight.data, ia3_scaling).to(orig_dtype)
 
-                if not self.is_feedforward and (base_layer.bias is not None):
-                    scaling = self.ia3_l[active_adapter].reshape(base_layer.bias.shape)
-                    base_layer.bias.data = torch.mul(base_layer.bias.data, scaling.data).to(orig_dtype)
+                    if not self.is_feedforward and (base_layer.bias is not None):
+                        scaling = self.ia3_l[active_adapter].reshape(base_layer.bias.shape)
+                        base_layer.bias.data = torch.mul(base_layer.bias.data, scaling.data).to(orig_dtype)
 
                 self.merged_adapters.append(active_adapter)
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2596,6 +2596,36 @@ class TestPeftCustomModel(PeftCommonTester):
         assert torch.allclose(output_unmerged, output_unmerged_again, atol=1e-6, rtol=1e-6)
         assert torch.allclose(model.base_model.model.conv.base_layer.weight.data, original_weight)
 
+    @pytest.mark.parametrize("module_type", ["linear", "conv2d"])
+    def test_ia3_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self, module_type):
+        torch.manual_seed(0)
+        if module_type == "linear":
+            model = MLP()
+            target_name = "lin0"
+        elif module_type == "conv2d":
+            model = ModelConv2D()
+            target_name = "conv2d"
+        else:
+            raise ValueError(f"Wrong module_type passed, expected 'linear' or 'conv2d', got {module_type}")
+
+        config = IA3Config(target_modules=[target_name], feedforward_modules=[])
+        model = get_peft_model(model, config)
+        layer = getattr(model.base_model.model, target_name)
+        base_layer = layer.get_base_layer()
+
+        base_layer.weight.data.fill_(1)
+        base_layer.bias.data.fill_(torch.finfo(base_layer.bias.dtype).max)
+        layer.ia3_l["default"].data.fill_(2)
+        original_weight = base_layer.weight.data.clone()
+        original_bias = base_layer.bias.data.clone()
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged bias"):
+            layer.merge(safe_merge=True)
+
+        assert torch.equal(base_layer.weight.data, original_weight)
+        assert torch.equal(base_layer.bias.data, original_bias)
+        assert layer.merged_adapters == []
+
     def test_glora_safe_merge_does_not_corrupt_base_layer_on_non_finite_adapter(self):
         # Regression test: GLoRA's merge() used to accumulate the merged weights directly onto
         # base_layer.weight.data/bias.data *before* the safe_merge isfinite check, so a broken


### PR DESCRIPTION
I was checking the other `safe_merge` implementations after #3611 and noticed IA3 only validates the merged weight. For non-feedforward layers it then scales the bias without checking the result, so a safe merge can still commit a non-finite bias.

This computes and validates both candidates before updating the layer, for Linear/Conv1D and Conv2d/Conv3d. I added regression tests for both paths.

I ran 168 IA3 merge tests and the full `make quality` checks. I also wrote a small [TorchLean](https://github.com/lean-dojo/TorchLean) model of the atomicity property and can attach it if useful :)