### PR TITLE
FIX Reject MiSS and PSOFT ranks the layer cannot support

### DIFF
--- a/src/peft/tuners/miss/layer.py
+++ b/src/peft/tuners/miss/layer.py
@@ -76,6 +76,8 @@ class MissLayer(BaseTunerLayer):
 
         if r <= 0:
             raise ValueError(f"`r` should be a positive integer value but the value passed is {r}")
+        if r > self.in_features:
+            raise ValueError(f"`r` ({r}) must be less than or equal to in_features ({self.in_features})")
 
         self.miss_r[adapter_name] = r
         self.miss_mini_r[adapter_name] = mini_r

--- a/src/peft/tuners/psoft/layer.py
+++ b/src/peft/tuners/psoft/layer.py
@@ -241,6 +241,11 @@ class PsoftLayer(BaseTunerLayer):
         init_weights = config.init_weights
 
         r = int(config.r)
+        if r > min(self.in_features, self.out_features):
+            raise ValueError(
+                f"`r` ({r}) must be less than or equal to min(in_features, out_features) "
+                f"({self.in_features}, {self.out_features})"
+            )
 
         self.fan_in_fan_out = config.fan_in_fan_out
 

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -2836,30 +2836,6 @@ class TestPsoftInitialization:
 
         return MLP(bias=bias).to(self.torch_device).eval()
 
-    @pytest.mark.parametrize("in_features,out_features", [(16, 32), (32, 16)])
-    @pytest.mark.parametrize("r", [17, 32])
-    def test_psoft_rank_exceeds_bound_raises(self, in_features, out_features, r):
-        model = nn.Sequential(nn.Linear(in_features, out_features)).to(self.torch_device)
-        config = PsoftConfig(target_modules=["0"], r=r)
-        msg = f"`r` ({r}) must be less than or equal to min(in_features, out_features) ({in_features}, {out_features})"
-        with pytest.raises(ValueError, match=re.escape(msg)):
-            get_peft_model(model, config)
-
-    @pytest.mark.parametrize("in_features,out_features", [(16, 32), (32, 16)])
-    def test_psoft_rank_at_bound_forward_and_merge(self, in_features, out_features):
-        torch.manual_seed(0)
-        model = nn.Sequential(nn.Linear(in_features, out_features)).to(self.torch_device).eval()
-        config = PsoftConfig(target_modules=["0"], r=16, init_weights=False)
-        model = get_peft_model(model, config)
-        data = torch.randn(2, in_features, device=self.torch_device)
-
-        with torch.no_grad():
-            output = model(data)
-            model.merge_adapter()
-            output_merged = model(data)
-
-        torch.testing.assert_close(output_merged, output)
-
     def test_psoft_svd_lowrank_niter_warns_when_backend_not_lowrank_and_user_changes_value(self):
         default_niter = PsoftConfig.__dataclass_fields__["psoft_svd_lowrank_niter"].default
 
@@ -2917,37 +2893,50 @@ class TestPsoftInitialization:
                 cayley_neumann_eps=bad_eps,
             )
 
+    @pytest.mark.parametrize("r", [11, 32])
+    def test_psoft_rank_exceeds_bound_raises(self, r):
+        # lin0 is Linear(10, 30), so the rank cannot exceed 10
+        model = self.get_model()
+        config = PsoftConfig(target_modules=["lin0"], r=r)
+        msg = f"`r` ({r}) must be less than or equal to min(in_features, out_features) (10, 30)"
+        with pytest.raises(ValueError, match=re.escape(msg)):
+            get_peft_model(model, config)
+
+        # a rank equal to the bound is allowed
+        get_peft_model(self.get_model(), PsoftConfig(target_modules=["lin0"], r=10))
+
 
 class TestMissInitialization:
     """Basic sanity tests for the MiSS tuner."""
 
     torch_device = infer_device()
 
