### PR TITLE
[perf] Qwen3.8-27B LoRA SFT with FSDP (examples/sft) on 8x B200: 52.8 s to 34.7 s per optimizer step, mostly from the pure-torch delta-rule fallback

### DIFF
--- a/examples/sft/configs/fsdp_config.yaml
+++ b/examples/sft/configs/fsdp_config.yaml
@@ -8,7 +8,7 @@ fsdp_config:
   fsdp_cpu_ram_efficient_loading: true
   fsdp_forward_prefetch: false
   fsdp_offload_params: false
-  fsdp_sharding_strategy: FULL_SHARD
+  fsdp_sharding_strategy: SHARD_GRAD_OP
   fsdp_state_dict_type: SHARDED_STATE_DICT
   fsdp_sync_module_states: true
   fsdp_use_orig_params: false

--- a/examples/sft/qwen_chunk_views.py
+++ b/examples/sft/qwen_chunk_views.py
@@ -17,7 +17,8 @@
 The recurrence is adapted from Transformers' modeling_qwen3_5.py. Its arithmetic
 and dtype conversions are retained. Disjoint chunk gradients are assembled with
 unbind/stack, and triangular-row gradients are accumulated directly into their
-slices. Higher derivatives use the original differentiable row recurrence.
+slices. Independent local attention products are batched before the ordered
+state recurrence. Higher derivatives use the original differentiable row recurrence.
 """
 
 import torch

--- a/examples/sft/qwen_chunk_views.py
+++ b/examples/sft/qwen_chunk_views.py
@@ -126,16 +126,18 @@ def torch_chunk_gated_delta_rule(
     chunk_outputs = []
     mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1)
 
+    # Local attention products are independent of the recurrent state.
+    attention_chunks = (query @ key.transpose(-1, -2) * decay_mask).unbind(2)
+
     # for each chunk
     query_chunks = query.unbind(2)
     key_chunks = key.unbind(2)
     value_chunks = value.unbind(2)
     k_cumdecay_chunks = k_cumdecay.unbind(2)
-    decay_mask_chunks = decay_mask.unbind(2)
     g_chunks = g.unbind(2)
     for i in range(total_sequence_length // chunk_size):
         q_i, k_i, v_i = query_chunks[i], key_chunks[i], value_chunks[i]
-        attn = q_i @ k_i.transpose(-1, -2) * decay_mask_chunks[i]
+        attn = attention_chunks[i]
         v_prime = (k_cumdecay_chunks[i]) @ last_recurrent_state
         v_new = v_i - v_prime
         attn_inter = (q_i * g_chunks[i][:, :, :, None].exp()) @ last_recurrent_state

--- a/examples/sft/qwen_chunk_views.py
+++ b/examples/sft/qwen_chunk_views.py
@@ -1,0 +1,178 @@
+# Copyright 2025 The Qwen Team and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chunk views and row gradients for the Transformers 5.16.1 Qwen fallback.
+
+The recurrence is adapted from Transformers' modeling_qwen3_5.py. Its arithmetic
+and dtype conversions are retained. Disjoint chunk gradients are assembled with
+unbind/stack, and triangular-row gradients are accumulated directly into their
+slices. Higher derivatives use the original differentiable row recurrence.
+"""
+
+import torch
+import torch.nn.functional as F
+
+
+def _l2norm(x: torch.FloatTensor, dim: int = -1, eps: float = 1e-6):
+    """This function is intended to align with the l2norm implementation in the FLA library."""
+    inv_norm = torch.rsqrt((x * x).sum(dim=dim, keepdim=True) + eps)
+    return x * inv_norm
+
+
+class _TriangularRows(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, attn):
+        work = attn.clone()
+        rows = []
+        subs = []
+        for i in range(1, attn.shape[-1]):
+            row = work[..., i, :i].clone()
+            sub = work[..., :i, :i].clone()
+            work[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
+            rows.append(row)
+            subs.append(sub)
+        ctx.size = attn.shape[-1]
+        ctx.save_for_backward(attn, *(rows + subs))
+        return work
+
+    @staticmethod
+    def backward(ctx, output_grad):
+        count = ctx.size - 1
+        saved = ctx.saved_tensors
+        attn = saved[0]
+        if torch.is_grad_enabled():
+            # Rebuild the ordinary autograd graph when higher derivatives are requested.
+            work = attn.clone()
+            for i in range(1, ctx.size):
+                row = work[..., i, :i].clone()
+                sub = work[..., :i, :i].clone()
+                work[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
+            return torch.autograd.grad(work, attn, output_grad, create_graph=True)[0]
+        rows = saved[1 : count + 1]
+        subs = saved[count + 1 :]
+        grad = output_grad.clone()
+        for i in range(ctx.size - 1, 0, -1):
+            incoming = grad[..., i, :i].clone()
+            grad[..., i, :i] = incoming + (incoming.unsqueeze(-2) * subs[i - 1]).sum(-1)
+            grad[..., :i, :i].add_(rows[i - 1].unsqueeze(-1) * incoming.unsqueeze(-2))
+        return grad
+
+
+def torch_chunk_gated_delta_rule(
+    query,
+    key,
+    value,
+    g,
+    beta,
+    chunk_size=64,
+    initial_state=None,
+    output_final_state=False,
+    use_qk_l2norm_in_kernel=False,
+    **kwargs,
+):
+    initial_dtype = query.dtype
+    if use_qk_l2norm_in_kernel:
+        query = _l2norm(query, dim=-1, eps=1e-6)
+        key = _l2norm(key, dim=-1, eps=1e-6)
+    query, key, value, beta, g = [
+        x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
+    ]
+
+    batch_size, num_heads, sequence_length, k_head_dim = key.shape
+    v_head_dim = value.shape[-1]
+    pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
+    query = F.pad(query, (0, 0, 0, pad_size))
+    key = F.pad(key, (0, 0, 0, pad_size))
+    value = F.pad(value, (0, 0, 0, pad_size))
+    beta = F.pad(beta, (0, pad_size))
+    g = F.pad(g, (0, pad_size))
+    total_sequence_length = sequence_length + pad_size
+    scale = 1 / (query.shape[-1] ** 0.5)
+    query = query * scale
+
+    v_beta = value * beta.unsqueeze(-1)
+    k_beta = key * beta.unsqueeze(-1)
+    # reshape to chunks
+    query, key, value, k_beta, v_beta = [
+        x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1]) for x in (query, key, value, k_beta, v_beta)
+    ]
+    g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
+    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0)
+
+    # chunk decay
+    g = g.cumsum(dim=-1)
+    decay_mask = ((g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float()).tril()
+    attn = -((k_beta @ key.transpose(-1, -2)) * decay_mask).masked_fill(mask, 0)
+    attn = _TriangularRows.apply(attn)
+    attn = attn + torch.eye(chunk_size, dtype=attn.dtype, device=attn.device)
+    value = attn @ v_beta
+    k_cumdecay = attn @ (k_beta * g.exp().unsqueeze(-1))
+    last_recurrent_state = (
+        torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim, dtype=value.dtype, device=value.device)
+        if initial_state is None
+        else initial_state.to(value)
+    )
+    chunk_outputs = []
+    mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1)
+
+    # for each chunk
+    query_chunks = query.unbind(2)
+    key_chunks = key.unbind(2)
+    value_chunks = value.unbind(2)
+    k_cumdecay_chunks = k_cumdecay.unbind(2)
+    decay_mask_chunks = decay_mask.unbind(2)
+    g_chunks = g.unbind(2)
+    for i in range(total_sequence_length // chunk_size):
+        q_i, k_i, v_i = query_chunks[i], key_chunks[i], value_chunks[i]
+        attn = q_i @ k_i.transpose(-1, -2) * decay_mask_chunks[i]
+        v_prime = (k_cumdecay_chunks[i]) @ last_recurrent_state
+        v_new = v_i - v_prime
+        attn_inter = (q_i * g_chunks[i][:, :, :, None].exp()) @ last_recurrent_state
+        chunk_outputs.append(attn_inter + attn @ v_new)
+        last_recurrent_state = (
+            last_recurrent_state * g_chunks[i][:, :, -1, None, None].exp()
+            + (k_i * (g_chunks[i][:, :, -1, None] - g_chunks[i]).exp()[..., None]).transpose(-1, -2) @ v_new
+        )
+
+    core_attn_out = torch.stack(chunk_outputs, dim=2)
+    if not output_final_state:
+        last_recurrent_state = None
+    core_attn_out = core_attn_out.reshape(core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1])
+    core_attn_out = core_attn_out[:, :, :sequence_length]
+    core_attn_out = core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)
+    return core_attn_out, last_recurrent_state
+
+
+def enable_chunk_views(model):
+    """Use the validated fallback for Qwen text SFT without changing other models."""
+    import transformers
+
+    if transformers.__version__ != "5.16.1":
+        return False
+
+    from transformers.utils import is_kernels_available
+
+    if is_kernels_available():
+        return False
+    if model.config.get_text_config().model_type != "qwen3_5_text":
+        return False
+
+    from transformers.integrations.hub_kernels import use_kernel_func_from_hub_with_fallback
+    from transformers.models.qwen3_5 import modeling_qwen3_5
+
+    # Preserve the upstream preference for an installed FLA implementation.
+    modeling_qwen3_5.torch_chunk_gated_delta_rule = use_kernel_func_from_hub_with_fallback(
+        "chunk_gated_delta_rule", "fla"
+    )(torch_chunk_gated_delta_rule)
+    return True

