### PR TITLE
FIX safe_merge must leave the base layer untouched when it raises

### DIFF
--- a/src/peft/tuners/adamss/layer.py
+++ b/src/peft/tuners/adamss/layer.py
@@ -487,9 +487,11 @@ class Linear(nn.Module, AdamssLayer):
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
-                    base_layer.weight.data = orig_weight
-
-                    # Also update bias if present
+                    # Compute and validate the bias before committing anything. Assigning the
+                    # weight first would leave the base layer half-merged when the bias turns
+                    # out to be non-finite, and since `merged_adapters` is only appended to
+                    # after this block, `unmerge()` would not know to undo it.
+                    orig_bias = None
                     if base_layer.bias is not None:
                         orig_bias = base_layer.bias.data.clone()
                         delta_bias = self.get_delta_bias(active_adapter)
@@ -498,6 +500,9 @@ class Linear(nn.Module, AdamssLayer):
                             raise ValueError(
                                 f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
                             )
+
+                    base_layer.weight.data = orig_weight
+                    if orig_bias is not None:
                         base_layer.bias.data = orig_bias
                 else:
                     delta_weight = self.get_delta_weight(active_adapter)

--- a/src/peft/tuners/boft/layer.py
+++ b/src/peft/tuners/boft/layer.py
@@ -839,6 +839,11 @@ class Conv2d(nn.Module, BOFTLayer):
                         self.out_features, self.in_features, base_layer.kernel_size[0], base_layer.kernel_size[0]
                     )
 
+                    if not torch.isfinite(orig_weight).all():
+                        raise ValueError(
+                            f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
+                        )
+
                     self.set_base_weight(orig_weight.contiguous().to(orig_dtype))
                 else:
                     butterfly_oft_mat, boft_s = self.get_delta_weight(active_adapter)

--- a/src/peft/tuners/road/layer.py
+++ b/src/peft/tuners/road/layer.py
@@ -264,8 +264,11 @@ class Linear(nn.Module, RoadLayer):
                             f"NaNs detected in the merged weights. The adapter {active_adapter} seems to be broken"
                         )
 
-                    base_layer.weight.data = orig_weight.contiguous().to(orig_dtype)
-
+                    # Compute and validate the bias before committing anything. Assigning the
+                    # weight first would leave the base layer half-merged when the bias turns
+                    # out to be non-finite, and since `merged_adapters` is only appended to
+                    # after this block, `unmerge()` would not know to undo it.
+                    orig_bias = None
                     if base_layer.bias is not None:
                         orig_bias = base_layer.bias.clone()
                         orig_bias = torch.matmul(road_R.to(orig_dtype), orig_bias)
@@ -275,6 +278,8 @@ class Linear(nn.Module, RoadLayer):
                                 f"NaNs detected in the merged bias. The adapter {active_adapter} seems to be broken"
                             )
 
+                    base_layer.weight.data = orig_weight.contiguous().to(orig_dtype)
+                    if orig_bias is not None:
                         base_layer.bias.data = orig_bias.contiguous().to(orig_dtype)
                 else:
                     orig_weight = base_layer.weight.data

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -2690,6 +2690,81 @@ class TestPeftCustomModel(PeftCommonTester):
         assert torch.equal(layer.base_layer.bias.data, original_bias)
         assert layer.merged_adapters == []
 
+    def test_boft_conv2d_safe_merge_raises_on_non_finite_weights(self):
+        # BOFT's Conv2d.merge had a safe_merge branch that was a verbatim copy of the unsafe
+        # one: the isfinite check that Linear.merge performs was simply missing, so a broken
+        # adapter was merged into the base weight without complaint and the whole tensor
+        # silently became NaN.
+        torch.manual_seed(0)
+        model = ModelConv2D()
+        # 45 = in_channels * kernel_size**2, the divisibility BOFT requires for this conv.
+        config = BOFTConfig(target_modules=["conv2d"], boft_block_size=45, boft_n_butterfly_factor=1)
+        model = get_peft_model(model, config)
+        layer = model.base_model.model.conv2d
+        original_weight = layer.base_layer.weight.data.clone()
+
+        layer.boft_R["default"].data[0, 0, 0, 0] = float("nan")
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged weights"):
+            layer.merge(safe_merge=True)
+
+        assert torch.isfinite(layer.base_layer.weight.data).all()
+        assert torch.equal(layer.base_layer.weight.data, original_weight)
+        assert layer.merged_adapters == []
+
+    def test_adamss_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self):
+        # AdaMSS committed the merged weight to the base layer and only then computed and
+        # validated the bias, so a non-finite bias raised with the weight already overwritten.
+        # merged_adapters is appended to after that block, so unmerge() could not undo it.
+        torch.manual_seed(0)
+        model = MLP()
+        config = AdamssConfig(target_modules=["lin0"], r=8)
+        model = get_peft_model(model, config)
+        layer = model.base_model.model.lin0
+        original_weight = layer.base_layer.weight.data.clone()
+        original_bias = layer.base_layer.bias.data.clone()
+
+        # adamss_B is zero-initialised, which makes the weight delta exactly zero and would hide
+        # a premature commit; give it a small non-zero value so the delta is real but finite.
+        for param in layer.adamss_B["default"]:
+            param.data.normal_(0.0, 0.02)
+        # get_delta_bias is the last column of the adapter path, so poisoning only that column
+        # leaves the weight delta finite while the bias delta is not.
+        layer.adamss_newB["default"][:, -1] = float("nan")
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged bias"):
+            layer.merge(safe_merge=True)
+
+        assert torch.equal(layer.base_layer.weight.data, original_weight)
+        assert torch.equal(layer.base_layer.bias.data, original_bias)
+        assert layer.merged_adapters == []
+
+    def test_road_safe_merge_does_not_mutate_base_layer_on_non_finite_bias(self):
+        # Same ordering defect as AdaMSS above. RoAd applies the same rotation to the weight and
+        # the bias, so the trigger is a float16 overflow that the large bias reaches and the
+        # small weights do not, rather than an injected non-finite value.
+        torch.manual_seed(0)
+        model = MLP()
+        config = RoadConfig(target_modules=["lin0"], group_size=2)
+        model = get_peft_model(model, config)
+        layer = model.base_model.model.lin0
+        layer.base_layer.to(torch.float16)
+        layer.road_theta["default"].data = layer.road_theta["default"].data.to(torch.float16)
+        layer.road_alpha["default"].data = layer.road_alpha["default"].data.to(torch.float16)
+        with torch.no_grad():
+            layer.base_layer.weight.fill_(1e-3)
+            layer.base_layer.bias.fill_(6e4)  # just under float16 max; the merge tips it over
+            layer.road_alpha["default"].data.fill_(8.0)
+        original_weight = layer.base_layer.weight.data.clone()
+        original_bias = layer.base_layer.bias.data.clone()
+
+        with pytest.raises(ValueError, match="NaNs detected in the merged bias"):
+            layer.merge(safe_merge=True)
+
+        assert torch.equal(layer.base_layer.weight.data, original_weight)
+        assert torch.equal(layer.base_layer.bias.data, original_bias)
+        assert layer.merged_adapters == []
+
     @pytest.mark.parametrize("safe_merge", [False, True])
     @pytest.mark.parametrize("module_type", ["linear", "conv2d"])
     def test_merge_with_lora_bias_when_base_layer_has_no_bias_warns_and_raises(self, safe_merge, module_type):


