### PR TITLE
FIX Conv LoRA does not preserve dilation and padding_mode

### DIFF
--- a/src/peft/tuners/lora/layer.py
+++ b/src/peft/tuners/lora/layer.py
@@ -1593,9 +1593,24 @@ class _ConvNd(nn.Module, LoraLayer):
         kernel_size = base_layer.kernel_size
         stride = base_layer.stride
         padding = base_layer.padding
+        dilation = base_layer.dilation
+        padding_mode = base_layer.padding_mode
         conv_layer = type(base_layer)
         out_kernel = out_stride = (1,) * (self._kernel_dim - 2)
-        self.lora_A[adapter_name] = conv_layer(self.in_features, r, kernel_size, stride, padding, bias=False)
+        # lora_A mirrors the spatial configuration of the base layer, so it has to carry
+        # over dilation and padding_mode as well -- otherwise a dilated base layer and the
+        # adapter produce different spatial output shapes, and a non-default padding_mode
+        # is silently applied as zero padding on the adapter branch.
+        self.lora_A[adapter_name] = conv_layer(
+            self.in_features,
+            r,
+            kernel_size,
+            stride,
+            padding,
+            dilation=dilation,
+            padding_mode=padding_mode,
+            bias=False,
+        )
         self.lora_B[adapter_name] = conv_layer(
             r, self.out_features, out_kernel, out_stride, groups=base_layer.groups, bias=lora_bias
         )

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2634,6 +2634,38 @@ class TestPeftCustomModel(PeftCommonTester):
         assert torch.allclose(output_unmerged, output_unmerged_again, atol=1e-6, rtol=1e-6)
         assert torch.allclose(model.base_model.model.conv.base_layer.weight.data, original_weight)
 
+    @pytest.mark.parametrize("conv_cls", [nn.Conv1d, nn.Conv2d])
+    def test_lora_conv_preserves_dilation_and_padding_mode(self, conv_cls):
+        # Regression test for #3697: the LoRA conv branch mirrors the spatial configuration of the
+        # base layer, but dilation and padding_mode were not carried over. A dilated base layer and
+        # the adapter then produce different spatial shapes (the forward pass fails outright), and a
+        # non-default padding_mode is silently applied as zero padding on the adapter branch.
+        # Conv3d goes through the same _ConvNd.update_layer, so it is covered by construction.
+        kernel_dim = {nn.Conv1d: 1, nn.Conv2d: 2}[conv_cls]
+
+        class DilatedConvModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv = conv_cls(1, 1, kernel_size=3, padding=2, dilation=2, padding_mode="reflect")
+
+            def forward(self, X):
+                return self.conv(X)
+
+        torch.manual_seed(0)
+        model = DilatedConvModel()
+        inputs = torch.randn(1, 1, *([8] * kernel_dim))
+        output_base = model(inputs)
+
+        model = get_peft_model(model, LoraConfig(r=1, target_modules=["conv"]))
+        layer = model.base_model.model.conv
+
+        assert layer.lora_A["default"].dilation == layer.base_layer.dilation
+        assert layer.lora_A["default"].padding_mode == layer.base_layer.padding_mode
+
+        # Without the propagated dilation the adapter branch has a different spatial shape and
+        # adding it to the base output raises, so this also guards the forward pass itself.
+        assert model(inputs).shape == output_base.shape
+
     def test_glora_safe_merge_does_not_corrupt_base_layer_on_non_finite_adapter(self):
         # Regression test: GLoRA's merge() used to accumulate the merged weights directly onto
         # base_layer.weight.data/bias.data *before* the safe_merge isfinite check, so a broken


### PR DESCRIPTION
Fixes #3697

## Problem

`_ConvNd.update_layer` builds `lora_A` to mirror the spatial configuration of the base convolution, but only carries over `kernel_size`, `stride` and `padding`:

```python
self.lora_A[adapter_name] = conv_layer(self.in_features, r, kernel_size, stride, padding, bias=False)
```

The base layer's `dilation` and `padding_mode` are dropped, so:

- a **dilated** base layer and the adapter branch produce different spatial output shapes, and the forward pass fails outright (the reproduction in the issue);
- a **non-default `padding_mode`** (e.g. `"reflect"`) is silently applied as zero padding on the adapter branch, giving inconsistent boundary behaviour.

## Fix

Pass both through when constructing `lora_A`.

This matches what DoRA already does for the same base layer — `dora.py` forwards `stride`, `padding`, `dilation` and `groups` — so the adapter path respecting the base layer's geometry is already the convention here; `lora_A` was just missing it.

`lora_B` is deliberately left unchanged: it is a 1x1 convolution constructed with no padding, so neither `dilation` nor `padding_mode` has any effect on it.

Neither argument changes the shape of the `lora_A` weight, so `get_delta_weight` and merging are unaffected — this is purely forward-pass geometry.

## Test

Added `test_lora_conv_preserves_dilation_and_padding_mode`, parametrized over `Conv1d` and `Conv2d`, next to the existing conv regression tests in `TestPeftCustomModel`. It asserts that `lora_A` carries the base layer's `dilation` and `padding_mode`, and that the adapted model still produces the base output shape (which fails on `main`, since the mismatched adapter output cannot be added to the base output).

`Conv3d` goes through the same `_ConvNd.update_layer`, so it is covered by construction; I left it out of the parametrization only to avoid depending on 3-D reflect-padding support.

## Verification

- `ruff check` and `ruff format --check` both pass on the changed files with the pinned `ruff==0.16.4`.
- I could not run the test suite locally (this machine only has Python 3.7, so no supported torch), so I'd appreciate CI confirming the new test — happy to iterate if anything needs adjusting.