--- a/examples/sft/train.py
+++ b/examples/sft/train.py
@@ -7,6 +7,7 @@ from transformers import HfArgumentParser, set_seed
 from trl import SFTConfig, SFTTrainer
 from utils import create_and_prepare_model, create_datasets
 
+
 if os.environ.get("PERF_RUN_DIR"):
     from perf_harness import instrument
 
@@ -104,6 +105,12 @@ def main(model_args, data_args, training_args):
 
     # model
     model, peft_config, tokenizer = create_and_prepare_model(model_args, data_args, training_args)
+
+    if os.environ.get("PERF_CHUNK_VIEWS") == "1":
+        from qwen_chunk_views import enable_chunk_views
+
+        if not training_args.bf16 or not enable_chunk_views(model):
+            raise ValueError("Chunk views require BF16 Qwen text SFT with Transformers 5.16.1 and no hub kernels.")
 
     # gradient ckpt
     model.config.use_cache = not training_args.gradient_checkpointing

--- a/examples/sft/train.py
+++ b/examples/sft/train.py
@@ -106,11 +106,10 @@ def main(model_args, data_args, training_args):
     # model
     model, peft_config, tokenizer = create_and_prepare_model(model_args, data_args, training_args)
 
-    if os.environ.get("PERF_CHUNK_VIEWS") == "1":
+    if training_args.bf16:
         from qwen_chunk_views import enable_chunk_views
 
