### PR TITLE
fix(dora): use base layer device instead of hardcoding cuda in ephemeral offload

### DIFF
--- a/src/peft/tuners/lora/variants.py
+++ b/src/peft/tuners/lora/variants.py
@@ -19,7 +19,6 @@ from typing import Any, Optional
 
 import torch
 import torch.nn.functional as F
-from accelerate.utils.imports import is_xpu_available
 from torch import nn
 
 from peft.tuners._buffer_dict import BufferDict
@@ -151,10 +150,9 @@ class DoraLinearVariant(LoraVariant):
                 lora_B = lora_B.to(lora_A.device)
             else:
                 if lora_B.device.type not in ["cuda", "xpu"]:
-                    if is_xpu_available():
-                        lora_B = lora_B.to("xpu")
-                    else:
-                        lora_B = lora_B.to("cuda")
+                    # Move offloaded LoRA weights to the base layer's device (device-agnostic)
+                    target_device = module.get_base_layer().weight.device
+                    lora_B = lora_B.to(target_device)
                 lora_A = lora_A.to(lora_B.device)
         scaling = module.scaling[adapter_name]
         dora_layer.update_layer(


### PR DESCRIPTION
### What does this PR do?

Fixes a device-hostile codepath in `DoraLinearVariant.init` during ephemeral GPU offload.

When `ephemeral_gpu_offload=True` and both `lora_A` and `lora_B` are on CPU (offloaded), the code currently tries to move them to either `"xpu"` or — as a last resort — `"cuda"`. This hardcoded `"cuda"` fallback crashes on non-CUDA accelerators (Ascend NPU, etc.) with `Torch not compiled with CUDA enabled`.

**Fix:** Instead of checking `is_xpu_available()` and falling back to `"cuda"`, use `module.get_base_layer().weight.device` as the target device. This is:
- Device-agnostic (works on CUDA, NPU, XPU, MPS, etc.)
- Consistent with the existing `_move_adapter_to_device_of_base_layer` pattern already used elsewhere in the codebase
- More correct: the base layer is always on the active compute device, so this always moves the offloaded LoRA weights to the right place

**Change:**

```diff
         if module.ephemeral_gpu_offload:
             if lora_A.device.type in ["cuda", "xpu"]:
                 lora_B = lora_B.to(lora_A.device)
             else:
                 if lora_B.device.type not in ["cuda", "xpu"]:
-                    if is_xpu_available():
-                        lora_B = lora_B.to("xpu")
-                    else:
-                        lora_B = lora_B.to("cuda")
+                    target_device = module.get_base_layer().weight.device
+                    lora_B = lora_B.to(target_device)
                 lora_A = lora_A.to(lora_B.device)
```

Also removes the now-unused `is_xpu_available` import.

### Verification

On Ascend NPU (torch 2.14 + torch_npu) with `ephemeral_gpu_offload=True` and `use_dora=True`:
- **Before**: `lora_B.to("cuda")` → `AssertionError: Torch not compiled with CUDA enabled`
- **After**: `lora_B.to("npu")` via base layer device → weights correctly placed on NPU, forward pass succeeds