### PR TITLE
Validate quantized LoRA bias before committing safe merges

### DIFF
--- a/src/peft/tuners/lora/bnb.py
+++ b/src/peft/tuners/lora/bnb.py
@@ -119,16 +119,19 @@ if is_bnb_available():
                         f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                     )
 
+                bias_data = None
+                if self.lora_bias[active_adapter]:
+                    bias_data = self.get_base_layer().bias.data + self.lora_B[active_adapter].bias
+                    if safe_merge and not torch.isfinite(bias_data).all():
+                        raise ValueError(
+                            f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
+                        )
+
                 self.get_base_layer().weight = bnb.nn.Int8Params(
                     w_data.to("cpu"), requires_grad=False, has_fp16_weights=weight.has_fp16_weights
                 ).to(weight.device)
 
-                if self.lora_bias[active_adapter]:
-                    bias_data = self.get_base_layer().bias.data + self.lora_B[active_adapter].bias
-                    if safe_merge and not torch.isfinite(bias_data):
-                        raise ValueError(
-                            f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
-                        )
+                if bias_data is not None:
                     self.get_base_layer().bias.data = bias_data
 
                 state.reset_grads()
@@ -393,6 +396,14 @@ if is_bnb_4bit_available():
                         f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                     )
 
+                bias_data = None
+                if self.lora_bias[active_adapter]:
+                    bias_data = self.get_base_layer().bias.data + self.lora_B[active_adapter].bias
+                    if safe_merge and not torch.isfinite(bias_data).all():
+                        raise ValueError(
+                            f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
+                        )
+
                 if "bnb_quantized" in kwargs:
                     kwargs["bnb_quantized"] = False
                 kwargs["requires_grad"] = False
@@ -401,12 +412,7 @@ if is_bnb_4bit_available():
                 kwargs = {k: v for k, v in kwargs.items() if not k.startswith("_")}
                 self.get_base_layer().weight = bnb.nn.Params4bit(w_data.to("cpu"), **kwargs).to(weight.device)
 
-                if self.lora_bias[active_adapter]:
-                    bias_data = self.get_base_layer().bias.data + self.lora_B[active_adapter].bias
-                    if safe_merge and not torch.isfinite(bias_data):
-                        raise ValueError(
-                            f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
-                        )
+                if bias_data is not None:
                     self.get_base_layer().bias.data = bias_data
 
                 self.merged_adapters.append(active_adapter)

--- a/tests/test_common_gpu.py
+++ b/tests/test_common_gpu.py
@@ -1072,7 +1072,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         with torch.inference_mode():
             out_before_merge = F.softmax(model(random_input).logits, dim=-1)
 
-        model.merge_and_unload()
+        model.merge_and_unload(safe_merge=True)
         with torch.inference_mode():
             out_after_merge = F.softmax(model(random_input).logits, dim=-1)
 
@@ -1080,6 +1080,49 @@ class PeftGPUCommonTests(unittest.TestCase):
         rtol = 1
         assert not torch.allclose(out_base, out_before_merge, atol=atol, rtol=rtol)
         assert torch.allclose(out_before_merge, out_after_merge, atol=atol, rtol=rtol)
+
+    def _test_bnb_lora_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self, quantization):
+        if quantization == "4bit":
+            quantization_config = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_use_double_quant=False,
+                bnb_4bit_compute_dtype=torch.float32,
+            )
+            layer_type = LoraLinear4bit
+        else:
+            quantization_config = BitsAndBytesConfig(load_in_8bit=True)
+            layer_type = LoraLinear8bitLt
+
+        model = AutoModelForCausalLM.from_pretrained(
+            "peft-internal-testing/opt-125m",
+            quantization_config=quantization_config,
+            dtype=torch.float32,
+        )
+        model = get_peft_model(model, LoraConfig(r=8, init_lora_weights=False, lora_bias=True))
+        layer = next(module for module in model.modules() if isinstance(module, layer_type))
+        base_layer = layer.get_base_layer()
+        original_weight = base_layer.weight
+        original_bias = base_layer.bias.data.clone()
+        layer.lora_B["default"].bias.data.fill_(float("inf"))
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged bias"):
+            layer.merge(safe_merge=True)
+
+        assert base_layer.weight is original_weight
+        assert torch.equal(base_layer.bias.data, original_bias)
+        assert layer.merged_adapters == []
+
+    @require_non_cpu
+    @pytest.mark.single_gpu_tests
+    @require_bitsandbytes
+    def test_4bit_lora_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self):
+        self._test_bnb_lora_safe_merge_does_not_mutate_base_layer_on_non_finite_bias("4bit")
+
+    @require_non_cpu
+    @pytest.mark.single_gpu_tests
+    @require_bitsandbytes
+    def test_8bit_lora_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self):
+        self._test_bnb_lora_safe_merge_does_not_mutate_base_layer_on_non_finite_bias("8bit")
 
     @require_non_cpu
     @pytest.mark.single_gpu_tests
@@ -1196,7 +1239,7 @@ class PeftGPUCommonTests(unittest.TestCase):
         with torch.inference_mode():
             out_before_merge = F.softmax(model(random_input).logits, dim=-1)
 
-        model.merge_and_unload()
+        model.merge_and_unload(safe_merge=True)
         with torch.inference_mode():
             out_after_merge = F.softmax(model(random_input).logits, dim=-1)
 


### PR DESCRIPTION
I was following up on #3611 and noticed the bitsandbytes LoRA paths still validate `lora_bias` after replacing the quantized weight. The check also treats a multi-element finite mask as one boolean, so a normal safe merge with bias stops before finishing.

This validates the weight and bias candidates first, then commits them together for both 4-bit and 8-bit layers. I added regression coverage for rejected merges and switched the existing healthy bias cases to `safe_merge=True`.

I ran all six affected 4-bit/8-bit merge tests on an A100 and the full `make quality` checks. I also wrote a small [TorchLean](https://github.com/lean-dojo/TorchLean) model of the atomicity property and can attach it if useful :)