### PR TITLE
FIX AdaMSS safe_merge leaves base weight modified when bias validation fails

### DIFF
--- a/src/peft/tuners/adamss/layer.py
+++ b/src/peft/tuners/adamss/layer.py
@@ -487,9 +487,10 @@ class Linear(nn.Module, AdamssLayer):
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
-                    base_layer.weight.data = orig_weight
-
-                    # Also update bias if present
+                    # Also compute the bias if present. Both the weight and the bias are
+                    # validated before either is written back, so that a failed check
+                    # leaves the base layer completely untouched.
+                    orig_bias = None
                     if base_layer.bias is not None:
                         orig_bias = base_layer.bias.data.clone()
                         delta_bias = self.get_delta_bias(active_adapter)
@@ -498,6 +499,9 @@ class Linear(nn.Module, AdamssLayer):
                             raise ValueError(
                                 f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
                             )
+
+                    base_layer.weight.data = orig_weight
+                    if orig_bias is not None:
                         base_layer.bias.data = orig_bias
                 else:
                     delta_weight = self.get_delta_weight(active_adapter)

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2690,6 +2690,32 @@ class TestPeftCustomModel(PeftCommonTester):
         assert torch.equal(layer.base_layer.bias.data, original_bias)
         assert layer.merged_adapters == []
 
+    def test_adamss_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self):
+        # AdaMSS used to write the merged weight to the base layer before computing and
+        # validating the merged bias. A non-finite bias would then raise, but the base weight
+        # was already modified -- defeating the whole point of safe_merge.
+        torch.manual_seed(0)
+        model = MLP()
+        config = AdamssConfig(target_modules=["lin0"], r=2, num_subspaces=1)
+        model = get_peft_model(model, config)
+
+        layer = model.base_model.model.lin0
+        original_weight = layer.base_layer.weight.data.clone()
+        original_bias = layer.base_layer.bias.data.clone()
+
+        # newB has shape (r, in_features + 1); its last column feeds the bias delta only
+        # (get_delta_weight returns delta[:, :-1], get_delta_bias returns delta[:, -1]).
+        # Poisoning just that column makes the merged bias non-finite while the merged
+        # weight stays finite, which is exactly the case that used to corrupt the weight.
+        layer.adamss_newB["default"][:, -1] = float("inf")
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged bias"):
+            layer.merge(safe_merge=True)
+
+        assert torch.equal(layer.base_layer.weight.data, original_weight)
+        assert torch.equal(layer.base_layer.bias.data, original_bias)
+        assert layer.merged_adapters == []
+
     @pytest.mark.parametrize("safe_merge", [False, True])
     @pytest.mark.parametrize("module_type", ["linear", "conv2d"])
     def test_merge_with_lora_bias_when_base_layer_has_no_bias_warns_and_raises(self, safe_merge, module_type):


### PR DESCRIPTION
Fixes #3689

## Problem

`AdamssLayer.Linear.merge(safe_merge=True)` writes the merged weight to the base layer **before** it computes and validates the merged bias:

```python
if not torch.isfinite(orig_weight).all():
    raise ValueError(...)

base_layer.weight.data = orig_weight     # <-- published here

# Also update bias if present
if base_layer.bias is not None:
    orig_bias = base_layer.bias.data.clone()
    delta_bias = self.get_delta_bias(active_adapter)
    orig_bias += delta_bias.to(orig_dtype)
    if not torch.isfinite(orig_bias).all():
        raise ValueError(...)            # <-- but weight is already modified
    base_layer.bias.data = orig_bias
```

If the bias check fails, the method raises but the base weight has already been replaced, while `merged_adapters` stays empty. The layer is left silently corrupted — which defeats the documented point of `safe_merge` ("check for NaNs **before** merging the weights").

## Fix

Compute and validate both the weight and the bias first, and only write either back once both checks pass. This restores the validate-on-a-copy-then-assign contract the rest of PEFT follows — the same shape as the existing LoRA and GLoRA `safe_merge` paths.

The error messages, the order of validation (weight first, then bias), and the non-safe-merge branch are all unchanged.

## Test

Added `test_adamss_safe_merge_does_not_mutate_base_layer_on_non_finite_bias` in `tests/test_custom_models.py`, directly alongside the existing `test_lora_safe_merge_does_not_mutate_base_layer_on_non_finite_bias` and the GLoRA equivalent, following the same structure and assertions.

Triggering *only* a bias failure needs a targeted poison, so the test sets the last column of `adamss_newB` to `inf`. That column feeds the bias delta alone — `get_delta_weight` returns `delta_weight[:, :-1]` and `get_delta_bias` returns `delta_weight[:, -1]`, and matmul keeps columns independent — so the merged weight stays finite while the merged bias does not. That is exactly the case that used to corrupt the base weight. The test asserts the base weight, the base bias, and `merged_adapters` are all untouched after the raise.

## Verification

- `ruff check` and `ruff format --check` pass on both changed files (using the pinned `ruff==0.16.4`).
- I was not able to run the test suite locally (my environment only has Python 3.7, so no supported torch), so I'd appreciate CI confirming the new test — happy to iterate if anything needs adjusting.
