### PR TITLE
fix: handle scalar adapter state entries

### DIFF
--- a/src/peft/utils/save_and_load.py
+++ b/src/peft/utils/save_and_load.py
@@ -297,7 +297,11 @@ def _find_mismatched_keys(
             continue
 
         # see https://github.com/huggingface/transformers/blob/09f9f566de83eef1f13ee83b5a1bbeebde5c80c1/src/transformers/modeling_utils.py#L3858-L3864
-        if (state_dict[key].shape[-1] == 1) and (state_dict[key].numel() * 2 == tensor.numel()):
+        if (
+            state_dict[key].ndim > 0
+            and (state_dict[key].shape[-1] == 1)
+            and (state_dict[key].numel() * 2 == tensor.numel())
+        ):
             # This skips size mismatches for 4-bit weights. Two 4-bit values share an 8-bit container, causing size
             # differences. Without matching with module type or parameter type it seems like a practical way to detect
             # valid 4bit weights.

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -4638,6 +4638,29 @@ class TestPeftCustomModel(PeftCommonTester):
         extra_weight = target.base_model.model.embed_tokens_extra.weight
         assert torch.allclose(extra_weight, torch.full_like(extra_weight, 123.0))
 
+    def test_ignore_mismatched_sizes_with_scalar_modules_to_save(self, tmp_path):
+        class ModelWithBatchNorm(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(3, 3)
+                self.norm = nn.BatchNorm1d(3)
+
+            def forward(self, x):
+                return self.norm(self.linear(x))
+
+        config = LoraConfig(target_modules=["linear"], modules_to_save=["norm"])
+        model = get_peft_model(ModelWithBatchNorm(), config)
+        model.base_model.model.norm.modules_to_save["default"].num_batches_tracked.fill_(7)
+        model.save_pretrained(tmp_path)
+        state_dict = safe_load_file(tmp_path / "adapter_model.safetensors")
+        assert state_dict["base_model.model.norm.num_batches_tracked"].ndim == 0
+
+        loaded = PeftModel.from_pretrained(
+            ModelWithBatchNorm(), tmp_path, ignore_mismatched_sizes=True, torch_device="cpu"
+        )
+
+        assert loaded.base_model.model.norm.modules_to_save["default"].num_batches_tracked.item() == 7
+
     @pytest.mark.parametrize(
         "config0",
         [

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -4638,6 +4638,7 @@ class TestPeftCustomModel(PeftCommonTester):
         extra_weight = target.base_model.model.embed_tokens_extra.weight
         assert torch.allclose(extra_weight, torch.full_like(extra_weight, 123.0))
 
+    # Regression test for #3676: modules_to_save can include scalar state entries.
     def test_ignore_mismatched_sizes_with_scalar_modules_to_save(self, tmp_path):
         class ModelWithBatchNorm(nn.Module):
             def __init__(self):

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -4638,8 +4638,8 @@ class TestPeftCustomModel(PeftCommonTester):
         extra_weight = target.base_model.model.embed_tokens_extra.weight
         assert torch.allclose(extra_weight, torch.full_like(extra_weight, 123.0))
 
-    # Regression test for #3676: modules_to_save can include scalar state entries.
     def test_ignore_mismatched_sizes_with_scalar_modules_to_save(self, tmp_path):
+        # Regression test for #3676: modules_to_save can include scalar state entries.
         class ModelWithBatchNorm(nn.Module):
             def __init__(self):
                 super().__init__()


### PR DESCRIPTION
Fixes #3676.

### Summary

Loading an adapter with `ignore_mismatched_sizes=True` raises `IndexError` when the checkpoint contains a scalar state entry, such as `BatchNorm1d.num_batches_tracked`. `_find_mismatched_keys` indexes `shape[-1]` while checking the packed 4-bit exception, but scalar tensors have no last dimension.

The packed-weight exception now runs only for tensors with at least one dimension. Scalar entries continue through the normal shape comparison and load unchanged.

### Regression

The test saves a LoRA adapter with a `BatchNorm1d` module in `modules_to_save`, verifies the saved `num_batches_tracked` entry is scalar, loads with `ignore_mismatched_sizes=True`, and checks that the value is restored.

### Validation

- `ruff check src/peft/utils/save_and_load.py tests/test_custom_models.py` passed.
- `ruff format --check src/peft/utils/save_and_load.py tests/test_custom_models.py` passed.
- `git diff --check` passed.
- Python compilation of the changed files passed.
- Source-level guard cases for scalar, packed-weight, and ordinary mismatch entries passed.
- End-to-end pytest was not run locally because the available PEFT quality environment has no PyTorch. CI should run the focused test on the final commit.

### Coordination

BenjaminBossan confirmed the bug and invited a PR in [#3676](https://github.com/huggingface/peft/issues/3676).

AI assistance disclosure: AI-assisted development tools were used during investigation and implementation. The reported tests were run against the final diff.