-        if not training_args.bf16 or not enable_chunk_views(model):
-            raise ValueError("Chunk views require BF16 Qwen text SFT with Transformers 5.16.1 and no hub kernels.")
+        enable_chunk_views(model)
 
     # gradient ckpt
     model.config.use_cache = not training_args.gradient_checkpointing

--- a/examples/sft/train.py
+++ b/examples/sft/train.py
@@ -7,6 +7,11 @@ from transformers import HfArgumentParser, set_seed
 from trl import SFTConfig, SFTTrainer
 from utils import create_and_prepare_model, create_datasets
 
+if os.environ.get("PERF_RUN_DIR"):
+    from perf_harness import instrument
+
+    instrument(SFTTrainer)
+
 
 # Define and parse arguments.
 @dataclass


### PR DESCRIPTION
> [!NOTE]
> Experimental PR. It records where the time went while training a Qwen3.8-27B LoRA with `examples/sft` under FSDP on a B200 node, what I think causes it, and some possible fixes. Discussion welcome.

## Setup and Key Improvement

**Hardware.** One node, 8 × NVIDIA B200 (sm_100, 183 GB each), driver 580.126.20, CUDA 13.0. Model weights are read from a shared Hugging Face cache on network storage; the dataset is copied to node-local disk before each run.

