### PR TITLE
Reject PSOFT/MiSS ranks larger than the layer can support

### DIFF
--- a/src/peft/tuners/miss/layer.py
+++ b/src/peft/tuners/miss/layer.py
@@ -76,6 +76,10 @@ class MissLayer(BaseTunerLayer):
 
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
+        if r > self.in_features:
+            raise ValueError(
+                f"MiSS requires `r` <= in_features but got r={r} for a layer with in_features={self.in_features}."
+            )
 
         self.miss_r[adapter_name] = r
         self.miss_mini_r[adapter_name] = mini_r

--- a/src/peft/tuners/psoft/layer.py
+++ b/src/peft/tuners/psoft/layer.py
@@ -241,6 +241,12 @@ class PsoftLayer(BaseTunerLayer):
         init_weights = config.init_weights
 
         r = int(config.r)
+        max_r = min(self.in_features, self.out_features)
+        if r > max_r:
+            raise ValueError(
+                f"PSOFT requires `r` <= min(in_features, out_features) but got r={r} for a layer with "
+                f"in_features={self.in_features}, out_features={self.out_features} (max usable r is {max_r})."
+            )
 
         self.fan_in_fan_out = config.fan_in_fan_out
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -46,6 +46,7 @@ from peft import (
     LoftQConfig,
     LoKrConfig,
     LoraConfig,
+    MissConfig,
     PeanutConfig,
     PeftMixedModel,
     PeftModel,
@@ -2891,6 +2892,57 @@ class TestPsoftInitialization:
                 use_cayley_neumann=True,
                 cayley_neumann_eps=bad_eps,
             )
+
+    def test_psoft_rejects_rank_above_min_in_out_features(self):
+        # SVD factors are at most rank min(in, out). A larger r builds an r×r R that cannot multiply the
+        # projected features, so fail at adapter init instead of on the first forward (#3702).
+        class Tiny(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = nn.Linear(16, 32)
+
+            def forward(self, x):
+                return self.lin(x)
+
+        msg = re.escape("PSOFT requires `r` <= min(in_features, out_features)")
+        with pytest.raises(ValueError, match=msg):
+            get_peft_model(Tiny(), PsoftConfig(target_modules=["lin"]))  # default r=32 > min(16, 32)
+
+        with pytest.raises(ValueError, match=msg):
+            get_peft_model(Tiny(), PsoftConfig(target_modules=["lin"], r=17))
+
+        model = get_peft_model(Tiny(), PsoftConfig(target_modules=["lin"], r=16))
+        x = torch.randn(2, 16)
+        model.eval()
+        with torch.no_grad():
+            model(x)  # does not raise
+
+
+class TestMissInitialization:
+    def test_miss_rejects_rank_above_in_features(self):
+        # Merge reshapes the base weight into blocks of size r along in_features. r > in_features yields
+        # n_blocks=0 and a 0-element reshape; fail at adapter init instead (#3701).
+        class Tiny(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin0 = nn.Linear(16, 32)
+                self.lin1 = nn.Linear(32, 16)
+
+            def forward(self, x):
+                return self.lin1(self.lin0(x))
+
+        msg = re.escape("MiSS requires `r` <= in_features")
+        with pytest.raises(ValueError, match=msg):
+            get_peft_model(Tiny(), MissConfig(target_modules=["lin0", "lin1"], init_weights=False))  # default r=64
+
+        model = get_peft_model(Tiny(), MissConfig(target_modules=["lin0", "lin1"], r=16, init_weights=False))
+        model.eval()
+        x = torch.randn(2, 16)
+        with torch.no_grad():
+            before = model(x)
+            model.merge_adapter()
+            after = model(x)
+        torch.testing.assert_close(before, after)
 
 
 class TestPeanutInitialization:


### PR DESCRIPTION
## Summary
- PSOFT (`#3702`): `r > min(in_features, out_features)` is accepted, then the first forward hits a shape error (`r×r` `R` vs SVD features of rank `k`). Default `r=32` trips this on small linears.
- MiSS (`#3701`): `r > in_features` still forwards, but `merge_adapter()` reshapes into `n_blocks = in_features // r == 0` and crashes.
- Per @BenjaminBossan: do not support those ranks; fail at adapter init with a helpful error. Pooled into one PR. Tests in `tests/test_initialization.py`.

## Test plan
- [x] `TestPsoftInitialization::test_psoft_rejects_rank_above_min_in_out_features`
- [x] `TestMissInitialization::test_miss_rejects_rank_above_in_features` (also checks merge still works at `r == in_features`)
- [ ] CI green

Fixes #3702
Fixes #3701


Made with [Cursor](https://cursor.com)