### PR DESCRIPTION
# PR description

Closes #3682, closes #3689, closes #3705.

Every `merge()` docstring in PEFT makes the same promise about `safe_merge=True`:

> the merge operation will be performed in a copy of the original weights and check for NaNs before merging the weights

That implies two things — a non-finite merged tensor raises, and when it raises the base layer is left exactly as it was. Three implementations break it, in two different ways.

## BOFT `Conv2d` never checked at all (#3682)

Its `safe_merge` branch is a verbatim copy of the unsafe one, missing the `isfinite` check that BOFT `Linear.merge` performs a few hundred lines above. A broken adapter merged without complaint:

```
raised: NO
base weight finite after merge: False | NaN count: 144 / 144
merged_adapters: ['default']
```

The whole weight tensor becomes NaN and the caller is told the merge succeeded. Fixed by adding the check, identical to the `Linear` one.

## AdaMSS and RoAd commit the weight before validating the bias (#3689, #3705)

Both assign `base_layer.weight.data` and only then compute and check the bias, so a non-finite bias raises with the weight already overwritten:

```
AdaMSS   raised: NaNs detected in the merged bias...
         base weight unchanged: False | max abs delta: 0.031418412923812866
         merged_adapters: []

RoAd     raised: NaNs detected in the merged bias...
         base weight unchanged: False | max abs delta: 0.007002830505371086
         merged_adapters: []
```

`merged_adapters` is appended to *after* that block, so the adapter is never recorded as merged and `unmerge()` does not know there is anything to undo. The caller sees an exception, reasonably concludes the merge did not happen, and holds a silently modified base layer with no way back. Fixed by computing and validating the bias first, then committing weight and bias together.

## Scope

Found by auditing all 60 `merge()` implementations that accept `safe_merge`. The other apparent gaps are **not** bugs, and I left them alone:

- `hira` (3 sites) delegates to a `_merge()` that computes, checks, then copies — the cleanest implementation of this pattern in the repo.
- `ln_tuning` swaps modules rather than merging arithmetically, and says so in a comment.
- `lora/inc` raises `NotImplementedError`.

One thing I could **not** verify: `road/bnb.py` assigns `bias.data` under `safe_merge` with no finite check at all, in both the 8-bit and 4-bit classes. That path needs a GPU and I do not have one, so it is untouched here and only mentioned in #3705.

## Tests

Three tests in `TestPeftCustomModel`, alongside the existing `test_lora_safe_merge_does_not_mutate_base_layer_on_non_finite_bias`, which they follow in shape. **All three fail on base** — `DID NOT RAISE ValueError` for BOFT, and changed-weight assertions for AdaMSS and RoAd. A BOFT `Linear` control is included so the Linear/Conv2d asymmetry stays pinned.

Two deliberate choices worth flagging for review:

- The AdaMSS test seeds `adamss_B` with small non-zero values before poisoning `adamss_newB`'s last column. `adamss_B` is zero-initialised, which makes the weight delta exactly zero — my first attempt at this test passed against the broken implementation for that reason. Without that line the test would quietly stop testing anything.
- The RoAd test triggers a real float16 overflow rather than injecting a non-finite value. RoAd applies the same `road_R` to the weight and the bias, so an injected NaN fails the weight check first and never reaches the ordering bug.

`ruff check` and `ruff format --check` are clean on the pinned 0.16.4. The full BOFT/AdaMSS/RoAd selection of `tests/test_custom_models.py` is 1370 passed, 115 skipped, 0 failed.

Verified on torch 2.14.0+cpu, transformers 5.17.0, python 3.12.7.