**Env installation.** Python 3.11.16, torch 2.14.0+cu130 from PyPI (cuDNN 9.24.0.43 and NCCL 2.30.7 bundled), transformers 5.16.1, trl 1.12.0, accelerate 1.14.0, datasets 5.0.1, peft 0.20.1.dev0 as an editable install of `main` at `f5ea6b00`. No flash-attn, no `fla`, no `causal_conv1d` and no hub `kernels`, so the 48 linear-attention layers run transformers' pure-torch `torch_chunk_gated_delta_rule` fallback and the 16 full-attention layers run SDPA. I did not install `fla`; transformers' Qwen3.5 model doc says the DeltaNet path needs it for its fast kernels, and the peft example's README does not mention it. The largest change below measures what that fallback costs and trims it; installing `fla` is the plainer fix.

**Script.** `examples/sft/train.py` launched as in `examples/sft/run_peft_fsdp.sh` with the repo's `configs/fsdp_config.yaml` (8-process FSDP, bf16). Flags as in that script except the model (`Qwen/Qwen3.8-27B` instead of the gated Llama-2-70b), the step budget (`--max_steps 15` instead of one epoch), `--use_flash_attn False`, `--packing False`, periodic eval and checkpoints off, `--report_to none`, and `--fsdp_transformer_layer_cls_to_wrap Qwen3_5DecoderLayer` on the launcher, without which the unmodified job does not start (see the note at the end). The full command is under Reproduce.

**Model and job.** Qwen3.8-27B in its text-only view (`Qwen3_5ForCausalLM`, 26.95 B parameters, 64 layers of which 48 are gated delta-rule linear attention and 16 full attention, hidden 5120, bf16, frozen) with LoRA r=8, alpha 16, dropout 0.1 on all linear layers (992 tensors, 58.4 M parameters). Each optimizer update trains on 4 microbatches of 8 chat-formatted `smangrul/ultrachat-10k-chatml` samples per rank, each microbatch padded to its longest sequence with a 2048-token cap, with non-reentrant gradient checkpointing on.

**Measurement.** 15 optimizer updates per process (`--max_steps 15`); seeds `--seed 100 --data_seed 100` and `PYTHONHASHSEED=100`, so three runs of the unmodified code are bit-identical. Update time is the median of updates 6 to 15 of the wall interval between consecutive refreshes of the Trainer's own progress bar on rank 0, which includes the data loading and logging between step bodies; a CUDA-synchronized step-body timer, taken as the maximum over the 8 ranks, agrees within 20 ms. Profiles cover updates 6 to 8 (baseline) and update 6 (optimized) on all 8 ranks. The unmodified update takes 52.78 s with the GPU 80 to 84% busy.

**Improvements in short.** Three changes to `examples/sft/train.py`, a new `examples/sft/qwen_chunk_views.py` and one line of `examples/sft/configs/fsdp_config.yaml`. One world size was measured.

| GPUs | upstream `f5ea6b00` | this branch | |
|---|---|---|---|
| 8 × B200 | 52.78 s | 34.74 s | 1.52× |

Neither change depends on the B200: the largest part of the gap comes from the pure-torch delta-rule fallback that transformers runs when `fla` is not installed (its Qwen3.5 doc page says to install it; I had not), and the FSDP change applies on any node with about 48 GB of free memory per rank.

## What this PR does

Five commits, three files, limited to the SFT example so nothing in `src/peft` changes. Two of the commits carry no speed change of their own: the first adds an opt-in measurement hook, the last turns the trial flag into the default.

The steady-update column is the plain (unrecorded, unprofiled) 15-update benchmark under the final measurement protocol. The three optimization rows were timed on the campaign commits named in the row, against the 53.03 s reference of the same protocol; the last row is the final interleaved baseline/candidate pair run on the delivered branch, and its 52.78 s → 34.74 s is the delivery number.

