### PR TITLE
docs: Fix duplicate TOC entries

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -81,6 +81,10 @@
         title: DeLoRA
       - local: package_reference/fourierft
         title: FourierFT
+      - local: package_reference/frod
+        title: FRoD
+      - local: package_reference/glora
+        title: GLoRA
       - local: package_reference/gralora
         title: GraLoRA
       - local: package_reference/hira
@@ -182,6 +186,10 @@
       title: DeLoRA
     - local: package_reference/fourierft
       title: FourierFT
+    - local: package_reference/frod
+      title: FRoD
+    - local: package_reference/glora
+      title: GLoRA
     - local: package_reference/gralora
       title: GraLoRA
     - local: package_reference/hira
@@ -226,26 +234,6 @@
       title: PSOFT
     - local: package_reference/pvera
       title: PVeRA
-    - local: package_reference/fourierft
-      title: FourierFT
-    - local: package_reference/frod
-      title: FRoD
-    - local: package_reference/glora
-      title: GLoRA
-    - local: package_reference/gralora
-      title: GraLoRA
-    - local: package_reference/vblora
-      title: VB-LoRA
-    - local: package_reference/hira
-      title: HiRA
-    - local: package_reference/hra
-      title: HRA
-    - local: package_reference/deft
-      title: DEFT
-    - local: package_reference/cpt
-      title: CPT
-    - local: package_reference/trainable_tokens
-      title: Trainable Tokens
     - local: package_reference/randlora
       title: RandLora
     - local: package_reference/road

--- a/docs/source/package_reference/glora.md
+++ b/docs/source/package_reference/glora.md
@@ -103,6 +103,6 @@ model.merge_and_unload()
 - GLoRA supports all standard PEFT adapter management features (add, delete, switch, merge, etc).
 
 ## See Also
-- [Adapter conceptual guide](../conceptual_guides/adapter.md)
+- [Adapter methods overview](../methods/overview#adapter-methods)
 - [LoRA reference](./lora.md)
 - [Paper: https://huggingface.co/papers/2306.07967](https://huggingface.co/papers/2306.07967)


### PR DESCRIPTION
This is a continuation of #3461. Some entries in the TOC were duplicated and messing with the sorting.
Also fixes a broken link in the GLoRA docs.