-    @pytest.mark.parametrize("init_weights", [True, False, "mini"])
-    @pytest.mark.parametrize("r", [17, 64])
+    def get_model(self):
+        class MLP(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin0 = nn.Linear(10, 30)
+                self.lin1 = nn.Linear(30, 2)
+
+            def forward(self, X):
+                X = self.lin0(X)
+                X = self.lin1(X)
+                return X
+
+        return MLP().to(self.torch_device)
+
+    @pytest.mark.parametrize("init_weights", [True, False, "bat", "mini"])
+    @pytest.mark.parametrize("r", [11, 64])
     def test_miss_rank_exceeds_bound_raises(self, init_weights, r):
-        model = nn.Sequential(nn.Linear(16, 32)).to(self.torch_device)
-        config = MissConfig(target_modules=["0"], r=r, init_weights=init_weights)
-        msg = f"`r` ({r}) must be less than or equal to in_features (16)"
+        # lin0 is Linear(10, 30), so the rank cannot exceed 10
+        model = self.get_model()
+        config = MissConfig(target_modules=["lin0"], r=r, init_weights=init_weights)
+        msg = f"`r` ({r}) must be less than or equal to in_features (10)"
         with pytest.raises(ValueError, match=re.escape(msg)):
             get_peft_model(model, config)
 
-    @pytest.mark.parametrize(
-        "init_weights,out_features", [(True, 32), (False, 32), ("bat", 32), ("mini", 32), (False, 8)]
-    )
-    def test_miss_rank_at_bound_forward_and_merge(self, init_weights, out_features):
-        torch.manual_seed(0)
-        model = nn.Sequential(nn.Linear(16, out_features)).to(self.torch_device).eval()
-        config = MissConfig(target_modules=["0"], r=16, init_weights=init_weights)
-        model = get_peft_model(model, config)
-        data = torch.randn(2, 16, device=self.torch_device)
-
-        with torch.no_grad():
-            output = model(data)
-            model.merge_adapter()
-            output_merged = model(data)
-
-        torch.testing.assert_close(output_merged, output)
+        # a rank equal to the bound is allowed
+        get_peft_model(self.get_model(), MissConfig(target_modules=["lin0"], r=10, init_weights=init_weights))
 
 
 class TestPeanutInitialization:

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -46,6 +46,7 @@ from peft import (
     LoftQConfig,
     LoKrConfig,
     LoraConfig,
+    MissConfig,
     PeanutConfig,
     PeftMixedModel,
     PeftModel,
@@ -2835,6 +2836,30 @@ class TestPsoftInitialization:
 
         return MLP(bias=bias).to(self.torch_device).eval()
 
+    @pytest.mark.parametrize("in_features,out_features", [(16, 32), (32, 16)])
+    @pytest.mark.parametrize("r", [17, 32])
+    def test_psoft_rank_exceeds_bound_raises(self, in_features, out_features, r):
+        model = nn.Sequential(nn.Linear(in_features, out_features)).to(self.torch_device)
+        config = PsoftConfig(target_modules=["0"], r=r)
+        msg = f"`r` ({r}) must be less than or equal to min(in_features, out_features) ({in_features}, {out_features})"
+        with pytest.raises(ValueError, match=re.escape(msg)):
+            get_peft_model(model, config)
+
+    @pytest.mark.parametrize("in_features,out_features", [(16, 32), (32, 16)])
+    def test_psoft_rank_at_bound_forward_and_merge(self, in_features, out_features):
+        torch.manual_seed(0)
+        model = nn.Sequential(nn.Linear(in_features, out_features)).to(self.torch_device).eval()
+        config = PsoftConfig(target_modules=["0"], r=16, init_weights=False)
+        model = get_peft_model(model, config)
+        data = torch.randn(2, in_features, device=self.torch_device)
+
+        with torch.no_grad():
+            output = model(data)
+            model.merge_adapter()
+            output_merged = model(data)
+
+        torch.testing.assert_close(output_merged, output)
+
     def test_psoft_svd_lowrank_niter_warns_when_backend_not_lowrank_and_user_changes_value(self):
         default_niter = PsoftConfig.__dataclass_fields__["psoft_svd_lowrank_niter"].default
 
@@ -2891,6 +2916,38 @@ class TestPsoftInitialization:
                 use_cayley_neumann=True,
                 cayley_neumann_eps=bad_eps,
             )
+
+
+class TestMissInitialization:
+    """Basic sanity tests for the MiSS tuner."""
+
+    torch_device = infer_device()
+
+    @pytest.mark.parametrize("init_weights", [True, False, "mini"])
+    @pytest.mark.parametrize("r", [17, 64])
+    def test_miss_rank_exceeds_bound_raises(self, init_weights, r):
+        model = nn.Sequential(nn.Linear(16, 32)).to(self.torch_device)
+        config = MissConfig(target_modules=["0"], r=r, init_weights=init_weights)
+        msg = f"`r` ({r}) must be less than or equal to in_features (16)"
+        with pytest.raises(ValueError, match=re.escape(msg)):
+            get_peft_model(model, config)
+
+    @pytest.mark.parametrize(
+        "init_weights,out_features", [(True, 32), (False, 32), ("bat", 32), ("mini", 32), (False, 8)]
+    )
+    def test_miss_rank_at_bound_forward_and_merge(self, init_weights, out_features):
+        torch.manual_seed(0)
+        model = nn.Sequential(nn.Linear(16, out_features)).to(self.torch_device).eval()
+        config = MissConfig(target_modules=["0"], r=16, init_weights=init_weights)
+        model = get_peft_model(model, config)
+        data = torch.randn(2, 16, device=self.torch_device)
+
+        with torch.no_grad():
+            output = model(data)
+            model.merge_adapter()
+            output_merged = model(data)
+
+        torch.testing.assert_close(output_merged, output)
 
 
 class TestPeanutInitialization:

--- a/tests/test_lora_intruders.py
+++ b/tests/test_lora_intruders.py
@@ -53,7 +53,7 @@ class TestLoraIntruders:
         with hub_online_once(model_id):
             base_model = AutoModelForCausalLM.from_pretrained(model_id)
 
-        cfg = MissConfig(target_modules=["q_proj"])
+        cfg = MissConfig(target_modules=["q_proj"], r=8)
         peft_model = get_peft_model(base_model, cfg)
 
         return peft_model


### PR DESCRIPTION
Fixes #3701
Fixes #3702

Adds an early rank check at adapter creation for two tuners, pooled into one PR as requested in https://github.com/huggingface/peft/issues/3702#issuecomment-5599656815.

- MiSS: `r > in_features` now raises a `ValueError` in `update_layer`. Before, forward padded the input and ran, and `merge_adapter()` failed with `cannot reshape tensor of 0 elements`.
- PSOFT: `r > min(in_features, out_features)` now raises a `ValueError` in `update_layer`. Before, the first forward failed with `mat1 and mat2 shapes cannot be multiplied`.

Both messages name the requested rank and the layer dimensions. Ranks at the bound still work, and the new tests check that merged output matches the unmerged forward output for them.

Tests were added to `tests/test_initialization.py` next to the existing PSOFT tests, plus a new `TestMissInitialization` class.

Tests run (CPU, torch 2.11.0, transformers 5.11.0):

```
pytest tests/test_initialization.py -k "psoft or miss"     # 28 passed
pytest tests/test_custom_models.py -k "miss or psoft"      # 997 passed, 55 skipped
ruff check / ruff format --check (ruff 0.16.4)             # clean
```