| commit | change | steady update (8×B200) |
|---|---|---|
| | baseline, upstream `f5ea6b00` | 53.03 s (protocol reference); 52.78 s in the final pair |
| `99260107` | Opt-in measurement hook in `train.py`: when `PERF_RUN_DIR` is set, import `perf_harness` and instrument `SFTTrainer`. Inert otherwise, and it was on in both arms of every measurement. Note for review: `perf_harness.py` lives in the campaign workspace, not in this repo, so this commit may not belong upstream. | 53.03 s (not a new measurement) |
| `a6d0a767` (campaign `f7be11c4`) | Chunk views and direct triangular-row gradients for transformers' pure-torch delta-rule fallback, in the new `qwen_chunk_views.py`. The fallback writes each 64-token chunk's output into `core_attn_out[:, :, i]` and updates 63 rows of the chunk attention matrix in place, so the backward carried 578,016 SelectBackward and 141,216 CopySlices nodes per update across the 8 ranks. The helper unbinds the chunk axis once and stacks the outputs, and gives the row loop a custom backward that accumulates straight into the row slices; forward arithmetic and dtype conversions are unchanged. After it, 85,824 SelectBackward and 0 CopySlices. It is installed only for transformers 5.16.1, model type `qwen3_5_text`, and no hub kernels; anything else keeps the upstream path. | 41.70 s (−21.4%) |
| `eaceddca` (campaign `ad07658b`) | `fsdp_sharding_strategy: FULL_SHARD` → `SHARD_GRAD_OP` in `configs/fsdp_config.yaml`. FULL_SHARD frees every gathered parameter after each forward, so each of the 992 separately wrapped LoRA tensors plus the 64 decoder layers was re-gathered for every microbatch and checkpoint recompute: 97,440 all-gathers per update across the 8 ranks. SHARD_GRAD_OP keeps the gathered storage through the no-sync accumulation window: 8,584 all-gathers, and exposed communication 102.3 → 45.6 rank-seconds in the profiled update. Costs about 48 GB more per rank. | 35.75 s (−32.6%) |
| `88c8bf4c` (campaign `55abdf68`) | Compute the per-chunk `query @ key.T * decay_mask` once for all chunks before the ordered state recurrence instead of inside the loop; those products do not depend on the recurrent state. That removes 4 × 48 × (chunks − 1) GEMM launches per rank per update: 171,648 across the 8 ranks, exactly the predicted count. | 34.73 s (−34.5%) |
| `09b07a70` | Remove the `PERF_CHUNK_VIEWS` trial flag: the helper is enabled whenever `--bf16` is set and its version and model checks pass. Helper AST unchanged except the docstring. | 34.74 s (−34.2%) in the final pair against 52.78 s |

Peak allocated memory per rank goes from 49.8 to 98.1 GB (reserved 53.9 to 101.3 GB); the extra is about one unsharded bf16 copy of the 27 B base weights, which fits the B200 with headroom. The first update takes 37.1 s (was 54.7 s), and the five warm-up updates together 176.6 s (was 266.1 s). Startup before the first update is 150 s (was 158 s) and the final full-state save 99 s (was 101 s), so the whole 15-update job goes from 1080 s to 798 s. Model, precision (`mixed_precision: bf16` with the original parameter loading dtype), world size (8), microbatch 8, accumulation 4, LoRA configuration, optimizer, data order and the checkpointing mode are unchanged.

Kernel time per update per rank (all-rank totals from the kernel table divided by the profiled rank-updates, 24 for the baseline and 8 for the optimized run) went from element-wise 29.7 s, communication 20.6 s, GEMM 8.0 s, device copies 1.3 s, attention 0.5 s to 20.2 s, 9.1 s, 7.5 s, 0.3 s, 0.5 s; exposed communication 12.6 → 4.7 s, idle 10.3 to 12.6 s → 3.3 to 4.6 s per rank. Profiling adds overhead (the profiled update is 64 s against 52.8 s plain on the baseline and 37.9 s against 34.7 s optimized), so these are attribution figures, not the timing claim.

