### PR TITLE
FIX Merging several adapters at once on torchao

### DIFF
--- a/src/peft/tuners/lora/torchao.py
+++ b/src/peft/tuners/lora/torchao.py
@@ -70,10 +70,13 @@ class TorchaoLoraLinear(Linear):
 
         self._check_dtype_supported()
 
-        base_layer = self.get_base_layer()
-        weight = base_layer.weight
-
         for active_adapter in adapter_names:
+            # Re-read the weight each round: the loop deletes the local and
+            # re-quantizes the base layer, so the previous round's tensor is
+            # neither current nor still bound. unmerge below reads it inside the
+            # loop for the same reason.
+            base_layer = self.get_base_layer()
+            weight = base_layer.weight
             try:
                 weight = weight.dequantize()
             except NotImplementedError as exc:

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -23,7 +23,7 @@ import torch
 from accelerate.utils.memory import clear_device_cache
 from transformers import AutoModelForCausalLM, BitsAndBytesConfig, TorchAoConfig
 
-from peft import BOFTConfig, MissConfig, OFTConfig, ShiraConfig, VeraConfig, get_peft_model
+from peft import BOFTConfig, LoraConfig, MissConfig, OFTConfig, ShiraConfig, VeraConfig, get_peft_model
 from peft.import_utils import (
     is_bnb_4bit_available,
     is_bnb_available,
@@ -337,6 +337,42 @@ class TestQuantization:
             out_non_quant = model(dummy_input).logits
 
         check_outputs_similar(out_non_quant, out_quant)
+
+    @pytest.mark.skipif(not is_torchao_available(), reason="torchao is not installed")
+    def test_torchao_lora_merge_several_adapters_in_one_call(self, dummy_input):
+        """merge_adapter takes a list of adapter names, so two in one call must work.
+
+        TorchaoLoraLinear.merge read the weight once before the loop and deleted
+        the local at the end of every round, so the second adapter raised
+        UnboundLocalError (#3728). Not part of the parametrized matrix above:
+        the tuner is LoRA and the layer is torchao-specific.
+        """
+        from torchao.utils import TorchAOBaseTensor
+
+        model = TorchAoInt8WeightOnlyLoader().load_model()
+        torch.manual_seed(SEED)
+        model = get_peft_model(model, LoraConfig(init_lora_weights=False, target_modules=["q_proj", "v_proj"])).eval()
+        model.add_adapter("other", LoraConfig(init_lora_weights=False, target_modules=["q_proj", "v_proj"]))
+
+        with torch.inference_mode():
+            out_before = model(dummy_input).logits
+
+        model.base_model.merge_adapter(adapter_names=["default", "other"])
+
+        lora_layers = [m for m in model.modules() if hasattr(m, "lora_A") and hasattr(m, "merged_adapters")]
+        assert lora_layers
+        for layer in lora_layers:
+            assert layer.merged_adapters == ["default", "other"]
+            # Each round has to leave the base layer re-quantized for the next one.
+            assert isinstance(layer.get_base_layer().weight, TorchAOBaseTensor)
+
+        # Both deltas are in the weight now, so the output moved; unmerging both
+        # brings it back, which is what proves the second round merged for real.
+        model.unmerge_adapter()
+        with torch.inference_mode():
+            out_unmerged = model(dummy_input).logits
+
+        check_outputs_similar(out_before, out_unmerged)
 
     @pytest.mark.parametrize("quant", QUANTIZATION_BACKENDS, ids=_quant_id)
     @pytest.mark.parametrize("config_cls,config_kwargs", TEST_CASES, ids=_peft_id)


### PR DESCRIPTION
Fixes #3728.

`TorchaoLoraLinear.merge` read the base weight once, before the loop over `adapter_names`, and deleted the local at the end of every round:

```python
base_layer = self.get_base_layer()
weight = base_layer.weight

for active_adapter in adapter_names:
    weight = weight.dequantize()
    ...
    del base_layer.weight
    base_layer.weight = weight
    quantize_(base_layer, self.get_apply_tensor_subclass())
    del weight            # gone for the next round
```

So a second adapter in the same call raised `UnboundLocalError`. `merge_adapter` accepts a list, so this is reachable from the public API, and `del weight` is not the only reason the name cannot be carried: the round re-quantizes the base layer, which makes the previous round's tensor stale too. `unmerge` in the same file reads `base_layer` and `weight` inside its loop, which is why it survives several adapters.

Moving the two reads into the loop is the whole change. Merging a single adapter runs exactly as before.

## Reproduction

The issue's script, on CPU:

```
before: UnboundLocalError: cannot access local variable 'weight' where it is not associated with a value
after:  merged_adapters = ['default', 'other']
```

## Test

`tests/test_quantization.py::TestQuantization::test_torchao_lora_merge_several_adapters_in_one_call`

The existing torchao merge tests live in `TestPeftTorchao`, which is `@require_non_cpu`, and the parametrized matrix in `test_quantization.py` carries BOFT, OFT, MISS, SHIRA and VeRA but no LoRA case, so neither covers this. Rather than widen the matrix, which that file asks to keep small, the new test is a single CPU case on the `TorchAoInt8WeightOnlyLoader` already defined there. It merges both adapters in one call, asserts every LoRA layer lists both in `merged_adapters` and still holds a `TorchAOBaseTensor` weight, then unmerges both and compares the output with the pre-merge output, which is what shows the second round merged for real rather than merely not raising.

```
pytest tests/test_quantization.py -k torchao_lora_merge_several   1 passed
pytest tests/test_quantization.py -k torchao                     55 passed, 2 skipped
ruff check / ruff format --check                                 clean
```

Reverting the source change fails the new test with the `UnboundLocalError` from the issue. Ran on CPU with torchao 0.18.0, torch 2.14.0, transformers 5.17.0; I have no GPU here, so the `TestPeftTorchao` suite was not exercised.
