### PR TITLE
fix(ln_tuning): fallback to base layer when adapter is not present on layer

### DIFF
--- a/src/peft/tuners/ln_tuning/layer.py
+++ b/src/peft/tuners/ln_tuning/layer.py
@@ -80,6 +80,8 @@ class LNTuningLayer(nn.Module, BaseTunerLayer):
                 f"Trying to merge {len(adapter_names)} adapters, but LN "
                 f"tuning does not allow merging more than one adapter at a time"
             )
+        if adapter_names[0] not in self.ln_tuning_layers:
+            return
         merged_adapters = set(self.merged_adapters)
         if merged_adapters:
             warnings.warn(f"Already merged with {merged_adapters}. Unmerging first.")
@@ -117,7 +119,10 @@ class LNTuningLayer(nn.Module, BaseTunerLayer):
                     f"adapters, but LN tuning does not allow inference with more than one adapter at a time"
                 )
             active_adapter = self.active_adapters[0]
-            result = self.ln_tuning_layers[active_adapter](x, *args, **kwargs)
+            if active_adapter in self.ln_tuning_layers:
+                result = self.ln_tuning_layers[active_adapter](x, *args, **kwargs)
+            else:
+                result = self.base_layer(x, *args, **kwargs)
 
         return result
 

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -6583,6 +6583,21 @@ class TestRequiresGrad:
             "base_model.model.layernorm1.ln_tuning_layers.adapter1.bias",
         )
 
+    def test_forward_and_merge_lntuning_different_targets(self):
+        config0 = LNTuningConfig(target_modules=["layernorm0", "layernorm1"])
+        peft_model = get_peft_model(MLP_LayerNorm(), config0)
+
+        config1 = LNTuningConfig(target_modules=["layernorm0"])
+        peft_model.add_adapter("second", config1)
+        peft_model.set_adapter("second")
+
+        output = peft_model(torch.randn(4, 10))
+        assert output.shape == (4, 2)
+
+        peft_model.merge_adapter()
+        output = peft_model(torch.randn(4, 10))
+        assert output.shape == (4, 2)
+
     def test_requires_grad_lntuning_same_targets(self):
         config0 = LNTuningConfig(
             target_modules=["layernorm0"],


### PR DESCRIPTION
Fixes #3574. When an active LN-Tuning adapter targets only a subset of adapted layers, forward and merge now safely skip missing adapter weights and fall back to the base layer rather than raising a KeyError. Added a regression test for asymmetric multi-adapter setups.