Traces (torch.profiler with shapes, memory and Python stacks, all 8 ranks; gzipped JSON, https://ui.perfetto.dev opens it directly; the README next to them lists code, script, hardware, env and capture window). The optimized trace is of campaign commit `55abdf68`, which is the delivered code before the trial flag was removed; the delivered head `09b07a70` itself was not profiled.
- baseline: https://drive.google.com/open?id=1VhogrKqzOVaBiExZurFu0UeOzh2L1U8H (updates 6 to 8)
- optimized: https://drive.google.com/open?id=1ofpXnqdq2ApxjlwqfM73iWUDeWugOtTO (update 6)

## Observations from the profile

Four observations, each with what I think causes it and a possible fix that does not depend on this PR.

1. **With no `fla` installed, the pure-torch delta-rule fallback wrote each chunk's output through slice views, and the backward on rank 0 carried 203,952 SelectBackward and 51,792 CopySlices nodes over three updates.** `transformers/models/qwen3_5/modeling_qwen3_5.py:294-297` updates 63 rows of the chunk attention matrix in place with slice writes, and `:310-316` indexes `query[:, :, i]`, `key[:, :, i]` per chunk and writes the result into `core_attn_out[:, :, i]`. Each in-place slice write is a CopySlices node and each chunk index a SelectBackward node, and the fallback runs 48 layers × 4 microbatches × (forward + recompute) per update. Over rank 0's three profiled updates (12 microbatches, 323 chunk iterations in total) the trace had exactly 48 × (58 × 12 + 11 × 323) = 203,952 SelectBackward and 48 × (63 × 12 + 323) = 51,792 CopySlices nodes, and the kernels under those nodes occupied 28.5 s of that 191.5 s window, 25.9 s of it not overlapping communication. A possible fix: unbind the chunk axis once and stack the outputs, and give the row loop a custom backward that accumulates into the row slices (`examples/sft/qwen_chunk_views.py:34-68` and `:134-151`); bit-identical outputs and gradients, 53.03 → 41.70 s here. The change would fit in transformers; the example carries it here because peft's install pulls no `fla`.

2. **The fallback launched the `q_i @ k_i.T * decay_mask` product inside the ordered chunk loop, once per chunk: 171,648 GEMM launches per update across the 8 ranks.** `modeling_qwen3_5.py:312` computes `q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]` inside the ordered loop over up to 32 chunks; only the state products after it are sequential. That is 4 launches (forward, recompute, dQ, dK) × 48 layers × surplus chunks: 171,648 GEMM launches per update across 8 ranks, and BmmBackward lost time went from 10.3 to 3.9 rank-seconds once they were gone. A possible fix: one batched product before the loop (`qwen_chunk_views.py:131`), 35.75 → 34.73 s. The same shape of fix applies to any chunked linear-attention fallback in transformers; the remaining per-chunk products consume or update the state and stay ordered.

3. **Under FULL_SHARD, each of the 992 separately wrapped LoRA tensors was gathered again for every microbatch and checkpoint recompute: 97,440 all-gathers per update across the 8 ranks.** `src/peft/utils/other.py:1271-1300` (`fsdp_auto_wrap_policy`) ORs the transformer-layer policy with a lambda policy that wraps each trainable leaf weight on its own (`:1294-1298`), giving 992 LoRA handles next to the 64 decoder-layer handles. With `fsdp_sharding_strategy: FULL_SHARD` (`examples/sft/configs/fsdp_config.yaml:11`), `_post_forward_reshard` (`torch/distributed/fsdp/_runtime_utils.py:486`) frees the gathered storage after every forward, so with gradient checkpointing and accumulation 4 each handle is gathered again for every microbatch and recompute: 97,440 all-gathers per update across 8 ranks, 17,088 of them 80 KB and 4,032 of them 96 KB on rank 0 over three updates, and 15.1 s of exposed communication per update on rank 0. Forward prefetch (`fsdp_config.yaml:9`) made no difference in an exact A/B: 52.83 s against 52.76 s. A possible fix: `SHARD_GRAD_OP` keeps the gathered parameters through the no-sync window (`_runtime_utils.py:811`, and `_flat_param.py:1385` skips the gather when the storage is there): 8,584 all-gathers, 41.70 → 35.75 s, for about 48 GB more per rank. Whether the example's default trades that memory is a per-model and per-GPU decision; the SFT README could say that with a frozen base and LoRA the parameter gathers, not the gradient reductions, are the communication cost, and name the memory price of retaining them.

4. **With each rank padded to its own longest sequence, rank 0 ran 323 delta-rule chunks per layer and rank 5 ran 371 in the same microsteps, and the early ranks waited in the collectives.** The collator pads each rank's microbatch to its own longest sequence (`trl/trainer/sft_trainer.py:500-505`, `pad_to_multiple_of` unset), and the delta-rule loop runs `ceil(S/64)` chunks per layer, so in the baseline's microsteps 21 to 32 rank 0 ran 323 chunks per layer and rank 5 ran 371. Rank 0 spent 69.2 s in collectives over three profiled updates against 49.9 s on rank 5, and after retention the reduce-scatter residency grew from 8.7 to 50.6 rank-seconds while carrying 934 MB: ranks arrive early and wait. A possible fix, not in this PR: length-grouped sampling or a global pad length would balance it, but both change batch composition, so that is a training-recipe decision per model rather than an exact-equivalence change.

I can do 1 and 2 as a transformers PR or keep them in this example; 3 is in this PR for the example config only and needs the memory decision; 4 is a recipe change I would leave to the maintainers.

## Correctness verification

To make sure the optimizations do not change what the model computes, I instrumented the points listed below to record intermediate values, and required every optimization to keep those values within a tolerance. The tool is a small opt-in recorder (`perf_harness.py`, hooked through `examples/sft/train.py:11` when `PERF_RUN_DIR` is set) with a comparator that freezes the baseline records by hash before any optimization is measured.

| What is recorded | Where | Actual difference to baseline | Tolerance |
|---|---|---|---|
| loss, unrounded, per microbatch<br>microbatches 1 to 60 (15-update gate) and 1 to 982 (250-update gate) | `SFTTrainer.compute_loss`, returned value | 0 (identical) | 0 |
| LM-head logits, first 2 rows × first 64 vocabulary entries at the cross-entropy `log_softmax` input, 64 sampled values and the norm<br>same microbatches | same | 0 (identical) | 0 |
| final LoRA tensors, 64 sampled values and the norm per tensor (992)<br>after update 15, and after update 250 in the full gate | `on_step_end` | 0 (identical) | 0 |
| LoRA tensors, same reduction<br>after updates 1 and 5 | same | 0 (identical) | 0 |
| LoRA gradients before clipping, 64 sampled values and the norm per tensor (992)<br>after the backward of updates 1, 5, 15 and 250 | `SFTTrainer._clip_grad_norm`, before the clip | 0 (identical) | 0 |
| initial LoRA tensors (992)<br>before update 1 | `on_train_begin` | identical | exact |
| number of recorded tensors and of gradient tensors<br>every recorded point | same | 992, identical; 7,936 record files in the full gate | exact |
| dataset fingerprint, trainable parameter names, shapes and dtypes<br>train begin | same | identical | exact |
| `input_ids`, `attention_mask`, `labels`, full tensors<br>every microbatch | `compute_loss` | identical | exact |
| shape and dtype of every recorded tensor, and that every value is finite<br>every recorded point | same | identical, all finite | exact |

"Actual difference to baseline" is the largest absolute difference between this branch and the unmodified code over all listed points and all 8 ranks. "Tolerance" is 2× the spread of three runs of the unmodified code; that spread was zero in all 112,544 floating-point fields (`runs/correctness/baseline/derive.log`), so the 15-update gate is exact, and the 250-update gate is exact by construction (`compare_full.py`). The 250-update gate covers 982 microbatches per rank, including the one-microbatch tail update at each of the six epoch boundaries. Component checks on the helper: 16 CPU output, state and gradient cases including non-reentrant checkpointing, `gradcheck` and `gradgradcheck` of the custom row backward, and full-shape B200 comparisons at 1373, 1655 and 2048 tokens with a maximum absolute difference of 0 in the outputs and the q, k, v, g and beta gradients on every timed repeat.

## Reproduce

**Model.** Qwen3.8-27B (`Qwen/Qwen3.8-27B`, revision `1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0`) loaded by `AutoModelForCausalLM` as `Qwen3_5ForCausalLM`: 64 layers (48 gated delta-rule linear attention with 16 key heads × 128 and 48 value heads × 128, 16 full attention with 24 query and 4 key-value heads × 256), hidden 5120, FFN 17408, vocabulary 248,320 resized to the tokenizer's 248,080, 26.95 B parameters, bf16, frozen. LoRA r=8, alpha 16, dropout 0.1 on `all-linear` (992 tensors, 58,363,904 parameters). AdamW, lr 1e-4, cosine schedule, no warm-up, weight decay 1e-4, gradient clipping at 1.0, non-reentrant gradient checkpointing, 8-process FSDP. Per rank per update: 4 microbatches of 8 samples of `smangrul/ultrachat-10k-chatml` in chatml format, each microbatch padded to its longest sequence, at most 2048 tokens (dataset fingerprint `d28215d42747a7cb`). Loss: the trainer's chunked next-token cross-entropy.

**The measured job** (every flag is `run_peft_fsdp.sh`'s except those listed under Script; `--max_steps 15` gives 5 warm-up plus 10 measured updates, `--report_to none` and a temporary output directory keep the run clean):
```
cd examples/sft
accelerate launch --config_file configs/fsdp_config.yaml --num_processes 8 \
  --fsdp_transformer_layer_cls_to_wrap Qwen3_5DecoderLayer train.py \
  --seed 100 --data_seed 100 --model_name_or_path Qwen/Qwen3.8-27B \
  --dataset_name smangrul/ultrachat-10k-chatml --chat_template_format chatml \
  --add_special_tokens False --append_concat_token False --splits "train,test" \
  --max_length 2048 --max_steps 15 --logging_steps 1 --log_level info --logging_strategy steps \
  --eval_strategy no --save_strategy no --bf16 True --packing False \
  --learning_rate 1e-4 --lr_scheduler_type cosine --weight_decay 1e-4 --warmup_steps 0 --max_grad_norm 1.0 \
  --output_dir <tmp out> --per_device_train_batch_size 8 --per_device_eval_batch_size 8 \
  --gradient_accumulation_steps 4 --gradient_checkpointing True --use_reentrant False \
  --dataset_text_field content --use_flash_attn False --use_peft_lora True \
  --lora_r 8 --lora_alpha 16 --lora_dropout 0.1 --lora_target_modules all-linear \
  --use_4bit_quantization False --report_to none
```
`configs/fsdp_config.yaml` is the repo's own file: `TRANSFORMER_BASED_WRAP`, `BACKWARD_PRE` prefetch, no forward prefetch, no offload, `SHARDED_STATE_DICT`, `sync_module_states`, `use_orig_params: false`, `mixed_precision: bf16`, 8 processes. This PR changes its one `fsdp_sharding_strategy` line. `--fsdp_transformer_layer_cls_to_wrap Qwen3_5DecoderLayer` is needed on both sides because the default wrap list also names `Qwen3_5VisionBlock`, which the text-only model does not contain, and accelerate refuses to start. `HF_HUB_OFFLINE=1` with `PYTHONHASHSEED=100` and the dataset staged to local disk are the wrapper's, not the script's.

**Seeds.** `--seed 100` (the script's own default) and `--data_seed 100` seed LoRA initialization, LoRA dropout, and the sampler; `PYTHONHASHSEED=100` fixes hashing. With these, three runs of the unmodified code agree bit for bit on every recorded value, which is what makes the zero-tolerance gate possible.

**Timing.** Median of updates 6 to 15 of the interval between consecutive refreshes of the Trainer's tqdm bar on rank 0 (`TQDM_BAR_FORMAT` extended with `elapsed_s`, `TQDM_MININTERVAL=0`), so the number includes the batch fetch and logging between step bodies. A CUDA-synchronized `perf_counter` around each update on every rank, reduced as the maximum over the 8 ranks, gives the same medians within 20 ms (52.768 and 34.726 s). Updates 1 to 5 are warm-up: the first update carries the first cuBLAS, cuDNN and NCCL calls (54.7 s baseline, 67.3 s on a cold cache in the earliest run). The baseline and candidate of the delivery number were run back to back on the same node with recording off. Startup is the time to `on_train_begin` on the slowest rank; save is the time of the script's unconditional final `save_model`. Profiles: `torch.profiler` with CPU and CUDA activities, `record_shapes`, `profile_memory` and `with_stack`, one gzip'd chrome trace per rank, started at update 6 after the five warm-ups; three updates for the baseline (updates 6 to 8) and one update for the optimized code (update 6), because the three-update export exhausted host memory on the later runs. Profile timings are not used as speed measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmRLsAd9T1rnWBr2by7EAd




